### PR TITLE
Valkyriztion: Fix failing tests in `grant_edit_job_spec.rb`

### DIFF
--- a/spec/jobs/hyrax/grant_edit_job_spec.rb
+++ b/spec/jobs/hyrax/grant_edit_job_spec.rb
@@ -2,7 +2,7 @@
 RSpec.describe Hyrax::GrantEditJob do
   let(:depositor) { create(:user) }
 
-  context "when use_valkyrie is false" do
+  context "when use_valkyrie is false", :active_fedora do
     let(:file_set) { create(:file_set) }
 
     it 'grants a user edit access to a FileSet' do


### PR DESCRIPTION
### Fixes

Fix failing tests in `spec/jobs/hyrax/grant_edit_job_spec.rb` for Koppie

### Type of change (for release notes)

- `notes-valkyrie` Valkyrie Progress

### Changes proposed in this pull request:
* Mark tests as `:active_fedora` only when Valkyrie is not used
*

@samvera/hyrax-code-reviewers
