### PR TITLE
Skip work_usage_spec.rb tests for Valkyrie

### DIFF
--- a/spec/presenters/hyrax/work_usage_spec.rb
+++ b/spec/presenters/hyrax/work_usage_spec.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-RSpec.describe Hyrax::WorkUsage, type: :model do
+RSpec.describe Hyrax::WorkUsage, :active_fedora, type: :model do
   let!(:work) { create(:work, id: 'abc12345xy') }
 
   let(:dates) do


### PR DESCRIPTION
### Fixes

Per @dlpierce's recommendation, I am editing the `work_usage_spec.rb` file to skip tests until Valkyrization of analytics is complete. This will remove failing specs for instances like Koppie where Valkyrie is used.

### Type of change (for release notes)

- `notes-valkyrie` Valkyrie Progress

### Changes proposed in this pull request:
* Skip tests in `spec/presenters/hyrax/work_usage_spec.rb` when Valkyrie is used. Once the Valkyrization of analytics is done, the test file should be edited to match the setup of a Valkyrie setup.
*
*

@samvera/hyrax-code-reviewers
