### PR TITLE
Attempts to fix the failing specs for shares_controller_spec.

### DIFF
--- a/spec/controllers/hyrax/my/shares_controller_spec.rb
+++ b/spec/controllers/hyrax/my/shares_controller_spec.rb
@@ -9,18 +9,9 @@ RSpec.describe Hyrax::My::SharesController, :clean_repo, type: :controller do
       let(:other_user)   { create(:user) }
       let(:someone_else) { create(:user) }
 
-      let(:my_work) { valkyrie_create(:monograph, depositor: user.user_key) }
-      let(:unshared_work) { valkyrie_create(:monograph, depositor: other_user.user_key) }
       let!(:shared_with_me) do
         valkyrie_create(:monograph, depositor: other_user.user_key, edit_users: [user, other_user])
       end
-      let(:read_shared_with_me) do
-        valkyrie_create(:monograph, depositor: other_user.user_key, read_users: [user, other_user])
-      end
-      let(:shared_with_someone_else) do
-        valkyrie_create(:monograph, depositor: other_user.user_key, edit_users: [someone_else, other_user])
-      end
-      let(:my_collection) { valkyrie_create(:hyrax_collection, :public, user: user) }
 
       it "responds with success" do
         get :index
@@ -35,13 +26,25 @@ RSpec.describe Hyrax::My::SharesController, :clean_repo, type: :controller do
           expect(assigns[:document_list].length).to eq 2
 
           get :index, params: { per_page: 2, page: 2 }
-          expect(assigns[:document_list].length).to be >= 1
+          expect(assigns[:document_list].length).to eq 1
         end
       end
 
-      it "shows only documents that are shared with me via edit access" do
-        get :index
-        expect(assigns[:document_list].map(&:id)).to contain_exactly(shared_with_me.id)
+      context "with other extant documents" do
+        let!(:my_work) { valkyrie_create(:monograph, depositor: user.user_key) }
+        let!(:unshared_work) { valkyrie_create(:monograph, depositor: other_user.user_key) }
+        let!(:read_shared_with_me) do
+          valkyrie_create(:monograph, depositor: other_user.user_key, read_users: [user, other_user])
+        end
+        let!(:shared_with_someone_else) do
+          valkyrie_create(:monograph, depositor: other_user.user_key, edit_users: [someone_else, other_user])
+        end
+        let!(:my_collection) { valkyrie_create(:hyrax_collection, :public, user: user) }
+
+        it "shows only documents that are shared with me via edit access" do
+          get :index
+          expect(assigns[:document_list].map(&:id)).to contain_exactly(shared_with_me.id)
+        end
       end
     end
   end

--- a/spec/controllers/hyrax/my/shares_controller_spec.rb
+++ b/spec/controllers/hyrax/my/shares_controller_spec.rb
@@ -1,22 +1,26 @@
 # frozen_string_literal: true
-RSpec.describe Hyrax::My::SharesController, type: :controller do
+RSpec.describe Hyrax::My::SharesController, :clean_repo, type: :controller do
   describe "logged in user" do
     let(:user) { create(:user) }
 
-    before do
-      sign_in user
-    end
+    before { sign_in user }
 
     describe "#index" do
       let(:other_user)   { create(:user) }
       let(:someone_else) { create(:user) }
 
-      let!(:my_work)                  { create(:work, user: user) }
-      let!(:unshared_work)            { create(:work, user: other_user) }
-      let!(:shared_with_me)           { create(:work, user: other_user, edit_users: [user, other_user]) }
-      let!(:read_shared_with_me)      { create(:work, user: other_user, read_users: [user, other_user]) }
-      let!(:shared_with_someone_else) { create(:work, user: other_user, edit_users: [someone_else, other_user]) }
-      let!(:my_collection)            { create(:public_collection_lw, user: user) }
+      let(:my_work) { valkyrie_create(:monograph, depositor: user.user_key) }
+      let(:unshared_work) { valkyrie_create(:monograph, depositor: other_user.user_key) }
+      let!(:shared_with_me) do
+        valkyrie_create(:monograph, depositor: other_user.user_key, edit_users: [user, other_user])
+      end
+      let(:read_shared_with_me) do
+        valkyrie_create(:monograph, depositor: other_user.user_key, read_users: [user, other_user])
+      end
+      let(:shared_with_someone_else) do
+        valkyrie_create(:monograph, depositor: other_user.user_key, edit_users: [someone_else, other_user])
+      end
+      let(:my_collection) { valkyrie_create(:hyrax_collection, :public, user: user) }
 
       it "responds with success" do
         get :index
@@ -24,10 +28,12 @@ RSpec.describe Hyrax::My::SharesController, type: :controller do
       end
 
       context "with multiple pages of results" do
-        before { 2.times { create(:work, user: other_user, edit_users: [user, other_user]) } }
+        before { 2.times { valkyrie_create(:monograph, depositor: other_user.user_key, edit_users: [user, other_user]) } }
+
         it "paginates" do
           get :index, params: { per_page: 2 }
           expect(assigns[:document_list].length).to eq 2
+
           get :index, params: { per_page: 2, page: 2 }
           expect(assigns[:document_list].length).to be >= 1
         end


### PR DESCRIPTION
### Fixes

Fixes rspec failures for `spec/controllers/hyrax/my/shares_controller_spec.rb`.

### Type of change (for release notes)

- `notes-valkyrie` Valkyrie Progress

### Detailed Description

Swaps out AF factory objects with Valkyrie Monographs.

@samvera/hyrax-code-reviewers
