### PR TITLE
Utilizes Valkyrie patterns for collection_types_controller_spec.

### DIFF
--- a/docker-compose-koppie.yml
+++ b/docker-compose-koppie.yml
@@ -99,8 +99,8 @@ services:
       - /dev/shm:/dev/shm
     shm_size: 2G
     ports:
-      - "4445:4444"
-      - "5960:5900"
+      - "4446:4444"
+      - "5961:5900"
     networks:
       - koppie
 

--- a/spec/controllers/hyrax/admin/collection_types_controller_spec.rb
+++ b/spec/controllers/hyrax/admin/collection_types_controller_spec.rb
@@ -307,7 +307,7 @@ RSpec.describe Hyrax::Admin::CollectionTypesController, type: :controller, clean
       end
 
       context "when collections exist of this type" do
-        let!(:collection) { FactoryBot.create(:collection_lw, collection_type: collection_type_to_destroy) }
+        let!(:collection) { valkyrie_create(:pcdm_collection, collection_type_gid: collection_type_to_destroy.to_global_id.to_s) }
 
         it "doesn't delete the collection type or collection" do
           delete :destroy, params: { id: collection_type_to_destroy }
@@ -315,7 +315,7 @@ RSpec.describe Hyrax::Admin::CollectionTypesController, type: :controller, clean
           expect(response).to redirect_to(admin_collection_types_path)
           expect(flash[:alert]).to eq "Collection type cannot be altered as it has collections"
           expect(Hyrax::CollectionType.exists?(collection_type_to_destroy.id)).to be true
-          expect(Collection.exists?(collection.id)).to be true
+          expect(Hyrax.query_service.find_by(id: collection.id)).to be_present
         end
       end
     end


### PR DESCRIPTION
### Fixes

Fixes `spec/controllers/hyrax/admin/collection_types_controller_spec.rb`.

### Summary

Utilizes Valkyrie patterns for collection_types_controller_spec.


### Type of change (for release notes)

- `notes-valkyrie` Valkyrie Progress

### Changes proposed in this pull request:
* docker-compose-koppie.yml: bumps up the ports for each chrome port so that dassie and koppie tests can run simultaneously.
* spec/controllers/hyrax/admin/collection_types_controller_spec.rb: converts collection to Valkyrie object and tests for its existence with a query instead of method.

@samvera/hyrax-code-reviewers
