### PR TITLE
Fix unreliability of batch_edit_spec.rb

### DIFF
--- a/spec/features/batch_edit_spec.rb
+++ b/spec/features/batch_edit_spec.rb
@@ -67,48 +67,43 @@ RSpec.describe 'batch', type: :feature, clean_repo: true, js: true do
       end
     end
 
-    it 'updates permissions and roles' do
+    it 'updates visibility' do
       click_on 'batch-edit'
       find('#edit_permissions_link').click
-      expect(page).to have_content('Batch Edit Descriptions')
+      batch_edit_expand('permissions_visibility')
+      find('#generic_work_visibility_authenticated').click
+      find('#permissions_visibility_save').click
 
-      # Set visibility to private
-      within "#form_permissions_visibility" do
-        batch_edit_expand('permissions_visibility')
-        find('#generic_work_visibility_authenticated').click
-        find('#permissions_visibility_save').click
+      expect(page).to have_selector('.status', text: 'Changes Saved', visible: true, wait: 30)
 
-        ajax_wait(30)
-        # This was `expect(page).to have_content 'Changes Saved'`, however in debugging,
-        # the `have_content` check was ignoring the `within` scoping and finding
-        # "Changes Saved" for other field areas
-        find('.status', text: 'Changes Saved')
-      end
-
-      within "#form_permissions" do
-        batch_edit_expand('permissions_sharing')
-        page.select('donor', from: 'new_group_name_skel')
-        page.select('View/Download', from: 'new_group_permission_skel')
-        page.find('#add_new_group_skel').click
-        find('#collapse_permissions_sharing table', text: 'View/Download')
-        find('#collapse_permissions_sharing table', text: 'donor')
-        find('#permissions_sharing_save').click
-
-        ajax_wait(30)
-        # This was `expect(page).to have_content 'Changes Saved'`, however in debugging,
-        # the `have_content` check was ignoring the `within` scoping and finding
-        # "Changes Saved" for other field areas
-        find('.status', text: 'Changes Saved')
-      end
-
-      # Visit work permissions and verify
+      # Verify work is updated
       visit "/concern/generic_works/#{work1.id}/edit#share"
       page.find('#generic_work_visibility_authenticated:checked')
-      page.find('#share table', text: 'donor')
 
-      # Visit file permissions and verify
+      # Verify fileset is updated
       visit "concern/file_sets/#{work1.file_sets.first.id}/edit#permissions_display"
       page.find('#file_set_visibility_authenticated:checked')
+    end
+
+    it 'updates sharing' do
+      click_on 'batch-edit'
+      find('#edit_permissions_link').click
+      batch_edit_expand('permissions_sharing')
+      page.select('donor', from: 'new_group_name_skel')
+      page.select('View/Download', from: 'new_group_permission_skel')
+      page.find('#add_new_group_skel').click
+      find('#collapse_permissions_sharing table', text: 'View/Download')
+      find('#collapse_permissions_sharing table', text: 'donor')
+      find('#permissions_sharing_save').click
+
+      expect(page).to have_selector('.status', text: 'Changes Saved', visible: true, wait: 30)
+
+      # Verify work is updated
+      visit "/concern/generic_works/#{work1.id}/edit#share"
+      page.find('#share table', text: 'donor')
+
+      # Verify fileset is updated
+      visit "concern/file_sets/#{work1.file_sets.first.id}/edit#permissions_display"
       page.find('#permissions_display table', text: 'donor')
     end
   end


### PR DESCRIPTION
### Fixes

`spec/features/batch_edit_spec.rb` is unreliable, and often leads to CI failures due to ajax call related issues. I rewrote one of the key specs in the file to separate different testing scenarios and make the spec file more reliable in CI.

### Changes proposed in this pull request:
* Separate tests for editing visibility and sharing in `spec/features/batch_edit_spec.rb`
*
*

@samvera/hyrax-code-reviewers
