### PR TITLE
Valkyrize collection feature spec

### DIFF
--- a/app/controllers/concerns/hyrax/collections_controller_behavior.rb
+++ b/app/controllers/concerns/hyrax/collections_controller_behavior.rb
@@ -39,7 +39,7 @@ module Hyrax
 
       respond_to do |format|
         format.html
-        format.json { render json: @curation_concern }
+        format.json { render 'hyrax/base/show' }
       end
     end
 


### PR DESCRIPTION
### Summary

Convert collection feature spec to valkyrie resources, add sorting spec; ref #6408 

### Guidance for testing, such as acceptance criteria or new user interface behaviors:
* Collection json response is correct; id is `id: 'abc123'`, not a hash like `id: { id: 'abc123' }`

### Changes proposed in this pull request:
* Use hyrax/base/show jbuilder partial for collection json response format.


@samvera/hyrax-code-reviewers
