### PR TITLE
Swaps to create so that IDs are minted, allowing queries to perform.

### DIFF
--- a/spec/helpers/hyrax/membership_helper_spec.rb
+++ b/spec/helpers/hyrax/membership_helper_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Hyrax::MembershipHelper do
       end
 
       context 'when it is a member of a collection' do
-        let(:work) { build(:monograph, :as_collection_member) }
+        let(:work) { valkyrie_create(:monograph, :as_collection_member) }
         let(:collection) { Hyrax.custom_queries.find_parent_collections(resource: work).first }
 
         it 'gives collection details' do
@@ -37,7 +37,7 @@ RSpec.describe Hyrax::MembershipHelper do
       end
 
       context 'when it is a member of a collection' do
-        let(:resource) { build(:hyrax_work, :as_collection_member) }
+        let(:resource) { valkyrie_create(:hyrax_work, :as_collection_member) }
         let(:collection) { Hyrax.custom_queries.find_parent_collections(resource: resource).first }
 
         it 'gives collection details' do


### PR DESCRIPTION
### Fixes

Fixes `spec/helpers/hyrax/membership_helper_spec.rb`.

### Summary

Swaps to create so that IDs are minted, allowing queries to perform.

### Type of change (for release notes)

- `notes-valkyrie` Valkyrie Progress

### Detailed Description

More detailed description, if necessary. Try to be as descriptive as you can: even if you think that the PR content is obvious, it may not be obvious to others. Include tracebacks if helpful, and be sure to call out any bits of the PR that may be work-in-progress.

Description can have multiple paragraphs and you can use code examples inside:

`#member_of_collections_json` relies on a custom query that uses [this code](https://github.com/samvera/valkyrie/blob/b4a0b5ab0e3cdea0d7c98002530622aeebf4215a/lib/valkyrie/persistence/postgres/query_service.rb#L105C61-L105C61). The only way that either object will appear in that search is for the ID to be minted, which only happens with Valkyrie objects upon creation.

@samvera/hyrax-code-reviewers
