### PR TITLE
Use class methods for Valkyrie model duck‐typing

### DIFF
--- a/app/forms/hyrax/forms/pcdm_object_form.rb
+++ b/app/forms/hyrax/forms/pcdm_object_form.rb
@@ -26,6 +26,9 @@ module Hyrax
     ##
     # A form for PCDM objects: resources which have collection relationships and
     # generally resemble +Hyrax::Work+.
+    #
+    # Although File Sets are technically also PCDM objects, they use a separate
+    # form class: +Hyrax::Forms::FileSetForm+.
     class PcdmObjectForm < Hyrax::Forms::ResourceForm
       include Hyrax::FormFields(:core_metadata)
 

--- a/app/models/hyrax/administrative_set.rb
+++ b/app/models/hyrax/administrative_set.rb
@@ -33,7 +33,7 @@ module Hyrax
 
     ##
     # @return [Boolean] true
-    def collection?
+    def self.collection?
       true
     end
 

--- a/app/models/hyrax/administrative_set.rb
+++ b/app/models/hyrax/administrative_set.rb
@@ -33,7 +33,7 @@ module Hyrax
 
     ##
     # @return [Boolean] true
-    def self.collection?
+    def self.pcdm_collection?
       true
     end
 

--- a/app/models/hyrax/file_set.rb
+++ b/app/models/hyrax/file_set.rb
@@ -114,13 +114,13 @@ module Hyrax
 
     ##
     # @return [Boolean] true
-    def pcdm_object?
+    def self.file_set?
       true
     end
 
     ##
     # @return [Boolean] true
-    def file_set?
+    def self.pcdm_object?
       true
     end
   end

--- a/app/models/hyrax/pcdm_collection.rb
+++ b/app/models/hyrax/pcdm_collection.rb
@@ -56,13 +56,7 @@ module Hyrax
 
     ##
     # @return [Boolean] true
-    def collection?
-      true
-    end
-
-    ##
-    # @return [Boolean] true
-    def pcdm_object?
+    def self.pcdm_collection?
       true
     end
 

--- a/app/models/hyrax/resource.rb
+++ b/app/models/hyrax/resource.rb
@@ -104,35 +104,30 @@ module Hyrax
     def collection?
       self.class.collection?
     end
-    deprecation_deprecate :collection?, message: :"class.collection?"
 
     ##
     # @return [Boolean]
     def file?
       self.class.file?
     end
-    deprecation_deprecate :file?, message: :"class.file?"
 
     ##
     # @return [Boolean]
     def file_set?
       self.class.file_set?
     end
-    deprecation_deprecate :file_set?, message: :"class.file_set?"
 
     ##
     # @return [Boolean]
     def pcdm_collection?
       self.class.pcdm_collection?
     end
-    deprecation_deprecate :pcdm_collection?, message: :"class.pcdm_collection?"
 
     ##
     # @return [Boolean]
     def pcdm_object?
       self.class.pcdm_object?
     end
-    deprecation_deprecate :pcdm_object?, message: :"class.pcdm_object?"
 
     ##
     # Works are PCDM Objects which are not File Sets.
@@ -141,7 +136,6 @@ module Hyrax
     def work?
       self.class.work?
     end
-    deprecation_deprecate :work?, message: :"class.work?"
 
     def ==(other)
       attributes.except(:created_at, :updated_at) == other.attributes.except(:created_at, :updated_at)

--- a/app/models/hyrax/resource.rb
+++ b/app/models/hyrax/resource.rb
@@ -50,6 +50,44 @@ module Hyrax
         I18n.translate("hyrax.models.#{model_name.i18n_key}", default: model_name.human)
       end
 
+      ##
+      # @return [Boolean]
+      def collection?
+        pcdm_collection?
+      end
+
+      ##
+      # @return [Boolean]
+      def file?
+        false
+      end
+
+      ##
+      # @return [Boolean]
+      def file_set?
+        false
+      end
+
+      ##
+      # @return [Boolean]
+      def pcdm_collection?
+        false
+      end
+
+      ##
+      # @return [Boolean]
+      def pcdm_object?
+        false
+      end
+
+      ##
+      # Works are PCDM Objects which are not File Sets.
+      #
+      # @return [Boolean]
+      def work?
+        pcdm_object? && !file_set?
+      end
+
       private
 
       ##
@@ -64,32 +102,46 @@ module Hyrax
     ##
     # @return [Boolean]
     def collection?
-      false
+      self.class.collection?
     end
+    deprecation_deprecate :collection?, message: :"class.collection?"
 
     ##
     # @return [Boolean]
     def file?
-      false
+      self.class.file?
     end
+    deprecation_deprecate :file?, message: :"class.file?"
 
     ##
     # @return [Boolean]
     def file_set?
-      false
+      self.class.file_set?
     end
+    deprecation_deprecate :file_set?, message: :"class.file_set?"
+
+    ##
+    # @return [Boolean]
+    def pcdm_collection?
+      self.class.pcdm_collection?
+    end
+    deprecation_deprecate :pcdm_collection?, message: :"class.pcdm_collection?"
 
     ##
     # @return [Boolean]
     def pcdm_object?
-      false
+      self.class.pcdm_object?
     end
+    deprecation_deprecate :pcdm_object?, message: :"class.pcdm_object?"
 
     ##
+    # Works are PCDM Objects which are not File Sets.
+    #
     # @return [Boolean]
     def work?
-      false
+      self.class.work?
     end
+    deprecation_deprecate :work?, message: :"class.work?"
 
     def ==(other)
       attributes.except(:created_at, :updated_at) == other.attributes.except(:created_at, :updated_at)

--- a/app/models/hyrax/work.rb
+++ b/app/models/hyrax/work.rb
@@ -108,13 +108,7 @@ module Hyrax
 
     ##
     # @return [Boolean] true
-    def pcdm_object?
-      true
-    end
-
-    ##
-    # @return [Boolean] true
-    def work?
+    def self.pcdm_object?
       true
     end
   end

--- a/lib/hyrax/specs/shared_specs/hydra_works.rb
+++ b/lib/hyrax/specs/shared_specs/hydra_works.rb
@@ -29,6 +29,31 @@ RSpec.shared_examples 'a Hyrax::Resource' do
     it { is_expected.to respond_to :pcdm_object? }
     it { is_expected.to respond_to :work? }
   end
+
+  it do
+    is_expected.to respond_to :collection?
+    expect(resource.collection?).to eq resource.class.collection?
+  end
+  it do
+    is_expected.to respond_to :file?
+    expect(resource.file?).to eq resource.class.file?
+  end
+  it do
+    is_expected.to respond_to :file_set?
+    expect(resource.file_set?).to eq resource.class.file_set?
+  end
+  it do
+    is_expected.to respond_to :pcdm_collection?
+    expect(resource.pcdm_collection?).to eq resource.class.pcdm_collection?
+  end
+  it do
+    is_expected.to respond_to :pcdm_object?
+    expect(resource.pcdm_object?).to eq resource.class.pcdm_object?
+  end
+  it do
+    is_expected.to respond_to :work?
+    expect(resource.work?).to eq resource.class.work?
+  end
 end
 
 RSpec.shared_examples 'belongs to collections' do

--- a/lib/hyrax/specs/shared_specs/hydra_works.rb
+++ b/lib/hyrax/specs/shared_specs/hydra_works.rb
@@ -19,11 +19,16 @@ RSpec.shared_examples 'a Hyrax::Resource' do
     end
   end
 
-  it { is_expected.to respond_to :collection? }
-  it { is_expected.to respond_to :file? }
-  it { is_expected.to respond_to :file_set? }
-  it { is_expected.to respond_to :pcdm_object? }
-  it { is_expected.to respond_to :work? }
+  describe '#class' do
+    subject(:klass) { resource.class }
+
+    it { is_expected.to respond_to :collection? }
+    it { is_expected.to respond_to :file? }
+    it { is_expected.to respond_to :file_set? }
+    it { is_expected.to respond_to :pcdm_collection? }
+    it { is_expected.to respond_to :pcdm_object? }
+    it { is_expected.to respond_to :work? }
+  end
 end
 
 RSpec.shared_examples 'belongs to collections' do
@@ -128,14 +133,20 @@ end
 RSpec.shared_examples 'a Hyrax::PcdmCollection' do
   subject(:collection) { described_class.new }
 
-  it { is_expected.to be_collection }
-  it { is_expected.to be_pcdm_object }
-  it { is_expected.not_to be_file_set }
-  it { is_expected.not_to be_work }
-
   it_behaves_like 'a Hyrax::Resource'
   it_behaves_like 'a model with core metadata'
   it_behaves_like 'has members'
+
+  describe '#class' do
+    subject(:klass) { collection.class }
+
+    it { is_expected.to be_collection }
+    it { is_expected.not_to be_file }
+    it { is_expected.not_to be_file_set }
+    it { is_expected.to be_pcdm_collection }
+    it { is_expected.not_to be_pcdm_object }
+    it { is_expected.not_to be_work }
+  end
 
   describe '#collection_type_gid' do
     let(:gid) { Hyrax::CollectionType.find_or_create_default_collection_type.to_global_id.to_s }
@@ -151,7 +162,19 @@ end
 RSpec.shared_examples 'a Hyrax::AdministrativeSet' do
   subject(:admin_set) { described_class.new }
 
+  it_behaves_like 'a Hyrax::Resource'
   it_behaves_like 'a model with core metadata'
+
+  describe '#class' do
+    subject(:klass) { admin_set.class }
+
+    it { is_expected.to be_collection }
+    it { is_expected.not_to be_file }
+    it { is_expected.not_to be_file_set }
+    it { is_expected.not_to be_pcdm_collection }
+    it { is_expected.not_to be_pcdm_object }
+    it { is_expected.not_to be_work }
+  end
 
   it 'has an #alternative_title' do
     expect { admin_set.alternative_title = ['Moomin'] }
@@ -191,11 +214,16 @@ RSpec.shared_examples 'a Hyrax::Work' do
   it_behaves_like 'belongs to collections'
   it_behaves_like 'has members'
 
-  it { is_expected.not_to be_collection }
-  it { is_expected.not_to be_file }
-  it { is_expected.not_to be_file_set }
-  it { is_expected.to be_pcdm_object }
-  it { is_expected.to be_work }
+  describe '#class' do
+    subject(:klass) { work.class }
+
+    it { is_expected.not_to be_collection }
+    it { is_expected.not_to be_file }
+    it { is_expected.not_to be_file_set }
+    it { is_expected.not_to be_pcdm_collection }
+    it { is_expected.to be_pcdm_object }
+    it { is_expected.to be_work }
+  end
 
   describe '#admin_set_id' do
     it 'is nil by default' do
@@ -259,11 +287,16 @@ RSpec.shared_examples 'a Hyrax::FileSet', valkyrie_adapter: :test_adapter do
   it_behaves_like 'a model with core metadata'
   it_behaves_like 'a model with basic metadata'
 
-  it { is_expected.not_to be_collection }
-  it { is_expected.not_to be_file }
-  it { is_expected.to be_file_set }
-  it { is_expected.to be_pcdm_object }
-  it { is_expected.not_to be_work }
+  describe '#class' do
+    subject(:klass) { fileset.class }
+
+    it { is_expected.not_to be_collection }
+    it { is_expected.not_to be_file }
+    it { is_expected.to be_file_set }
+    it { is_expected.not_to be_pcdm_collection }
+    it { is_expected.to be_pcdm_object }
+    it { is_expected.not_to be_work }
+  end
 
   describe 'files' do
     it 'has empty file_ids by default' do

--- a/lib/hyrax/specs/shared_specs/hydra_works.rb
+++ b/lib/hyrax/specs/shared_specs/hydra_works.rb
@@ -196,7 +196,7 @@ RSpec.shared_examples 'a Hyrax::AdministrativeSet' do
     it { is_expected.to be_collection }
     it { is_expected.not_to be_file }
     it { is_expected.not_to be_file_set }
-    it { is_expected.not_to be_pcdm_collection }
+    it { is_expected.to be_pcdm_collection }
     it { is_expected.not_to be_pcdm_object }
     it { is_expected.not_to be_work }
   end


### PR DESCRIPTION
It may be necessary to determine whether a model *class* represents a PCDM Object, File Set, etc, not just a model *instance*. This commit defines the former and aliases ~~and deprecates~~ the latter.

~~`collection?` and `pcdm_collection?` are split, in that `Hyrax::AdministrativeSet` and `Hyrax::PcdmCollection` are both the former, but not both the latter. Is this right, or should those methods be synonyms?~~ They’re effectively synonyms now.

`work?` is an alias for `pcdm_object? & !file_set?`.

`Hyrax::PcdmCollection` used to think it was a `pcdm_object?`, but it shouldn’t have.

~~There’s probably a fair amount of `model.try(:work?)` which needs to be changed to `model.class.try(:work?) || model.try(:work?)` before the old methods can be removed. We’ll need to support both for as long as we support ActiveFedora, but normalizing on a single place for querying this information, and having that place be the model class, seemed desirable for Valkyrie resources.~~ For the time being, we’ll just support both.

Notably, this enables the use of these methods for determining which form or indexer to use for a class of resource, instead of relying on class inheritance checks.