### PR TITLE
Valkyrization: Fix failing tests in `spec/lib/hyrax/analytics_spec.rb`

### DIFF
--- a/.koppie/config/analytics.yml
+++ b/.koppie/config/analytics.yml
@@ -1,12 +1,12 @@
 analytics:
   google:
     analytics_id: <%= ENV['GOOGLE_ANALYTICS_ID'] %>
-    app_name: <%= ENV.fetch('GOOGLE_OAUTH_APP_NAME', 'nurax-pg') %>
-    app_version: <%= ENV.fetch['GOOGLE_OAUTH_APP_VERSION'] %>
+    app_name: <%= ENV['GOOGLE_OAUTH_APP_NAME'] %>
+    app_version: <%= ENV['GOOGLE_OAUTH_APP_VERSION'] %>
     privkey_value: <%= ENV['GOOGLE_OAUTH_PRIVATE_KEY_VALUE'] %>
-    privkey_path: <%= ENV.fetch['GOOGLE_OAUTH_PRIVATE_KEY_PATH'] %>
-    privkey_secret: <%= ENV.fetch['GOOGLE_OAUTH_PRIVATE_KEY_SECRET'] %>
-    client_email: <%= ENV.fetch['GOOGLE_OAUTH_CLIENT_EMAIL'] %>
+    privkey_path: <%= ENV['GOOGLE_OAUTH_PRIVATE_KEY_PATH'] %>
+    privkey_secret: <%= ENV['GOOGLE_OAUTH_PRIVATE_KEY_SECRET'] %>
+    client_email: <%= ENV['GOOGLE_OAUTH_CLIENT_EMAIL'] %>
   matomo:
     base_url: <%= ENV['MATOMO_BASE_URL'] %>
     site_id: <%= ENV['MATOMO_SITE_ID'] %>


### PR DESCRIPTION
### Fixes

Fix failing tests in `spec/lib/hyrax/analytics_spec.rb` for Koppie

### Summary

I fixed errors in `.koppie/config/analytics.yml` such as:

```yml
privkey_path: <%= ENV.fetch['GOOGLE_OAUTH_PRIVATE_KEY_PATH'] %>
```

The `fetch` method is used with square brackets instead of open parenthesis. I changed the `analytics.yml` file for Koppie to match that of Dassie.

### Type of change (for release notes)

- `notes-valkyrie` Valkyrie Progress

### Changes proposed in this pull request:
* Use the same `analytics.yml` config for both Dassie and Koppie
*
*

@samvera/hyrax-code-reviewers
