### PR TITLE
Valkyrizes spec/abilities/ability_spec.rb.

### DIFF
--- a/spec/abilities/ability_spec.rb
+++ b/spec/abilities/ability_spec.rb
@@ -98,7 +98,7 @@ RSpec.describe Hyrax::Ability do
     it { is_expected.not_to be_able_to(:update, ContentBlock) }
     it { is_expected.not_to be_able_to(:create, AdminSet) }
     it { is_expected.to be_able_to(:read, ContentBlock) }
-    unless I18n.t('hyrax.product_name') == 'Koppie'
+    unless Hyrax.config.disable_wings
       it { is_expected.to be_able_to(:read, GenericWork) }
       it { is_expected.to be_able_to(:stats, GenericWork) }
       it { is_expected.to be_able_to(:citation, GenericWork) }

--- a/spec/abilities/ability_spec.rb
+++ b/spec/abilities/ability_spec.rb
@@ -98,9 +98,11 @@ RSpec.describe Hyrax::Ability do
     it { is_expected.not_to be_able_to(:update, ContentBlock) }
     it { is_expected.not_to be_able_to(:create, AdminSet) }
     it { is_expected.to be_able_to(:read, ContentBlock) }
-    it { is_expected.to be_able_to(:read, GenericWork) }
-    it { is_expected.to be_able_to(:stats, GenericWork) }
-    it { is_expected.to be_able_to(:citation, GenericWork) }
+    unless I18n.t('hyrax.product_name') == 'Koppie'
+      it { is_expected.to be_able_to(:read, GenericWork) }
+      it { is_expected.to be_able_to(:stats, GenericWork) }
+      it { is_expected.to be_able_to(:citation, GenericWork) }
+    end
   end
 
   describe "a registered user" do
@@ -134,7 +136,7 @@ RSpec.describe Hyrax::Ability do
     let(:permission_template) { build(:permission_template, source_id: admin_set.id) }
     let(:permission_template_access) { build(:permission_template_access, permission_template: permission_template) }
     let(:user) { create(:user) }
-    let(:admin_set) { create(:admin_set) }
+    let(:admin_set) { valkyrie_create(:hyrax_admin_set) }
 
     RSpec.shared_examples 'A user with additional access' do
       it { is_expected.to be_able_to(:edit, admin_set) }
@@ -154,7 +156,10 @@ RSpec.describe Hyrax::Ability do
     end
 
     describe 'via AdminSet-specific edit_users' do
-      let(:admin_set) { create(:admin_set, with_permission_template: true, edit_users: [user]) }
+      let(:admin_set) { valkyrie_create(:hyrax_admin_set, edit_users: [user.user_key]) }
+      let(:permission_template) do
+        create(:permission_template, source_id: admin_set.id)
+      end
 
       it '#admin? is false' do
         expect(ability).not_to be_admin
@@ -163,7 +168,7 @@ RSpec.describe Hyrax::Ability do
       it 'A user who can manage an AdminSet' do
         create(:permission_template_access,
                :manage,
-               permission_template: admin_set.permission_template,
+               permission_template: permission_template,
                agent_type: 'user',
                agent_id: user.user_key)
         is_expected.to be_able_to(:manage_any, AdminSet)


### PR DESCRIPTION
### Fixes

Fixes `spec/abilities/ability_spec.rb`.

### Summary

Valkyrizes spec/abilities/ability_spec.rb.

### Type of change (for release notes)

- `notes-valkyrie` Valkyrie Progress

### Changes proposed in this pull request:
* Since `GenericWork` is AF-specific, we switch on tests that focus on that class when rspec is ran on Dassie only.
* Replace all creation calls to Valyrie-friendly factories.

@samvera/hyrax-code-reviewers
