### PR TITLE
Marks test suite as ActiveFedora-only, since importer has no Valkyrization.

### DIFF
--- a/spec/services/hyrax/user_stat_importer_spec.rb
+++ b/spec/services/hyrax/user_stat_importer_spec.rb
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
-RSpec.describe Hyrax::UserStatImporter do
+
+# NOTE: This importer service seems to be ActiveFedora-specific. May need to be
+#   Valkyrized in the future.
+RSpec.describe Hyrax::UserStatImporter, :active_fedora do
   before do
     allow(Hyrax.config).to receive(:analytic_start_date) { dates[0] }
 


### PR DESCRIPTION
### Fixes

Fixes `spec/services/hyrax/user_stat_importer_spec.rb`.

### Summary

Marks test suite as ActiveFedora-only, since importer has no Valkyrization.

### Type of change (for release notes)

- `notes-valkyrie` Valkyrie Progress

@samvera/hyrax-code-reviewers
