### PR TITLE
Add support for valkyrie resources to Ability

### DIFF
--- a/app/models/concerns/hyrax/ability.rb
+++ b/app/models/concerns/hyrax/ability.rb
@@ -53,6 +53,7 @@ module Hyrax
       include Hyrax::Ability::CollectionAbility
       include Hyrax::Ability::CollectionTypeAbility
       include Hyrax::Ability::PermissionTemplateAbility
+      include Hyrax::Ability::ResourceAbility
       include Hyrax::Ability::SolrDocumentAbility
 
       class_attribute :admin_group_name, :registered_group_name, :public_group_name
@@ -76,6 +77,7 @@ module Hyrax
                              :collection_abilities,
                              :collection_type_abilities,
                              :permission_template_abilities,
+                             :resource_abilities,
                              :solr_document_abilities,
                              :trophy_abilities]
     end

--- a/app/models/concerns/hyrax/ability/resource_ability.rb
+++ b/app/models/concerns/hyrax/ability/resource_ability.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+module Hyrax
+  module Ability
+    module ResourceAbility
+      def resource_abilities
+        if admin?
+          can [:manage], ::Hyrax::Resource
+        else
+          can [:edit, :update, :destroy], ::Hyrax::Resource do |res|
+            test_edit(res.id)
+          end
+          can :read, ::Hyrax::Resource do |res|
+            test_read(res.id)
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/abilities/file_set_abilities_spec.rb
+++ b/spec/abilities/file_set_abilities_spec.rb
@@ -7,8 +7,8 @@ RSpec.describe Hyrax::Ability do
   let(:creating_user) { create(:user) }
   let(:user) { create(:user) }
   let(:current_user) { user }
-  let(:generic_work) { create(:generic_work, visibility: visibility, user: creating_user) }
-  let(:file_set) { create(:file_set, visibility: visibility, user: creating_user) }
+  let(:generic_work) { valkyrie_create(:hyrax_work, visibility_setting: visibility, edit_users: [creating_user]) }
+  let(:file_set) { valkyrie_create(:hyrax_file_set, visibility_setting: visibility, edit_users: [creating_user]) }
 
   describe 'without embargo' do
     describe 'creator of object' do

--- a/spec/abilities/permission_template_ability_spec.rb
+++ b/spec/abilities/permission_template_ability_spec.rb
@@ -6,14 +6,14 @@ RSpec.describe Hyrax::Ability do
   let(:user) { create(:user) }
   let(:current_user) { user }
   let(:collection_type) { FactoryBot.create(:collection_type) }
-  let!(:collection) { create(:collection_lw, with_permission_template: true, collection_type: collection_type) }
-  let(:permission_template) { collection.permission_template }
-  let!(:permission_template_access) do
-    create(:permission_template_access,
-           :manage,
-           permission_template: permission_template,
-           agent_type: 'group',
-           agent_id: 'manage_group')
+  let!(:collection) { valkyrie_create(:hyrax_collection, collection_type: collection_type, access_grants: [access_grant]) }
+  let(:access_grant) { { agent_type: 'group', access: 'manage', agent_id: 'manage_group' } }
+  let(:permission_template) { Hyrax::PermissionTemplate.find_by(source_id: collection.id) }
+  let(:permission_template_access) do
+    Hyrax::PermissionTemplateAccess.find_by(permission_template_id: permission_template.id.to_s,
+                                            agent_type: access_grant[:agent_type],
+                                            agent_id: access_grant[:agent_id],
+                                            access: access_grant[:access])
   end
 
   context 'when admin user' do
@@ -37,16 +37,7 @@ RSpec.describe Hyrax::Ability do
   end
 
   context 'when user has manage access for the source' do
-    before do
-      create(:permission_template_access,
-             :manage,
-             permission_template: permission_template,
-             agent_type: 'user',
-             agent_id: user.user_key)
-      collection.permission_template.reset_access_controls_for(
-        collection: collection, interpret_visibility: true
-      )
-    end
+    let(:access_grant) { { agent_type: 'user', access: 'manage', agent_id: user.user_key } }
 
     it 'allows most template abilities' do
       is_expected.to be_able_to(:create, permission_template)
@@ -72,16 +63,7 @@ RSpec.describe Hyrax::Ability do
   end
 
   context 'when user has deposit access for the source' do
-    before do
-      create(:permission_template_access,
-             :deposit,
-             permission_template: permission_template,
-             agent_type: 'user',
-             agent_id: user.user_key)
-      collection.permission_template.reset_access_controls_for(
-        collection: collection, interpret_visibility: true
-      )
-    end
+    let(:access_grant) { { agent_type: 'user', access: 'deposit', agent_id: user.user_key } }
 
     it 'denies all template abilities' do
       is_expected.not_to be_able_to(:manage, Hyrax::PermissionTemplate)
@@ -101,16 +83,7 @@ RSpec.describe Hyrax::Ability do
   end
 
   context 'when user has view access for the source' do
-    before do
-      create(:permission_template_access,
-             :view,
-             permission_template: permission_template,
-             agent_type: 'user',
-             agent_id: user.user_key)
-      collection.permission_template.reset_access_controls_for(
-        collection: collection, interpret_visibility: true
-      )
-    end
+    let(:access_grant) { { agent_type: 'user', access: 'view', agent_id: user.user_key } }
 
     it 'denies all template abilities' do
       is_expected.not_to be_able_to(:manage, Hyrax::PermissionTemplate)


### PR DESCRIPTION
### Summary

Ability was lacking the logic to support Hyrax::Resource objects. This gap had not shown up during normal site usage, but was revealed while adapting file_set_abilities_spec for valkyrie resources.

@samvera/hyrax-code-reviewers
