### PR TITLE
Rows not explicitly set warning for FileSets

### DIFF
--- a/app/presenters/hyrax/file_set_presenter.rb
+++ b/app/presenters/hyrax/file_set_presenter.rb
@@ -118,13 +118,15 @@ module Hyrax
     end
 
     def fetch_parent_presenter
-      ids = Hyrax::SolrService.query("{!field f=member_ids_ssim}#{id}", fl: Hyrax.config.id_field)
+      ids = Hyrax::SolrService.query("{!field f=member_ids_ssim}#{id}", fl: Hyrax.config.id_field, rows: 1)
                               .map { |x| x.fetch(Hyrax.config.id_field) }
-      Hyrax.logger.warn("Couldn't find a parent work for FileSet: #{id}.") if ids.empty?
-      ids.each do |id|
-        doc = ::SolrDocument.find(id)
-        next if current_ability.can?(:edit, doc)
-        raise WorkflowAuthorizationException if doc.suppressed? && current_ability.can?(:read, doc)
+      if ids.empty?
+        Hyrax.logger.warn("Couldn't find a parent work for FileSet: #{id}.")
+      else
+        doc = ::SolrDocument.find(ids.first)
+        unless current_ability.can?(:edit, doc)
+          raise WorkflowAuthorizationException if doc.suppressed? && current_ability.can?(:read, doc)
+        end
       end
       Hyrax::PresenterFactory.build_for(ids: ids,
                                         presenter_class: WorkShowPresenter,


### PR DESCRIPTION
### Summary

Visiting any fileset page results in the following warning being logged:
```
WARN: Calling Hyrax::SolrService.get without passing an explicit value for ':rows' is not recommended. You will end up with Solr's default (usually set to 10)
```
I traced it back to this query which does not set rows:
https://github.com/samvera/hyrax/blob/main/app/presenters/hyrax/file_set_presenter.rb#L121

Our production server logs this message 30,000+ times per day, so we'd like to reduce that verbosity.

### Guidance for testing, such as acceptance criteria or new user interface behaviors:
In dassie or koppie, visit any fileset page in a work. The warning should appear in your console (or server log).

### Type of change (for release notes)
notes-bugfix

### Detailed Description

I explicitly set rows to 1 in this PR after asking about it on hyrax slack, since filesets should not belong to multiple works in modern hyrax. Let me know if this is likely to cause problems and I could set it to another value (maybe the default number of rows configured, or just 10). Since I reduced it to 1 row, I removed the loop as well.

### Changes proposed in this pull request:
* Explicitly set rows to 1 in fetch_parent_presenter to resolve warning about unset rows parameter, and remove looping

@samvera/hyrax-code-reviewers
