### PR TITLE
Marks test suite as ActiveFedora-only, since presenter calls to multiple classes not Valkyrized.

### DIFF
--- a/spec/presenters/hyrax/file_usage_spec.rb
+++ b/spec/presenters/hyrax/file_usage_spec.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-# NOTE: This presenter is currently utilizing multiple classes that are solely focused on ActiveFedora objects and classes. 
+# NOTE: This presenter is currently utilizing multiple classes that are solely focused on ActiveFedora objects and classes.
 #   This class, as well as others involving Statistics and Analytics should be Valkyrized in the future.
 RSpec.describe Hyrax::FileUsage, :active_fedora, type: :model do
   let(:user) { build(:user) }

--- a/spec/presenters/hyrax/file_usage_spec.rb
+++ b/spec/presenters/hyrax/file_usage_spec.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
-RSpec.describe Hyrax::FileUsage, type: :model do
+# NOTE: This presenter is currently utilizing multiple classes that are solely focused on ActiveFedora objects and classes. 
+#   This class, as well as others involving Statistics and Analytics should be Valkyrized in the future.
+RSpec.describe Hyrax::FileUsage, :active_fedora, type: :model do
   let(:user) { build(:user) }
   let(:file) do
     create(:file_set, user: user)


### PR DESCRIPTION
### Fixes

Fixes `spec/presenters/hyrax/file_usage_spec.rb`.

### Summary

Marks test suite as ActiveFedora-only, since presenter calls to multiple classes not Valkyrized.

### Type of change (for release notes)

- `notes-valkyrie` Valkyrie Progress

@samvera/hyrax-code-reviewers
