### PR TITLE
Valkyrization: Fix failing tests in changes_required_notification_spec.rb

### DIFF
--- a/lib/wings/active_fedora_converter.rb
+++ b/lib/wings/active_fedora_converter.rb
@@ -93,7 +93,7 @@ module Wings
     # then the id hasn't been minted and shouldn't yet be set.
     # @return [String]
     def id
-      return resource[:id].to_s if resource[:id].present? && resource[:id]&.is_a?(::Valkyrie::ID)
+      return resource.id.to_s if resource.id.present? && resource.id&.is_a?(::Valkyrie::ID)
       return "" unless resource.respond_to?(:alternate_ids)
 
       resource.alternate_ids.first.to_s

--- a/spec/services/hyrax/workflow/changes_required_notification_spec.rb
+++ b/spec/services/hyrax/workflow/changes_required_notification_spec.rb
@@ -4,8 +4,8 @@ RSpec.describe Hyrax::Workflow::ChangesRequiredNotification do
   let(:depositor) { FactoryBot.create(:user) }
   let(:to_user) { FactoryBot.create(:user) }
   let(:cc_user) { FactoryBot.create(:user) }
-  let(:work) { FactoryBot.create(:work, user: depositor) }
-  let(:entity) { FactoryBot.create(:sipity_entity, proxy_for_global_id: work.to_global_id) }
+  let(:work) { FactoryBot.valkyrie_create(:work, depositor: depositor.user_key) }
+  let(:entity) { FactoryBot.create(:sipity_entity, proxy_for_global_id: Hyrax::GlobalID(work).to_s) }
   let(:comment) { double("comment", comment: 'A pleasant read') }
   let(:recipients) { { 'to' => [to_user], 'cc' => [cc_user] } }
 

--- a/spec/services/hyrax/workflow/changes_required_notification_spec.rb
+++ b/spec/services/hyrax/workflow/changes_required_notification_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Hyrax::Workflow::ChangesRequiredNotification do
   let(:depositor) { FactoryBot.create(:user) }
   let(:to_user) { FactoryBot.create(:user) }
   let(:cc_user) { FactoryBot.create(:user) }
-  let(:work) { FactoryBot.valkyrie_create(:work, depositor: depositor.user_key) }
+  let(:work) { FactoryBot.valkyrie_create(:monograph, depositor: depositor.user_key, title: 'Test title') }
   let(:entity) { FactoryBot.create(:sipity_entity, proxy_for_global_id: Hyrax::GlobalID(work).to_s) }
   let(:comment) { double("comment", comment: 'A pleasant read') }
   let(:recipients) { { 'to' => [to_user], 'cc' => [cc_user] } }
@@ -14,7 +14,7 @@ RSpec.describe Hyrax::Workflow::ChangesRequiredNotification do
       expect(approver)
         .to receive(:send_message)
         .with(anything,
-              "Test title (<a href=\"/concern/generic_works/#{work.id}\">#{work.id}</a>) " \
+              "Test title (<a href=\"/concern/monographs/#{work.id}\">#{work.id}</a>) " \
               "requires additional changes before approval.\n 'A pleasant read'",
               anything)
         .exactly(3)


### PR DESCRIPTION
### Fixes

Fix failing tests in `spec/services/hyrax/workflow/changes_required_notification_spec.rb` for Koppie

### Type of change (for release notes)

- `notes-valkyrie` Valkyrie Progress

### Changes proposed in this pull request:
* Make work and entity creation compatible with Valkyrie

@samvera/hyrax-code-reviewers
