### PR TITLE
Collection Location field fixes; Valkyrize collection dashboard feature spec

### DIFF
--- a/.koppie/app/forms/collection_resource_form.rb
+++ b/.koppie/app/forms/collection_resource_form.rb
@@ -3,5 +3,6 @@
 # Generated via
 #  `rails generate hyrax:collection_resource CollectionResource`
 class CollectionResourceForm < Hyrax::Forms::PcdmCollectionForm
+  include Hyrax::FormFields(:basic_metadata)
   include Hyrax::FormFields(:collection_resource)
 end

--- a/.koppie/app/indexers/collection_resource_indexer.rb
+++ b/.koppie/app/indexers/collection_resource_indexer.rb
@@ -3,5 +3,6 @@
 # Generated via
 #  `rails generate hyrax:collection_resource CollectionResource`
 class CollectionResourceIndexer < Hyrax::PcdmCollectionIndexer
+  include Hyrax::Indexer(:basic_metadata)
   include Hyrax::Indexer(:collection_resource)
 end

--- a/.koppie/app/models/collection_resource.rb
+++ b/.koppie/app/models/collection_resource.rb
@@ -27,5 +27,6 @@ class CollectionResource < Hyrax::PcdmCollection
   # * add Valkyrie attributes to this class
   # * update form and indexer to process the attributes
   #
+  include Hyrax::Schema(:basic_metadata)
   include Hyrax::Schema(:collection_resource)
 end

--- a/.koppie/config/metadata/collection_resource.yaml
+++ b/.koppie/config/metadata/collection_resource.yaml
@@ -22,177 +22,19 @@
 #  `rails generate hyrax:collection_resource CollectionResource`
 
 attributes:
-  description:
+  target_audience:
     type: string
-    multiple: true
     form:
       primary: true
-    index_keys:
-      - "description_tesim"
-    predicate: http://purl.org/dc/elements/1.1/description
-  creator:
+      multiple: true
+    predicate: http://hyrax-example.com/target_audience
+  department:
     type: string
-    multiple: true
     form:
-      required: false
-      primary: false
-    index_keys:
-      - "creator_tesim"
-    predicate: http://purl.org/dc/elements/1.1/creator
-  rights_statement:
-    type: string
-    multiple: true
-    form:
-      primary: false
-    index_keys:
-      - "rights_statement_tesim"
-    predicate: http://www.europeana.eu/schemas/edm/rights
-  abstract:
-    type: string
-    multiple: true
-    form:
-      primary: false
-    index_keys:
-      - "abstract_tesim"
-    predicate: http://purl.org/dc/terms/abstract
-  access_right:
-    type: string
-    multiple: true
-    form:
-      primary: false
-    index_keys:
-      - "access_right_tesim"
-    predicate: http://purl.org/dc/terms/accessRights
-  alternative_title:
-    type: string
-    multiple: true
-    form:
-      primary: false
-    index_keys:
-      - "alternative_title_tesim"
-    predicate: http://purl.org/dc/terms/alternative
-  based_near:
-    type: string
-    multiple: true
-    form:
-      primary: false
-    index_keys:
-      - "based_near_sim"
-      - "based_near_tesim"
-    predicate: http://xmlns.com/foaf/0.1/based_near
-  bibliographic_citation:
-    type: string
-    multiple: true
-    predicate: http://purl.org/dc/terms/bibliographicCitation
-  contributor:
-    type: string
-    multiple: true
-    form:
-      primary: false
-    index_keys:
-      - "contributor_tesim"
-    predicate: http://purl.org/dc/elements/1.1/contributor
-  date_created:
-    type: date_time
-    multiple: true
-    form:
-      primary: false
-    index_keys:
-      - "date_created_tesim"
-    predicate: http://purl.org/dc/terms/created
-  identifier:
-    type: string
-    multiple: true
-    form:
-      primary: false
-    index_keys:
-      - "identifier_tesim"
-    predicate: http://purl.org/dc/terms/identifier
-  import_url:
-    type: string
-    predicate: http://scholarsphere.psu.edu/ns#importUrl
-  keyword:
-    type: string
-    multiple: true
-    index_keys:
-      - "keyword_sim"
-      - "keyword_tesim"
-    form:
-      primary: false
-    predicate: http://schema.org/keywords
-  publisher:
-    type: string
-    multiple: true
-    form:
-      primary: false
-    index_keys:
-      - "publisher_tesim"
-    predicate: http://purl.org/dc/elements/1.1/publisher
-  label:
+      primary: true
+    predicate: http://hyrax-example.com/department
+  course:
     type: string
     form:
       primary: false
-    index_keys:
-      - "label_tesim"
-    predicate: info:fedora/fedora-system:def/model#downloadFilename
-  language:
-    type: string
-    multiple: true
-    form:
-      primary: false
-    index_keys:
-      - "language_tesim"
-    predicate: http://purl.org/dc/elements/1.1/language
-  license:
-    type: string
-    multiple: true
-    form:
-      primary: false
-    index_keys:
-      - "license_tesim"
-    predicate: http://purl.org/dc/terms/license
-  relative_path:
-    type: string
-    predicate: http://scholarsphere.psu.edu/ns#relativePath
-  related_url:
-    type: string
-    multiple: true
-    form:
-      primary: false
-    index_keys:
-      - "related_url_tesim"
-    predicate: http://www.w3.org/2000/01/rdf-schema#seeAlso
-  resource_type:
-    type: string
-    multiple: true
-    form:
-      primary: false
-    index_keys:
-      - "resource_type_sim"
-      - "resource_type_tesim"
-    predicate: http://purl.org/dc/terms/type
-  rights_notes:
-    type: string
-    multiple: true
-    form:
-      primary: false
-    index_keys:
-      - "rights_notes_tesim"
-    predicate: http://purl.org/dc/elements/1.1/rights
-  source:
-    type: string
-    multiple: true
-    form:
-      primary: false
-    index_keys:
-      - "source_tesim"
-    predicate: http://purl.org/dc/terms/source
-  subject:
-    type: string
-    multiple: true
-    index_keys:
-      - "subject_sim"
-      - "subject_tesim"
-    form:
-      primary: false
-    predicate: http://purl.org/dc/elements/1.1/subject
+    predicate: http://hyrax-example.com/course

--- a/app/controllers/hyrax/my/collections_controller.rb
+++ b/app/controllers/hyrax/my/collections_controller.rb
@@ -12,7 +12,7 @@ module Hyrax
           config.add_facet_field Hyrax.config.collection_type_index_field,
                                  helper_method: :collection_type_label, limit: 5,
                                  pivot: ['has_model_ssim', Hyrax.config.collection_type_index_field],
-                                 skip_item: ->(item) { item.value == "Collection" },
+                                 skip_item: ->(item) { item.value == Hyrax.config.collection_class.to_s },
                                  label: I18n.t('hyrax.dashboard.my.heading.collection_type')
           # This causes AdminSets to also be shown with the Collection Type label
           config.add_facet_field 'has_model_ssim',

--- a/app/forms/concerns/hyrax/basic_metadata_form_fields_behavior.rb
+++ b/app/forms/concerns/hyrax/basic_metadata_form_fields_behavior.rb
@@ -33,6 +33,7 @@ module Hyrax
           loc
         end
       end
+      based_near << Hyrax::ControlledVocabularies::Location.new if based_near.empty?
     end
   end
 end

--- a/app/forms/hyrax/forms/collection_form.rb
+++ b/app/forms/hyrax/forms/collection_form.rb
@@ -35,6 +35,12 @@ module Hyrax
         end
       end
 
+      # This describes the parameters we are expecting to receive from the client
+      # @return [Array] a list of parameters used by sanitize_params
+      def self.build_permitted_params
+        super + [{ based_near_attributes: [:id, :_destroy] }]
+      end
+
       # @param model [::Collection] the collection model that backs this form
       # @param current_ability [Ability] the capabilities of the current user
       # @param repository [Blacklight::Solr::Repository] the solr repository
@@ -121,6 +127,19 @@ module Hyrax
 
       def list_child_collections
         collection_member_service.available_member_subcollections.documents
+      end
+
+      protected
+
+      def initialize_field(key)
+        # rubocop:disable Lint/AssignmentInCondition
+        if class_name = model_class.properties[key.to_s].try(:class_name)
+          # Initialize linked properties such as based_near
+          self[key] += [class_name.new]
+        else
+          super
+        end
+        # rubocop:enable Lint/AssignmentInCondition
       end
 
       private

--- a/app/indexers/hyrax/location_indexer.rb
+++ b/app/indexers/hyrax/location_indexer.rb
@@ -14,11 +14,7 @@ module Hyrax
 
     def based_near_label_lookup(locations)
       locations.map do |loc|
-        if URI.parse(loc)
-          location_service.full_label(loc)
-        else
-          loc
-        end
+        location_service.full_label(loc)
       end
     end
 

--- a/app/indexers/hyrax/pcdm_collection_indexer.rb
+++ b/app/indexers/hyrax/pcdm_collection_indexer.rb
@@ -7,6 +7,7 @@ module Hyrax
     include Hyrax::ResourceIndexer
     include Hyrax::PermissionIndexer
     include Hyrax::VisibilityIndexer
+    include Hyrax::LocationIndexer
     include Hyrax::ThumbnailIndexer
     include Hyrax::Indexer(:core_metadata)
 

--- a/app/services/hyrax/location_service.rb
+++ b/app/services/hyrax/location_service.rb
@@ -10,6 +10,9 @@ module Hyrax
       Rails.cache.fetch(cache_key(id), expires_in: CACHE_EXPIRATION) do
         label.call(find(id))
       end
+    rescue URI::InvalidURIError
+      # Old data may be just a string, display it.
+      uri
     end
 
     private

--- a/app/services/hyrax/multiple_membership_checker.rb
+++ b/app/services/hyrax/multiple_membership_checker.rb
@@ -145,7 +145,7 @@ module Hyrax
     def collection_titles_from_list(collection_list)
       collection_list.map do |collection|
         collection.title.first
-      end.to_sentence
+      end.sort.to_sentence
     end
   end
 end

--- a/app/views/collections/edit_fields/_based_near.html.erb
+++ b/app/views/collections/edit_fields/_based_near.html.erb
@@ -1,8 +1,12 @@
 <%= f.input key,
-  as: :multi_value,
-  input_html: {
-    class: 'form-control',
-    data: { 'autocomplete-url' => "/authorities/search/geonames",
-            'autocomplete' => key }
-  },
-  required: f.object.required?(key) %>
+            as: :controlled_vocabulary,
+            placeholder: 'Search for a location',
+            input_html: {
+              class: 'form-control',
+              data: { 'autocomplete-url' => "/authorities/search/geonames",
+                      'autocomplete' => key }
+            },
+            ### Required for the ControlledVocabulary javascript:
+            wrapper_html: { data: { 'autocomplete-url' => "/authorities/search/geonames",
+                                    'field-name' => key }},
+            required: f.object.required?(key) %>

--- a/app/views/hyrax/admin/admin_sets/edit.html.erb
+++ b/app/views/hyrax/admin/admin_sets/edit.html.erb
@@ -1,5 +1,5 @@
 <% provide :page_header do %>
-  <h1><span class="fa fa-edit" aria-hidden="true"></span> <%= t('.header', title: @form.title) %></h1>
+  <h1><span class="fa fa-edit" aria-hidden="true"></span> <%= t('.header', title: Array(@form.title).first) %></h1>
 <% end %>
 
 <div class="row">

--- a/lib/wings/model_registry.rb
+++ b/lib/wings/model_registry.rb
@@ -24,6 +24,10 @@ module Wings
       instance.register(*args)
     end
 
+    def self.unregister(*args)
+      instance.unregister(*args)
+    end
+
     def self.lookup(*args)
       instance.lookup(*args)
     end
@@ -38,6 +42,10 @@ module Wings
 
     def register(valkyrie, active_fedora)
       @map[valkyrie.name] = active_fedora.name
+    end
+
+    def unregister(valkyrie)
+      @map.delete(valkyrie.name)
     end
 
     def lookup(valkyrie)

--- a/lib/wings/setup.rb
+++ b/lib/wings/setup.rb
@@ -129,7 +129,6 @@ end
 
 Wings::ModelRegistry.register(Hyrax::AccessControl,     Hydra::AccessControl)
 Wings::ModelRegistry.register(Hyrax::AdministrativeSet, AdminSet)
-Wings::ModelRegistry.register(CollectionResource,       ::Collection)
 Wings::ModelRegistry.register(Hyrax::PcdmCollection,    ::Collection)
 Wings::ModelRegistry.register(Hyrax::FileSet,           FileSet)
 Wings::ModelRegistry.register(Hyrax::Embargo,           Hydra::AccessControls::Embargo)

--- a/lib/wings/setup.rb
+++ b/lib/wings/setup.rb
@@ -129,6 +129,7 @@ end
 
 Wings::ModelRegistry.register(Hyrax::AccessControl,     Hydra::AccessControl)
 Wings::ModelRegistry.register(Hyrax::AdministrativeSet, AdminSet)
+Wings::ModelRegistry.register(CollectionResource,       ::Collection)
 Wings::ModelRegistry.register(Hyrax::PcdmCollection,    ::Collection)
 Wings::ModelRegistry.register(Hyrax::FileSet,           FileSet)
 Wings::ModelRegistry.register(Hyrax::Embargo,           Hydra::AccessControls::Embargo)

--- a/spec/controllers/concerns/hyrax/works_controller_behavior_spec.rb
+++ b/spec/controllers/concerns/hyrax/works_controller_behavior_spec.rb
@@ -167,7 +167,7 @@ RSpec.describe Hyrax::WorksControllerBehavior, :clean_repo, type: :controller do
       end
 
       context 'when adding a collection' do
-        let(:collection) { FactoryBot.valkyrie_create(:pcdm_collection) }
+        let(:collection) { FactoryBot.valkyrie_create(:hyrax_collection) }
 
         let(:create_params) do
           { title: 'comet in moominland',
@@ -198,7 +198,7 @@ RSpec.describe Hyrax::WorksControllerBehavior, :clean_repo, type: :controller do
         end
 
         context 'with both setter styles' do
-          let(:other_collection) { FactoryBot.valkyrie_create(:pcdm_collection) }
+          let(:other_collection) { FactoryBot.valkyrie_create(:hyrax_collection) }
           let(:create_params) do
             { title: 'comet in moominland',
               member_of_collections_attributes:

--- a/spec/controllers/hyrax/dashboard/collections_controller_spec.rb
+++ b/spec/controllers/hyrax/dashboard/collections_controller_spec.rb
@@ -22,6 +22,7 @@ RSpec.describe Hyrax::Dashboard::CollectionsController, :clean_repo do
         FactoryBot.valkyrie_create(:hyrax_collection,
                                    :public,
                                    title: ["My collection"],
+                                   creator: user.user_key,
                                    depositor: user.user_key,
                                    edit_users: [user])
       end

--- a/spec/factories/hyrax_collection.rb
+++ b/spec/factories/hyrax_collection.rb
@@ -3,7 +3,7 @@
 ##
 # Use this factory for generic Hyrax/HydraWorks Collections in valkyrie.
 FactoryBot.define do
-  factory :hyrax_collection, class: 'CollectionResource', aliases: [:pcdm_collection, :collection_resource] do
+  factory :hyrax_collection, class: 'CollectionResource', aliases: [:collection_resource] do
     sequence(:title) { |n| ["The Tove Jansson Collection #{n}"] }
     collection_type_gid { Hyrax::CollectionType.find_or_create_default_collection_type.to_global_id.to_s }
 
@@ -22,6 +22,7 @@ FactoryBot.define do
 
     after(:build) do |collection, evaluator|
       collection.depositor ||= evaluator.user.user_key
+      collection.creator += [evaluator.user.user_key] if collection.respond_to?(:creator) && collection.creator.blank?
       collection.collection_type_gid = evaluator.collection_type.to_global_id.to_s if evaluator.collection_type
     end
 

--- a/spec/factories/hyrax_collection.rb
+++ b/spec/factories/hyrax_collection.rb
@@ -22,7 +22,6 @@ FactoryBot.define do
 
     after(:build) do |collection, evaluator|
       collection.depositor ||= evaluator.user.user_key
-      collection.creator += [evaluator.user.user_key] if collection.respond_to?(:creator) && collection.creator.blank?
       collection.collection_type_gid = evaluator.collection_type.to_global_id.to_s if evaluator.collection_type
     end
 

--- a/spec/factories/hyrax_collection.rb
+++ b/spec/factories/hyrax_collection.rb
@@ -9,6 +9,7 @@ FactoryBot.define do
 
     transient do
       with_permission_template { true }
+      collection_type { nil }
       with_index { true }
       user { create(:user) }
       edit_groups { [] }
@@ -21,6 +22,7 @@ FactoryBot.define do
 
     after(:build) do |collection, evaluator|
       collection.depositor ||= evaluator.user.user_key
+      collection.collection_type_gid = evaluator.collection_type.to_global_id.to_s if evaluator.collection_type
     end
 
     after(:create) do |collection, evaluator|

--- a/spec/factories/hyrax_collection.rb
+++ b/spec/factories/hyrax_collection.rb
@@ -3,7 +3,7 @@
 ##
 # Use this factory for generic Hyrax/HydraWorks Collections in valkyrie.
 FactoryBot.define do
-  factory :hyrax_collection, class: 'Hyrax::PcdmCollection', aliases: [:pcdm_collection] do
+  factory :hyrax_collection, class: 'CollectionResource', aliases: [:pcdm_collection, :collection_resource] do
     sequence(:title) { |n| ["The Tove Jansson Collection #{n}"] }
     collection_type_gid { Hyrax::CollectionType.find_or_create_default_collection_type.to_global_id.to_s }
 
@@ -78,7 +78,7 @@ FactoryBot.define do
       end
     end
 
-    factory :collection_resource, class: 'CollectionResource' do
+    factory :pcdm_collection, class: 'Hyrax::PcdmCollection' do
     end
   end
 end

--- a/spec/factories/hyrax_work.rb
+++ b/spec/factories/hyrax_work.rb
@@ -31,6 +31,7 @@ FactoryBot.define do
     end
 
     transient do
+      user               { create(:user) }
       edit_users         { [] }
       edit_groups        { [] }
       read_users         { [] }
@@ -42,6 +43,8 @@ FactoryBot.define do
     end
 
     after(:build) do |work, evaluator|
+      work.depositor ||= evaluator.user.user_key
+
       if evaluator.visibility_setting
         Hyrax::VisibilityWriter
           .new(resource: work)
@@ -49,7 +52,7 @@ FactoryBot.define do
       end
 
       work.permission_manager.edit_groups = work.permission_manager.edit_groups.to_a + evaluator.edit_groups
-      work.permission_manager.edit_users  = work.permission_manager.edit_users.to_a + evaluator.edit_users
+      work.permission_manager.edit_users  = work.permission_manager.edit_users.to_a + evaluator.edit_users << evaluator.user
       work.permission_manager.read_users  = work.permission_manager.read_users.to_a + evaluator.read_users
       work.permission_manager.read_groups = work.permission_manager.read_groups.to_a + evaluator.read_groups
 
@@ -63,7 +66,7 @@ FactoryBot.define do
           .assign_access_for(visibility: evaluator.visibility_setting)
       end
       work.permission_manager.edit_groups = work.permission_manager.edit_groups.to_a + evaluator.edit_groups
-      work.permission_manager.edit_users  = work.permission_manager.edit_users.to_a + evaluator.edit_users
+      work.permission_manager.edit_users  = work.permission_manager.edit_users.to_a + evaluator.edit_users << evaluator.user
       work.permission_manager.read_users  = work.permission_manager.read_users.to_a + evaluator.read_users
       work.permission_manager.read_groups = work.permission_manager.read_groups.to_a + evaluator.read_groups
 

--- a/spec/factories/hyrax_work.rb
+++ b/spec/factories/hyrax_work.rb
@@ -31,7 +31,6 @@ FactoryBot.define do
     end
 
     transient do
-      user               { create(:user) }
       edit_users         { [] }
       edit_groups        { [] }
       read_users         { [] }
@@ -43,8 +42,6 @@ FactoryBot.define do
     end
 
     after(:build) do |work, evaluator|
-      work.depositor ||= evaluator.user.user_key
-
       if evaluator.visibility_setting
         Hyrax::VisibilityWriter
           .new(resource: work)
@@ -52,7 +49,7 @@ FactoryBot.define do
       end
 
       work.permission_manager.edit_groups = work.permission_manager.edit_groups.to_a + evaluator.edit_groups
-      work.permission_manager.edit_users  = work.permission_manager.edit_users.to_a + evaluator.edit_users << evaluator.user
+      work.permission_manager.edit_users  = work.permission_manager.edit_users.to_a + evaluator.edit_users
       work.permission_manager.read_users  = work.permission_manager.read_users.to_a + evaluator.read_users
       work.permission_manager.read_groups = work.permission_manager.read_groups.to_a + evaluator.read_groups
 
@@ -66,7 +63,7 @@ FactoryBot.define do
           .assign_access_for(visibility: evaluator.visibility_setting)
       end
       work.permission_manager.edit_groups = work.permission_manager.edit_groups.to_a + evaluator.edit_groups
-      work.permission_manager.edit_users  = work.permission_manager.edit_users.to_a + evaluator.edit_users << evaluator.user
+      work.permission_manager.edit_users  = work.permission_manager.edit_users.to_a + evaluator.edit_users
       work.permission_manager.read_users  = work.permission_manager.read_users.to_a + evaluator.read_users
       work.permission_manager.read_groups = work.permission_manager.read_groups.to_a + evaluator.read_groups
 

--- a/spec/features/collection_spec.rb
+++ b/spec/features/collection_spec.rb
@@ -4,17 +4,8 @@ RSpec.describe 'collection', type: :feature do
 
   before { sign_in(user) }
 
-  # Ensure CollectionResource is the collection model so it is not excluded by solr search builder filters.
-  # This can likely be removed alongside Wings.
-  around(:each) do |example|
-    current_collection_model = Hyrax.config.collection_model
-    Hyrax.config.collection_model = 'CollectionResource'
-    example.run
-    Hyrax.config.collection_model = current_collection_model
-  end
-
   shared_context 'with many indexed members' do
-    let(:collection) { FactoryBot.valkyrie_create(:collection_resource, user: user, title: ['collection title'], description: ['collection description']) }
+    let(:collection) { FactoryBot.valkyrie_create(:hyrax_collection, user: user, title: ['collection title'], description: ['collection description']) }
 
     before do
       docs = (0..12).map do |n|
@@ -34,7 +25,7 @@ RSpec.describe 'collection', type: :feature do
 
   describe 'collection show page' do
     let(:collection) do
-      FactoryBot.valkyrie_create(:collection_resource,
+      FactoryBot.valkyrie_create(:hyrax_collection,
                                  user: user,
                                  description: ['collection description'],
                                  collection_type_gid: collection_type.to_global_id.to_s,
@@ -43,8 +34,8 @@ RSpec.describe 'collection', type: :feature do
     let(:collection_type) { FactoryBot.create(:collection_type, :nestable) }
     let(:work1) { FactoryBot.valkyrie_create(:monograph, title: ["King Louie"], read_users: [user]) }
     let(:work2) { FactoryBot.valkyrie_create(:monograph, title: ["King Kong"], read_users: [user]) }
-    let(:col1) { FactoryBot.valkyrie_create(:collection_resource, title: ["Sub-collection 1"], read_users: [user]) }
-    let(:col2) { FactoryBot.valkyrie_create(:collection_resource, title: ["Sub-collection 2"], read_users: [user]) }
+    let(:col1) { FactoryBot.valkyrie_create(:hyrax_collection, title: ["Sub-collection 1"], read_users: [user]) }
+    let(:col2) { FactoryBot.valkyrie_create(:hyrax_collection, title: ["Sub-collection 2"], read_users: [user]) }
 
     it "shows a collection with a listing of Descriptive Metadata and catalog-style search results" do
       visit "/collections/#{collection.id}"
@@ -98,7 +89,7 @@ RSpec.describe 'collection', type: :feature do
 
   context "with a non-nestable collection type" do
     let(:collection) do
-      FactoryBot.valkyrie_create(:collection_resource,
+      FactoryBot.valkyrie_create(:hyrax_collection,
                                  user: user,
                                  description: ['collection description'],
                                  collection_type_gid: collection_type.to_global_id.to_s)
@@ -133,7 +124,7 @@ RSpec.describe 'collection', type: :feature do
 
   describe 'show subcollection pages of a collection' do
     include_context 'with many indexed members' do
-      let(:model_name) { 'CollectionResource' }
+      let(:model_name) { Hyrax.config.collection_class.to_s }
     end
 
     it "shows a collection with a listing of Descriptive Metadata and catalog-style search results" do

--- a/spec/features/dashboard/collection_spec.rb
+++ b/spec/features/dashboard/collection_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe 'collection', type: :feature, clean_repo: true do
   let(:solr_model_field) { 'has_model_ssim' }
 
   # Setting Title on admin sets to avoid false positive matches with collections.
-  let(:admin_set_a) { FactoryBot.valkyrie_create(:hyrax_admin_set, :with_permission_template, user: admin_user, title: ['Set A'], description: 'A' ) }
+  let(:admin_set_a) { FactoryBot.valkyrie_create(:hyrax_admin_set, :with_permission_template, user: admin_user, title: ['Set A'], description: 'A') }
   let(:admin_set_b) { FactoryBot.valkyrie_create(:hyrax_admin_set, :with_permission_template, user: user, title: ['Set B'], edit_users: [user.user_key]) }
   let(:collection1) { FactoryBot.valkyrie_create(:hyrax_collection, :public, user: user, collection_type: collection_type) }
   let(:collection2) { FactoryBot.valkyrie_create(:hyrax_collection, :public, user: user, collection_type: collection_type) }
@@ -63,17 +63,18 @@ RSpec.describe 'collection', type: :feature, clean_repo: true do
     end
 
     context 'when admin user' do
-      let(:admin_set_b) do FactoryBot.valkyrie_create(:hyrax_admin_set,
-                                                      :with_permission_template,
-                                                      user: user,
-                                                      title: ['Set B'],
-                                                      edit_users: [user.user_key],
-                                                      access_grants: [{ agent_type: Hyrax::PermissionTemplateAccess::USER,
-                                                                        agent_id: user.user_key,
-                                                                        access: Hyrax::PermissionTemplateAccess::MANAGE },
-                                                                      { agent_type: Hyrax::PermissionTemplateAccess::GROUP,
-                                                                        agent_id: 'admin',
-                                                                        access: Hyrax::PermissionTemplateAccess::MANAGE }])
+      let(:admin_set_b) do
+        FactoryBot.valkyrie_create(:hyrax_admin_set,
+                                   :with_permission_template,
+                                   user: user,
+                                   title: ['Set B'],
+                                   edit_users: [user.user_key],
+                                   access_grants: [{ agent_type: Hyrax::PermissionTemplateAccess::USER,
+                                                     agent_id: user.user_key,
+                                                     access: Hyrax::PermissionTemplateAccess::MANAGE },
+                                                   { agent_type: Hyrax::PermissionTemplateAccess::GROUP,
+                                                     agent_id: 'admin',
+                                                     access: Hyrax::PermissionTemplateAccess::MANAGE }])
       end
 
       before do
@@ -163,30 +164,36 @@ RSpec.describe 'collection', type: :feature, clean_repo: true do
 
   describe 'Managed Collections tab (for non-admin users with shared access' do
     let(:user2) { create(:user) }
-    let(:collection1) { FactoryBot.valkyrie_create(:hyrax_collection, :public,
-                                                   user: user, collection_type: collection_type,
-                                                   access_grants: [{ agent_type: Hyrax::PermissionTemplateAccess::USER,
-                                                                     agent_id: user.user_key,
-                                                                     access: Hyrax::PermissionTemplateAccess::MANAGE },
-                                                                   { agent_type: Hyrax::PermissionTemplateAccess::USER,
-                                                                     agent_id: user2.user_key,
-                                                                     access: Hyrax::PermissionTemplateAccess::MANAGE }]) }
-    let(:collection2) { FactoryBot.valkyrie_create(:hyrax_collection, :public,
-                                                   user: user, collection_type: collection_type,
-                                                   access_grants: [{ agent_type: Hyrax::PermissionTemplateAccess::USER,
-                                                                     agent_id: user.user_key,
-                                                                     access: Hyrax::PermissionTemplateAccess::MANAGE },
-                                                                   { agent_type: Hyrax::PermissionTemplateAccess::USER,
-                                                                     agent_id: user2.user_key,
-                                                                     access: Hyrax::PermissionTemplateAccess::DEPOSIT }]) }
-    let(:collection4) { FactoryBot.valkyrie_create(:hyrax_collection, :public,
-                                                   user: admin_user, collection_type: user_collection_type,
-                                                   access_grants: [{ agent_type: Hyrax::PermissionTemplateAccess::USER,
-                                                                     agent_id: user.user_key,
-                                                                     access: Hyrax::PermissionTemplateAccess::MANAGE },
-                                                                   { agent_type: Hyrax::PermissionTemplateAccess::USER,
-                                                                     agent_id: user2.user_key,
-                                                                     access: Hyrax::PermissionTemplateAccess::VIEW }]) }
+    let(:collection1) do
+      FactoryBot.valkyrie_create(:hyrax_collection, :public,
+                                 user: user, collection_type: collection_type,
+                                 access_grants: [{ agent_type: Hyrax::PermissionTemplateAccess::USER,
+                                                   agent_id: user.user_key,
+                                                   access: Hyrax::PermissionTemplateAccess::MANAGE },
+                                                 { agent_type: Hyrax::PermissionTemplateAccess::USER,
+                                                   agent_id: user2.user_key,
+                                                   access: Hyrax::PermissionTemplateAccess::MANAGE }])
+    end
+    let(:collection2) do
+      FactoryBot.valkyrie_create(:hyrax_collection, :public,
+                                 user: user, collection_type: collection_type,
+                                 access_grants: [{ agent_type: Hyrax::PermissionTemplateAccess::USER,
+                                                   agent_id: user.user_key,
+                                                   access: Hyrax::PermissionTemplateAccess::MANAGE },
+                                                 { agent_type: Hyrax::PermissionTemplateAccess::USER,
+                                                   agent_id: user2.user_key,
+                                                   access: Hyrax::PermissionTemplateAccess::DEPOSIT }])
+    end
+    let(:collection4) do
+      FactoryBot.valkyrie_create(:hyrax_collection, :public,
+                                 user: admin_user, collection_type: user_collection_type,
+                                 access_grants: [{ agent_type: Hyrax::PermissionTemplateAccess::USER,
+                                                   agent_id: user.user_key,
+                                                   access: Hyrax::PermissionTemplateAccess::MANAGE },
+                                                 { agent_type: Hyrax::PermissionTemplateAccess::USER,
+                                                   agent_id: user2.user_key,
+                                                   access: Hyrax::PermissionTemplateAccess::VIEW }])
+    end
 
     before do
       user
@@ -255,11 +262,13 @@ RSpec.describe 'collection', type: :feature, clean_repo: true do
 
         fill_in('Title', with: title)
         fill_in('Description', with: description)
-        # fill_in('Related URL', with: 'http://example.com/')
+        fill_in('Creator', with: 'Doe, Jane')
+        fill_in('Related URL', with: 'http://example.com/')
 
         click_button("Save")
         expect(page).to have_content 'Collection was successfully created.'
         expect(page).to have_content title
+        click_link('Additional fields')
         expect(page).to have_content description
       end
 
@@ -270,13 +279,16 @@ RSpec.describe 'collection', type: :feature, clean_repo: true do
     end
 
     context 'when user can create collections of one type' do
-      # let(:location) { 'Minneapolis, Minnesota, United States' }
-      # let(:geonames_data) { '{"geonames":[{"geonameId":5037649,"name":"Minneapolis", "countryName":"United States","adminName1":"Minnesota"}]}' }
+      let(:location) { 'Minneapolis, Minnesota, United States' }
+      let(:geonames_data) { '{"geonames":[{"geonameId":5037649,"name":"Minneapolis", "countryName":"United States","adminName1":"Minnesota"}]}' }
 
       before do
-        # stub_request(:get, 'http://api.geonames.org/searchJSON')
-        #   .with(query: hash_including({ 'q': 'minneapolis' }))
-        #   .to_return(status: 200, body: geonames_data)
+        stub_request(:get, 'http://api.geonames.org/searchJSON')
+          .with(query: hash_including({ 'q': 'minneapolis' }))
+          .to_return(status: 200, body: geonames_data)
+        stub_request(:get, 'http://www.geonames.org/getJSON')
+          .with(query: hash_including({ 'geonameId': '5037649' }))
+          .to_return(status: 200, body: File.open(File.join(fixture_path, 'geonames.json')))
         user_collection_type
         sign_in user
         visit '/dashboard/my/collections'
@@ -292,20 +304,21 @@ RSpec.describe 'collection', type: :feature, clean_repo: true do
 
         fill_in('Title', with: title)
         fill_in('Description', with: description)
-        # fill_in('Related URL', with: 'http://example.com/')
+        fill_in('Creator', with: 'Doe, Jane')
+        fill_in('Related URL', with: 'http://example.com/')
 
-        # find('#s2id_collection_based_near').click
-        # expect(page).to have_content 'Please enter 2 or more characters'
-        # find('#s2id_autogen1_search').send_keys("minneapolis")
-        # expect(page).to have_content location
-        # find('#s2id_autogen1_search').send_keys(:enter)
+        click_link('Search for a location')
+        expect(page).to have_content 'Please enter 2 or more characters'
+        find('#s2id_autogen1_search').send_keys("minneapolis")
+        expect(page).to have_content location
+        find('#s2id_autogen1_search').send_keys(:enter)
 
         click_button("Save")
         expect(page).to have_content 'Collection was successfully created.'
         expect(page).to have_content title
+        click_link('Additional fields')
         expect(page).to have_content description
-        # click_link('Additional fields')
-        # expect(page).to have_content location
+        expect(page).to have_content location
       end
     end
 
@@ -807,7 +820,7 @@ RSpec.describe 'collection', type: :feature, clean_repo: true do
 
     context 'from dashboard -> collections action menu' do
       context 'for a collection' do
-        let(:collection) { FactoryBot.valkyrie_create(:hyrax_collection, title:['A Collection of Tests'], description: ['Test Description'], user: user) }
+        let(:collection) { FactoryBot.valkyrie_create(:hyrax_collection, title: ['A Collection of Tests'], description: ['Test Description'], user: user) }
         let(:work1) { FactoryBot.valkyrie_create(:hyrax_work, title: ["King Louie"], member_of_collection_ids: [collection.id], user: user) }
         let(:work2) { FactoryBot.valkyrie_create(:hyrax_work, title: ["King Kong"], member_of_collection_ids: [collection.id], user: user) }
 
@@ -1002,6 +1015,7 @@ RSpec.describe 'collection', type: :feature, clean_repo: true do
       end
 
       it "displays a confirmation when form data has changed" do
+        click_link('Additional fields')
         fill_in('Description', with: new_description)
         click_link('Sharing')
         within('#nav-safety-modal') do
@@ -1010,6 +1024,7 @@ RSpec.describe 'collection', type: :feature, clean_repo: true do
       end
 
       it "changes tab when user dismisses the confirmation by clicking OK" do
+        click_link('Additional fields')
         fill_in('Description', with: new_description)
         click_link('Sharing')
         within('#nav-safety-modal') do
@@ -1022,6 +1037,7 @@ RSpec.describe 'collection', type: :feature, clean_repo: true do
       end
 
       it "does not redisplay the confirmation unless form data is changed" do
+        click_link('Additional fields')
         expect(page).to have_selector('#description', class: 'active')
         expect(page).not_to have_selector('#discovery', class: 'active')
         fill_in('Description', with: new_description)

--- a/spec/features/dashboard/collection_spec.rb
+++ b/spec/features/dashboard/collection_spec.rb
@@ -929,8 +929,8 @@ RSpec.describe 'collection', type: :feature, clean_repo: true do
       end
 
       context 'with brandable set' do
-        let(:brandable_collection_id) { FactoryBot.valkyrie_create(:hyrax_collection, user: user, creator: 'A User', collection_type_gid: brandable_collection_type.to_global_id.to_s).id }
-        let(:not_brandable_collection_id) { FactoryBot.valkyrie_create(:hyrax_collection, user: user, creator: 'A User', collection_type_gid: not_brandable_collection_type.to_global_id.to_s).id }
+        let(:brandable_collection_id) { FactoryBot.valkyrie_create(:hyrax_collection, user: user, creator: 'A User', collection_type: brandable_collection_type).id }
+        let(:not_brandable_collection_id) { FactoryBot.valkyrie_create(:hyrax_collection, user: user, creator: 'A User', collection_type: not_brandable_collection_type).id }
         let(:brandable_collection_type) { create(:collection_type, :brandable) }
         let(:not_brandable_collection_type) { create(:collection_type, :not_brandable) }
 
@@ -946,8 +946,8 @@ RSpec.describe 'collection', type: :feature, clean_repo: true do
       end
 
       context 'with discoverable set' do
-        let(:discoverable_collection_id) { FactoryBot.valkyrie_create(:hyrax_collection, user: user, creator: 'A User', collection_type_gid: discoverable_collection_type.to_global_id.to_s).id }
-        let(:not_discoverable_collection_id) { FactoryBot.valkyrie_create(:hyrax_collection, user: user, creator: 'A User', collection_type_gid: not_discoverable_collection_type.to_global_id.to_s).id }
+        let(:discoverable_collection_id) { FactoryBot.valkyrie_create(:hyrax_collection, user: user, creator: 'A User', collection_type: discoverable_collection_type).id }
+        let(:not_discoverable_collection_id) { FactoryBot.valkyrie_create(:hyrax_collection, user: user, creator: 'A User', collection_type: not_discoverable_collection_type).id }
         let(:discoverable_collection_type) { create(:collection_type, :discoverable) }
         let(:not_discoverable_collection_type) { create(:collection_type, :not_discoverable) }
 

--- a/spec/features/dashboard/collection_spec.rb
+++ b/spec/features/dashboard/collection_spec.rb
@@ -1,17 +1,5 @@
 # frozen_string_literal: true
 RSpec.describe 'collection', type: :feature, clean_repo: true do
-  # Ensure CollectionResource is the collection model so it is not excluded by solr search builder filters.
-  # This can likely be removed alongside Wings.
-  around(:each) do |example|
-    current_collection_model = Hyrax.config.collection_model
-    # current_admin_set_model = Hyrax.config.admin_set_model
-    Hyrax.config.collection_model = 'CollectionResource'
-    # Hyrax.config.admin_set_model = "Hyrax::AdministrativeSet"
-    example.run
-    Hyrax.config.collection_model = current_collection_model
-    # Hyrax.config.admin_set_model = current_admin_set_model
-  end
-
   include Selectors::Dashboard
 
   let(:user) { create(:user) }
@@ -24,10 +12,10 @@ RSpec.describe 'collection', type: :feature, clean_repo: true do
   # Setting Title on admin sets to avoid false positive matches with collections.
   let(:admin_set_a) { FactoryBot.valkyrie_create(:hyrax_admin_set, :with_permission_template, user: admin_user, title: ['Set A'], description: 'A' ) }
   let(:admin_set_b) { FactoryBot.valkyrie_create(:hyrax_admin_set, :with_permission_template, user: user, title: ['Set B'], edit_users: [user.user_key]) }
-  let(:collection1) { FactoryBot.valkyrie_create(:collection_resource, :public, user: user, collection_type: collection_type) }
-  let(:collection2) { FactoryBot.valkyrie_create(:collection_resource, :public, user: user, collection_type: collection_type) }
-  let(:collection3) { FactoryBot.valkyrie_create(:collection_resource, :public, user: admin_user, collection_type: collection_type) }
-  let(:collection4) { FactoryBot.valkyrie_create(:collection_resource, :public, user: admin_user, collection_type: user_collection_type) }
+  let(:collection1) { FactoryBot.valkyrie_create(:hyrax_collection, :public, user: user, collection_type: collection_type) }
+  let(:collection2) { FactoryBot.valkyrie_create(:hyrax_collection, :public, user: user, collection_type: collection_type) }
+  let(:collection3) { FactoryBot.valkyrie_create(:hyrax_collection, :public, user: admin_user, collection_type: collection_type) }
+  let(:collection4) { FactoryBot.valkyrie_create(:hyrax_collection, :public, user: admin_user, collection_type: user_collection_type) }
 
   describe 'Your Collections tab' do
     context 'when non-admin user' do
@@ -36,11 +24,6 @@ RSpec.describe 'collection', type: :feature, clean_repo: true do
         admin_user
         admin_set_a
         admin_set_b
-        # create(:permission_template_access,
-        #        :manage,
-        #        permission_template: Hyrax::PermissionTemplate.find_by!(source_id: admin_set_b.id),
-        #        agent_type: 'user',
-        #        agent_id: user.user_key)
         collection1
         collection2
         collection3
@@ -98,16 +81,6 @@ RSpec.describe 'collection', type: :feature, clean_repo: true do
         admin_user
         admin_set_a
         admin_set_b
-        # create(:permission_template_access,
-        #        :manage,
-        #        permission_template: Hyrax::PermissionTemplate.find_by!(source_id: admin_set_a.id),
-        #        agent_type: 'user',
-        #        agent_id: admin_user.user_key)
-        # create(:permission_template_access,
-        #        :manage,
-        #        permission_template: Hyrax::PermissionTemplate.find_by!(source_id: admin_set_b.id),
-        #        agent_type: 'group',
-        #        agent_id: 'admin')
         collection1
         collection2
         collection3
@@ -190,7 +163,7 @@ RSpec.describe 'collection', type: :feature, clean_repo: true do
 
   describe 'Managed Collections tab (for non-admin users with shared access' do
     let(:user2) { create(:user) }
-    let(:collection1) { FactoryBot.valkyrie_create(:collection_resource, :public,
+    let(:collection1) { FactoryBot.valkyrie_create(:hyrax_collection, :public,
                                                    user: user, collection_type: collection_type,
                                                    access_grants: [{ agent_type: Hyrax::PermissionTemplateAccess::USER,
                                                                      agent_id: user.user_key,
@@ -198,7 +171,7 @@ RSpec.describe 'collection', type: :feature, clean_repo: true do
                                                                    { agent_type: Hyrax::PermissionTemplateAccess::USER,
                                                                      agent_id: user2.user_key,
                                                                      access: Hyrax::PermissionTemplateAccess::MANAGE }]) }
-    let(:collection2) { FactoryBot.valkyrie_create(:collection_resource, :public,
+    let(:collection2) { FactoryBot.valkyrie_create(:hyrax_collection, :public,
                                                    user: user, collection_type: collection_type,
                                                    access_grants: [{ agent_type: Hyrax::PermissionTemplateAccess::USER,
                                                                      agent_id: user.user_key,
@@ -206,7 +179,7 @@ RSpec.describe 'collection', type: :feature, clean_repo: true do
                                                                    { agent_type: Hyrax::PermissionTemplateAccess::USER,
                                                                      agent_id: user2.user_key,
                                                                      access: Hyrax::PermissionTemplateAccess::DEPOSIT }]) }
-    let(:collection4) { FactoryBot.valkyrie_create(:collection_resource, :public,
+    let(:collection4) { FactoryBot.valkyrie_create(:hyrax_collection, :public,
                                                    user: admin_user, collection_type: user_collection_type,
                                                    access_grants: [{ agent_type: Hyrax::PermissionTemplateAccess::USER,
                                                                      agent_id: user.user_key,
@@ -222,24 +195,6 @@ RSpec.describe 'collection', type: :feature, clean_repo: true do
       collection2
       collection3
       collection4
-      # create(:permission_template_access,
-      #        :manage,
-      #        permission_template: Hyrax::PermissionTemplate.find_by!(source_id: collection1.id),
-      #        agent_type: 'user',
-      #        agent_id: user2.user_key)
-      # collection1.permission_template.reset_access_controls_for(collection: collection1, interpret_visibility: true)
-      # create(:permission_template_access,
-      #        :deposit,
-      #        permission_template: Hyrax::PermissionTemplate.find_by!(source_id: collection2.id),
-      #        agent_type: 'user',
-      #        agent_id: user2.user_key)
-      # collection2.permission_template.reset_access_controls_for(collection: collection2, interpret_visibility: true)
-      # create(:permission_template_access,
-      #        :view,
-      #        permission_template: Hyrax::PermissionTemplate.find_by!(source_id: collection4.id),
-      #        agent_type: 'user',
-      #        agent_id: user2.user_key)
-      # collection4.permission_template.reset_access_controls_for(collection: collection4, interpret_visibility: true)
       sign_in user2
       visit '/dashboard/my/collections'
     end
@@ -300,7 +255,7 @@ RSpec.describe 'collection', type: :feature, clean_repo: true do
 
         fill_in('Title', with: title)
         fill_in('Description', with: description)
-        fill_in('Related URL', with: 'http://example.com/')
+        # fill_in('Related URL', with: 'http://example.com/')
 
         click_button("Save")
         expect(page).to have_content 'Collection was successfully created.'
@@ -315,13 +270,13 @@ RSpec.describe 'collection', type: :feature, clean_repo: true do
     end
 
     context 'when user can create collections of one type' do
-      let(:location) { 'Minneapolis, Minnesota, United States' }
-      let(:geonames_data) { '{"geonames":[{"geonameId":5037649,"name":"Minneapolis", "countryName":"United States","adminName1":"Minnesota"}]}' }
+      # let(:location) { 'Minneapolis, Minnesota, United States' }
+      # let(:geonames_data) { '{"geonames":[{"geonameId":5037649,"name":"Minneapolis", "countryName":"United States","adminName1":"Minnesota"}]}' }
 
       before do
-        stub_request(:get, 'http://api.geonames.org/searchJSON')
-          .with(query: hash_including({ 'q': 'minneapolis' }))
-          .to_return(status: 200, body: geonames_data)
+        # stub_request(:get, 'http://api.geonames.org/searchJSON')
+        #   .with(query: hash_including({ 'q': 'minneapolis' }))
+        #   .to_return(status: 200, body: geonames_data)
         user_collection_type
         sign_in user
         visit '/dashboard/my/collections'
@@ -337,20 +292,20 @@ RSpec.describe 'collection', type: :feature, clean_repo: true do
 
         fill_in('Title', with: title)
         fill_in('Description', with: description)
-        fill_in('Related URL', with: 'http://example.com/')
+        # fill_in('Related URL', with: 'http://example.com/')
 
-        find('#s2id_collection_based_near').click
-        expect(page).to have_content 'Please enter 2 or more characters'
-        find('#s2id_autogen1_search').send_keys("minneapolis")
-        expect(page).to have_content location
-        find('#s2id_autogen1_search').send_keys(:enter)
+        # find('#s2id_collection_based_near').click
+        # expect(page).to have_content 'Please enter 2 or more characters'
+        # find('#s2id_autogen1_search').send_keys("minneapolis")
+        # expect(page).to have_content location
+        # find('#s2id_autogen1_search').send_keys(:enter)
 
         click_button("Save")
         expect(page).to have_content 'Collection was successfully created.'
         expect(page).to have_content title
         expect(page).to have_content description
-        click_link('Additional fields')
-        expect(page).to have_content location
+        # click_link('Additional fields')
+        # expect(page).to have_content location
       end
     end
 
@@ -627,7 +582,7 @@ RSpec.describe 'collection', type: :feature, clean_repo: true do
 
   describe 'collection show page' do
     let(:collection) do
-      FactoryBot.valkyrie_create(:collection_resource, user: user, members: [work1, work2], description: ['collection description'])
+      FactoryBot.valkyrie_create(:hyrax_collection, user: user, members: [work1, work2], description: ['collection description'])
     end
     let!(:work1) { FactoryBot.valkyrie_create(:monograph, title: ["King Louie"], user: user) }
     let!(:work2) { FactoryBot.valkyrie_create(:monograph, title: ["King Kong"], user: user) }
@@ -771,7 +726,7 @@ RSpec.describe 'collection', type: :feature, clean_repo: true do
 
       sign_in user
     end
-    let(:collection) { FactoryBot.valkyrie_create(:collection_resource, title: ['A Collection of Testing'], user: user) }
+    let(:collection) { FactoryBot.valkyrie_create(:hyrax_collection, title: ['A Collection of Testing'], user: user) }
 
     it "shows a collection with a listing of Descriptive Metadata and catalog-style search results" do
       visit '/dashboard/my/collections'
@@ -852,7 +807,7 @@ RSpec.describe 'collection', type: :feature, clean_repo: true do
 
     context 'from dashboard -> collections action menu' do
       context 'for a collection' do
-        let(:collection) { FactoryBot.valkyrie_create(:collection_resource, title:['A Collection of Tests'], description: ['Test Description'], user: user) }
+        let(:collection) { FactoryBot.valkyrie_create(:hyrax_collection, title:['A Collection of Tests'], description: ['Test Description'], user: user) }
         let(:work1) { FactoryBot.valkyrie_create(:hyrax_work, title: ["King Louie"], member_of_collection_ids: [collection.id], user: user) }
         let(:work2) { FactoryBot.valkyrie_create(:hyrax_work, title: ["King Kong"], member_of_collection_ids: [collection.id], user: user) }
 
@@ -1028,8 +983,8 @@ RSpec.describe 'collection', type: :feature, clean_repo: true do
     end
 
     context "navigate through tabs", js: true do
-      let!(:empty_collection) { FactoryBot.valkyrie_create(:collection_resource, :public, title: ['Empty Collection'], user: user) }
-      let(:collection) { FactoryBot.valkyrie_create(:collection_resource, user: user, collection_type: collection_type) }
+      let!(:empty_collection) { FactoryBot.valkyrie_create(:hyrax_collection, :public, title: ['Empty Collection'], user: user) }
+      let(:collection) { FactoryBot.valkyrie_create(:hyrax_collection, user: user, collection_type: collection_type) }
       let(:collection_type) { create(:collection_type, :brandable, :discoverable, :sharable) }
       let!(:confirm_modal_text) { 'Are you sure you want to leave this tab? Any unsaved data will be lost.' }
       let!(:new_description) { 'New Description' }

--- a/spec/forms/hyrax/forms/collection_form_spec.rb
+++ b/spec/forms/hyrax/forms/collection_form_spec.rb
@@ -149,7 +149,8 @@ RSpec.describe Hyrax::Forms::CollectionForm, skip: !(Hyrax.config.collection_cla
                          { related_url: [] },
                          :visibility,
                          :collection_type_gid,
-                         { permissions_attributes: [:type, :name, :access, :id, :_destroy] }]
+                         { permissions_attributes: [:type, :name, :access, :id, :_destroy] },
+                         { based_near_attributes: [:id, :_destroy] }]
     end
   end
 

--- a/spec/support/wings_models.rb
+++ b/spec/support/wings_models.rb
@@ -2,6 +2,8 @@
 
 return if Hyrax.config.disable_wings
 
-# Clear existing Collection mapping to allow reverse lookups to resolve CollectionResource
-Wings::ModelRegistry.register(Hyrax::PcdmCollection, ActiveFedora::Base)
+# Clear existing Collection mapping to allow reverse lookups to resolve CollectionResource.
+# Then restore PcdmCollection for any code directly using that model.
+Wings::ModelRegistry.unregister(Hyrax::PcdmCollection)
 Wings::ModelRegistry.register(CollectionResource, ::Collection)
+Wings::ModelRegistry.register(Hyrax::PcdmCollection, ::Collection)

--- a/spec/support/wings_models.rb
+++ b/spec/support/wings_models.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+return if Hyrax.config.disable_wings
+Wings::ModelRegistry.register(CollectionResource, ::Collection)

--- a/spec/support/wings_models.rb
+++ b/spec/support/wings_models.rb
@@ -1,4 +1,7 @@
 # frozen_string_literal: true
 
 return if Hyrax.config.disable_wings
+
+# Clear existing Collection mapping to allow reverse lookups to resolve CollectionResource
+Wings::ModelRegistry.register(Hyrax::PcdmCollection, ActiveFedora::Base)
 Wings::ModelRegistry.register(CollectionResource, ::Collection)

--- a/spec/views/collections/edit_fields/_based_near.html.erb_spec.rb
+++ b/spec/views/collections/edit_fields/_based_near.html.erb_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe 'collections/edit_fields/_based_near.html.erb', type: :view do
 
   before do
     assign(:form, form)
+    form.prepopulate!
     render inline: form_template
   end
 

--- a/spec/views/collections/edit_fields/_based_near.html.erb_spec.rb
+++ b/spec/views/collections/edit_fields/_based_near.html.erb_spec.rb
@@ -1,7 +1,11 @@
 # frozen_string_literal: true
 RSpec.describe 'collections/edit_fields/_based_near.html.erb', type: :view do
-  let(:collection) { build :collection_resource }
-  let(:form) { Hyrax::Forms::ResourceForm.for(collection) }
+  RSpec.shared_examples 'check for based_near autocomplete url' do
+    it 'has url for autocomplete service' do
+      expect(rendered).to have_selector('input[data-autocomplete-url="/authorities/search/geonames"][data-autocomplete="based_near"]')
+    end
+  end
+
   let(:form_template) do
     %(
       <%= simple_form_for @form, url: [hyrax, :dashboard, @form] do |f| %>
@@ -12,11 +16,21 @@ RSpec.describe 'collections/edit_fields/_based_near.html.erb', type: :view do
 
   before do
     assign(:form, form)
-    form.prepopulate!
+    form.prepopulate! if form.is_a?(Valkyrie::ChangeSet)
     render inline: form_template
   end
 
-  it 'has url for autocomplete service' do
-    expect(rendered).to have_selector('input[data-autocomplete-url="/authorities/search/geonames"][data-autocomplete="based_near"]')
+  context 'ActiveFedora', :active_fedora do
+    let(:collection) { Collection.new }
+    let(:form) { Hyrax::Forms::CollectionForm.new(collection, nil, controller) }
+
+    include_examples 'check for based_near autocomplete url'
+  end
+
+  context 'Valkyrie' do
+    let(:collection) { CollectionResource.new }
+    let(:form) { Hyrax::Forms::ResourceForm.for(collection) }
+
+    include_examples 'check for based_near autocomplete url'
   end
 end

--- a/spec/views/hyrax/dashboard/collections/_form.html.erb_spec.rb
+++ b/spec/views/hyrax/dashboard/collections/_form.html.erb_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe 'hyrax/dashboard/collections/_form.html.erb', type: :view do
       expect(rendered).to have_selector("input#collection_date_created")
       expect(rendered).to have_selector("input#collection_language")
       expect(rendered).to have_selector("input#collection_identifier")
-      expect(rendered).to have_selector("div#collection_based_near")
+      expect(rendered).to have_selector("div.controlled_vocabulary.collection_based_near")
       expect(rendered).to have_selector("input#collection_related_url")
       expect(rendered).to have_selector("select#collection_license")
       expect(rendered).to have_selector("select#collection_resource_type")

--- a/spec/views/hyrax/dashboard/collections/_form.html.erb_spec.rb
+++ b/spec/views/hyrax/dashboard/collections/_form.html.erb_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe 'hyrax/dashboard/collections/_form.html.erb', type: :view do
       expect(rendered).to have_selector("input#collection_date_created")
       expect(rendered).to have_selector("input#collection_language")
       expect(rendered).to have_selector("input#collection_identifier")
-      expect(rendered).to have_selector("input#collection_based_near")
+      expect(rendered).to have_selector("div#collection_based_near")
       expect(rendered).to have_selector("input#collection_related_url")
       expect(rendered).to have_selector("select#collection_license")
       expect(rendered).to have_selector("select#collection_resource_type")

--- a/spec/views/records/edit_fields/_based_near.html.erb_spec.rb
+++ b/spec/views/records/edit_fields/_based_near.html.erb_spec.rb
@@ -1,7 +1,11 @@
 # frozen_string_literal: true
 RSpec.describe 'records/edit_fields/_based_near.html.erb', type: :view do
-  let(:work) { Monograph.new }
-  let(:form) { Hyrax::Forms::ResourceForm.for(work) }
+  RSpec.shared_examples 'check for based_near autocomplete url' do
+    it 'has url for autocomplete service' do
+      expect(rendered).to have_selector('input[data-autocomplete-url="/authorities/search/geonames"][data-autocomplete="based_near"]')
+    end
+  end
+
   let(:form_template) do
     %(
       <%= simple_form_for [main_app, @form] do |f| %>
@@ -12,11 +16,21 @@ RSpec.describe 'records/edit_fields/_based_near.html.erb', type: :view do
 
   before do
     assign(:form, form)
-    form.prepopulate!
+    form.prepopulate! if form.is_a?(Valkyrie::ChangeSet)
     render inline: form_template
   end
 
-  it 'has url for autocomplete service' do
-    expect(rendered).to have_selector('input[data-autocomplete-url="/authorities/search/geonames"][data-autocomplete="based_near"]')
+  context 'ActiveFedora', :active_fedora do
+    let(:work) { GenericWork.new }
+    let(:form) { Hyrax::GenericWorkForm.new(work, nil, controller) }
+
+    include_examples 'check for based_near autocomplete url'
+  end
+
+  context 'Valkyrie' do
+    let(:work) { Monograph.new }
+    let(:form) { Hyrax::Forms::ResourceForm.for(work) }
+
+    include_examples 'check for based_near autocomplete url'
   end
 end

--- a/spec/views/records/edit_fields/_based_near.html.erb_spec.rb
+++ b/spec/views/records/edit_fields/_based_near.html.erb_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 RSpec.describe 'records/edit_fields/_based_near.html.erb', type: :view do
-  let(:work) { GenericWork.new }
-  let(:form) { Hyrax::GenericWorkForm.new(work, nil, controller) }
+  let(:work) { Monograph.new }
+  let(:form) { Hyrax::Forms::ResourceForm.for(work) }
   let(:form_template) do
     %(
       <%= simple_form_for [main_app, @form] do |f| %>
@@ -12,6 +12,7 @@ RSpec.describe 'records/edit_fields/_based_near.html.erb', type: :view do
 
   before do
     assign(:form, form)
+    form.prepopulate!
     render inline: form_template
   end
 


### PR DESCRIPTION
### Fixes

Fixes #5155 ; refs #3819

### Summary

Improves support for the collection location field.

### Guidance for testing, such as acceptance criteria or new user interface behaviors:
* Collections in both dassie and koppie can set the location field using the geonames lookup form.
* CollectionResource has basic metadata behaviors.

### Detailed Description

This epic began with the goal of updating `spec/features/dashboard/collection_spec.rb` for valkyrie compatibility. However, due to differences in collection metadata in the established `Collection` and `Hyrax::PcdmCollection` models for dassie and koppie respectively, it became clear that the `:hyrax_collection` factory needed some changes.

Fields such as description and based_near are expected by the spec, but were not available on the bare bones `Hyrax::PcdmCollection` model generated by the hyrax_collection factory. The generated CollectionResource model is already present, although with some slight differences in metadata compared to the basic_metadata schema. The significant differences are creator is not a required form field, and description is a primary field. I believe by modifying the collection model used for most specs we can ensure the suggested inclusion of basic metadata into an application's collection model is well tested. Applications are still free to use a minimal collection based on `PcdmCollection`.

Once basic metadata was included, the based_near/location field demanded fixes to function on collections as it does for works. Some feature specs needed additional actions to trigger the additional fields button, or to supply a creator value.

### Changes proposed in this pull request:
* Adopt CollectionResource as the default model for the `:hyrax_collection` factory. The Wings model registry is modified during specs to reflect this.
* Include the `:basic_metadata` schema in koppie's `CollectionResource`, bringing the model into closer alignment with what is in use in dassie.
* Change the based_near form partial for collections to match works; fix specs broken by this.
* Update a few collection specs for valkyrie and for use of CollectionResource.
* Fix a flaky failure in the multiple membership checker.
* 
