### PR TITLE
Valkyrizes `spec/services/hyrax/statistics/depositors/summary_spec.rb`.

### DIFF
--- a/spec/services/hyrax/statistics/depositors/summary_spec.rb
+++ b/spec/services/hyrax/statistics/depositors/summary_spec.rb
@@ -2,19 +2,33 @@
 RSpec.describe Hyrax::Statistics::Depositors::Summary, :clean_repo do
   let(:user1) { create(:user) }
   let(:user2) { create(:user) }
-  let!(:old_work) { create(:work, user: user1) }
-  let(:two_days_ago_date) { Time.zone.now - 2.days }
 
+  let(:two_days_ago_date) { Time.zone.now - 2.days }
   let(:start_date) { nil }
   let(:end_date) { nil }
-  let!(:work1) { create(:work, user: user1) }
-  let!(:work2) { create(:work, user: user2) }
-  let!(:collection1) { create(:public_collection_lw, user: user1) }
+
+  if Hyrax.config.disable_wings
+    let!(:old_work) { valkyrie_create(:monograph, depositor: user1.user_key) }
+    let!(:work1) { valkyrie_create(:monograph, depositor: user1.user_key) }
+    let!(:work2) { valkyrie_create(:monograph, depositor: user2.user_key) }
+    let!(:collection1) { valkyrie_create(:hyrax_collection, :public, user: user1) }
+  else
+    let!(:old_work) { create(:work, user: user1) }
+    let!(:work1) { create(:work, user: user1) }
+    let!(:work2) { create(:work, user: user2) }
+    let!(:collection1) { create(:public_collection_lw, user: user1) }
+  end
+
   let(:service) { described_class.new(start_date, end_date) }
 
   before do
-    allow(old_work).to receive(:create_date).and_return(two_days_ago_date.to_datetime)
-    old_work.update_index
+    if Hyrax.config.disable_wings
+      allow(old_work).to receive(:created_at).and_return(two_days_ago_date.to_datetime)
+      Hyrax.index_adapter.save(resource: old_work)
+    else
+      allow(old_work).to receive(:create_date).and_return(two_days_ago_date.to_datetime)
+      old_work.update_index
+    end
   end
 
   describe '.depositors' do

--- a/spec/services/hyrax/statistics/depositors/summary_spec.rb
+++ b/spec/services/hyrax/statistics/depositors/summary_spec.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-RSpec.describe Hyrax::Statistics::Depositors::Summary, :clean_repo do
+RSpec.describe Hyrax::Statistics::Depositors::Summary, :clean_repo, index_adapter: :solr_index do
   let(:user1) { create(:user) }
   let(:user2) { create(:user) }
 
@@ -7,28 +7,16 @@ RSpec.describe Hyrax::Statistics::Depositors::Summary, :clean_repo do
   let(:start_date) { nil }
   let(:end_date) { nil }
 
-  if Hyrax.config.disable_wings
-    let!(:old_work) { valkyrie_create(:monograph, depositor: user1.user_key) }
-    let!(:work1) { valkyrie_create(:monograph, depositor: user1.user_key) }
-    let!(:work2) { valkyrie_create(:monograph, depositor: user2.user_key) }
-    let!(:collection1) { valkyrie_create(:hyrax_collection, :public, user: user1) }
-  else
-    let!(:old_work) { create(:work, user: user1) }
-    let!(:work1) { create(:work, user: user1) }
-    let!(:work2) { create(:work, user: user2) }
-    let!(:collection1) { create(:public_collection_lw, user: user1) }
-  end
+  let!(:old_work) { valkyrie_create(:monograph, depositor: user1.user_key) }
+  let!(:work1) { valkyrie_create(:monograph, depositor: user1.user_key) }
+  let!(:work2) { valkyrie_create(:monograph, depositor: user2.user_key) }
+  let!(:collection1) { valkyrie_create(:hyrax_collection, :public, user: user1) }
 
   let(:service) { described_class.new(start_date, end_date) }
 
   before do
-    if Hyrax.config.disable_wings
-      allow(old_work).to receive(:created_at).and_return(two_days_ago_date.to_datetime)
-      Hyrax.index_adapter.save(resource: old_work)
-    else
-      allow(old_work).to receive(:create_date).and_return(two_days_ago_date.to_datetime)
-      old_work.update_index
-    end
+    allow(old_work).to receive(:created_at).and_return(two_days_ago_date.to_datetime)
+    Hyrax.index_adapter.save(resource: old_work)
   end
 
   describe '.depositors' do


### PR DESCRIPTION
### Fixes

Fixes `spec/services/hyrax/statistics/depositors/summary_spec.rb`.

### Summary

Valkyrizes `spec/services/hyrax/statistics/depositors/summary_spec.rb`.

### Type of change (for release notes)

- `notes-valkyrie` Valkyrie Progress

### Detailed Description

Swaps between ActiveFedora and Valkyrie objects depending on environment. Tried using Valkyrie objects only, but the indexing was defaulting to `Valkyrie::Indexing::NullIndexingAdapter` within the Dassie environment, which is essentially pass-through, making it hard to manipulate with the `before` statement.

@samvera/hyrax-code-reviewers
