### PR TITLE
Only default admin_set_id when it is unset

### DIFF
--- a/app/forms/hyrax/forms/pcdm_object_form.rb
+++ b/app/forms/hyrax/forms/pcdm_object_form.rb
@@ -36,7 +36,7 @@ module Hyrax
       property :proxy_depositor
 
       # pcdm relationships
-      property :admin_set_id, prepopulator: proc { |_opts| self.admin_set_id = Hyrax::AdminSetCreateService.find_or_create_default_admin_set.id.to_s }
+      property :admin_set_id, prepopulator: :admin_set_prepopulator
       property :member_ids, default: [], type: Valkyrie::Types::Array
       property :member_of_collection_ids, default: [], type: Valkyrie::Types::Array
       property :member_of_collections_attributes, virtual: true, populator: :in_collections_populator
@@ -51,6 +51,10 @@ module Hyrax
       property :find_child_work, default: nil, virtual: true
 
       private
+
+      def admin_set_prepopulator
+        self.admin_set_id ||= Hyrax::AdminSetCreateService.find_or_create_default_admin_set.id.to_s
+      end
 
       def in_collections_populator(fragment:, **_options)
         adds = []

--- a/spec/features/edit_work_resource_spec.rb
+++ b/spec/features/edit_work_resource_spec.rb
@@ -1,13 +1,18 @@
 # frozen_string_literal: true
 
-RSpec.describe 'Editing an existing Hyrax::Work Resource', :js, :workflow, :feature do
+RSpec.describe 'Editing an existing Hyrax::Work Resource', :js, :workflow, :feature, :clean_repo do
   let(:user) { FactoryBot.create(:user) }
 
   let(:work) do
-    FactoryBot.valkyrie_create(:comet_in_moominland, edit_users: [user])
+    FactoryBot.valkyrie_create(:comet_in_moominland, :with_admin_set, admin_set: old_admin_set, edit_users: [user])
   end
+  let(:default_admin_set) { Hyrax::AdminSetCreateService.find_or_create_default_admin_set }
+  let(:old_admin_set) { FactoryBot.valkyrie_create(:hyrax_admin_set, :with_permission_template, title: ['Old Admin Set'], user: user) }
+  let(:new_admin_set) { FactoryBot.valkyrie_create(:hyrax_admin_set, :with_permission_template, title: ['New Admin Set'], user: user) }
 
   before do
+    default_admin_set
+    new_admin_set
     work # create it
     sign_in user
   end
@@ -16,6 +21,10 @@ RSpec.describe 'Editing an existing Hyrax::Work Resource', :js, :workflow, :feat
     visit edit_hyrax_monograph_path(work)
 
     fill_in('Title', with: 'Updated by Edit Work Spec')
+
+    click_link('Relationships')
+    expect(page).to have_select('Administrative Set', selected: 'Old Admin Set')
+    select('New Admin Set', from: 'Administrative Set')
 
     choose('monograph_visibility_open')
     check('agreement')
@@ -27,5 +36,7 @@ RSpec.describe 'Editing an existing Hyrax::Work Resource', :js, :workflow, :feat
     within(".work-title-wrapper") do
       expect(page).to have_content('Public')
     end
+
+    expect(page).to have_content('New Admin Set')
   end
 end


### PR DESCRIPTION
### Fixes

Fixes #6424 

### Summary

Makes PcdmObjectForm not always set admin_set_id to the default

### Guidance for testing, such as acceptance criteria or new user interface behaviors:
* A resource work's non-default admin set is preselected on the work edit form.

### Changes proposed in this pull request:
* Only set the form's admin_set_id to the default admin set when there is no preexisting value.

@samvera/hyrax-code-reviewers
