### PR TITLE
Valkyrization: Fix failing tests in notifications tests

### DIFF
--- a/spec/services/hyrax/workflow/changes_required_notification_spec.rb
+++ b/spec/services/hyrax/workflow/changes_required_notification_spec.rb
@@ -4,8 +4,8 @@ RSpec.describe Hyrax::Workflow::ChangesRequiredNotification do
   let(:depositor) { FactoryBot.create(:user) }
   let(:to_user) { FactoryBot.create(:user) }
   let(:cc_user) { FactoryBot.create(:user) }
-  let(:work) { FactoryBot.create(:work, user: depositor) }
-  let(:entity) { FactoryBot.create(:sipity_entity, proxy_for_global_id: work.to_global_id) }
+  let(:work) { valkyrie_create(:work, depositor: depositor.user_key) }
+  let(:entity) { FactoryBot.create(:sipity_entity, proxy_for_global_id: Hyrax::GlobalID(work).to_s) }
   let(:comment) { double("comment", comment: 'A pleasant read') }
   let(:recipients) { { 'to' => [to_user], 'cc' => [cc_user] } }
 

--- a/spec/services/hyrax/workflow/deposited_notification_spec.rb
+++ b/spec/services/hyrax/workflow/deposited_notification_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Hyrax::Workflow::DepositedNotification do
   let(:depositor) { FactoryBot.create(:user) }
   let(:to_user) { FactoryBot.create(:user) }
   let(:cc_user) { FactoryBot.create(:user) }
-  let(:work) { FactoryBot.create(:work, user: depositor) }
+  let(:work) { valkyrie_create(:work, depositor: depositor.user_key) }
   let(:entity) { FactoryBot.create(:sipity_entity, proxy_for: work) }
   let(:comment) { double("comment", comment: 'A pleasant read') }
   let(:recipients) { { 'to' => [to_user], 'cc' => [cc_user] } }

--- a/spec/services/hyrax/workflow/pending_review_notification_spec.rb
+++ b/spec/services/hyrax/workflow/pending_review_notification_spec.rb
@@ -3,8 +3,8 @@ RSpec.describe Hyrax::Workflow::PendingReviewNotification do
   let(:depositor) { create(:user) }
   let(:to_user) { create(:user) }
   let(:cc_user) { create(:user) }
-  let(:work) { create(:generic_work, user: depositor) }
-  let(:entity) { create(:sipity_entity, proxy_for_global_id: work.to_global_id.to_s) }
+  let(:work) { valkyrie_create(:work, depositor: depositor.user_key) }
+  let(:entity) { create(:sipity_entity, proxy_for_global_id: Hyrax::GlobalID(work).to_s) }
   let(:comment) { double("comment", comment: 'A pleasant read') }
   let(:recipients) { { 'to' => [to_user], 'cc' => [cc_user] } }
 


### PR DESCRIPTION
### Fixes

Fix failing notification tests for Koppie

### Type of change (for release notes)
- `notes-valkyrie` Valkyrie Progress

### Changes proposed in this pull request:
* Use `valkyrie_create` to create generic works in the tests

@samvera/hyrax-code-reviewers
