### PR TITLE
Updates create_child_work_spec.rb for valkyrie.

### DIFF
--- a/spec/features/create_child_work_spec.rb
+++ b/spec/features/create_child_work_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe 'Creating a new child Work', :workflow do
                     edit_users: [user.user_key])
   end
   let!(:persister) { Hyrax.persister }
+  let!(:query_service) { Hyrax.query_service }
 
   before do
     sign_in user
@@ -52,7 +53,7 @@ RSpec.describe 'Creating a new child Work', :workflow do
       visit "/concern/parent/#{parent.id}/monographs/#{curation_concern.id}/edit"
       click_on "Save"
 
-      expect(parent.member_ids.count).to eq 1
+      expect(query_service.find_by(id: parent.id).member_ids.count).to eq 1
     end
 
     it "doesn't lose other memberships" do
@@ -62,8 +63,8 @@ RSpec.describe 'Creating a new child Work', :workflow do
       visit "/concern/parent/#{parent.id}/monographs/#{curation_concern.id}/edit"
       click_on "Save"
 
-      expect(parent.member_ids.count).to eq 1
-      expect(new_parent.member_ids.count).to eq 1
+      expect(query_service.find_by(id: parent.id).member_ids.count).to eq 1
+      expect(query_service.find_by(id: new_parent.id).member_ids.count).to eq 1
     end
 
     context "with a parent that doesn't belong to this user" do
@@ -76,7 +77,7 @@ RSpec.describe 'Creating a new child Work', :workflow do
         first("input#parent_id", visible: false).set new_parent.id
         click_on "Save"
 
-        expect(new_parent.member_ids.count).to eq 0
+        expect(query_service.find_by(id: new_parent.id).member_ids.count).to eq 0
       end
     end
   end

--- a/spec/features/create_child_work_spec.rb
+++ b/spec/features/create_child_work_spec.rb
@@ -3,16 +3,20 @@ require 'redlock'
 
 RSpec.describe 'Creating a new child Work', :workflow do
   let(:user) { create(:user) }
-  let!(:sipity_entity) do
-    create(:sipity_entity, proxy_for_global_id: parent.to_global_id.to_s)
-  end
+  let!(:sipity_entity) { create(:sipity_entity, proxy_for: parent) }
   let(:redlock_client_stub) do # stub out redis connection
     client = double('redlock client')
     allow(client).to receive(:lock).and_yield(true)
     allow(Redlock::Client).to receive(:new).and_return(client)
     client
   end
-  let!(:parent) { create(:generic_work, user: user, title: ["Parent First"]) }
+  let!(:parent) do
+    valkyrie_create(:monograph,
+                    depositor: user.user_key,
+                    title: ["Parent First"],
+                    edit_users: [user.user_key])
+  end
+  let!(:persister) { Hyrax.persister }
 
   before do
     sign_in user
@@ -22,61 +26,57 @@ RSpec.describe 'Creating a new child Work', :workflow do
   end
 
   it 'creates the child work' do
-    visit "/concern/parent/#{parent.id}/generic_works/new"
+    visit "/concern/parent/#{parent.id}/monographs/new"
     work_title = 'My Test Work'
-    within('form.new_generic_work') do
+    within('form.new_monograph') do
       fill_in('Title', with: work_title)
       click_on('Save')
     end
-    visit "/concern/generic_works/#{parent.id}"
+    visit "/concern/monographs/#{parent.id}"
+
     expect(page).to have_content work_title
   end
 
   context "when it's being updated" do
-    let(:curation_concern) { create(:generic_work, user: user) }
-    let(:new_parent) { create(:generic_work, user: user) }
-    let!(:cc_sipity_entity) do
-      create(:sipity_entity, proxy_for_global_id: curation_concern.to_global_id.to_s)
-    end
-    let!(:new_sipity_entity) do
-      create(:sipity_entity, proxy_for_global_id: new_parent.to_global_id.to_s)
-    end
+    let(:curation_concern) { valkyrie_create(:monograph, depositor: user.user_key, edit_users: [user.user_key]) }
+    let(:new_parent) { valkyrie_create(:monograph, depositor: user.user_key, edit_users: [user.user_key]) }
+    let!(:cc_sipity_entity) { create(:sipity_entity, proxy_for: curation_concern) }
+    let!(:new_sipity_entity) { create(:sipity_entity, proxy_for: new_parent) }
 
     before do
-      parent.ordered_members << curation_concern
-      parent.save!
+      parent.member_ids << curation_concern.id
+      persister.save(resource: parent)
     end
+
     it 'can be updated' do
-      visit "/concern/parent/#{parent.id}/generic_works/#{curation_concern.id}/edit"
+      visit "/concern/parent/#{parent.id}/monographs/#{curation_concern.id}/edit"
       click_on "Save"
 
-      expect(parent.reload.ordered_members.to_a.length).to eq 1
+      expect(parent.member_ids.count).to eq 1
     end
-    it "doesn't lose other memberships" do
-      new_parent.ordered_members << curation_concern
-      new_parent.save!
 
-      visit "/concern/parent/#{parent.id}/generic_works/#{curation_concern.id}/edit"
+    it "doesn't lose other memberships" do
+      new_parent.member_ids << curation_concern.id
+      persister.save(resource: new_parent)
+
+      visit "/concern/parent/#{parent.id}/monographs/#{curation_concern.id}/edit"
       click_on "Save"
 
-      expect(parent.reload.ordered_members.to_a.length).to eq 1
-      expect(new_parent.reload.ordered_members.to_a.length).to eq 1
-
-      expect(curation_concern.reload.in_works_ids.length).to eq 2
+      expect(parent.member_ids.count).to eq 1
+      expect(new_parent.member_ids.count).to eq 1
     end
 
     context "with a parent that doesn't belong to this user" do
       let(:new_user) { create(:user) }
-      let(:new_parent) { create(:generic_work, user: new_user) }
+      let(:new_parent) { valkyrie_create(:monograph, depositor: new_user.user_key) }
 
       it "fails to update" do
-        visit "/concern/parent/#{parent.id}/generic_works/#{curation_concern.id}/edit"
-        first("input#generic_work_in_works_ids", visible: false).set new_parent.id
+        visit "/concern/parent/#{parent.id}/monographs/#{curation_concern.id}/edit"
+        first("input#monograph_in_works_ids", visible: false).set new_parent.id
         first("input#parent_id", visible: false).set new_parent.id
         click_on "Save"
 
-        expect(new_parent.reload.ordered_members.to_a.length).to eq 0
-        expect(page).to have_content "Works can only be related to each other if user has ability to edit both."
+        expect(new_parent.member_ids.count).to eq 0
       end
     end
   end


### PR DESCRIPTION
### Fixes

Fixes `create_child_work_spec.rb`.

### Summary

Updates create_child_work_spec.rb for valkyrie.

### Type of change (for release notes)

- `notes-valkyrie` Valkyrie Progress

### Changes proposed in this pull request:
* Swaps to valkyrie monographs for work objects.
* Switches to updated sipity entity factory proxy setting.
* Points elements to monograph paths.
* Removes any error messaging or object variables that are ActiveFedora specific.

@samvera/hyrax-code-reviewers
