### PR TITLE
Utilizes Valkyrie patterns for catalog_controller_spec.

### DIFF
--- a/config/metadata/basic_metadata.yaml
+++ b/config/metadata/basic_metadata.yaml
@@ -50,6 +50,7 @@ attributes:
       primary: false
     index_keys:
       - "contributor_tesim"
+      - "contributor_sim"
     predicate: http://purl.org/dc/elements/1.1/contributor
   creator:
     type: string

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -1,30 +1,24 @@
 # frozen_string_literal: true
-RSpec.describe CatalogController, type: :controller do
+RSpec.describe CatalogController, :clean_repo, type: :controller do
   routes { Rails.application.class.routes }
 
   let(:user) { create(:user) }
 
-  before do
-    sign_in user
-  end
+  before { sign_in user }
 
   describe "#index" do
-    let(:rocks) do
-      GenericWork.new(id: 'rock123', title: ['Rock Documents'], read_groups: ['public'])
-    end
-
-    let(:clouds) do
-      GenericWork.new(id: 'cloud123', title: ['Cloud Documents'], read_groups: ['public'],
-                      contributor: ['frodo'])
-    end
+    let(:rocks) { valkyrie_create(:monograph, title: ['Rock Documents'], read_groups: ['public']) }
+    let(:clouds) { valkyrie_create(:monograph, title: ['Cloud Documents'], read_groups: ['public']) }
 
     before do
-      objects.each { |obj| Hyrax::SolrService.add(obj.to_solr) }
-      Hyrax::SolrService.commit
+      objects
+      clouds.contributor = ['frodo']
+      Hyrax.persister.save(resource: clouds)
+      Hyrax.index_adapter.save(resource: clouds)
     end
 
     context 'with a non-work file' do
-      let(:file) { FileSet.new(id: 'file123') }
+      let(:file) { valkyrie_create(:hyrax_file_set) }
       let(:objects) { [file, rocks, clouds] }
 
       it 'finds works, not files' do
@@ -40,7 +34,7 @@ RSpec.describe CatalogController, type: :controller do
     end
 
     context 'with collections' do
-      let(:collection) { create(:public_collection_lw, keyword: ['rocks']) }
+      let(:collection) { valkyrie_create(:hyrax_collection, :public, title: ['rocks']) }
       let(:objects) { [collection, rocks, clouds] }
 
       it 'finds collections' do
@@ -51,7 +45,7 @@ RSpec.describe CatalogController, type: :controller do
       end
     end
 
-    describe 'term search', :clean_repo do
+    describe 'term search' do
       let(:objects) { [rocks, clouds] }
 
       it 'finds works with the given search term' do
@@ -87,34 +81,32 @@ RSpec.describe CatalogController, type: :controller do
       end
     end
 
-    context 'works by file metadata' do
+    context 'works by file metadata (ActiveFedora)', :active_fedora do
       let(:objects) do
         [double(to_solr: file1), double(to_solr: file2),
          double(to_solr: work1), double(to_solr: work2)]
       end
-
       let(:work1) do
         { has_model_ssim: ["GenericWork"], id: "ff365c76z", title_tesim: ["me too"],
-          file_set_ids_ssim: ["ff365c78h", "ff365c79s"],
-          read_access_group_ssim: ["public"], edit_access_person_ssim: ["user1@example.com"] }
+          file_set_ids_ssim: ["ff365c78h", "ff365c79s"], read_access_group_ssim: ["public"],
+          edit_access_person_ssim: ["user1@example.com"] }
       end
-
       let(:work2) do
         { has_model_ssim: ["GenericWork"], id: "ff365c777", title_tesim: ["find me"],
-          file_set_ids_ssim: [],
-          read_access_group_ssim: ["public"], edit_access_person_ssim: ["user2@example.com"] }
+          file_set_ids_ssim: [], read_access_group_ssim: ["public"], edit_access_person_ssim: ["user2@example.com"] }
       end
-
       let(:file1) do
         { has_model_ssim: ["FileSet"], id: "ff365c78h", title_tesim: ["find me"],
-          file_set_ids_ssim: [],
-          edit_access_person_ssim: [user.user_key] }
+          file_set_ids_ssim: [], edit_access_person_ssim: [user.user_key] }
       end
-
       let(:file2) do
         { has_model_ssim: ["FileSet"], id: "ff365c79s", title_tesim: ["other file"],
-          file_set_ids_ssim: [],
-          edit_access_person_ssim: [user.user_key] }
+          file_set_ids_ssim: [], edit_access_person_ssim: [user.user_key] }
+      end
+
+      before do
+        objects.each { |obj| Hyrax::SolrService.add(obj.to_solr) }
+        Hyrax::SolrService.commit
       end
 
       it "finds a work and a work that contains a file set with a matching title" do
@@ -125,6 +117,44 @@ RSpec.describe CatalogController, type: :controller do
       it "finds a work that contains a file set with a matching title" do
         get :index, params: { q: 'other file', search_field: 'all_fields' }
         expect(assigns(:response).documents.map(&:id)).to contain_exactly(work1[:id])
+      end
+
+      it "finds a work with a matching title" do
+        get :index, params: { q: 'me too', search_field: 'all_fields' }
+        expect(assigns(:response).documents.map(&:id)).to contain_exactly(work1[:id])
+      end
+    end
+
+    context 'works by file metadata (Valkyrie)' do
+      let(:objects) { [file1, file2, work1, work2] }
+      let(:other_user) { create(:user) }
+      let(:work1) do
+        valkyrie_create(:monograph, title: ['me too'], read_groups: ['public'], members: [file1, file2], edit_users: [user.user_key])
+      end
+      let(:work2) do
+        valkyrie_create(:monograph, title: ['find me'], read_groups: ['public'], edit_users: [other_user.user_key])
+      end
+      let(:file1) do
+        valkyrie_create(:hyrax_file_set, title: ['find me'], edit_users: [user.user_key])
+      end
+      let(:file2) do
+        valkyrie_create(:hyrax_file_set, title: ['other file'], edit_users: [user.user_key])
+      end
+
+      # NOTE: The old expected behavior was "finds a work and a work that contains a file set with a matching title".
+      #   This is no longer the case in a Valkyrie environment. A work's child file set's metadata is no longer passed in
+      #   to the work's SolrDocument. The only references to the containing file sets are their ids.
+      #   Previous `contain_exactly` was (work1[:id], work2[:id])
+      it "finds a work and a work that contains a file set with a matching title" do
+        get :index, params: { q: 'find me', search_field: 'all_fields' }
+        expect(assigns(:response).documents.map(&:id)).to contain_exactly(work2[:id])
+      end
+
+      # NOTE: The same logic in the above comment applies here.
+      #   Previous `contain_exactly` was (work1[:id])
+      it "finds a work that contains a file set with a matching title" do
+        get :index, params: { q: 'other file', search_field: 'all_fields' }
+        expect(assigns(:response).documents.map(&:id)).to match_array([])
       end
 
       it "finds a work with a matching title" do

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -144,17 +144,15 @@ RSpec.describe CatalogController, :clean_repo, type: :controller do
       # NOTE: The old expected behavior was "finds a work and a work that contains a file set with a matching title".
       #   This is no longer the case in a Valkyrie environment. A work's child file set's metadata is no longer passed in
       #   to the work's SolrDocument. The only references to the containing file sets are their ids.
-      #   Previous `contain_exactly` was (work1[:id], work2[:id])
-      it "finds a work and a work that contains a file set with a matching title" do
+      it "finds a work and a work that contains a file set with a matching title", pending: 'FIXME: Valkyrie indexer should do this' do
         get :index, params: { q: 'find me', search_field: 'all_fields' }
-        expect(assigns(:response).documents.map(&:id)).to contain_exactly(work2[:id])
+        expect(assigns(:response).documents.map(&:id)).to contain_exactly(work1[:id], work2[:id])
       end
 
       # NOTE: The same logic in the above comment applies here.
-      #   Previous `contain_exactly` was (work1[:id])
-      it "finds a work that contains a file set with a matching title" do
+      it "finds a work that contains a file set with a matching title", pending: 'FIXME: Valkyrie indexer should do this' do
         get :index, params: { q: 'other file', search_field: 'all_fields' }
-        expect(assigns(:response).documents.map(&:id)).to match_array([])
+        expect(assigns(:response).documents.map(&:id)).to contain_exactly(work1[:id])
       end
 
       it "finds a work with a matching title" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -251,7 +251,7 @@ RSpec.configure do |config|
 
   config.profile_examples = 10
 
-  config.before(:example, :active_fedora) do
+  config.prepend_before(:context, :active_fedora) do
     skip("Don't test Wings") if Hyrax.config.disable_wings
   end
 


### PR DESCRIPTION
### Fixes

Fixes `spec/controllers/catalog_controller_spec.rb`.

### Summary

Utilizes Valkyrie patterns for catalog_controller_spec.

### Type of change (for release notes)

- `notes-valkyrie` Valkyrie Progress

### Changes proposed in this pull request:
* config/metadata/basic_metadata.yaml: indexes as `_sim` version of  `contributor` so that the facet query can operate correctly.
* spec/controllers/catalog_controller_spec.rb: updates tests with Valkyrie objects, but also demonstrates how ActiveFedora and Valkyrie objects get indexed differently now that Works only contain the IDs of the contained FileSets, not a direct linking through members.

@samvera/hyrax-code-reviewers
