### PR TITLE
Valkyrization: Fix failing tests in content_update_event_job_spec.rb

### DIFF
--- a/spec/jobs/content_update_event_job_spec.rb
+++ b/spec/jobs/content_update_event_job_spec.rb
@@ -2,6 +2,7 @@
 RSpec.describe ContentUpdateEventJob do
   let(:user) { create(:user) }
   let(:mock_time) { Time.zone.at(1) }
+  let(:curation_concern) { valkyrie_create(:hyrax_file_set, title: ['Hamlet'], depositor: user.user_key) }
   let(:event) do
     {
       action: "User <a href=\"/users/#{user.to_param}\">#{user.user_key}</a> has updated <a href=\"/concern/file_sets/#{curation_concern.id}\">Hamlet</a>",
@@ -13,31 +14,13 @@ RSpec.describe ContentUpdateEventJob do
     allow(Time).to receive(:now).at_least(:once).and_return(mock_time)
   end
 
-  context "when use_valkyrie is false" do
-    let(:curation_concern) { create(:file_set, title: ['Hamlet'], user: user) }
+  it "logs the event to the depositor's profile and the FileSet" do
+    expect do
+      described_class.perform_now(curation_concern, user)
+    end.to change { user.profile_events.length }.by(1)
+                                                .and change { curation_concern.events.length }.by(1)
 
-    it "logs the event to the depositor's profile and the FileSet" do
-      expect do
-        described_class.perform_now(curation_concern, user)
-      end.to change { user.profile_events.length }.by(1)
-                                                  .and change { curation_concern.events.length }.by(1)
-
-      expect(user.profile_events.first).to eq(event)
-      expect(curation_concern.events.first).to eq(event)
-    end
-  end
-
-  context "when use_valkyrie is true" do
-    let(:curation_concern) { valkyrie_create(:hyrax_file_set, title: ['Hamlet']) }
-
-    it "logs the event to the depositor's profile and the FileSet" do
-      expect do
-        described_class.perform_now(curation_concern, user)
-      end.to change { user.profile_events.length }.by(1)
-                                                  .and change { curation_concern.events.length }.by(1)
-
-      expect(user.profile_events.first).to eq(event)
-      expect(curation_concern.events.first).to eq(event)
-    end
+    expect(user.profile_events.first).to eq(event)
+    expect(curation_concern.events.first).to eq(event)
   end
 end


### PR DESCRIPTION
### Fixes

Fixes failing tests in `spec/jobs/content_update_event_job_spec.rb` for Koppie.

### Summary

I changed the tests to use `valkyrie_create` exclusively, per @dlpierce's recommendation (See #6455). This will ensure the tests for this event follow a similar structure to other tests like `/spec/jobs/content_deposit_event_job_spec.rb`.

### Type of change (for release notes)

- `notes-valkyrie` Valkyrie Progress

### Changes proposed in this pull request:
* Remove the use of different testing contexts when Valkyrie is used vs not
* Use `valkyrie_create` to create a file set
*

@samvera/hyrax-code-reviewers
