### PR TITLE
Adds :active_fedora tag to change_content_depositor_service_spec again.

### DIFF
--- a/spec/services/hyrax/change_content_depositor_service_spec.rb
+++ b/spec/services/hyrax/change_content_depositor_service_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Hyrax::ChangeContentDepositorService do
     described_class.call(work, receiver, false)
   end
 
-  context "for Active Fedora objects" do
+  context "for Active Fedora objects", :active_fedora do
     let!(:file) do
       create(:file_set, user: depositor)
     end


### PR DESCRIPTION
### Fixes

Fixes `change_content_depositor_service_spec.rb`.

### Summary

Adds :active_fedora tag to change_content_depositor_service_spec again.

### Type of change (for release notes)

- `notes-valkyrie` Valkyrie Progress

@samvera/hyrax-code-reviewers
