### PR TITLE
Last batch of mock_model rspec fixes.

### DIFF
--- a/app/services/hyrax/custom_queries/find_file_metadata.rb
+++ b/app/services/hyrax/custom_queries/find_file_metadata.rb
@@ -64,7 +64,7 @@ module Hyrax
       # @example
       #   Hyrax.query_service.find_file_metadata_by_use(use: ::RDF::URI("http://pcdm.org/ExtractedText"))
       def find_many_file_metadata_by_use(resource:, use:)
-        return [] unless resource.try(:file_ids)
+        return [] if resource.try(:file_ids).blank?
 
         results = find_many_file_metadata_by_ids(ids: resource.file_ids)
         results.select { |fm| fm.pcdm_use.include?(use) }

--- a/spec/lib/hyrax/arkivo/actor_spec.rb
+++ b/spec/lib/hyrax/arkivo/actor_spec.rb
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
-RSpec.describe Hyrax::Arkivo::Actor do
+
+return if Hyrax.config.disable_wings
+
+RSpec.describe Hyrax::Arkivo::Actor, :active_fedora do
   before do
     # Don't test characterization on these items; it breaks TravisCI and it's slow
     allow(CharacterizeJob).to receive(:perform_later)

--- a/spec/views/hyrax/my/collections/_list_collections.html.erb_spec.rb
+++ b/spec/views/hyrax/my/collections/_list_collections.html.erb_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe 'hyrax/my/collections/_list_collections.html.erb', type: :view do
       allow(view)
         .to receive(:available_parent_collections_data)
         .with(collection: collection_presenter)
-        .and_return([mock_model(Collection)])
+        .and_return([mock_model('MockCollection')])
 
       view.lookup_context.prefixes.push 'hyrax/my'
       render 'hyrax/my/collections/list_collections', collection_presenter: collection_presenter, is_admin_set: doc.admin_set?


### PR DESCRIPTION
### Fixes

Fixes `spec/lib/hyrax/arkivo/actor_spec.rb` and `spec/views/hyrax/my/collections/_list_collections.html.erb_spec.rb`.

### Summary

Updates 2 test files and 1 query method to get their tests passing.

### Type of change (for release notes)

- `notes-valkyrie` Valkyrie Progress

### Changes proposed in this pull request:
* app/services/hyrax/custom_queries/find_file_metadata.rb: when object's `file_ids` are an empty array, they will pass along to the next step, which calls `map!`. That usually doesn't produce an error, but the FactoryBots seem to set that field as a frozen array, which does produce an error. I also verified that this change may help to possibly eliminate ~10 other failures in different spec files.
* spec/lib/hyrax/arkivo/actor_spec.rb: the tested actor has no Valkyrie switch option, so this has been skipped when testing Koppie.
* spec/views/hyrax/my/collections/_list_collections.html.erb_spec.rb: `mock_model` produces an error when the classname exists in the system, so this creates a fictitious class instead.

@samvera/hyrax-code-reviewers
