### PR TITLE
Valkyrization: Fix failing tests in `work_create_spec.rb`

### DIFF
--- a/spec/hyrax/transactions/work_create_spec.rb
+++ b/spec/hyrax/transactions/work_create_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe Hyrax::Transactions::WorkCreate, :clean_repo do
   subject(:tx)     { described_class.new }
   let(:change_set) { Hyrax::ChangeSet.for(resource) }
   let(:resource)   { build(:hyrax_work) }
+  let(:default_admin_set_id) { Hyrax::AdminSetCreateService.find_or_create_default_admin_set.id }
 
   describe '#call' do
     it 'is a success' do
@@ -19,7 +20,7 @@ RSpec.describe Hyrax::Transactions::WorkCreate, :clean_repo do
 
     it 'sets the default admin set' do
       expect(tx.call(change_set).value!)
-        .to have_attributes admin_set_id: Valkyrie::ID.new('admin_set/default')
+        .to have_attributes admin_set_id: default_admin_set_id
     end
 
     context 'when an admin set is already assigned to the work' do


### PR DESCRIPTION
### Fixes

Fix failing tests in `spec/hyrax/transactions/work_create_spec.rb` for Koppie.

### Type of change (for release notes)
- `notes-valkyrie` Valkyrie Progress

### Changes proposed in this pull request:
As referenced in `app/services/hyrax/admin_set_create_service.rb`, some Valkyrie adapters do not support hardcoded IDs (e.g. postgres). The default admin set ID in Koppie is not set to `admin_set/default`. 

I edited the test file to retrieve the default admin set ID set in the application and use it when checking if the default admin set is assigned to the work.

@samvera/hyrax-code-reviewers
