### PR TITLE
Improve the Hyrax form API

### DIFF
--- a/app/controllers/hyrax/admin/admin_sets_controller.rb
+++ b/app/controllers/hyrax/admin/admin_sets_controller.rb
@@ -182,7 +182,7 @@ module Hyrax
       @form ||=
         case @admin_set
         when Valkyrie::Resource
-          Hyrax::Forms::ResourceForm.for(@admin_set)
+          Hyrax::Forms::ResourceForm.for(resource: @admin_set)
         else
           form_class.new(@admin_set, current_ability, repository)
         end

--- a/app/controllers/hyrax/dashboard/collections_controller.rb
+++ b/app/controllers/hyrax/dashboard/collections_controller.rb
@@ -512,7 +512,7 @@ module Hyrax
         @form ||=
           case @collection
           when Valkyrie::Resource
-            form = Hyrax::Forms::ResourceForm.for(@collection)
+            form = Hyrax::Forms::ResourceForm.for(resource: @collection)
             form.prepopulate!
             form
           else

--- a/app/controllers/hyrax/file_sets_controller.rb
+++ b/app/controllers/hyrax/file_sets_controller.rb
@@ -121,7 +121,7 @@ module Hyrax
     end
 
     def valkyrie_update_metadata
-      change_set = Hyrax::Forms::ResourceForm.for(file_set)
+      change_set = Hyrax::Forms::ResourceForm.for(resource: file_set)
 
       result =
         change_set.validate(attributes) &&
@@ -233,7 +233,7 @@ module Hyrax
 
       case file_set
       when Hyrax::Resource
-        @form = Hyrax::Forms::ResourceForm.for(file_set)
+        @form = Hyrax::Forms::ResourceForm.for(resource: file_set)
         @form.prepopulate!
       else
         @form = form_class.new(file_set)

--- a/app/forms/concerns/hyrax/contained_in_works_behavior.rb
+++ b/app/forms/concerns/hyrax/contained_in_works_behavior.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+module Hyrax
+  ##
+  # A module of form behaviours common to PCDM Objects and FileSets.
+  module ContainedInWorksBehavior
+    ##
+    # @api private
+    InWorksPrepopulator = proc do |_options|
+      self.in_works_ids =
+        if persisted?
+          Hyrax.query_service
+               .find_inverse_references_by(resource: model, property: :member_ids)
+               .select(&:work?)
+               .map(&:id)
+        else
+          []
+        end
+    end
+
+    def self.included(descendant) # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
+      descendant.property :depositor
+
+      descendant.property :visibility, default: VisibilityIntention::PRIVATE, populator: :visibility_populator
+
+      descendant.property :agreement_accepted, virtual: true, default: false, prepopulator: proc { |_opts| self.agreement_accepted = !model.new_record }
+
+      descendant.collection(:permissions,
+                 virtual: true,
+                 default: [],
+                 form: Hyrax::Forms::Permission,
+                 populator: :permission_populator,
+                 prepopulator: proc { |_opts| self.permissions = Hyrax::AccessControl.for(resource: model).permissions })
+
+      descendant.property :embargo, form: Hyrax::Forms::Embargo, populator: :embargo_populator
+      descendant.property :lease, form: Hyrax::Forms::Lease, populator: :lease_populator
+
+      # virtual properties for embargo/lease;
+      descendant.property :embargo_release_date, virtual: true, prepopulator: proc { |_opts| self.embargo_release_date = model.embargo&.embargo_release_date }
+      descendant.property :visibility_after_embargo, virtual: true, prepopulator: proc { |_opts| self.visibility_after_embargo = model.embargo&.visibility_after_embargo }
+      descendant.property :visibility_during_embargo, virtual: true, prepopulator: proc { |_opts| self.visibility_during_embargo = model.embargo&.visibility_during_embargo }
+
+      descendant.property :lease_expiration_date, virtual: true,  prepopulator: proc { |_opts| self.lease_expiration_date = model.lease&.lease_expiration_date }
+      descendant.property :visibility_after_lease, virtual: true, prepopulator: proc { |_opts| self.visibility_after_lease = model.lease&.visibility_after_lease }
+      descendant.property :visibility_during_lease, virtual: true, prepopulator: proc { |_opts| self.visibility_during_lease = model.lease&.visibility_during_lease }
+
+      descendant.property :in_works_ids, virtual: true, prepopulator: InWorksPrepopulator
+    end
+
+    def embargo_populator(**)
+      self.embargo = Hyrax::EmbargoManager.embargo_for(resource: model)
+    end
+
+    def lease_populator(**)
+      self.lease = Hyrax::LeaseManager.lease_for(resource: model)
+    end
+
+    # https://trailblazer.to/2.1/docs/reform.html#reform-populators-populator-collections
+    def permission_populator(collection:, index:, **)
+      Hyrax::Forms::Permission.new(collection[index])
+    end
+
+    def visibility_populator(fragment:, doc:, **)
+      case fragment
+      when "embargo"
+        self.visibility = doc['visibility_during_embargo']
+
+        doc['embargo'] = doc.slice('visibility_after_embargo',
+                                   'visibility_during_embargo',
+                                   'embargo_release_date')
+      when "lease"
+        self.visibility = doc['visibility_during_lease']
+        doc['lease'] = doc.slice('visibility_after_lease',
+                                   'visibility_during_lease',
+                                   'lease_expiration_date')
+      else
+        self.visibility = fragment
+      end
+    end
+  end
+end

--- a/app/forms/concerns/hyrax/contained_in_works_behavior.rb
+++ b/app/forms/concerns/hyrax/contained_in_works_behavior.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 module Hyrax
   ##
-  # A module of form behaviours common to PCDM Objects and FileSets.
+  # A module of form behaviours for resources which can be contained in works.
   module ContainedInWorksBehavior
     ##
     # @api private
@@ -17,64 +17,8 @@ module Hyrax
         end
     end
 
-    def self.included(descendant) # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
-      descendant.property :depositor
-
-      descendant.property :visibility, default: VisibilityIntention::PRIVATE, populator: :visibility_populator
-
-      descendant.property :agreement_accepted, virtual: true, default: false, prepopulator: proc { |_opts| self.agreement_accepted = !model.new_record }
-
-      descendant.collection(:permissions,
-                 virtual: true,
-                 default: [],
-                 form: Hyrax::Forms::Permission,
-                 populator: :permission_populator,
-                 prepopulator: proc { |_opts| self.permissions = Hyrax::AccessControl.for(resource: model).permissions })
-
-      descendant.property :embargo, form: Hyrax::Forms::Embargo, populator: :embargo_populator
-      descendant.property :lease, form: Hyrax::Forms::Lease, populator: :lease_populator
-
-      # virtual properties for embargo/lease;
-      descendant.property :embargo_release_date, virtual: true, prepopulator: proc { |_opts| self.embargo_release_date = model.embargo&.embargo_release_date }
-      descendant.property :visibility_after_embargo, virtual: true, prepopulator: proc { |_opts| self.visibility_after_embargo = model.embargo&.visibility_after_embargo }
-      descendant.property :visibility_during_embargo, virtual: true, prepopulator: proc { |_opts| self.visibility_during_embargo = model.embargo&.visibility_during_embargo }
-
-      descendant.property :lease_expiration_date, virtual: true,  prepopulator: proc { |_opts| self.lease_expiration_date = model.lease&.lease_expiration_date }
-      descendant.property :visibility_after_lease, virtual: true, prepopulator: proc { |_opts| self.visibility_after_lease = model.lease&.visibility_after_lease }
-      descendant.property :visibility_during_lease, virtual: true, prepopulator: proc { |_opts| self.visibility_during_lease = model.lease&.visibility_during_lease }
-
+    def self.included(descendant)
       descendant.property :in_works_ids, virtual: true, prepopulator: InWorksPrepopulator
-    end
-
-    def embargo_populator(**)
-      self.embargo = Hyrax::EmbargoManager.embargo_for(resource: model)
-    end
-
-    def lease_populator(**)
-      self.lease = Hyrax::LeaseManager.lease_for(resource: model)
-    end
-
-    # https://trailblazer.to/2.1/docs/reform.html#reform-populators-populator-collections
-    def permission_populator(collection:, index:, **)
-      Hyrax::Forms::Permission.new(collection[index])
-    end
-
-    def visibility_populator(fragment:, doc:, **)
-      case fragment
-      when "embargo"
-        self.visibility = doc['visibility_during_embargo']
-
-        doc['embargo'] = doc.slice('visibility_after_embargo',
-                                   'visibility_during_embargo',
-                                   'embargo_release_date')
-      when "lease"
-        self.visibility = doc['visibility_during_lease']
-        doc['lease'] = doc.slice('visibility_after_lease',
-                                   'visibility_during_lease',
-                                   'lease_expiration_date')
-      else
-        self.visibility = fragment
-      end
     end
   end
 end

--- a/app/forms/concerns/hyrax/deposit_agreement_behavior.rb
+++ b/app/forms/concerns/hyrax/deposit_agreement_behavior.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+module Hyrax
+  ##
+  # A module of form behaviours for depositors and depositor agreements.
+  module DepositAgreementBehavior
+    def self.included(descendant)
+      descendant.property :depositor
+
+      descendant.property :agreement_accepted, virtual: true, default: false, prepopulator: proc { |_opts| self.agreement_accepted = !model.new_record }
+    end
+  end
+end

--- a/app/forms/concerns/hyrax/leaseability_behavior.rb
+++ b/app/forms/concerns/hyrax/leaseability_behavior.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+module Hyrax
+  ##
+  # A module of form behaviours for embargoes, leases, and resulting
+  # visibilities.
+  module LeaseabilityBehavior
+    def self.included(descendant) # rubocop:disable Metrics/AbcSize
+      descendant.property :visibility, default: VisibilityIntention::PRIVATE, populator: :visibility_populator
+
+      descendant.property :embargo, form: Hyrax::Forms::Embargo, populator: :embargo_populator
+      descendant.property :lease, form: Hyrax::Forms::Lease, populator: :lease_populator
+
+      # virtual properties for embargo/lease;
+      descendant.property :embargo_release_date, virtual: true, prepopulator: proc { |_opts| self.embargo_release_date = model.embargo&.embargo_release_date }
+      descendant.property :visibility_after_embargo, virtual: true, prepopulator: proc { |_opts| self.visibility_after_embargo = model.embargo&.visibility_after_embargo }
+      descendant.property :visibility_during_embargo, virtual: true, prepopulator: proc { |_opts| self.visibility_during_embargo = model.embargo&.visibility_during_embargo }
+
+      descendant.property :lease_expiration_date, virtual: true,  prepopulator: proc { |_opts| self.lease_expiration_date = model.lease&.lease_expiration_date }
+      descendant.property :visibility_after_lease, virtual: true, prepopulator: proc { |_opts| self.visibility_after_lease = model.lease&.visibility_after_lease }
+      descendant.property :visibility_during_lease, virtual: true, prepopulator: proc { |_opts| self.visibility_during_lease = model.lease&.visibility_during_lease }
+    end
+
+    def embargo_populator(**)
+      self.embargo = Hyrax::EmbargoManager.embargo_for(resource: model)
+    end
+
+    def lease_populator(**)
+      self.lease = Hyrax::LeaseManager.lease_for(resource: model)
+    end
+
+    def visibility_populator(fragment:, doc:, **)
+      case fragment
+      when "embargo"
+        self.visibility = doc['visibility_during_embargo']
+
+        doc['embargo'] = doc.slice('visibility_after_embargo',
+                                   'visibility_during_embargo',
+                                   'embargo_release_date')
+      when "lease"
+        self.visibility = doc['visibility_during_lease']
+        doc['lease'] = doc.slice('visibility_after_lease',
+                                   'visibility_during_lease',
+                                   'lease_expiration_date')
+      else
+        self.visibility = fragment
+      end
+    end
+  end
+end

--- a/app/forms/concerns/hyrax/permission_behavior.rb
+++ b/app/forms/concerns/hyrax/permission_behavior.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+module Hyrax
+  ##
+  # A module of form behaviours for populating permissions.
+  module PermissionBehavior
+    def self.included(descendant)
+      descendant.collection(:permissions,
+                 virtual: true,
+                 default: [],
+                 form: Hyrax::Forms::Permission,
+                 populator: :permission_populator,
+                 prepopulator: proc { |_opts| self.permissions = Hyrax::AccessControl.for(resource: model).permissions })
+    end
+
+    # https://trailblazer.to/2.1/docs/reform.html#reform-populators-populator-collections
+    def permission_populator(collection:, index:, **)
+      Hyrax::Forms::Permission.new(collection[index])
+    end
+  end
+end

--- a/app/forms/hyrax/forms/administrative_set_form.rb
+++ b/app/forms/hyrax/forms/administrative_set_form.rb
@@ -5,7 +5,7 @@ module Hyrax
     ##
     # @api public
     # @see https://github.com/samvera/valkyrie/wiki/ChangeSets-and-Dirty-Tracking
-    class AdministrativeSetForm < Valkyrie::ChangeSet
+    class AdministrativeSetForm < Hyrax::Forms::ResourceForm
       ##
       # @api private
       AdminSetMembersPopulator = lambda do |**_options|
@@ -22,10 +22,6 @@ module Hyrax
 
       property :title, required: true, primary: true
       property :description, primary: true
-
-      property :human_readable_type, writable: false
-      property :date_modified, readable: false
-      property :date_uploaded, readable: false
 
       property :creator
 

--- a/app/forms/hyrax/forms/file_set_form.rb
+++ b/app/forms/hyrax/forms/file_set_form.rb
@@ -12,7 +12,10 @@ module Hyrax
       # be configurable.
       include Hyrax::FormFields(:file_set_metadata)
 
+      include Hyrax::DepositAgreementBehavior
       include Hyrax::ContainedInWorksBehavior
+      include Hyrax::LeaseabilityBehavior
+      include Hyrax::PermissionBehavior
 
       property :representative_id, type: Valkyrie::Types::String, writeable: false
       property :thumbnail_id, type: Valkyrie::Types::String, writeable: false

--- a/app/forms/hyrax/forms/file_set_form.rb
+++ b/app/forms/hyrax/forms/file_set_form.rb
@@ -12,6 +12,8 @@ module Hyrax
       # be configurable.
       include Hyrax::FormFields(:file_set_metadata)
 
+      include Hyrax::ContainedInWorksBehavior
+
       property :representative_id, type: Valkyrie::Types::String, writeable: false
       property :thumbnail_id, type: Valkyrie::Types::String, writeable: false
     end

--- a/app/forms/hyrax/forms/pcdm_collection_form.rb
+++ b/app/forms/hyrax/forms/pcdm_collection_form.rb
@@ -5,7 +5,7 @@ module Hyrax
     ##
     # @api public
     # @see https://github.com/samvera/valkyrie/wiki/ChangeSets-and-Dirty-Tracking
-    class PcdmCollectionForm < Valkyrie::ChangeSet # rubocop:disable Metrics/ClassLength
+    class PcdmCollectionForm < Hyrax::Forms::ResourceForm # rubocop:disable Metrics/ClassLength
       include Hyrax::FormFields(:core_metadata)
 
       BannerInfoPrepopulator = lambda do |**_options|
@@ -32,10 +32,6 @@ module Hyrax
           end
         end
       end
-
-      property :human_readable_type, writable: false
-      property :date_modified, readable: false
-      property :date_uploaded, readable: false
 
       property :depositor, required: true
       property :collection_type_gid, required: true

--- a/app/forms/hyrax/forms/pcdm_object_form.rb
+++ b/app/forms/hyrax/forms/pcdm_object_form.rb
@@ -33,6 +33,9 @@ module Hyrax
       include Hyrax::FormFields(:core_metadata)
 
       include Hyrax::ContainedInWorksBehavior
+      include Hyrax::DepositAgreementBehavior
+      include Hyrax::LeaseabilityBehavior
+      include Hyrax::PermissionBehavior
 
       property :on_behalf_of
       property :proxy_depositor

--- a/app/forms/hyrax/forms/pcdm_object_form.rb
+++ b/app/forms/hyrax/forms/pcdm_object_form.rb
@@ -32,6 +32,8 @@ module Hyrax
     class PcdmObjectForm < Hyrax::Forms::ResourceForm
       include Hyrax::FormFields(:core_metadata)
 
+      include Hyrax::ContainedInWorksBehavior
+
       property :on_behalf_of
       property :proxy_depositor
 

--- a/app/forms/hyrax/forms/resource_batch_edit_form.rb
+++ b/app/forms/hyrax/forms/resource_batch_edit_form.rb
@@ -23,9 +23,9 @@ module Hyrax
         @batch_document_ids = batch_document_ids
         if @batch_document_ids.present?
           combined_fields = model_attributes(model, initialize_combined_fields)
-          super(model.class.new(combined_fields))
+          super(resource: model.class.new(combined_fields))
         else
-          super(model)
+          super(resource: model)
         end
       end
 

--- a/app/forms/hyrax/forms/resource_batch_edit_form.rb
+++ b/app/forms/hyrax/forms/resource_batch_edit_form.rb
@@ -3,7 +3,11 @@ module Hyrax
   module Forms
     class ResourceBatchEditForm < Hyrax::Forms::ResourceForm
       include Hyrax::FormFields(:basic_metadata)
+
       include Hyrax::ContainedInWorksBehavior
+      include Hyrax::DepositAgreementBehavior
+      include Hyrax::LeaseabilityBehavior
+      include Hyrax::PermissionBehavior
 
       self.required_fields = []
       self.model_class = Hyrax.primary_work_type

--- a/app/forms/hyrax/forms/resource_batch_edit_form.rb
+++ b/app/forms/hyrax/forms/resource_batch_edit_form.rb
@@ -3,6 +3,7 @@ module Hyrax
   module Forms
     class ResourceBatchEditForm < Hyrax::Forms::ResourceForm
       include Hyrax::FormFields(:basic_metadata)
+      include Hyrax::ContainedInWorksBehavior
 
       self.required_fields = []
       self.model_class = Hyrax.primary_work_type

--- a/app/forms/hyrax/forms/resource_form.rb
+++ b/app/forms/hyrax/forms/resource_form.rb
@@ -6,13 +6,7 @@ module Hyrax
     # @api public
     #
     # Returns the form class associated with a given model.
-    #
-    # @note The default case assumes that the provided model class is for a
-    #   PCDM object and returns a +Hyrax::Forms::PcdmObjectForm+. This is for
-    #   backwards‐compatibility with existing Hyrax instances. However, a
-    #   different +Hyrax::Forms::ResourceForm+ subclass will be returned in
-    #   some known cases where that is preferable.
-    def self.ResourceForm(model_class)
+    def self.ResourceForm(model_class) # rubocop:disable Metrics/MethodLength, Metrics/PerceivedComplexity
       @resource_forms ||= {}.compare_by_identity
       @resource_forms[model_class] ||=
         if model_class <= Hyrax::AdministrativeSet
@@ -31,20 +25,6 @@ module Hyrax
     #
     # This form wraps +Hyrax::ChangeSet+ in the +HydraEditor::Form+ interface.
     class ResourceForm < Hyrax::ChangeSet # rubocop:disable Metrics/ClassLength
-      ##
-      # @api private
-      InWorksPrepopulator = proc do |_options|
-        self.in_works_ids =
-          if persisted?
-            Hyrax.query_service
-                 .find_inverse_references_by(resource: model, property: :member_ids)
-                 .select(&:work?)
-                 .map(&:id)
-          else
-            []
-          end
-      end
-
       ##
       # @api private
       #
@@ -67,35 +47,8 @@ module Hyrax
       class_attribute :model_class
 
       property :human_readable_type, writable: false
-
-      property :depositor
-
-      property :visibility, default: VisibilityIntention::PRIVATE, populator: :visibility_populator
-
       property :date_modified, readable: false
       property :date_uploaded, readable: false
-      property :agreement_accepted, virtual: true, default: false, prepopulator: proc { |_opts| self.agreement_accepted = !model.new_record }
-
-      collection(:permissions,
-                 virtual: true,
-                 default: [],
-                 form: Hyrax::Forms::Permission,
-                 populator: :permission_populator,
-                 prepopulator: proc { |_opts| self.permissions = Hyrax::AccessControl.for(resource: model).permissions })
-
-      property :embargo, form: Hyrax::Forms::Embargo, populator: :embargo_populator
-      property :lease, form: Hyrax::Forms::Lease, populator: :lease_populator
-
-      # virtual properties for embargo/lease;
-      property :embargo_release_date, virtual: true, prepopulator: proc { |_opts| self.embargo_release_date = model.embargo&.embargo_release_date }
-      property :visibility_after_embargo, virtual: true, prepopulator: proc { |_opts| self.visibility_after_embargo = model.embargo&.visibility_after_embargo }
-      property :visibility_during_embargo, virtual: true, prepopulator: proc { |_opts| self.visibility_during_embargo = model.embargo&.visibility_during_embargo }
-
-      property :lease_expiration_date, virtual: true,  prepopulator: proc { |_opts| self.lease_expiration_date = model.lease&.lease_expiration_date }
-      property :visibility_after_lease, virtual: true, prepopulator: proc { |_opts| self.visibility_after_lease = model.lease&.visibility_after_lease }
-      property :visibility_during_lease, virtual: true, prepopulator: proc { |_opts| self.visibility_during_lease = model.lease&.visibility_during_lease }
-
-      property :in_works_ids, virtual: true, prepopulator: InWorksPrepopulator
 
       # provide a lock token for optimistic locking; we name this `version` for
       # backwards compatibility
@@ -185,37 +138,6 @@ module Hyrax
       end
 
       private
-
-      def embargo_populator(**)
-        self.embargo = Hyrax::EmbargoManager.embargo_for(resource: model)
-      end
-
-      def lease_populator(**)
-        self.lease = Hyrax::LeaseManager.lease_for(resource: model)
-      end
-
-      # https://trailblazer.to/2.1/docs/reform.html#reform-populators-populator-collections
-      def permission_populator(collection:, index:, **)
-        Hyrax::Forms::Permission.new(collection[index])
-      end
-
-      def visibility_populator(fragment:, doc:, **)
-        case fragment
-        when "embargo"
-          self.visibility = doc['visibility_during_embargo']
-
-          doc['embargo'] = doc.slice('visibility_after_embargo',
-                                     'visibility_during_embargo',
-                                     'embargo_release_date')
-        when "lease"
-          self.visibility = doc['visibility_during_lease']
-          doc['lease'] = doc.slice('visibility_after_lease',
-                                     'visibility_during_lease',
-                                     'lease_expiration_date')
-        else
-          self.visibility = fragment
-        end
-      end
 
       def _form_field_definitions
         self.class.definitions

--- a/app/services/hyrax/form_factory.rb
+++ b/app/services/hyrax/form_factory.rb
@@ -23,7 +23,7 @@ module Hyrax
     #
     # @see https://trailblazer.to/2.0/gems/reform/prepopulator.html
     def build(model, _ability, _controller)
-      Hyrax::Forms::ResourceForm.for(model).prepopulate!
+      Hyrax::Forms::ResourceForm.for(resource: model).prepopulate!
     end
   end
 end

--- a/spec/controllers/hyrax/dashboard/collections_controller_spec.rb
+++ b/spec/controllers/hyrax/dashboard/collections_controller_spec.rb
@@ -240,7 +240,7 @@ RSpec.describe Hyrax::Dashboard::CollectionsController, :clean_repo do
               skip("these validations only apply to Valkyrie forms") if
                 Hyrax.config.collection_class < ActiveFedora::Base
               allow(controller).to receive(:authorize!)
-              allow(Hyrax::Forms::ResourceForm).to receive(:for).with(collection).and_return(form)
+              allow(Hyrax::Forms::ResourceForm).to receive(:for).and_return(form)
               allow(form).to receive(:validate).with(any_args).and_return(false)
               allow(form).to receive(:prepopulate!).with(any_args).and_return(true)
             end
@@ -469,7 +469,7 @@ RSpec.describe Hyrax::Dashboard::CollectionsController, :clean_repo do
               skip("these validations only apply to Valkyrie forms") if
                 Hyrax.config.collection_class < ActiveFedora::Base
 
-              allow(Hyrax::Forms::ResourceForm).to receive(:for).with(collection).and_return(form)
+              allow(Hyrax::Forms::ResourceForm).to receive(:for).and_return(form)
               allow(form).to receive(:validate).with(any_args).and_return(false)
               allow(form).to receive(:prepopulate!).with(any_args).and_return(true)
             end

--- a/spec/controllers/hyrax/file_sets_controller_spec.rb
+++ b/spec/controllers/hyrax/file_sets_controller_spec.rb
@@ -720,7 +720,7 @@ RSpec.describe Hyrax::FileSetsController do
         end
 
         it "updates existing groups and users" do
-          change_set = Hyrax::Forms::ResourceForm.for(file_set)
+          change_set = Hyrax::Forms::ResourceForm.for(resource: file_set)
           Hyrax::Transactions::Container['change_set.update_file_set']
             .with_step_args(
               'file_set.save_acl' => { permissions_params: [{ "type" => 'group', "name" => 'group3', "access" => 'edit' }] }
@@ -751,7 +751,7 @@ RSpec.describe Hyrax::FileSetsController do
 
         context "when there's an error saving" do
           it "draws the edit page" do
-            change_set = Hyrax::Forms::ResourceForm.for(file_set)
+            change_set = Hyrax::Forms::ResourceForm.for(resource: file_set)
             allow(Hyrax::Forms::ResourceForm).to receive(:for).and_return(change_set)
             allow(change_set).to receive(:validate).and_return(false)
             post :update, params: { id: file_set, file_set: { keyword: [''] } }

--- a/spec/helpers/hyrax/lease_helper_spec.rb
+++ b/spec/helpers/hyrax/lease_helper_spec.rb
@@ -130,7 +130,7 @@ RSpec.describe Hyrax::LeaseHelper do
     context 'with a Hyrax::Forms::FailedSubmissionFormWrapper' do
       let(:resource) { Hyrax::Forms::FailedSubmissionFormWrapper.new(form: form, input_params: {}, permitted_params: {}) }
       let(:model) { FactoryBot.build(:hyrax_work) }
-      let(:form) { Hyrax::Forms::ResourceForm.for(model) }
+      let(:form) { Hyrax::Forms::ResourceForm.for(resource: model) }
 
       it 'returns false' do
         expect(lease_enforced?(resource)).to be false

--- a/spec/helpers/hyrax/membership_helper_spec.rb
+++ b/spec/helpers/hyrax/membership_helper_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Hyrax::MembershipHelper do
 
   describe '.member_of_collections_json' do
     context 'with a ChangeSet form' do
-      let(:resource) { Hyrax::Forms::ResourceForm.for(work) }
+      let(:resource) { Hyrax::Forms::ResourceForm.for(resource: work) }
       let(:work) { build(:monograph) }
 
       context 'when it has no collections' do
@@ -61,7 +61,7 @@ RSpec.describe Hyrax::MembershipHelper do
 
   describe '.work_members_json' do
     context 'with a ChangeSet form' do
-      let(:resource) { Hyrax::Forms::ResourceForm.for(work) }
+      let(:resource) { Hyrax::Forms::ResourceForm.for(resource: work) }
       let(:work) { build(:monograph) }
 
       context 'when it has no members' do

--- a/spec/helpers/hyrax/work_form_helper_spec.rb
+++ b/spec/helpers/hyrax/work_form_helper_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Hyrax::WorkFormHelper do
   describe '.form_tabs_for' do
     context 'with a change set style form' do
       let(:work) { build(:hyrax_work) }
-      let(:form) { Hyrax::Forms::ResourceForm.for(work) }
+      let(:form) { Hyrax::Forms::ResourceForm.for(resource: work) }
 
       it 'returns a default tab list' do
         expect(form_tabs_for(form: form)).to eq ["metadata", "files", "relationships"]
@@ -44,7 +44,7 @@ RSpec.describe Hyrax::WorkFormHelper do
   describe '.form_progress_sections_for' do
     context 'with a change set style form' do
       let(:work) { build(:hyrax_work) }
-      let(:form) { Hyrax::Forms::ResourceForm.for(work) }
+      let(:form) { Hyrax::Forms::ResourceForm.for(resource: work) }
 
       it 'returns an empty list' do
         expect(form_progress_sections_for(form: form)).to eq []
@@ -83,7 +83,7 @@ RSpec.describe Hyrax::WorkFormHelper do
     end
 
     context 'with a ChangeSet-style ResourceForm' do
-      let(:form) { Hyrax::Forms::ResourceForm.for(work) }
+      let(:form) { Hyrax::Forms::ResourceForm.for(resource: work) }
       let(:work) { FactoryBot.build(:hyrax_work) }
 
       it 'gives an empty hash' do

--- a/spec/validators/hyrax/collection_membership_validator_spec.rb
+++ b/spec/validators/hyrax/collection_membership_validator_spec.rb
@@ -3,7 +3,7 @@
 RSpec.describe Hyrax::CollectionMembershipValidator do
   subject(:validator) { described_class.new }
   let(:work) { FactoryBot.build(:hyrax_work, :as_collection_member) }
-  let(:form) { Hyrax::Forms::ResourceForm(Monograph).new(work) }
+  let(:form) { Hyrax::Forms::ResourceForm(Monograph).new(resource: work) }
 
   describe '#validate' do
     it 'is valid' do
@@ -18,7 +18,7 @@ RSpec.describe Hyrax::CollectionMembershipValidator do
     end
 
     context 'when record is a work form changeset' do
-      let(:form) { Hyrax::Forms::ResourceForm.for(work) }
+      let(:form) { Hyrax::Forms::ResourceForm.for(resource: work) }
       let(:work) { FactoryBot.build(:hyrax_work) }
       let(:mem_of_cols_attrs) { {} }
 

--- a/spec/views/collections/edit_fields/_based_near.html.erb_spec.rb
+++ b/spec/views/collections/edit_fields/_based_near.html.erb_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe 'collections/edit_fields/_based_near.html.erb', type: :view do
 
   context 'Valkyrie' do
     let(:collection) { CollectionResource.new }
-    let(:form) { Hyrax::Forms::ResourceForm.for(collection) }
+    let(:form) { Hyrax::Forms::ResourceForm.for(resource: collection) }
 
     include_examples 'check for based_near autocomplete url'
   end

--- a/spec/views/hyrax/base/_currently_shared.html.erb_spec.rb
+++ b/spec/views/hyrax/base/_currently_shared.html.erb_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe 'hyrax/base/_currently_shared.html.erb', type: :view do
   end
 
   context "with ResourceForm", valkyrie_adapter: :test_adapter do
-    let(:form) { Hyrax::Forms::ResourceForm.for(work).prepopulate! }
+    let(:form) { Hyrax::Forms::ResourceForm.for(resource: work).prepopulate! }
     let(:work) { FactoryBot.valkyrie_create(:hyrax_work, :public) }
 
     let(:file_set_form) do

--- a/spec/views/hyrax/base/_form.html.erb_spec.rb
+++ b/spec/views/hyrax/base/_form.html.erb_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe 'hyrax/base/_form.html.erb', type: :view do
   end
 
   context 'with a change_set style form' do
-    let(:form) { Hyrax::Forms::ResourceForm.for(work) }
+    let(:form) { Hyrax::Forms::ResourceForm.for(resource: work) }
     let(:work) { build(:monograph, title: 'comet in moominland') }
 
     context 'for a new object' do

--- a/spec/views/hyrax/base/_form_child_work_relationships.html.erb_spec.rb
+++ b/spec/views/hyrax/base/_form_child_work_relationships.html.erb_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 RSpec.describe "hyrax/base/_form_child_work_relationships.html.erb", type: :view do
   let(:work) { valkyrie_create(:monograph, :with_member_works) }
-  let(:form) { Hyrax::Forms::ResourceForm.for(work) }
+  let(:form) { Hyrax::Forms::ResourceForm.for(resource: work) }
 
   let(:f) do
     view.simple_form_for(form, url: '/update') do |work_form|

--- a/spec/views/hyrax/base/_form_files.html.erb_spec.rb
+++ b/spec/views/hyrax/base/_form_files.html.erb_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 RSpec.describe 'hyrax/base/_form_files.html.erb', type: :view do
   let(:model) { stub_model(GenericWork) }
-  let(:form) { Hyrax.config.disable_wings ? Hyrax::Forms::ResourceForm.for(model) : Hyrax::GenericWorkForm.new(model, double, controller) }
+  let(:form) { Hyrax.config.disable_wings ? Hyrax::Forms::ResourceForm.for(resource: model) : Hyrax::GenericWorkForm.new(model, double, controller) }
   let(:f) { double(object: form) }
 
   before do

--- a/spec/views/hyrax/base/_form_metadata.html.erb_spec.rb
+++ b/spec/views/hyrax/base/_form_metadata.html.erb_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe 'hyrax/base/_form_metadata.html.erb', type: :view do
   end
   let(:ability) { double }
   let(:work) { GenericWork.new }
-  let(:form) { Hyrax.config.disable_wings ? Hyrax::Forms::ResourceForm.for(work) : Hyrax::GenericWorkForm.new(work, ability, controller) }
+  let(:form) { Hyrax.config.disable_wings ? Hyrax::Forms::ResourceForm.for(resource: work) : Hyrax::GenericWorkForm.new(work, ability, controller) }
 
   let(:form_template) do
     %(

--- a/spec/views/hyrax/base/_form_progress.html.erb_spec.rb
+++ b/spec/views/hyrax/base/_form_progress.html.erb_spec.rb
@@ -3,7 +3,7 @@ RSpec.describe 'hyrax/base/_form_progress.html.erb', type: :view do
   let(:ability) { double }
   let(:user) { stub_model(User) }
   let(:form) do
-    Hyrax.config.disable_wings ? Hyrax::Forms::ResourceForm.for(work).prepopulate! : Hyrax::GenericWorkForm.new(work, ability, controller)
+    Hyrax.config.disable_wings ? Hyrax::Forms::ResourceForm.for(resource: work).prepopulate! : Hyrax::GenericWorkForm.new(work, ability, controller)
   end
   let(:page) do
     view.simple_form_for form do |f|

--- a/spec/views/hyrax/base/_form_relationships.html.erb_spec.rb
+++ b/spec/views/hyrax/base/_form_relationships.html.erb_spec.rb
@@ -3,7 +3,7 @@ RSpec.describe 'hyrax/base/_form_relationships.html.erb', type: :view do
   let(:ability) { double }
   let(:work) { FactoryBot.build(:monograph) }
   let(:form) do
-    Hyrax::Forms::ResourceForm.for(work).prepopulate!
+    Hyrax::Forms::ResourceForm.for(resource: work).prepopulate!
   end
   let(:service) { instance_double Hyrax::AdminSetService }
   let(:presenter) { instance_double Hyrax::AdminSetOptionsPresenter, select_options: [] }

--- a/spec/views/hyrax/base/_form_rendering.html.erb_spec.rb
+++ b/spec/views/hyrax/base/_form_rendering.html.erb_spec.rb
@@ -2,7 +2,7 @@
 RSpec.describe 'hyrax/base/_form_rendering.html.erb', type: :view do
   let(:ability) { double }
   let(:work) { stub_model(GenericWork, new_record?: false) }
-  let(:form) { Hyrax.config.disable_wings ? Hyrax::Forms::ResourceForm.for(work) : Hyrax::GenericWorkForm.new(work, ability, controller) }
+  let(:form) { Hyrax.config.disable_wings ? Hyrax::Forms::ResourceForm.for(resource: work) : Hyrax::GenericWorkForm.new(work, ability, controller) }
 
   let(:page) do
     view.simple_form_for form do |f|

--- a/spec/views/hyrax/base/_form_share.erb_spec.rb
+++ b/spec/views/hyrax/base/_form_share.erb_spec.rb
@@ -3,7 +3,7 @@ RSpec.describe 'hyrax/base/_form_share.html.erb', type: :view do
   let(:ability) { instance_double(Ability, admin?: false, user_groups: [], current_user: user) }
   let(:user) { stub_model(User) }
   let(:work) { GenericWork.new }
-  let(:form) { Hyrax.config.disable_wings ? Hyrax::Forms::ResourceForm.for(work) : Hyrax::GenericWorkForm.new(work, ability, controller) }
+  let(:form) { Hyrax.config.disable_wings ? Hyrax::Forms::ResourceForm.for(resource: work) : Hyrax::GenericWorkForm.new(work, ability, controller) }
   let(:form_template) do
     %(
       <%= simple_form_for [main_app, @form] do |f| %>

--- a/spec/views/hyrax/base/edit.html.erb_spec.rb
+++ b/spec/views/hyrax/base/edit.html.erb_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe 'hyrax/base/edit.html.erb', type: :view do
   let(:work) { stub_model(GenericWork, id: '456', title: ["A nice work"]) }
   let(:ability) { double }
   let(:controller_class) { Hyrax::GenericWorksController }
-  let(:form) { Hyrax.config.disable_wings ? Hyrax::Forms::ResourceForm.for(work) : Hyrax::GenericWorkForm.new(work, ability, controller) }
+  let(:form) { Hyrax.config.disable_wings ? Hyrax::Forms::ResourceForm.for(resource: work) : Hyrax::GenericWorkForm.new(work, ability, controller) }
 
   before do
     allow(view).to receive(:curation_concern).and_return(work)

--- a/spec/views/hyrax/dashboard/collections/_form.html.erb_spec.rb
+++ b/spec/views/hyrax/dashboard/collections/_form.html.erb_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 RSpec.describe 'hyrax/dashboard/collections/_form.html.erb', type: :view do
   let(:collection) { build :collection_resource }
-  let(:collection_form) { Hyrax::Forms::ResourceForm.for(collection) }
+  let(:collection_form) { Hyrax::Forms::ResourceForm.for(resource: collection) }
   let(:banner_info) { { file: "banner.gif", alttext: "Banner alt text" } }
   let(:logo_info) { [{ file: "logo.gif", alttext: "Logo alt text", linkurl: "http://abc.com" }] }
 

--- a/spec/views/hyrax/dashboard/collections/edit.html.erb_spec.rb
+++ b/spec/views/hyrax/dashboard/collections/edit.html.erb_spec.rb
@@ -2,7 +2,7 @@
 RSpec.describe 'hyrax/dashboard/collections/edit.html.erb', type: :view do
   let(:collection_type) { stub_model(Hyrax::CollectionType) }
   let(:collection) { build :hyrax_collection }
-  let(:form) { Hyrax::Forms::ResourceForm.for(collection) }
+  let(:form) { Hyrax::Forms::ResourceForm.for(resource: collection) }
 
   before do
     assign(:collection, collection)


### PR DESCRIPTION
This PR contains three related changes aimed at polishing up the API of `Hyrax::Forms::ResourceForm` and related classes :⁠—

- Make all of the core Valkyrie forms inherit from `Hyrax::Forms::ResourceForm`. The ones which didn’t previously are `Hyrax::Forms::PcdmCollectionForm` and `Hyrax::Forms::AdministrativeSetForm`. This required splitting off some of the existing behaviours which aren’t needed for collections into a separate module, `Hyrax::ContainedInWorksBehavior`, which is included in `Hyrax::Forms::PcdmObjectForm`, `Hyrax::Forms::FileSetForm`, and `Hyrax::Forms::ResourceBatchEditForm`.

    This module is a bit long and messy, and an alternative would be to have `Hyrax::Forms::PcdmObjectForm`, `Hyrax::Forms::FileSetForm`, and `Hyrax::Forms::ResourceBatchEditForm` inherit from a subclass of `Hyrax::Forms::ResourceForm` which defined those behaviours. But the module approach seemed more flexible.

    The module could also probably be broken down into more specific parts, but it seemed a bit unnecessary given that at this time all of the forms which include it require all of those behaviours.

- Use `resource_class.pcdm_collection?`, etc, in `Hyrax::Forms::ResourceForm.for` instead of `resource_class <= Hyrax::PcdmCollection`. This offers more flexibility to Hyrax applications to define modules that aren’t strict subclasses of builtin Hyrax ones. The `if` checks are a bit complicated, because Hyrax recognizes two types of PCDM collection (`AdministrativeSet` and `PcdmCollection`), and two types of PCDM object (`FileSet` and application‐defined model classes). The default is now to return a generic `Hyrax::Forms::ResourceForm` rather than a `Hyrax::Forms::PcdmObjectForm` since all application‐defined models should be returning `true` for `resource_class.pcdm_object?`; if an application has defined a resource which does *not* inherit from `Hyrax::Work`, they may need to define `self.pcdm_object?` on their model classes.

- Change the API from `Hyrax::Forms::ResourceForm.for(_)` to `Hyrax::Forms::ResourceForm.for(resource:_)`. The former is still supported, with a deprecation warning. Most places in Hyrax code take a `resource` argument as an explicit keyword argument, notably `Hyrax::ValkyrieIndexer.for(resource:_)` which is a very similar API. I have always been bothered that forms do not follow this pattern, and pre‐5.0 seems like a good time to make the switch.