### PR TITLE
Support all PCDM terms in `Hyrax::FileMetadata::Use`

### DIFF
--- a/app/actors/hyrax/actors/file_actor.rb
+++ b/app/actors/hyrax/actors/file_actor.rb
@@ -80,7 +80,7 @@ module Hyrax
           :original_file
         when Hyrax::FileMetadata::Use::EXTRACTED_TEXT
           :extracted_file
-        when Hyrax::FileMetadata::Use::THUMBNAIL
+        when Hyrax::FileMetadata::Use::THUMBNAIL_IMAGE
           :thumbnail_file
         else
           :original_file

--- a/app/models/hyrax/file_metadata.rb
+++ b/app/models/hyrax/file_metadata.rb
@@ -32,28 +32,39 @@ module Hyrax
     # Constants for PCDM Use URIs; use these constants in place of hard-coded
     # URIs in the `::Valkyrie::Vocab::PCDMUse` vocabulary.
     module Use
-      ORIGINAL_FILE = ::Valkyrie::Vocab::PCDMUse.OriginalFile
       EXTRACTED_TEXT = ::Valkyrie::Vocab::PCDMUse.ExtractedText
-      THUMBNAIL = ::Valkyrie::Vocab::PCDMUse.ThumbnailImage
+      INTERMEDIATE_FILE = ::Valkyrie::Vocab::PCDMUse.IntermediateFile
+      ORIGINAL_FILE = ::Valkyrie::Vocab::PCDMUse.OriginalFile
+      PRESERVATION_FILE = ::Valkyrie::Vocab::PCDMUse.PreservationFile
       SERVICE_FILE = ::Valkyrie::Vocab::PCDMUse.ServiceFile
+      THUMBNAIL_IMAGE = ::Valkyrie::Vocab::PCDMUse.ThumbnailImage
+      TRANSCRIPT = ::Valkyrie::Vocab::PCDMUse.Transcript
+
+      THUMBNAIL = ::Valkyrie::Vocab::PCDMUse.ThumbnailImage # for compatibility with earlier versions of Hyrax; prefer +THUMBNAIL_IMAGE+
 
       ##
       # @param use [RDF::URI, Symbol]
       #
       # @return [RDF::URI]
       # @raise [ArgumentError] if no use is known for the argument
-      def uri_for(use:)
+      def uri_for(use:) # rubocop:disable Metrics/MethodLength
         case use
         when RDF::URI
           use
-        when :original_file
-          ORIGINAL_FILE
         when :extracted_file
           EXTRACTED_TEXT
-        when :thumbnail_file
-          THUMBNAIL
+        when :intermediate_file
+          INTERMEDIATE_FILE
+        when :original_file
+          ORIGINAL_FILE
+        when :preservation_file
+          PRESERVATION_FILE
         when :service_file
           SERVICE_FILE
+        when :thumbnail_file
+          THUMBNAIL_IMAGE
+        when :transcript_file
+          TRANSCRIPT
         else
           raise ArgumentError, "No PCDM use is recognized for #{use}"
         end

--- a/app/models/hyrax/file_metadata.rb
+++ b/app/models/hyrax/file_metadata.rb
@@ -149,7 +149,7 @@ module Hyrax
     ##
     # @return [Boolean]
     def thumbnail_file?
-      pcdm_use.include?(Use::THUMBNAIL)
+      pcdm_use.include?(Use::THUMBNAIL_IMAGE)
     end
 
     ##

--- a/app/services/hyrax/custom_queries/navigators/find_files.rb
+++ b/app/services/hyrax/custom_queries/navigators/find_files.rb
@@ -65,7 +65,7 @@ module Hyrax
         def find_thumbnail(file_set:)
           find_exactly_one_file_by_use(
             file_set: file_set,
-            use: Hyrax::FileMetadata::Use::THUMBNAIL
+            use: Hyrax::FileMetadata::Use::THUMBNAIL_IMAGE
           )
         end
 

--- a/app/services/hyrax/valkyrie_persist_derivatives.rb
+++ b/app/services/hyrax/valkyrie_persist_derivatives.rb
@@ -59,7 +59,7 @@ module Hyrax
       if directives.key?(:container)
         "Hyrax::FileMetadata::Use::#{directives[:container].upcase}".constantize
       else
-        Hyrax::FileMetadata::Use::THUMBNAIL
+        Hyrax::FileMetadata::Use::THUMBNAIL_IMAGE
       end
     end
   end

--- a/spec/indexers/hyrax/indexers/file_set_indexer_spec.rb
+++ b/spec/indexers/hyrax/indexers/file_set_indexer_spec.rb
@@ -115,7 +115,7 @@ RSpec.describe Hyrax::Indexers::FileSetIndexer, if: Hyrax.config.use_valkyrie? d
     Hyrax::FileMetadata.new(
       id: SecureRandom.uuid,
       file_set_id: fileset_id,
-      type: [Hyrax::FileMetadata::Use::THUMBNAIL]
+      type: [Hyrax::FileMetadata::Use::THUMBNAIL_IMAGE]
     )
   end
 

--- a/spec/jobs/valkyrie_ingest_job_spec.rb
+++ b/spec/jobs/valkyrie_ingest_job_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe ValkyrieIngestJob do
 
       it 'adds an original_file file to the file_set' do
         described_class.perform_now(upload)
-        described_class.perform_now(thumbnail_upload, pcdm_use: Hyrax::FileMetadata::Use::THUMBNAIL)
+        described_class.perform_now(thumbnail_upload, pcdm_use: Hyrax::FileMetadata::Use::THUMBNAIL_IMAGE)
 
         reloaded_file_set = Hyrax.query_service.find_by(id: file_set.id)
         files = Hyrax.custom_queries.find_files(file_set: reloaded_file_set)

--- a/spec/models/hyrax/file_metadata_spec.rb
+++ b/spec/models/hyrax/file_metadata_spec.rb
@@ -90,7 +90,7 @@ RSpec.describe Hyrax::FileMetadata do
 
     context 'when use does not say file is the original file' do
       before do
-        file_metadata.pcdm_use = [described_class::Use::THUMBNAIL, pcdm_file_uri]
+        file_metadata.pcdm_use = [described_class::Use::THUMBNAIL_IMAGE, pcdm_file_uri]
       end
 
       it { is_expected.not_to be_original_file }
@@ -100,7 +100,7 @@ RSpec.describe Hyrax::FileMetadata do
   describe '#thumbnail_file?' do
     context 'when use says file is the thumbnail file' do
       before do
-        file_metadata.pcdm_use = [described_class::Use::THUMBNAIL, pcdm_file_uri]
+        file_metadata.pcdm_use = [described_class::Use::THUMBNAIL_IMAGE, pcdm_file_uri]
       end
 
       it { is_expected.to be_thumbnail_file }

--- a/spec/services/hyrax/listeners/file_metadata_listener_spec.rb
+++ b/spec/services/hyrax/listeners/file_metadata_listener_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe Hyrax::Listeners::FileMetadataListener, valkyrie_adapter: :test_a
       let(:metadata) do
         FactoryBot.valkyrie_create(:hyrax_file_metadata,
                                    file_set_id: file_set.id,
-                                   pcdm_use: Hyrax::FileMetadata::Use::THUMBNAIL)
+                                   pcdm_use: Hyrax::FileMetadata::Use::THUMBNAIL_IMAGE)
       end
 
       it 'does not index the file_set' do

--- a/spec/wings/hydra/works/services/add_file_to_file_set_spec.rb
+++ b/spec/wings/hydra/works/services/add_file_to_file_set_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Wings::Works::AddFileToFileSet, :active_fedora, :clean_repo do
 
   let(:original_file_use)  { Hyrax::FileMetadata::Use::ORIGINAL_FILE }
   let(:extracted_text_use) { Hyrax::FileMetadata::Use::EXTRACTED_TEXT }
-  let(:thumbnail_use)      { Hyrax::FileMetadata::Use::THUMBNAIL }
+  let(:thumbnail_use)      { Hyrax::FileMetadata::Use::THUMBNAIL_IMAGE }
 
   let(:pdf_filename)  { 'sample-file.pdf' }
   let(:pdf_mimetype)  { 'application/pdf' }

--- a/spec/wings/services/custom_queries/find_file_metadata_spec.rb
+++ b/spec/wings/services/custom_queries/find_file_metadata_spec.rb
@@ -154,7 +154,7 @@ RSpec.describe Wings::CustomQueries::FindFileMetadata, :active_fedora, :clean_re
 
     let(:original_file_use)  { Hyrax::FileMetadata::Use::ORIGINAL_FILE }
     let(:extracted_text_use) { Hyrax::FileMetadata::Use::EXTRACTED_TEXT }
-    let(:thumbnail_use)      { Hyrax::FileMetadata::Use::THUMBNAIL }
+    let(:thumbnail_use)      { Hyrax::FileMetadata::Use::THUMBNAIL_IMAGE }
 
     let(:pdf_filename)  { 'sample-file.pdf' }
     let(:pdf_mimetype)  { 'application/pdf' }


### PR DESCRIPTION
Our Hyrax application makes use of `pcdmuse:PreservationFile` and `pcdmuse:IntermediateFile`, and is currently overriding Hyrax to provide these constants. But the list of possible PCDM use terms is [short and well known](https://pcdm.org/2021/04/09/use), and there’s no reason why Hyrax couldn’t just provide all of them to begin with.

I’ve also taken the liberty of changing references to `Hyrax::FileMetadata::Use::THUMBNAIL` to be `Hyrax::FileMetadata::Use::THUMBNAIL_IMAGE`, since that better matches the naming convention of the other terms. `Hyrax::FileMetadata::Use::THUMBNAIL` is still supported, but probably should be discouraged.