### PR TITLE
Valkyrization: Fix failing tests in `admin_set_member_service_spec.rb`

### DIFF
--- a/spec/services/hyrax/admin_set_member_service_spec.rb
+++ b/spec/services/hyrax/admin_set_member_service_spec.rb
@@ -1,14 +1,14 @@
 # frozen_string_literal: true
 RSpec.describe Hyrax::AdminSetMemberService, clean_repo: true do
   subject(:builder) { described_class.new(scope: scope, collection: admin_set, params: { "id" => admin_set.id.to_s }) }
-  let(:admin_set) { FactoryBot.build(:admin_set) }
+  let(:admin_set) { valkyrie_create(:hyrax_admin_set) }
   let(:scope) { FakeSearchBuilderScope.new(current_ability: Ability.new(user)) }
   let(:user) { FactoryBot.create(:admin) }
 
   describe '#available_member_works' do
-    let!(:work1) { FactoryBot.create(:generic_work, admin_set: admin_set) }
-    let!(:work2) { FactoryBot.create(:generic_work) }
-    let!(:work3) { FactoryBot.create(:generic_work, admin_set: admin_set) }
+    let!(:work1) { valkyrie_create(:monograph, admin_set_id: admin_set.id) }
+    let!(:work2) { valkyrie_create(:monograph) }
+    let!(:work3) { valkyrie_create(:monograph, admin_set_id: admin_set.id) }
 
     it 'returns the members of the admin set' do
       expect(builder.available_member_works.response[:docs])


### PR DESCRIPTION
### Fixes

Fix failing tests in `spec/services/hyrax/admin_set_member_service_spec.rb` for Koppie

### Type of change (for release notes)

- `notes-valkyrie` Valkyrie Progress

### Changes proposed in this pull request:
* Use `valkyrie_create` to create the admin set and works in the tests
*
*

@samvera/hyrax-code-reviewers
