### PR TITLE
Adds active_fedora tag to AF-specific tests in transfers_controller_spec.

### DIFF
--- a/spec/controllers/hyrax/transfers_controller_spec.rb
+++ b/spec/controllers/hyrax/transfers_controller_spec.rb
@@ -27,37 +27,33 @@ RSpec.describe Hyrax::TransfersController, type: :controller do
       end
     end
 
-    describe "#new" do
-      let(:work) { create(:work, user: user) }
-
-      context 'when user is the depositor' do
-        it "is successful" do
-          expect(controller).to receive(:add_breadcrumb).exactly(3).times
-          sign_in user
-          get :new, params: { id: work.id }
-          expect(response).to be_successful
-          expect(assigns[:proxy_deposit_request]).to be_kind_of ProxyDepositRequest
-          expect(assigns[:proxy_deposit_request].work_id).to eq(work.id)
-        end
-      end
-
-      context 'with work resource' do
-        let(:work) { FactoryBot.valkyrie_create(:hyrax_work, depositor: user.user_key, edit_users: [user]) }
-
-        it "is successful" do
-          expect(controller).to receive(:add_breadcrumb).exactly(3).times
-          sign_in user
-          get :new, params: { id: work.id }
-          expect(response).to be_successful
-          expect(assigns[:proxy_deposit_request]).to be_kind_of ProxyDepositRequest
-          expect(assigns[:proxy_deposit_request].work_id).to eq(work.id)
-        end
+    shared_examples('loading #new action is successful') do
+      it "is successful" do
+        expect(controller).to receive(:add_breadcrumb).exactly(3).times
+        sign_in user
+        get :new, params: { id: work.id }
+        expect(response).to be_successful
+        expect(assigns[:proxy_deposit_request]).to be_kind_of ProxyDepositRequest
+        expect(assigns[:proxy_deposit_request].work_id).to eq(work.id)
       end
     end
 
-    describe "#create" do
-      let(:work) { create(:work, user: user) }
+    describe "#new" do
+      context 'with Active Fedora objects', :active_fedora do
+        let(:work) { create(:work, user: user) }
 
+        context 'when user is the depositor' do
+          include_examples 'loading #new action is successful'
+        end
+      end
+      context 'with work resource' do
+        let(:work) { FactoryBot.valkyrie_create(:hyrax_work, depositor: user.user_key, edit_users: [user]) }
+
+        include_examples 'loading #new action is successful'
+      end
+    end
+
+    shared_examples('common tests for #create') do
       it "is successful" do
         expect do
           post :create, params: {
@@ -88,104 +84,118 @@ RSpec.describe Hyrax::TransfersController, type: :controller do
         expect(assigns[:proxy_deposit_request].errors[:transfer_to]).to eq(['Must be an existing user'])
         expect(response).to be_successful
       end
+    end
 
+    describe "#create" do
+      context 'with Active Fedora objects', :active_fedora do
+        let(:work) { create(:work, user: user) }
+
+        include_examples 'common tests for #create'
+      end
       context 'with work resource' do
         let(:work) { FactoryBot.valkyrie_create(:hyrax_work, depositor: user.user_key, edit_users: [user]) }
 
-        it "is successful" do
-          expect do
-            post :create, params: {
-              id: work.id,
-              proxy_deposit_request: {
-                transfer_to: another_user.user_key,
-                sender_comment: 'Hi mom!'
-              }
-            }
-          end.to change(ProxyDepositRequest, :count).by(1)
-          expect(response).to redirect_to routes.url_helpers.transfers_path(locale: 'en')
-          expect(flash[:notice]).to eq('Transfer request created')
-          proxy_request = another_user.proxy_deposit_requests.first
-          expect(proxy_request.work_id).to eq(work.id)
-          expect(proxy_request.sending_user).to eq(user)
-          expect(proxy_request.sender_comment).to eq 'Hi mom!'
-          # AND A NOTIFICATION SHOULD HAVE BEEN CREATED
-          notification = another_user.reload.mailbox.inbox[0].messages[0]
-          expect(notification.subject).to eq("Ownership Change Request")
-          expect(notification.body).to eq("<a href=\"#{routes.url_helpers.user_path(user)}\">#{user.name}</a> " \
-                  "wants to transfer a work to you. Review all " \
-                  "<a href=\"#{routes.url_helpers.transfers_path}\">transfer requests</a>")
-        end
-        it "gives an error if the user is not found" do
-          expect do
-            post :create, params: { id: work.id, proxy_deposit_request: { transfer_to: 'foo' } }
-          end.not_to change(ProxyDepositRequest, :count)
-          expect(assigns[:proxy_deposit_request].errors[:transfer_to]).to eq(['Must be an existing user'])
-          expect(response).to be_successful
+        include_examples 'common tests for #create'
+      end
+    end
+
+    shared_context('with AF work with secondary depositor') do
+      let!(:incoming_work) do
+        GenericWork.new(title: ['incoming']) do |w|
+          w.apply_depositor_metadata(another_user.user_key)
+          w.save!
+          w.request_transfer_to(user)
         end
       end
     end
 
+    shared_context('with AF work with primary depositor') do
+      let!(:incoming_work) do
+        GenericWork.new(title: ['incoming']) do |w|
+          w.apply_depositor_metadata(user.user_key)
+          w.save!
+          w.request_transfer_to(another_user)
+        end
+      end
+    end
+
+    shared_context('with Valkyrie work with primary depositor') do
+      let(:work) { FactoryBot.valkyrie_create(:monograph, title: ['incoming'], depositor: user.user_key, edit_users: [user]) }
+      let!(:proxy_request) { ProxyDepositRequest.create!(work_id: work.id, receiving_user: another_user, sending_user: user) }
+    end
+
+    shared_context('with Valkyrie work with secondary depositor') do
+      let(:work) { FactoryBot.valkyrie_create(:monograph, title: ['incoming'], depositor: another_user.user_key, edit_users: [another_user]) }
+      let!(:proxy_request) { ProxyDepositRequest.create!(work_id: work.id, receiving_user: user, sending_user: another_user) }
+    end
+
+    def common_response_tests
+      expect(response).to redirect_to routes.url_helpers.transfers_path(locale: 'en')
+      expect(flash[:notice]).to eq("Transfer complete")
+      expect(assigns[:proxy_deposit_request].status).to eq('accepted')
+    end
+
+    shared_examples('common tests for #accept') do
+      it "is successful when retaining access rights" do
+        put :accept, params: { id: user.proxy_deposit_requests.first }
+        common_response_tests
+      end
+
+      it "is successful when resetting access rights" do
+        put :accept, params: { id: user.proxy_deposit_requests.first, reset: true }
+        common_response_tests
+      end
+
+      it "handles sticky requests" do
+        put :accept, params: { id: user.proxy_deposit_requests.first, sticky: true }
+        common_response_tests
+        expect(user.can_receive_deposits_from).to include(another_user)
+      end
+    end
+
+    shared_examples('does not allow other user in #accept') do
+      it "does not allow me" do
+        put :accept, params: { id: another_user.proxy_deposit_requests.first }
+        expect(response).to redirect_to root_path
+        expect(flash[:alert]).to eq("You are not authorized to access this page.")
+      end
+    end
+
     describe "#accept" do
-      context "when I am the receiver" do
-        let!(:incoming_work) do
-          GenericWork.new(title: ['incoming']) do |w|
-            w.apply_depositor_metadata(another_user.user_key)
-            w.save!
-            w.request_transfer_to(user)
+      context 'with Active Fedora objects', :active_fedora do
+        context "when I am the receiver" do
+          include_context 'with AF work with secondary depositor'
+
+          include_examples 'common tests for #accept'
+
+          it "is successful when retaining access rights (ActiveFedora specific)" do
+            put :accept, params: { id: user.proxy_deposit_requests.first }
+            expect(incoming_work.reload.edit_users).to match_array [another_user.user_key, user.user_key]
+          end
+
+          it "is successful when resetting access rights (ActiveFedora specific)" do
+            put :accept, params: { id: user.proxy_deposit_requests.first, reset: true }
+            expect(incoming_work.reload.edit_users).to eq([user.user_key])
+          end
+
+          context "already received sticky proxy" do
+            before do
+              user.can_receive_deposits_from << another_user
+            end
+            it "handles sticky requests and does not add another user" do
+              put :accept, params: { id: user.proxy_deposit_requests.first, sticky: true }
+              common_response_tests
+              expect(user.can_receive_deposits_from.to_a.count(another_user)).to eq 1
+            end
           end
         end
 
-        it "is successful when retaining access rights" do
-          put :accept, params: { id: user.proxy_deposit_requests.first }
-          expect(response).to redirect_to routes.url_helpers.transfers_path(locale: 'en')
-          expect(flash[:notice]).to eq("Transfer complete")
-          expect(assigns[:proxy_deposit_request].status).to eq('accepted')
-          expect(incoming_work.reload.edit_users).to match_array [another_user.user_key, user.user_key]
-        end
-        it "is successful when resetting access rights" do
-          put :accept, params: { id: user.proxy_deposit_requests.first, reset: true }
-          expect(response).to redirect_to routes.url_helpers.transfers_path(locale: 'en')
-          expect(flash[:notice]).to eq("Transfer complete")
-          expect(assigns[:proxy_deposit_request].status).to eq('accepted')
-          expect(incoming_work.reload.edit_users).to eq([user.user_key])
-        end
-        it "handles sticky requests" do
-          put :accept, params: { id: user.proxy_deposit_requests.first, sticky: true }
-          expect(response).to redirect_to routes.url_helpers.transfers_path(locale: 'en')
-          expect(flash[:notice]).to eq("Transfer complete")
-          expect(assigns[:proxy_deposit_request].status).to eq('accepted')
-          expect(user.can_receive_deposits_from).to include(another_user)
-        end
-        context "already received sticky proxy" do
-          before do
-            user.can_receive_deposits_from << another_user
-          end
-          it "handles sticky requests and does not add another user" do
-            put :accept, params: { id: user.proxy_deposit_requests.first, sticky: true }
-            expect(response).to redirect_to routes.url_helpers.transfers_path(locale: 'en')
-            expect(flash[:notice]).to eq("Transfer complete")
-            expect(assigns[:proxy_deposit_request].status).to eq('accepted')
-            expect(user.can_receive_deposits_from.to_a.count(another_user)).to eq 1
-          end
+        context "accepting one that isn't mine" do
+          include_context 'with AF work with primary depositor'
+
+          include_examples 'does not allow other user in #accept'
         end
       end
-
-      context "accepting one that isn't mine" do
-        let!(:incoming_work) do
-          GenericWork.new(title: ['incoming']) do |w|
-            w.apply_depositor_metadata(user.user_key)
-            w.save!
-            w.request_transfer_to(another_user)
-          end
-        end
-
-        it "does not allow me" do
-          put :accept, params: { id: another_user.proxy_deposit_requests.first }
-          expect(response).to redirect_to root_path
-          expect(flash[:alert]).to eq("You are not authorized to access this page.")
-        end
-      end
-
       context 'with work resource' do
         around do |example|
           @query_class = ProxyDepositRequest.work_query_service_class
@@ -195,158 +205,122 @@ RSpec.describe Hyrax::TransfersController, type: :controller do
         end
 
         context "when I am the receiver" do
-          let(:work) { FactoryBot.valkyrie_create(:monograph, title: ['incoming'], depositor: another_user.user_key, edit_users: [another_user]) }
-          let!(:proxy_request) { ProxyDepositRequest.create!(work_id: work.id, receiving_user: user, sending_user: another_user) }
+          include_context 'with Valkyrie work with secondary depositor'
 
-          it "is successful when retaining access rights" do
+          include_examples 'common tests for #accept'
+
+          it "is successful when retaining access rights (Valkyrie specific)" do
             put :accept, params: { id: user.proxy_deposit_requests.first }
-            expect(response).to redirect_to routes.url_helpers.transfers_path(locale: 'en')
-            expect(flash[:notice]).to eq("Transfer complete")
-            expect(assigns[:proxy_deposit_request].status).to eq('accepted')
             expect(Hyrax.query_service.find_by(id: work.id).edit_users).to match_array [another_user.user_key, user.user_key]
           end
-          it "is successful when resetting access rights" do
+          it "is successful when resetting access rights (Valkyrie specific)" do
             put :accept, params: { id: user.proxy_deposit_requests.first, reset: true }
-            expect(response).to redirect_to routes.url_helpers.transfers_path(locale: 'en')
-            expect(flash[:notice]).to eq("Transfer complete")
-            expect(assigns[:proxy_deposit_request].status).to eq('accepted')
             expect(Hyrax.query_service.find_by(id: work.id).edit_users).to match_array [user.user_key]
-          end
-          it "handles sticky requests" do
-            put :accept, params: { id: user.proxy_deposit_requests.first, sticky: true }
-            expect(response).to redirect_to routes.url_helpers.transfers_path(locale: 'en')
-            expect(flash[:notice]).to eq("Transfer complete")
-            expect(assigns[:proxy_deposit_request].status).to eq('accepted')
-            expect(user.can_receive_deposits_from).to include(another_user)
           end
         end
 
         context "accepting one that isn't mine" do
-          let(:work) { FactoryBot.valkyrie_create(:monograph, title: ['incoming'], depositor: user.user_key, edit_users: [user]) }
-          let!(:proxy_request) { ProxyDepositRequest.create!(work_id: work.id, receiving_user: another_user, sending_user: user) }
+          include_context 'with Valkyrie work with primary depositor'
 
-          it "does not allow me" do
-            put :accept, params: { id: another_user.proxy_deposit_requests.first }
-            expect(response).to redirect_to root_path
-            expect(flash[:alert]).to eq("You are not authorized to access this page.")
-          end
+          include_examples 'does not allow other user in #accept'
         end
       end
     end
 
+    def common_redirect_tests
+      expect(response).to redirect_to root_path
+      expect(flash[:alert]).to eq("You are not authorized to access this page.")
+    end
+
+    def common_rejection_tests
+      expect(response).to redirect_to routes.url_helpers.transfers_path(locale: 'en')
+      expect(flash[:notice]).to eq("Transfer rejected")
+      expect(assigns[:proxy_deposit_request].status).to eq('rejected')
+    end
+
     describe "#reject" do
-      context "when I am the receiver" do
-        let!(:incoming_work) do
-          GenericWork.new(title: ['incoming']) do |w|
-            w.apply_depositor_metadata(another_user.user_key)
-            w.save!
-            w.request_transfer_to(user)
+      context 'with Active Fedora objects', :active_fedora do
+        context "when I am the receiver" do
+          include_context 'with AF work with secondary depositor'
+
+          it "is successful" do
+            put :reject, params: { id: user.proxy_deposit_requests.first }
+            common_rejection_tests
           end
         end
 
-        it "is successful" do
-          put :reject, params: { id: user.proxy_deposit_requests.first }
-          expect(response).to redirect_to routes.url_helpers.transfers_path(locale: 'en')
-          expect(flash[:notice]).to eq("Transfer rejected")
-          expect(assigns[:proxy_deposit_request].status).to eq('rejected')
-        end
-      end
+        context "accepting one that isn't mine" do
+          include_context 'with AF work with primary depositor'
 
-      context "accepting one that isn't mine" do
-        let!(:incoming_work) do
-          GenericWork.new(title: ['incoming']) do |w|
-            w.apply_depositor_metadata(user.user_key)
-            w.save!
-            w.request_transfer_to(another_user)
+          it "does not allow me" do
+            put :reject, params: { id: another_user.proxy_deposit_requests.first }
+            common_redirect_tests
           end
-        end
-
-        it "does not allow me" do
-          put :reject, params: { id: another_user.proxy_deposit_requests.first }
-          expect(response).to redirect_to root_path
-          expect(flash[:alert]).to eq("You are not authorized to access this page.")
         end
       end
 
       context 'with work resource' do
         context "when I am the receiver" do
-          let(:work) { FactoryBot.valkyrie_create(:monograph, title: ['incoming'], depositor: another_user.user_key, edit_users: [another_user]) }
-          let!(:proxy_request) { ProxyDepositRequest.create!(work_id: work.id, receiving_user: user, sending_user: another_user) }
+          include_context 'with Valkyrie work with secondary depositor'
 
           it "is successful" do
             put :reject, params: { id: user.proxy_deposit_requests.first }
-            expect(response).to redirect_to routes.url_helpers.transfers_path(locale: 'en')
-            expect(flash[:notice]).to eq("Transfer rejected")
-            expect(assigns[:proxy_deposit_request].status).to eq('rejected')
+            common_rejection_tests
           end
         end
 
         context "accepting one that isn't mine" do
-          let(:work) { FactoryBot.valkyrie_create(:monograph, title: ['incoming'], depositor: user.user_key, edit_users: [user]) }
-          let!(:proxy_request) { ProxyDepositRequest.create!(work_id: work.id, receiving_user: another_user, sending_user: user) }
+          include_context 'with Valkyrie work with primary depositor'
 
           it "does not allow me" do
             put :reject, params: { id: another_user.proxy_deposit_requests.first }
-            expect(response).to redirect_to root_path
-            expect(flash[:alert]).to eq("You are not authorized to access this page.")
+            common_redirect_tests
           end
         end
       end
     end
 
+    def common_cancellation_tests
+      expect(response).to redirect_to routes.url_helpers.transfers_path(locale: 'en')
+      expect(flash[:notice]).to eq("Transfer canceled")
+    end
+
     describe "#destroy" do
-      context "when I am the sender" do
-        let!(:incoming_work) do
-          GenericWork.new(title: ['incoming']) do |w|
-            w.apply_depositor_metadata(user.user_key)
-            w.save!
-            w.request_transfer_to(another_user)
-          end
-        end
-
-        it "is successful" do
-          delete :destroy, params: { id: another_user.proxy_deposit_requests.first }
-          expect(response).to redirect_to routes.url_helpers.transfers_path(locale: 'en')
-          expect(flash[:notice]).to eq("Transfer canceled")
-        end
-      end
-
-      context "accepting one that isn't mine" do
-        let!(:incoming_work) do
-          GenericWork.new(title: ['incoming']) do |w|
-            w.apply_depositor_metadata(another_user.user_key)
-            w.save!
-            w.request_transfer_to(user)
-          end
-        end
-
-        it "does not allow me" do
-          delete :destroy, params: { id: user.proxy_deposit_requests.first }
-          expect(response).to redirect_to root_path
-          expect(flash[:alert]).to eq("You are not authorized to access this page.")
-        end
-      end
-
-      context 'with work resource' do
+      context 'with Active Fedora objects', :active_fedora do
         context "when I am the sender" do
-          let(:work) { FactoryBot.valkyrie_create(:monograph, title: ['incoming'], depositor: user.user_key, edit_users: [user]) }
-          let!(:proxy_request) { ProxyDepositRequest.create!(work_id: work.id, receiving_user: another_user, sending_user: user) }
+          include_context 'with AF work with primary depositor'
 
           it "is successful" do
             delete :destroy, params: { id: another_user.proxy_deposit_requests.first }
-            expect(response).to redirect_to routes.url_helpers.transfers_path(locale: 'en')
-            expect(flash[:notice]).to eq("Transfer canceled")
+            common_cancellation_tests
           end
         end
 
         context "accepting one that isn't mine" do
-          let(:work) { FactoryBot.valkyrie_create(:monograph, title: ['incoming'], depositor: another_user.user_key, edit_users: [another_user]) }
-          let!(:proxy_request) { ProxyDepositRequest.create!(work_id: work.id, receiving_user: user, sending_user: another_user) }
+          include_context 'with AF work with secondary depositor'
 
           it "does not allow me" do
             delete :destroy, params: { id: user.proxy_deposit_requests.first }
-            expect(response).to redirect_to root_path
-            expect(flash[:alert]).to eq("You are not authorized to access this page.")
+            common_redirect_tests
+          end
+        end
+      end
+      context 'with work resource' do
+        context "when I am the sender" do
+          include_context 'with Valkyrie work with primary depositor'
+
+          it "is successful" do
+            delete :destroy, params: { id: another_user.proxy_deposit_requests.first }
+            common_cancellation_tests
+          end
+        end
+
+        context "accepting one that isn't mine" do
+          include_context 'with Valkyrie work with secondary depositor'
+
+          it "does not allow me" do
+            delete :destroy, params: { id: user.proxy_deposit_requests.first }
+            common_redirect_tests
           end
         end
       end


### PR DESCRIPTION
### Fixes

Fixes `spec/controllers/hyrax/transfers_controller_spec.rb`.

### Summary

Adds active_fedora tag to AF-specific tests in transfers_controller_spec.

### Type of change (for release notes)

- `notes-valkyrie` Valkyrie Progress

### Changes proposed in this pull request:
* Groups and tags ActiceFedora specific tests.
* Refactors suite to throw repetitive code into `shared_examples`, `shared_context`, and methods.

@samvera/hyrax-code-reviewers
