### PR TITLE
Refactors collection_presenter_spec to cleanly split AF and Valkyrie testing.

### DIFF
--- a/spec/presenters/hyrax/collection_presenter_spec.rb
+++ b/spec/presenters/hyrax/collection_presenter_spec.rb
@@ -6,25 +6,16 @@ RSpec.describe Hyrax::CollectionPresenter do
           id: 'adc12v',
           title: ['A clever title'])
   end
-  let(:active_fedora_collection) do
-    build(:collection_lw,
-          id: 'adc12v',
-          description: ['a nice collection'],
-          based_near: ['Over there'],
-          title: ['A clever title'],
-          keyword: ['neologism'],
-          resource_type: ['Collection'],
-          related_url: ['http://example.com/'],
-          date_created: ['some date'],
-          with_solr_document: true)
-  end
-  let(:active_fedora_solr_hash) do
-    active_fedora_collection.to_solr
-  end
-
   let(:ability) { double(::Ability) }
   let(:solr_doc) { SolrDocument.new(solr_hash) }
   let(:solr_hash) { Hyrax::ValkyrieIndexer.for(resource: collection).to_solr }
+  let(:collection_type) { create(:collection_type) }
+
+  it { is_expected.to delegate_method(:resource_type).to(:solr_document) }
+  it { is_expected.to delegate_method(:based_near).to(:solr_document) }
+  it { is_expected.to delegate_method(:related_url).to(:solr_document) }
+  it { is_expected.to delegate_method(:identifier).to(:solr_document) }
+  it { is_expected.to delegate_method(:date_created).to(:solr_document) }
 
   describe ".terms" do
     subject { described_class.terms }
@@ -64,77 +55,9 @@ RSpec.describe Hyrax::CollectionPresenter do
     end
   end
 
-  describe '#collection_type' do
-    let(:collection_type) { create(:collection_type) }
+  describe('#to_s') { it { expect(presenter.to_s).to eq collection.title.first } }
 
-    describe 'when solr_document#collection_type_gid exists' do
-      let(:collection) { FactoryBot.build(:collection_lw, collection_type: collection_type) }
-      let(:solr_doc) { SolrDocument.new(collection.to_solr) }
-
-      it 'finds the collection type based on the solr_document#collection_type_gid if one exists' do
-        expect(presenter.collection_type).to eq(collection_type)
-      end
-    end
-  end
-
-  describe "#resource_type" do
-    let(:collection) { active_fedora_collection }
-    let(:solr_hash) { active_fedora_solr_hash }
-    it 'has resource_type' do
-      expect(presenter).to have_attributes resource_type: collection.resource_type
-    end
-  end
-
-  describe "#terms_with_values" do
-    let(:collection) { active_fedora_collection }
-    let(:solr_hash) { active_fedora_solr_hash }
-    it 'gives the list of terms that have values' do
-      expect(presenter.terms_with_values)
-        .to contain_exactly(:total_items, :size, :resource_type, :keyword,
-                            :date_created, :based_near, :related_url)
-    end
-  end
-
-  describe '#to_s' do
-    it { expect(presenter.to_s).to eq collection.title.first }
-  end
-
-  describe "#title" do
-    it { is_expected.to have_attributes title: collection.title }
-  end
-
-  describe '#keyword' do
-    let(:collection) { active_fedora_collection }
-    let(:solr_hash) { active_fedora_solr_hash }
-    it { is_expected.to have_attributes keyword: collection.keyword }
-  end
-
-  describe "#based_near" do
-    let(:collection) { active_fedora_collection }
-    let(:solr_hash) { active_fedora_solr_hash }
-    it { is_expected.to have_attributes based_near: collection.based_near }
-  end
-
-  describe "#related_url" do
-    let(:collection) { active_fedora_collection }
-    let(:solr_hash) { active_fedora_solr_hash }
-    it { is_expected.to have_attributes related_url: collection.related_url }
-  end
-
-  describe '#to_key' do
-    let(:collection) { active_fedora_collection }
-    let(:solr_hash) { active_fedora_solr_hash }
-    it { expect(presenter.to_key).to eq ['adc12v'] }
-  end
-
-  describe '#size' do
-    let(:collection) { active_fedora_collection }
-    let(:solr_hash) { active_fedora_solr_hash }
-    it 'returns a hard-coded string and issues a deprecation warning' do
-      expect(Deprecation).to receive(:warn).once
-      expect(presenter.size).to eq('unknown')
-    end
-  end
+  describe('#title') { it { is_expected.to have_attributes title: collection.title } }
 
   describe "#total_items", :clean_repo do
     context "empty collection" do
@@ -167,135 +90,6 @@ RSpec.describe Hyrax::CollectionPresenter do
     end
   end
 
-  describe "#total_viewable_items", :clean_repo do
-    subject { presenter.total_viewable_items }
-    let(:ability) { double(::Ability, user_groups: ['public'], current_user: user) }
-    let(:user) { create(:user) }
-    let(:collection) { FactoryBot.create(:collection_lw) }
-    let(:solr_hash) { collection.to_solr }
-
-    before { allow(ability).to receive(:admin?).and_return(false) }
-
-    context "empty collection" do
-      it { is_expected.to eq 0 }
-    end
-
-    context "collection with private work" do
-      let!(:work) { create(:private_work, member_of_collections: [collection]) }
-
-      it { is_expected.to eq 0 }
-    end
-
-    context "collection with private collection" do
-      let!(:work) { build(:private_collection_lw, member_of_collections: [collection]) }
-
-      it { is_expected.to eq 0 }
-    end
-
-    context "collection with public work" do
-      let!(:work) { create(:public_work, member_of_collections: [collection]) }
-
-      it { is_expected.to eq 1 }
-    end
-
-    context "collection with public collection" do
-      let!(:subcollection) { create(:public_collection_lw, member_of_collections: [collection]) }
-
-      it { is_expected.to eq 1 }
-    end
-
-    context "collection with public work and sub-collection" do
-      let!(:work) { create(:public_work, member_of_collections: [collection]) }
-      let!(:subcollection) { create(:public_collection_lw, member_of_collections: [collection]) }
-
-      it { is_expected.to eq 2 }
-    end
-
-    context "null members" do
-      let(:presenter) { described_class.new(SolrDocument.new(id: '123'), ability) }
-
-      it { is_expected.to eq 0 }
-    end
-  end
-
-  describe "#total_viewable_works", :clean_repo do
-    subject { presenter.total_viewable_works }
-    let(:ability) { double(::Ability, user_groups: ['public'], current_user: user) }
-    let(:user) { create(:user) }
-    let(:collection) { FactoryBot.create(:collection_lw) }
-    let(:solr_hash) { collection.to_solr }
-
-    before { allow(ability).to receive(:admin?).and_return(false) }
-
-    context "empty collection" do
-      it { is_expected.to eq 0 }
-    end
-
-    context "collection with private work" do
-      let!(:work) { create(:private_work, member_of_collections: [collection]) }
-
-      it { is_expected.to eq 0 }
-    end
-
-    context "collection with public work" do
-      let!(:work) { create(:public_work, member_of_collections: [collection]) }
-
-      it { is_expected.to eq 1 }
-    end
-
-    context "collection with public work and sub-collection" do
-      let!(:work) { create(:public_work, member_of_collections: [collection]) }
-      let!(:subcollection) { create(:public_collection_lw, member_of_collections: [collection]) }
-
-      it { is_expected.to eq 1 }
-    end
-
-    context "null members" do
-      let(:presenter) { described_class.new(SolrDocument.new(id: '123'), ability) }
-
-      it { is_expected.to eq 0 }
-    end
-  end
-
-  describe "#total_viewable_collections", :clean_repo do
-    subject { presenter.total_viewable_collections }
-    let(:ability) { double(::Ability, user_groups: ['public'], current_user: user) }
-    let(:user) { create(:user) }
-    let(:collection) { FactoryBot.create(:collection_lw) }
-    let(:solr_hash) { collection.to_solr }
-
-    before { allow(ability).to receive(:admin?).and_return(false) }
-
-    context "empty collection" do
-      it { is_expected.to eq 0 }
-    end
-
-    context "collection with private collection" do
-      let!(:subcollection) { build(:private_collection_lw, member_of_collections: [collection]) }
-
-      it { is_expected.to eq 0 }
-    end
-
-    context "collection with public collection" do
-      let!(:subcollection) { create(:public_collection_lw, member_of_collections: [collection]) }
-
-      it { is_expected.to eq 1 }
-    end
-
-    context "collection with public work and sub-collection" do
-      let!(:work) { create(:public_work, member_of_collections: [collection]) }
-      let!(:subcollection) { create(:public_collection_lw, member_of_collections: [collection]) }
-
-      it { is_expected.to eq 1 }
-    end
-
-    context "null members" do
-      let(:presenter) { described_class.new(SolrDocument.new(id: '123'), ability) }
-
-      it { is_expected.to eq 0 }
-    end
-  end
-
   describe "#parent_collection_count" do
     subject { presenter.parent_collection_count }
 
@@ -315,7 +109,7 @@ RSpec.describe Hyrax::CollectionPresenter do
       it { is_expected.to eq 0 }
     end
 
-    context('when parent_collections is has collections') do
+    context('when parent_collections is has collections', :active_fedora) do
       let(:collection1) { build(:collection_lw, title: ['col1']) }
       let(:collection2) { build(:collection_lw, title: ['col2']) }
       let!(:parent_docs) { [collection1, collection2] }
@@ -329,8 +123,6 @@ RSpec.describe Hyrax::CollectionPresenter do
   end
 
   describe "#collection_type_badge" do
-    let(:collection_type) { create(:collection_type) }
-
     before do
       allow(collection_type).to receive(:badge_color).and_return("#ffa510")
       allow(presenter).to receive(:collection_type).and_return(collection_type)
@@ -402,12 +194,6 @@ RSpec.describe Hyrax::CollectionPresenter do
     end
   end
 
-  it { is_expected.to delegate_method(:resource_type).to(:solr_document) }
-  it { is_expected.to delegate_method(:based_near).to(:solr_document) }
-  it { is_expected.to delegate_method(:related_url).to(:solr_document) }
-  it { is_expected.to delegate_method(:identifier).to(:solr_document) }
-  it { is_expected.to delegate_method(:date_created).to(:solr_document) }
-
   describe '#managed_access' do
     context 'when manager' do
       before do
@@ -458,6 +244,118 @@ RSpec.describe Hyrax::CollectionPresenter do
 
       it 'returns false' do
         expect(presenter.allow_batch?).to be true
+      end
+    end
+  end
+
+  context 'ActiveFedora-specific', :active_fedora do
+    let(:active_fedora_collection) do
+      build(:collection_lw,
+            id: 'adc12v',
+            description: ['a nice collection'],
+            based_near: ['Over there'],
+            title: ['A clever title'],
+            keyword: ['neologism'],
+            resource_type: ['Collection'],
+            related_url: ['http://example.com/'],
+            date_created: ['some date'],
+            with_solr_document: true)
+    end
+    let(:active_fedora_solr_hash) { active_fedora_collection.to_solr }
+    let(:collection) { active_fedora_collection }
+    let(:solr_hash) { active_fedora_solr_hash }
+
+    describe '#collection_type' do
+      describe 'when solr_document#collection_type_gid exists' do
+        let(:collection) { FactoryBot.build(:collection_lw, collection_type: collection_type) }
+        let(:solr_doc) { SolrDocument.new(collection.to_solr) }
+
+        it 'finds the collection type based on the solr_document#collection_type_gid if one exists' do
+          expect(presenter.collection_type).to eq(collection_type)
+        end
+      end
+    end
+
+    describe "#resource_type" do
+      it 'has resource_type' do
+        expect(presenter).to have_attributes resource_type: collection.resource_type
+      end
+    end
+
+    describe "#terms_with_values" do
+      it 'gives the list of terms that have values' do
+        expect(presenter.terms_with_values)
+          .to contain_exactly(:total_items, :size, :resource_type, :keyword,
+                              :date_created, :based_near, :related_url)
+      end
+    end
+
+    describe('#keyword') { it { is_expected.to have_attributes keyword: collection.keyword } }
+
+    describe('#based_near') { it { is_expected.to have_attributes based_near: collection.based_near } }
+
+    describe('#related_url') { it { is_expected.to have_attributes related_url: collection.related_url } }
+
+    describe('#to_key') { it { expect(presenter.to_key).to eq ['adc12v'] } }
+
+    describe '#size' do
+      it 'returns a hard-coded string and issues a deprecation warning' do
+        expect(Deprecation).to receive(:warn).once
+        expect(presenter.size).to eq('unknown')
+      end
+    end
+
+    context "total_viewable methods" do
+      let(:ability) { double(::Ability, user_groups: ['public'], current_user: user) }
+      let(:user) { create(:user) }
+      let(:collection) { FactoryBot.create(:collection_lw) }
+      let(:solr_hash) { collection.to_solr }
+
+      before { allow(ability).to receive(:admin?).and_return(false) }
+
+      describe "#total_viewable_items", :clean_repo do
+        subject { presenter.total_viewable_items }
+
+        it_behaves_like 'a total_viewable method'
+        it_behaves_like 'a collection with public collection'
+        it_behaves_like 'a collection with public work'
+        it_behaves_like 'a collection with private work'
+
+        context "collection with private collection" do
+          let!(:work) { build(:private_collection_lw, member_of_collections: [collection]) }
+
+          it { is_expected.to eq 0 }
+        end
+
+        context "collection with public work and sub-collection" do
+          let!(:work) { create(:public_work, member_of_collections: [collection]) }
+          let!(:subcollection) { create(:public_collection_lw, member_of_collections: [collection]) }
+
+          it { is_expected.to eq 2 }
+        end
+      end
+
+      describe "#total_viewable_works", :clean_repo do
+        subject { presenter.total_viewable_works }
+
+        it_behaves_like 'a total_viewable method'
+        it_behaves_like 'a collection with public work and sub-collection'
+        it_behaves_like 'a collection with public work'
+        it_behaves_like 'a collection with private work'
+      end
+
+      describe "#total_viewable_collections", :clean_repo do
+        subject { presenter.total_viewable_collections }
+
+        it_behaves_like 'a total_viewable method'
+        it_behaves_like 'a collection with public work and sub-collection'
+        it_behaves_like 'a collection with public collection'
+
+        context "collection with private collection" do
+          let!(:subcollection) { build(:private_collection_lw, member_of_collections: [collection]) }
+
+          it { is_expected.to eq 0 }
+        end
       end
     end
   end

--- a/spec/support/shared_examples_for_collection_presenter.rb
+++ b/spec/support/shared_examples_for_collection_presenter.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+RSpec.shared_examples "a total_viewable method" do
+  context('empty collection') { it { is_expected.to eq 0 } }
+
+  context "null members" do
+    let(:presenter) { described_class.new(SolrDocument.new(id: '123'), ability) }
+
+    it { is_expected.to eq 0 }
+  end
+end
+
+RSpec.shared_examples "a collection with public work and sub-collection" do
+  context "collection with public work and sub-collection" do
+    let!(:work) { create(:public_work, member_of_collections: [collection]) }
+    let!(:subcollection) { create(:public_collection_lw, member_of_collections: [collection]) }
+
+    it { is_expected.to eq 1 }
+  end
+end
+
+RSpec.shared_examples "a collection with public collection" do
+  context "collection with public collection" do
+    let!(:subcollection) { create(:public_collection_lw, member_of_collections: [collection]) }
+
+    it { is_expected.to eq 1 }
+  end
+end
+
+RSpec.shared_examples "a collection with public work" do
+  context "collection with public work" do
+    let!(:work) { create(:public_work, member_of_collections: [collection]) }
+
+    it { is_expected.to eq 1 }
+  end
+end
+
+RSpec.shared_examples "a collection with private work" do
+  context "collection with private work" do
+    let!(:work) { create(:private_work, member_of_collections: [collection]) }
+
+    it { is_expected.to eq 0 }
+  end
+end


### PR DESCRIPTION
### Fixes

Fixes `spec/presenters/hyrax/collection_presenter_spec.rb`.

### Summary

Refactors collection_presenter_spec to cleanly split AF and Valkyrie testing.

### Type of change (for release notes)

- `notes-valkyrie` Valkyrie Progress

### Changes proposed in this pull request:
* spec/presenters/hyrax/collection_presenter_spec.rb: 
  * amasses all of the AF-specific methods into a context that is skipped when testing Koppie.
  * refactors the file to make it easier to read and reduce the overall line count.
* spec/support/shared_examples_for_collection_presenter.rb: moves repetitive tests into shared examples.

@samvera/hyrax-code-reviewers
