### PR TITLE
Edit content_deposit_event_job_spec.rb

### DIFF
--- a/spec/jobs/content_deposit_event_job_spec.rb
+++ b/spec/jobs/content_deposit_event_job_spec.rb
@@ -2,17 +2,10 @@
 RSpec.describe ContentDepositEventJob do
   let(:user) { create(:user) }
   let(:mock_time) { Time.zone.at(1) }
-  let(:curation_concern) do
-    if Hyrax.config.use_valkyrie?
-      valkyrie_create(:monograph, title: ['MacBeth'], depositor: user.user_key)
-    else
-      create(:work, title: ['MacBeth'], user: user)
-    end
-  end
+  let(:curation_concern) { valkyrie_create(:monograph, title: ['MacBeth'], depositor: user.user_key) }
   let(:event) do
-    path = Hyrax.config.use_valkyrie? ? '/concern/monographs' : '/concern/generic_works'
     {
-      action: "User <a href=\"/users/#{user.to_param}\">#{user.user_key}</a> has deposited <a href=\"#{path}/#{curation_concern.id}\">MacBeth</a>",
+      action: "User <a href=\"/users/#{user.to_param}\">#{user.user_key}</a> has deposited <a href=\"/concern/monographs/#{curation_concern.id}\">MacBeth</a>",
       timestamp: '1'
     }
   end


### PR DESCRIPTION
### Fixes

In Dassie, when valkyrie is not enabled, wings will convert the objects from valkyrie resources when they are created through `FactoryBot.valkyrie_create`. Per @dlpierce 's recommendation, I am using `valkyrie_create` to create a work for the tests in `spec/jobs/content_deposit_event_job_spec.rb`.

### Type of change (for release notes)

- `notes-valkyrie` Valkyrie Progress

### Changes proposed in this pull request:
* Remove the use of separate work creation methods depending on whether Valkyrie is used or not, and use `valkyrie_create` for all.
*
*

@samvera/hyrax-code-reviewers
