### PR TITLE
Updates find_works_search_builder to allow for both id strings as well as Valkyrie id objects.

### DIFF
--- a/app/search_builders/hyrax/my/find_works_search_builder.rb
+++ b/app/search_builders/hyrax/my/find_works_search_builder.rb
@@ -20,17 +20,16 @@ class Hyrax::My::FindWorksSearchBuilder < Hyrax::My::SearchBuilder
 
   def show_only_other_works(solr_parameters)
     solr_parameters[:fq] ||= []
-    solr_parameters[:fq] += ["-#{Hyrax::SolrQueryBuilderService.construct_query_for_ids([@id])}"]
+    solr_parameters[:fq] += ["-#{Hyrax::SolrQueryBuilderService.construct_query_for_ids([parsed_id])}"]
   end
 
   def show_only_works_not_child(solr_parameters)
-    ids = Hyrax::SolrService.query("{!field f=id}#{@id}", fl: "member_ids_ssim", rows: 10_000).flat_map { |x| x.fetch("member_ids_ssim", []) }
+    ids = Hyrax::SolrService.query("{!field f=id}#{parsed_id}", fl: "member_ids_ssim", rows: 10_000).flat_map { |x| x.fetch("member_ids_ssim", []) }
     solr_parameters[:fq] ||= []
     solr_parameters[:fq] += ["-#{Hyrax::SolrQueryBuilderService.construct_query_for_ids([ids])}"]
   end
 
   def show_only_works_not_parent(solr_parameters)
-    parsed_id = @id.is_a?(String) ? @id : @id&.id
     solr_parameters[:fq] ||= []
     solr_parameters[:fq]  += [
       "-" + Hyrax::SolrQueryBuilderService.construct_query(member_ids_ssim: parsed_id)
@@ -39,5 +38,10 @@ class Hyrax::My::FindWorksSearchBuilder < Hyrax::My::SearchBuilder
 
   def only_works?
     true
+  end
+
+  # Since Valkyrie objects pass is an Id object, additional parsing is needed.
+  def parsed_id
+    @id.is_a?(String) ? @id : @id.id
   end
 end

--- a/app/search_builders/hyrax/my/find_works_search_builder.rb
+++ b/app/search_builders/hyrax/my/find_works_search_builder.rb
@@ -30,9 +30,10 @@ class Hyrax::My::FindWorksSearchBuilder < Hyrax::My::SearchBuilder
   end
 
   def show_only_works_not_parent(solr_parameters)
+    parsed_id = @id.is_a?(String) ? @id : @id&.id
     solr_parameters[:fq] ||= []
     solr_parameters[:fq]  += [
-      "-" + Hyrax::SolrQueryBuilderService.construct_query(member_ids_ssim: @id)
+      "-" + Hyrax::SolrQueryBuilderService.construct_query(member_ids_ssim: parsed_id)
     ]
   end
 

--- a/spec/search_builders/hyrax/my/find_works_search_builder_spec.rb
+++ b/spec/search_builders/hyrax/my/find_works_search_builder_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Hyrax::My::FindWorksSearchBuilder do
                                current_user: user,
                                params: params)
   end
-  let!(:work) { create(:generic_work, :public, title: ['foo'], user: user) }
+  let!(:work) { valkyrie_create(:monograph, :public, title: ['foo']) }
 
   let(:builder) { described_class.new(context) }
   let(:solr_params) { Blacklight::Solr::Request.new }
@@ -21,7 +21,7 @@ RSpec.describe Hyrax::My::FindWorksSearchBuilder do
 
     it "is successful" do
       subject
-      expect(solr_params[:fq]).to eq [ActiveFedora::SolrQueryBuilder.construct_query(title_tesim: q)]
+      expect(solr_params[:fq]).to eq [Hyrax::SolrQueryBuilderService.construct_query(title_tesim: q)]
     end
   end
 
@@ -49,7 +49,7 @@ RSpec.describe Hyrax::My::FindWorksSearchBuilder do
 
     it "is successful" do
       subject
-      expect(solr_params[:fq]).to eq ["-" + ActiveFedora::SolrQueryBuilder.construct_query(member_ids_ssim: work.id)]
+      expect(solr_params[:fq]).to eq ["-" + Hyrax::SolrQueryBuilderService.construct_query(member_ids_ssim: work.id.id)]
     end
   end
 

--- a/spec/search_builders/hyrax/my/find_works_search_builder_spec.rb
+++ b/spec/search_builders/hyrax/my/find_works_search_builder_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe Hyrax::My::FindWorksSearchBuilder do
 
     it "is successful" do
       subject
-      expect(solr_params[:fq]).to eq ["-" + Hyrax::SolrQueryBuilderService.construct_query_for_ids([work.id])]
+      expect(solr_params[:fq]).to eq ["-" + Hyrax::SolrQueryBuilderService.construct_query_for_ids([work.id.id])]
     end
   end
 
@@ -39,7 +39,7 @@ RSpec.describe Hyrax::My::FindWorksSearchBuilder do
 
     it "is successful" do
       subject
-      ids = Hyrax::SolrService.query("{!field f=id}#{work.id}", fl: "member_ids_ssim").flat_map { |x| x.fetch("member_ids_ssim", []) }
+      ids = Hyrax::SolrService.query("{!field f=id}#{work.id.id}", fl: "member_ids_ssim").flat_map { |x| x.fetch("member_ids_ssim", []) }
       expect(solr_params[:fq]).to eq ["-" + Hyrax::SolrQueryBuilderService.construct_query_for_ids([ids])]
     end
   end


### PR DESCRIPTION
### Fixes

Fixes `app/search_builders/hyrax/my/find_works_search_builder.rb` and associated rSpec.

### Summary

Updates find_works_search_builder to allow for both id strings as well as Valkyrie id objects.

### Type of change (for release notes)

- `notes-valkyrie` Valkyrie Progress

### Changes proposed in this pull request:
* app/search_builders/hyrax/my/find_works_search_builder.rb: ensures that ids that are passed in are processed as strings when building searches.
* spec/search_builders/hyrax/my/find_works_search_builder_spec.rb: updates testing to Valkyrie objects and removes ActiveFedora-specific SolrQueryBuilders.

@samvera/hyrax-code-reviewers
