### PR TITLE
Remove leftover collection model setter causing flakes

### DIFF
--- a/spec/abilities/collection_ability_spec.rb
+++ b/spec/abilities/collection_ability_spec.rb
@@ -20,10 +20,6 @@ RSpec.describe Hyrax::Ability, :clean_repo do
     Hyrax.config.collection_model = current_collection_model
   end
 
-  after :all do
-    Hyrax.config.collection_model = @current_collection_model
-  end
-
   # rubocop:disable RSpec/ExampleLength
   context 'when admin user' do
     let(:current_user) { admin }


### PR DESCRIPTION
This should have been removed when the above around block was added. It was causing flaky test failures, especially when running the whole suite with --order=defined

