### PR TITLE
Adapt more record view specs for valkyrie

### DIFF
--- a/spec/views/records/edit_fields/_description.html.erb_spec.rb
+++ b/spec/views/records/edit_fields/_description.html.erb_spec.rb
@@ -1,7 +1,59 @@
 # frozen_string_literal: true
 RSpec.describe 'records/edit_fields/_description.html.erb', type: :view do
-  let(:work) { GenericWork.new }
-  let(:form) { Hyrax::GenericWorkForm.new(work, nil, controller) }
+  RSpec.shared_examples 'description field behaviors' do
+    context "when single valued" do
+      before do
+        expect(form).to receive(:multiple?).and_return(false)
+      end
+
+      context "when not required" do
+        before do
+          expect(form).to receive(:required?).and_return(false)
+        end
+        it 'has text area' do
+          render inline: form_template
+          expect(rendered).to have_selector('textarea[class="form-control text optional"]')
+        end
+      end
+
+      context "when required" do
+        before do
+          expect(form).to receive(:required?).and_return(true)
+        end
+        it 'has text area' do
+          render inline: form_template
+          expect(rendered).to have_selector('textarea[class="form-control text required"]')
+        end
+      end
+    end
+
+    context "when multi valued" do
+      before do
+        expect(form).to receive(:multiple?).and_return(true)
+      end
+
+      context "when not required" do
+        before do
+          expect(form).to receive(:required?).and_return(false)
+        end
+        it 'has text area' do
+          render inline: form_template
+          expect(rendered).to have_selector('textarea.string.multi_value.optional.form-control.multi-text-field')
+        end
+      end
+
+      context "when required" do
+        before do
+          expect(form).to receive(:required?).and_return(true)
+        end
+        it 'has text area' do
+          render inline: form_template
+          expect(rendered).to have_selector('textarea.string.multi_value.required.form-control.multi-text-field')
+        end
+      end
+    end
+  end
+
   let(:form_template) do
     %(
       <%= simple_form_for [main_app, @form] do |f| %>
@@ -14,55 +66,17 @@ RSpec.describe 'records/edit_fields/_description.html.erb', type: :view do
     assign(:form, form)
   end
 
-  context "when single valued" do
-    before do
-      expect(form).to receive(:multiple?).and_return(false)
-    end
+  context 'ActiveFedora', :active_fedora do
+    let(:work) { GenericWork.new }
+    let(:form) { Hyrax::GenericWorkForm.new(work, nil, controller) }
 
-    context "when not required" do
-      before do
-        expect(form).to receive(:required?).and_return(false)
-      end
-      it 'has text area' do
-        render inline: form_template
-        expect(rendered).to have_selector('textarea[class="form-control text optional"]')
-      end
-    end
-
-    context "when required" do
-      before do
-        expect(form).to receive(:required?).and_return(true)
-      end
-      it 'has text area' do
-        render inline: form_template
-        expect(rendered).to have_selector('textarea[class="form-control text required"]')
-      end
-    end
+    include_examples 'description field behaviors'
   end
 
-  context "when multi valued" do
-    before do
-      expect(form).to receive(:multiple?).and_return(true)
-    end
+  context 'Valkyrie' do
+    let(:work) { Monograph.new }
+    let(:form) { Hyrax::Forms::ResourceForm.for(work) }
 
-    context "when not required" do
-      before do
-        expect(form).to receive(:required?).and_return(false)
-      end
-      it 'has text area' do
-        render inline: form_template
-        expect(rendered).to have_selector('textarea[class="string multi_value optional generic_work_description form-control multi-text-field"]')
-      end
-    end
-
-    context "when required" do
-      before do
-        expect(form).to receive(:required?).and_return(true)
-      end
-      it 'has text area' do
-        render inline: form_template
-        expect(rendered).to have_selector('textarea[class="string multi_value required generic_work_description form-control multi-text-field"]')
-      end
-    end
+    include_examples 'description field behaviors'
   end
 end

--- a/spec/views/records/edit_fields/_language.html.erb_spec.rb
+++ b/spec/views/records/edit_fields/_language.html.erb_spec.rb
@@ -1,5 +1,11 @@
 # frozen_string_literal: true
 RSpec.describe 'records/edit_fields/_language.html.erb', type: :view do
+  RSpec.shared_examples 'check for language autocomplete url' do
+    it 'has url for autocomplete service' do
+      expect(rendered).to have_selector('input[data-autocomplete-url="/authorities/search/local/languages"][data-autocomplete="language"]')
+    end
+  end
+
   let(:work) { GenericWork.new }
   let(:form) { Hyrax::GenericWorkForm.new(work, nil, controller) }
   let(:form_template) do
@@ -15,7 +21,17 @@ RSpec.describe 'records/edit_fields/_language.html.erb', type: :view do
     render inline: form_template
   end
 
-  it 'has url for autocomplete service' do
-    expect(rendered).to have_selector('input[data-autocomplete-url="/authorities/search/local/languages"][data-autocomplete="language"]')
+  context 'ActiveFedora', :active_fedora do
+    let(:work) { GenericWork.new }
+    let(:form) { Hyrax::GenericWorkForm.new(work, nil, controller) }
+
+    include_examples 'check for language autocomplete url'
+  end
+
+  context 'Valkyrie' do
+    let(:work) { Monograph.new }
+    let(:form) { Hyrax::Forms::ResourceForm.for(work) }
+
+    include_examples 'check for language autocomplete url'
   end
 end

--- a/spec/views/records/edit_fields/_subject.html.erb_spec.rb
+++ b/spec/views/records/edit_fields/_subject.html.erb_spec.rb
@@ -1,12 +1,11 @@
 # frozen_string_literal: true
-
-RSpec.shared_examples 'check for autocomplete url' do
-  it 'has url for autocomplete service' do
-    expect(rendered).to have_selector('input[data-autocomplete-url="/authorities/search/local/subjects"][data-autocomplete="subject"]')
-  end
-end
-
 RSpec.describe 'records/edit_fields/_subject.html.erb', type: :view do
+  RSpec.shared_examples 'check for subject autocomplete url' do
+    it 'has url for autocomplete service' do
+      expect(rendered).to have_selector('input[data-autocomplete-url="/authorities/search/local/subjects"][data-autocomplete="subject"]')
+    end
+  end
+
   let(:form_template) do
     %(
       <%= simple_form_for [main_app, @form] do |f| %>
@@ -24,13 +23,13 @@ RSpec.describe 'records/edit_fields/_subject.html.erb', type: :view do
     let(:work) { GenericWork.new }
     let(:form) { Hyrax::GenericWorkForm.new(work, nil, controller) }
 
-    include_examples 'check for autocomplete url'
+    include_examples 'check for subject autocomplete url'
   end
 
   context 'Valkyrie' do
     let(:work) { Monograph.new }
     let(:form) { Hyrax::Forms::ResourceForm.for(work) }
 
-    include_examples 'check for autocomplete url'
+    include_examples 'check for subject autocomplete url'
   end
 end


### PR DESCRIPTION
### Summary

Fixes more record edit field view specs for valkyrie while keeping AF tests. This is the same pattern used for the subject spec. Subject's shared examples are moved inside the top level describe with a more distinct name.