### PR TITLE
Valkyrize admin_sets_controller_spec; Fixes default AdminSet check

### DIFF
--- a/app/controllers/hyrax/admin/admin_sets_controller.rb
+++ b/app/controllers/hyrax/admin/admin_sets_controller.rb
@@ -99,7 +99,7 @@ module Hyrax
       case @admin_set
       when Valkyrie::Resource
         transactions['admin_set_resource.destroy'].call(@admin_set).value_or do |failure|
-          redirect_to hyrax.admin_admin_set_path(admin_set_id), alert: failure.first
+          return redirect_to hyrax.admin_admin_set_path(admin_set_id), alert: failure.first
         end
         after_delete_success
       else

--- a/app/models/admin_set.rb
+++ b/app/models/admin_set.rb
@@ -39,7 +39,7 @@ class AdminSet < ActiveFedora::Base
            predicate: Hyrax.config.admin_set_predicate,
            class_name: 'ActiveFedora::Base'
 
-  before_destroy :check_if_not_default_set, :check_if_empty
+  before_destroy :check_if_not_default_set, :check_if_empty, prepend: true
   after_destroy :destroy_permission_template
 
   def collection_type_gid

--- a/lib/hyrax/transactions/admin_set_destroy.rb
+++ b/lib/hyrax/transactions/admin_set_destroy.rb
@@ -8,7 +8,8 @@ module Hyrax
     #
     # @since 3.4.0
     class AdminSetDestroy < Transaction
-      DEFAULT_STEPS = ['admin_set_resource.check_empty',
+      DEFAULT_STEPS = ['admin_set_resource.check_default',
+                       'admin_set_resource.check_empty',
                        'admin_set_resource.delete',
                        'admin_set_resource.delete_acl'].freeze
 

--- a/lib/hyrax/transactions/container.rb
+++ b/lib/hyrax/transactions/container.rb
@@ -37,6 +37,7 @@ module Hyrax
       require 'hyrax/transactions/steps/apply_collection_type_permissions'
       require 'hyrax/transactions/steps/apply_permission_template'
       require 'hyrax/transactions/steps/change_depositor'
+      require 'hyrax/transactions/steps/check_for_default_admin_set'
       require 'hyrax/transactions/steps/check_for_empty_admin_set'
       require 'hyrax/transactions/steps/delete_access_control'
       require 'hyrax/transactions/steps/delete_all_file_metadata'
@@ -170,6 +171,10 @@ module Hyrax
       end
 
       namespace 'admin_set_resource' do |ops| # Hyrax::AdministrativeSet resource
+        ops.register 'check_default' do
+          Steps::CheckForDefaultAdminSet.new
+        end
+
         ops.register 'check_empty' do
           Steps::CheckForEmptyAdminSet.new
         end

--- a/lib/hyrax/transactions/steps/check_for_default_admin_set.rb
+++ b/lib/hyrax/transactions/steps/check_for_default_admin_set.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+require 'dry/monads'
+
+module Hyrax
+  module Transactions
+    module Steps
+      ##
+      # Validates non-defaultness of the {Hyrax::AdministrativeSet}; gives `Success`
+      # when not the default and `Failure` otherwise.
+      #
+      # Use this step to guard against destroying the default AdminSet.
+      class CheckForDefaultAdminSet
+        include Dry::Monads[:result]
+
+        ##
+        # @param [#find_inverse_references_by] query_service
+        def initialize(query_service: Hyrax.query_service)
+          @query_service = query_service
+        end
+
+        ##
+        # @param [Hyrax::AdministrativeSet] admin_set
+        #
+        # @return [Dry::Monads::Result]
+        def call(admin_set)
+          return Failure["Administrative set cannot be deleted as it is the default set", admin_set] if admin_set.id == Hyrax.config.default_admin_set_id
+          Success(admin_set)
+        end
+      end
+    end
+  end
+end

--- a/lib/hyrax/transactions/steps/check_for_empty_admin_set.rb
+++ b/lib/hyrax/transactions/steps/check_for_empty_admin_set.rb
@@ -26,7 +26,7 @@ module Hyrax
           members = @query_service
                     .find_inverse_references_by(property: :admin_set_id,
                                                 resource: admin_set)
-          return Failure[:admin_set_has_members, members] if members.any?
+          return Failure["Administrative set cannot be deleted as it is not empty", members] if members.any?
 
           Success(admin_set)
         end

--- a/spec/controllers/hyrax/admin/admin_sets_controller_spec.rb
+++ b/spec/controllers/hyrax/admin/admin_sets_controller_spec.rb
@@ -50,12 +50,16 @@ RSpec.describe Hyrax::Admin::AdminSetsController, :clean_repo do
     end
 
     describe "#show" do
-      before { controller.instance_variable_set(:@admin_set, admin_set) }
-
       context "when user has access through public group" do
         # Even though the user can view this admin set, they should not be able to view
         # it on the admin page.
-        let(:admin_set) { create(:adminset_lw, with_solr_document: true, with_permission_template: { view_groups: ['public'] }) }
+        let(:admin_set) do
+          valkyrie_create(:hyrax_admin_set,
+                          with_permission_template: true,
+                          access_grants: [{ agent_type: Hyrax::PermissionTemplateAccess::GROUP,
+                                            agent_id: 'public',
+                                            access: Hyrax::PermissionTemplateAccess::VIEW }])
+        end
 
         it 'is unauthorized' do
           get :show, params: { id: admin_set }
@@ -67,7 +71,13 @@ RSpec.describe Hyrax::Admin::AdminSetsController, :clean_repo do
       context "when user has access through registered group" do
         # Even though the user can view this admin set, the should not be able to view
         # it on the admin page.
-        let(:admin_set) { create(:adminset_lw, with_solr_document: true, with_permission_template: { view_groups: ['registered'] }) }
+        let(:admin_set) do
+          valkyrie_create(:hyrax_admin_set,
+                          with_permission_template: true,
+                          access_grants: [{ agent_type: Hyrax::PermissionTemplateAccess::GROUP,
+                                            agent_id: 'registered',
+                                            access: Hyrax::PermissionTemplateAccess::VIEW }])
+        end
 
         it 'is unauthorized' do
           get :show, params: { id: admin_set }
@@ -79,10 +89,16 @@ RSpec.describe Hyrax::Admin::AdminSetsController, :clean_repo do
       context "when user is directly granted view access" do
         # Even though the user can view this admin set, the should not be able to view
         # it on the admin page.
-        let(:admin_set) { create(:adminset_lw, with_solr_document: true, with_permission_template: { view_users: [user.user_key] }) }
+        let(:admin_set) do
+          valkyrie_create(:hyrax_admin_set,
+                          with_permission_template: true,
+                          access_grants: [{ agent_type: Hyrax::PermissionTemplateAccess::USER,
+                                            agent_id: user.user_key,
+                                            access: Hyrax::PermissionTemplateAccess::VIEW }])
+        end
 
         before do
-          create(:work, :public, admin_set: admin_set)
+          valkyrie_create(:hyrax_work, :public, admin_set_id: admin_set.id)
         end
 
         it 'defines a presenter' do
@@ -102,26 +118,28 @@ RSpec.describe Hyrax::Admin::AdminSetsController, :clean_repo do
       context "when user is directly granted manage access" do
         # Even though the user can view this admin set, the should not be able to view
         # it on the admin page.
-        let(:admin_set) { create(:adminset_lw, with_solr_document: true, with_permission_template: { manage_users: [user.user_key] }) }
-        let(:admin_set2) { create(:adminset_lw, with_solr_document: true, with_permission_template: true) }
+        let(:admin_set) do
+          valkyrie_create(:hyrax_admin_set,
+                          with_permission_template: true,
+                          access_grants: [{ agent_type: Hyrax::PermissionTemplateAccess::USER,
+                                            agent_id: user.user_key,
+                                            access: Hyrax::PermissionTemplateAccess::MANAGE }])
+        end
+        let(:admin_set2) { valkyrie_create(:hyrax_admin_set, with_permission_template: true) }
 
         context 'and user is accessing the managed set' do
-          before do
-            controller.instance_variable_set(:@admin_set, admin_set)
-          end
-
           it 'defines a form' do
             get :edit, params: { id: admin_set }
             expect(response).to be_successful
-            expect(assigns[:form]).to be_kind_of Hyrax::Forms::AdminSetForm
+            if Hyrax.config.disable_wings
+              expect(assigns[:form]).to be_kind_of Hyrax::Forms::AdministrativeSetForm
+            else
+              expect(assigns[:form]).to be_kind_of Hyrax::Forms::AdminSetForm
+            end
           end
         end
 
         context 'and user attempts to access another admin set' do
-          before do
-            controller.instance_variable_set(:@admin_set, admin_set2)
-          end
-
           it 'is unauthorized' do
             get :edit, params: { id: admin_set2 }
             expect(response).to redirect_to root_path
@@ -132,7 +150,7 @@ RSpec.describe Hyrax::Admin::AdminSetsController, :clean_repo do
     end
 
     describe "#files" do
-      let(:admin_set) { create(:admin_set) }
+      let(:admin_set) { valkyrie_create(:hyrax_admin_set) }
 
       it 'is unauthorized' do
         get :files, params: { id: admin_set }, format: :json
@@ -142,192 +160,205 @@ RSpec.describe Hyrax::Admin::AdminSetsController, :clean_repo do
     end
   end
 
-  ['admin', 'manager', 'creator'].each do |user_type|
-    context "as #{user_type == 'admin' ? '' : 'an admin set collection type '}#{user_type}" do
-      let(:user) do
-        case user_type
-        when 'admin'
-          admin
-        when 'creator'
-          creator
-        when 'manager'
-          manager
+  shared_examples('specs for varied user types') do
+    before do
+      sign_in user
+    end
+
+    describe "#index" do
+      it 'redirects to collection :index' do
+        get :index
+        expect(response).to redirect_to(my_collections_path)
+      end
+    end
+
+    describe "#new" do
+      it 'shows the new form' do
+        get :new
+        expect(response).to be_successful
+        expect(response).to render_template 'new'
+      end
+    end
+
+    describe "#create" do
+      context "when it's successful" do
+        before do
+          allow(Hyrax::AdminSetCreateService)
+            .to receive(:call!).with(any_args).and_return(saved_admin_set)
+        end
+        let(:admin_set) { FactoryBot.build(:hyrax_admin_set) }
+        let(:saved_admin_set) do
+          FactoryBot.valkyrie_create(:hyrax_admin_set,
+                                     title: 'Test title',
+                                     description: 'test description')
+        end
+
+        it 'creates admin set' do
+          post :create, params: { admin_set: { title: 'Test title',
+                                               description: 'test description',
+                                               workflow_name: 'default' } }
+          expect(response).to redirect_to(edit_admin_admin_set_path(assigns(:admin_set)))
         end
       end
 
-      before do
-        sign_in user
-      end
-
-      describe "#index" do
-        it 'redirects to collection :index' do
-          get :index
-          expect(response).to redirect_to(my_collections_path)
+      context "when it fails" do
+        before do
+          allow(Hyrax::AdminSetCreateService)
+            .to receive(:call!).with(any_args).and_raise(RuntimeError)
         end
-      end
 
-      describe "#new" do
         it 'shows the new form' do
-          get :new
-          expect(response).to be_successful
+          expect(Hyrax.logger).to receive(:error).with(/Failed to create admin set:/)
+          post :create, params: { admin_set: { title: 'Test title',
+                                               description: 'test description' } }
           expect(response).to render_template 'new'
+          expect(flash[:error]).to match(/Failed to create admin set:/)
         end
       end
+    end
 
-      describe "#create" do
-        context "when it's successful" do
+    context "when the user creates the admin set" do
+      describe "#show" do
+        context "when user created the admin set" do
+          let(:admin_set) { valkyrie_create(:hyrax_admin_set, edit_users: [user]) }
+
           before do
-            allow(Hyrax::AdminSetCreateService)
-              .to receive(:call!).with(any_args).and_return(saved_admin_set)
-          end
-          let(:admin_set) { FactoryBot.build(:hyrax_admin_set) }
-          let(:saved_admin_set) do
-            FactoryBot.valkyrie_create(:hyrax_admin_set,
-                                       title: 'Test title',
-                                       description: 'test description')
+            valkyrie_create(:hyrax_work, :public, admin_set_id: admin_set.id)
           end
 
-          it 'creates admin set' do
-            post :create, params: { admin_set: { title: 'Test title',
-                                                 description: 'test description',
-                                                 workflow_name: 'default' } }
-            expect(response).to redirect_to(edit_admin_admin_set_path(assigns(:admin_set)))
-          end
-        end
-
-        context "when it fails" do
-          before do
-            allow(Hyrax::AdminSetCreateService)
-              .to receive(:call!).with(any_args).and_raise(RuntimeError)
-          end
-
-          it 'shows the new form' do
-            expect(Hyrax.logger).to receive(:error).with(/Failed to create admin set:/)
-            post :create, params: { admin_set: { title: 'Test title',
-                                                 description: 'test description' } }
-            expect(response).to render_template 'new'
-            expect(flash[:error]).to match(/Failed to create admin set:/)
-          end
-        end
-      end
-
-      context "when the #{user_type} creates the admin set" do
-        describe "#show" do
-          context "when user created the admin set" do
-            let(:admin_set) { create(:admin_set, edit_users: [user]) }
-
-            before do
-              create(:work, :public, admin_set: admin_set)
-            end
-
-            it 'defines a presenter' do
-              get :show, params: { id: admin_set }
-              expect(response).to be_successful
-              expect(assigns[:presenter]).to be_kind_of Hyrax::AdminSetPresenter
-              expect(assigns[:presenter].id).to eq admin_set.id
-            end
-          end
-        end
-
-        describe "#edit" do
-          let(:admin_set) { create(:admin_set, edit_users: [user]) }
-
-          it 'defines a form' do
-            get :edit, params: { id: admin_set }
+          it 'defines a presenter' do
+            get :show, params: { id: admin_set }
             expect(response).to be_successful
+            expect(assigns[:presenter]).to be_kind_of Hyrax::AdminSetPresenter
+            expect(assigns[:presenter].id).to eq admin_set.id
+          end
+        end
+      end
+
+      describe "#edit" do
+        let(:admin_set) { valkyrie_create(:hyrax_admin_set, edit_users: [user]) }
+
+        it 'defines a form' do
+          get :edit, params: { id: admin_set }
+          expect(response).to be_successful
+          if Hyrax.config.disable_wings
+            expect(assigns[:form]).to be_kind_of Hyrax::Forms::AdministrativeSetForm
+          else
             expect(assigns[:form]).to be_kind_of Hyrax::Forms::AdminSetForm
           end
         end
+      end
 
-        describe "#files" do
-          let(:admin_set) { create(:admin_set, edit_users: [user]) }
+      describe "#files", skip: 'waiting for better thumbnail system, see samvera/hyrax#5764' do
+        let(:admin_set) { valkyrie_create(:hyrax_admin_set, edit_users: [user]) }
 
-          it 'shows a list of member files' do
-            get :files, params: { id: admin_set }, format: :json
-            expect(response).to be_successful
+        it 'shows a list of member files' do
+          get :files, params: { id: admin_set }, format: :json
+          expect(response).to be_successful
+        end
+      end
+
+      describe "#update" do
+        let(:admin_set) { valkyrie_create(:hyrax_admin_set, edit_users: [user]) }
+
+        it 'updates a record' do
+          patch :update, params: { id: admin_set,
+                                   admin_set: { title: "Improved title" } }
+          expect(response).to redirect_to(edit_admin_admin_set_path)
+          expect(assigns[:admin_set].title).to eq ['Improved title']
+        end
+      end
+
+      describe "#destroy" do
+        let(:admin_set) { valkyrie_create(:hyrax_admin_set, edit_users: [user]) }
+
+        context "with empty admin set" do
+          it "deletes the admin set" do
+            controller.request.set_header("HTTP_REFERER", "/admin/admin_sets")
+            delete :destroy, params: { id: admin_set }
+
+            expect(response).to have_http_status(:found)
+            expect(response).to redirect_to(my_collections_path)
+            expect(flash[:notice]).to eq "Administrative set successfully deleted"
+            expect(Hyrax.query_service.find_many_by_ids(ids: [admin_set.id]).to_a).to eq []
           end
         end
 
-        describe "#update" do
-          let(:admin_set) { create(:admin_set, edit_users: [user]) }
+        context "with empty admin set and referrer from the my/collections dashboard" do
+          it "deletes the admin set" do
+            controller.request.set_header("HTTP_REFERER", "/my/collections")
+            delete :destroy, params: { id: admin_set }
 
-          it 'updates a record' do
-            patch :update, params: { id: admin_set,
-                                     admin_set: { title: "Improved title" } }
-            expect(response).to redirect_to(edit_admin_admin_set_path)
-            expect(assigns[:admin_set].title).to eq ['Improved title']
+            expect(response).to have_http_status(:found)
+            expect(response).to redirect_to(my_collections_path)
+            expect(flash[:notice]).to eq "Administrative set successfully deleted"
+            expect(Hyrax.query_service.find_many_by_ids(ids: [admin_set.id]).to_a).to eq []
           end
         end
 
-        describe "#destroy" do
-          let(:admin_set) { create(:admin_set, edit_users: [user]) }
+        context "with empty admin set and referrer from the /collections dashboard" do
+          it "deletes the admin set" do
+            controller.request.set_header("HTTP_REFERER", "/collections")
+            delete :destroy, params: { id: admin_set }
 
-          context "with empty admin set" do
-            it "deletes the admin set" do
-              controller.request.set_header("HTTP_REFERER", "/admin/admin_sets")
-              delete :destroy, params: { id: admin_set }
+            expect(response).to have_http_status(:found)
+            expect(response).to redirect_to(dashboard_collections_path)
+            expect(flash[:notice]).to eq "Administrative set successfully deleted"
+            expect(Hyrax.query_service.find_many_by_ids(ids: [admin_set.id]).to_a).to eq []
+          end
+        end
 
-              expect(response).to have_http_status(:found)
-              expect(response).to redirect_to(my_collections_path)
-              expect(flash[:notice]).to eq "Administrative set successfully deleted"
-              expect(AdminSet.exists?(admin_set.id)).to be false
-            end
+        context "with a non-empty admin set" do
+          let(:work) { valkyrie_create(:hyrax_work, edit_users: [user], admin_set_id: admin_set.id) }
+
+          before do
+            work
           end
 
-          context "with empty admin set and referrer from the my/collections dashboard" do
-            it "deletes the admin set" do
-              controller.request.set_header("HTTP_REFERER", "/my/collections")
-              delete :destroy, params: { id: admin_set }
+          it "doesn't delete the admin set (or work)" do
+            reloaded = Hyrax.query_service.find_by(id: admin_set.id)
+            delete :destroy, params: { id: admin_set }
+            expect(response).to have_http_status(:found)
+            expect(response).to redirect_to(admin_admin_set_path(admin_set))
+            expect(flash[:alert]).to eq "Administrative set cannot be deleted as it is not empty"
+            expect(Hyrax.query_service.find_by(id: admin_set.id)).to eq reloaded
+            expect(Hyrax.query_service.find_by(id: work.id)).to eq work
+          end
+        end
 
-              expect(response).to have_http_status(:found)
-              expect(response).to redirect_to(my_collections_path)
-              expect(flash[:notice]).to eq "Administrative set successfully deleted"
-              expect(AdminSet.exists?(admin_set.id)).to be false
-            end
+        context "with the default admin set" do
+          let(:admin_set) { Hyrax::AdminSetCreateService.find_or_create_default_admin_set }
+
+          before do
+            admin_set.edit_users = [user.user_key]
+            admin_set.permission_manager.acl.save
+            Hyrax.persister.save(resource: admin_set)
           end
 
-          context "with empty admin set and referrer from the /collections dashboard" do
-            it "deletes the admin set" do
-              controller.request.set_header("HTTP_REFERER", "/collections")
-              delete :destroy, params: { id: admin_set }
-
-              expect(response).to have_http_status(:found)
-              expect(response).to redirect_to(dashboard_collections_path)
-              expect(flash[:notice]).to eq "Administrative set successfully deleted"
-              expect(AdminSet.exists?(admin_set.id)).to be false
-            end
-          end
-
-          context "with a non-empty admin set" do
-            let(:work) { create(:generic_work, user: user) }
-
-            before do
-              admin_set.members << work
-              admin_set.reload
-            end
-            it "doesn't delete the admin set (or work)" do
-              delete :destroy, params: { id: admin_set }
-              expect(response).to have_http_status(:found)
-              expect(response).to redirect_to(admin_admin_set_path(admin_set))
-              expect(flash[:alert]).to eq "Administrative set cannot be deleted as it is not empty"
-              expect(AdminSet.exists?(admin_set.id)).to be true
-              expect(GenericWork.exists?(work.id)).to be true
-            end
-          end
-
-          context "with the default admin set" do
-            let(:admin_set) { create(:admin_set, edit_users: [user], id: AdminSet::DEFAULT_ID) }
-
-            it "doesn't delete the admin set" do
-              delete :destroy, params: { id: admin_set }
-              expect(response).to have_http_status(:found)
-              expect(response).to redirect_to(admin_admin_set_path(admin_set))
-              expect(flash[:alert]).to eq "Administrative set cannot be deleted as it is the default set"
-              expect(AdminSet.exists?(admin_set.id)).to be true
-            end
+          it "doesn't delete the admin set" do
+            delete :destroy, params: { id: admin_set }
+            expect(response).to have_http_status(:found)
+            expect(response).to redirect_to(admin_admin_set_path(admin_set))
+            expect(flash[:alert]).to eq "Administrative set cannot be deleted as it is the default set"
+            expect(Hyrax.query_service.find_by(id: admin_set.id)).to eq admin_set
           end
         end
       end
     end
+  end
+
+  context "as an admin set collection type admin" do
+    let(:user) { admin }
+    include_examples 'specs for varied user types'
+  end
+
+  context "as a manager" do
+    let(:user) { manager }
+    include_examples 'specs for varied user types'
+  end
+
+  context "as a creator" do
+    let(:user) { creator }
+    include_examples 'specs for varied user types'
   end
 end


### PR DESCRIPTION
### Summary

Valkyrizes admin_sets_controller_spec and fixes default AdminSet check

### Guidance for testing, such as acceptance criteria or new user interface behaviors:
* Default admin set and its access control object cannot be deleted

### Detailed Description

Converts admin_sets_controller_spec to use valkyrie_create allowing dassie and koppie to run it.

It was discovered that the destroy admin set transaction did not prevent deletion of the default admin set and caused this spec to fail. A check step has been added.

Further, thanks to the difference in how the access control reference is stored, it was discovered that the access control for a legacy AdminSet is deleted prior to running the checks for if the admin set is the default one, or that it is empty. This is fixed by prepending those before_destroy callbacks.

The displayed error messages for admin set transactions were updated to match the old behavior.

It was noted that the following pattern of writing a spec that runs repeatedly by iterating over an array caused negative side effects even when the containing context was skipped via use of the `:active_fedora` tag. This has been converted to a shared example in this spec.

```ruby
context 'Active Fedora only', :active_fedora do
  ['admin', 'manager', 'creator'].each do |user_type|
    context "as #{user_type == 'admin' ? '' : 'an admin set collection type '}#{user_type}" do
      it 'checks stuff' do
        ...
      end
    end
  end
end
```

### Changes proposed in this pull request:
* Convert spec for valkyrie resources
* Prepend AdminSet before_destroy callbacks
* Add transaction step to check for default admin set when destroying
* Align non-empty admin set error message

@samvera/hyrax-code-reviewers
