### PR TITLE
Refactors _subject.html.erb_spec.rb to cleanly split AF and Valkyrie testing.

### DIFF
--- a/spec/views/records/edit_fields/_subject.html.erb_spec.rb
+++ b/spec/views/records/edit_fields/_subject.html.erb_spec.rb
@@ -1,7 +1,12 @@
 # frozen_string_literal: true
+
+RSpec.shared_examples 'check for autocomplete url' do
+  it 'has url for autocomplete service' do
+    expect(rendered).to have_selector('input[data-autocomplete-url="/authorities/search/local/subjects"][data-autocomplete="subject"]')
+  end
+end
+
 RSpec.describe 'records/edit_fields/_subject.html.erb', type: :view do
-  let(:work) { GenericWork.new }
-  let(:form) { Hyrax::GenericWorkForm.new(work, nil, controller) }
   let(:form_template) do
     %(
       <%= simple_form_for [main_app, @form] do |f| %>
@@ -15,7 +20,17 @@ RSpec.describe 'records/edit_fields/_subject.html.erb', type: :view do
     render inline: form_template
   end
 
-  it 'has url for autocomplete service' do
-    expect(rendered).to have_selector('input[data-autocomplete-url="/authorities/search/local/subjects"][data-autocomplete="subject"]')
+  context 'ActiveFedora', :active_fedora do
+    let(:work) { GenericWork.new }
+    let(:form) { Hyrax::GenericWorkForm.new(work, nil, controller) }
+
+    include_examples 'check for autocomplete url'
+  end
+
+  context 'Valkyrie' do
+    let(:work) { Monograph.new }
+    let(:form) { Hyrax::Forms::ResourceForm.for(work) }
+
+    include_examples 'check for autocomplete url'
   end
 end


### PR DESCRIPTION
### Fixes

Fixes `spec/views/records/edit_fields/_subject.html.erb_spec.rb`

### Summary

Refactors _subject.html.erb_spec.rb to cleanly split AF and Valkyrie testing.

### Type of change (for release notes)

- `notes-valkyrie` Valkyrie Progress

@samvera/hyrax-code-reviewers
