### PR TITLE
Don’t require `::Collection` for search builders

### DIFF
--- a/app/search_builders/hyrax/dashboard/collections_search_builder.rb
+++ b/app/search_builders/hyrax/dashboard/collections_search_builder.rb
@@ -9,7 +9,7 @@ module Hyrax
 
       # This overrides the models in FilterByType
       def models
-        [::AdminSet, Hyrax::AdministrativeSet, ::Collection, Hyrax.config.collection_class].uniq.compact
+        [::AdminSet, Hyrax::AdministrativeSet, "Collection".safe_constantize, Hyrax.config.collection_class].uniq.compact
       end
 
       # adds a filter to exclude collections and admin sets created by the

--- a/app/search_builders/hyrax/my/collections_search_builder.rb
+++ b/app/search_builders/hyrax/my/collections_search_builder.rb
@@ -18,7 +18,7 @@ class Hyrax::My::CollectionsSearchBuilder < ::Hyrax::CollectionSearchBuilder
   # This overrides the models in FilterByType
   # @return [Array<Class>] a list of classes to include
   def models
-    [::AdminSet, Hyrax::AdministrativeSet, ::Collection, Hyrax.config.collection_class].uniq.compact
+    [::AdminSet, Hyrax::AdministrativeSet, "Collection".safe_constantize, Hyrax.config.collection_class].uniq.compact
   end
 
   private


### PR DESCRIPTION
This applies the change in 8e3a4cd to the overrides in collection search builders as well.
