### PR TITLE
Valkyrization: Fix failing tests in `change_depositor_event_job_spec.rb`

### DIFF
--- a/spec/jobs/change_depositor_event_job_spec.rb
+++ b/spec/jobs/change_depositor_event_job_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe ChangeDepositorEventJob do
     allow(Time).to receive(:now).at_least(:once).and_return(mock_time)
   end
 
-  context "when passing an ActiveFedora work" do
+  context "when passing an ActiveFedora work", :active_fedora do
     let(:generic_work) { create(:generic_work, title: ['BethsMac'], user: new_user, proxy_depositor: previous_user.user_key) }
 
     it "logs the event to the proxy depositor's profile, the depositor's dashboard, and the FileSet" do


### PR DESCRIPTION
### Fixes

Fix failing tests in `spec/jobs/change_depositor_event_job_spec.rb` for Koppie

### Type of change (for release notes)

- `notes-valkyrie` Valkyrie Progress

### Changes proposed in this pull request:
* Mark tests as `:active_fedora` only when Valkyrie is not used

@samvera/hyrax-code-reviewers
