### PR TITLE
Valkyrization: Fix failing tests in content_new_version_event_job_spec.rb

### DIFF
--- a/spec/jobs/content_new_version_event_job_spec.rb
+++ b/spec/jobs/content_new_version_event_job_spec.rb
@@ -1,8 +1,7 @@
 # frozen_string_literal: true
 RSpec.describe ContentNewVersionEventJob do
   let(:user) { create(:user) }
-  let(:file_set) { create(:file_set, title: ['Hamlet'], user: user) }
-  let(:generic_work) { create(:generic_work, title: ['BethsMac'], user: user) }
+  let(:file_set) { valkyrie_create(:hyrax_file_set, title: ['Hamlet'], depositor: user.user_key) }
   let(:mock_time) { Time.zone.at(1) }
   let(:event) { { action: "User <a href=\"/users/#{user.to_param}\">#{user.user_key}</a> has added a new version of <a href=\"/concern/file_sets/#{file_set.id}\">Hamlet</a>", timestamp: '1' } }
 


### PR DESCRIPTION
### Fixes

Fix failing tests in `spec/jobs/content_new_version_event_job_spec.rb` for Koppie.

### Type of change (for release notes)

- `notes-valkyrie` Valkyrie Progress

### Changes proposed in this pull request:
* Use `valkyrie_create` to create a file set
* Remove unused `:generic_work` definition
*

@samvera/hyrax-code-reviewers
