### PR TITLE
Add change_depositor step to fix valkyrie batch deposit as a proxy depositor

### DIFF
--- a/app/jobs/create_work_job.rb
+++ b/app/jobs/create_work_job.rb
@@ -49,6 +49,7 @@ class CreateWorkJob < Hyrax::ApplicationJob
       .with_step_args(
         'work_resource.add_file_sets' => { uploaded_files: files },
         'change_set.set_user_as_depositor' => { user: user },
+        'work_resource.change_depositor' => { user: ::User.find_by_user_key(form.on_behalf_of) },
         'work_resource.save_acl' => { permissions_params: permissions_params }
       )
       .call(form)


### PR DESCRIPTION
### Fixes

Batch creating valkyrie works as a proxy depositor.

### Guidance for testing, such as acceptance criteria or new user interface behaviors:
* As a non-admin, create a work using the batch form while setting a "on behalf of" user.
* Work is shown in Managed Works dashboard tab
*

