### PR TITLE
Don’t require `::Collection` for `filter_by_type`

### DIFF
--- a/app/search_builders/hyrax/filter_by_type.rb
+++ b/app/search_builders/hyrax/filter_by_type.rb
@@ -53,7 +53,7 @@ module Hyrax
 
     def collection_classes
       return [] if only_works?
-      [::Collection, Hyrax.config.collection_class].uniq
+      ["Collection".safe_constantize, Hyrax.config.collection_class].uniq.compact
     end
   end
 end


### PR DESCRIPTION
For applications that configure their collection class with `Hyrax.config.collection_class`, there’s no reason to require that `::Collection` exist also. I believe we’ve removed most references to it from Hyrax at this point, but this one remains.