### PR TITLE
Marks test suite as ActiveFedora-only, since indexer is only used with AF objects.

### DIFF
--- a/spec/indexers/hyrax/collection_indexer_spec.rb
+++ b/spec/indexers/hyrax/collection_indexer_spec.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
-RSpec.describe Hyrax::CollectionIndexer do
+
+# Marked as AF-only, since Valkyrie Collection indexing is handled by Hyrax::PcdmCollectionIndexer.
+RSpec.describe Hyrax::CollectionIndexer, :active_fedora do
   let(:indexer) { described_class.new(collection) }
   let(:collection) { build(:collection_lw) }
   let(:col1id) { 'col1' }


### PR DESCRIPTION
### Fixes

Fixes `spec/indexers/hyrax/collection_indexer_spec.rb`.

### Summary

Marks test suite as ActiveFedora-only, since indexer is only used with AF objects.

### Type of change (for release notes)

- `notes-valkyrie` Valkyrie Progress

@samvera/hyrax-code-reviewers
