### PR TITLE
Fix broken attempt to intercept persister save calls

### DIFF
--- a/.koppie/app/models/collection.rb
+++ b/.koppie/app/models/collection.rb
@@ -1,1 +1,1 @@
-Collection = Hyrax::PcdmCollection
+Collection = CollectionResource


### PR DESCRIPTION
Trying to cause simulated save failures in this way was not working. I believe this is caused by the change_set.apply step saving the persister object it uses to an ivar at init time, which seems to occur when the class loads, too late for a :before hook to have any effect on it. Valkyrie creates a new persister instance everytime metadata_adapter.persister is called, so we don't get the same object back later.

Intercepting at the transaction step call is low level enough to get the intended result.

Also, this aligns koppie's Collection compatibility class with the earlier switch to CollectionResource.

### Fixes
spec/controllers/hyrax/dashboard/collections_controller_spec.rb in koppie
