### PR TITLE
Marks the right form ActiveFedora only.

### DIFF
--- a/spec/forms/hyrax/forms/file_set_edit_form_spec.rb
+++ b/spec/forms/hyrax/forms/file_set_edit_form_spec.rb
@@ -1,5 +1,9 @@
 # frozen_string_literal: true
-RSpec.describe Hyrax::Forms::FileSetEditForm do
+
+# This uses app/services/hydra_editor/field_metadata_service.rb, which calls
+#   #reflect_on_association on the FileSet class. This is an ActiveFedora-specific
+#   method that doesn't translate to Valkyrie Work behavior.
+RSpec.describe Hyrax::Forms::FileSetEditForm, :active_fedora do
   subject { described_class.new(FileSet.new) }
 
   describe '#terms' do

--- a/spec/forms/hyrax/forms/file_set_form_spec.rb
+++ b/spec/forms/hyrax/forms/file_set_form_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe Hyrax::Forms::FileSetForm, :active_fedora do
+RSpec.describe Hyrax::Forms::FileSetForm do
   subject(:form) { described_class.new(file_set) }
   let(:file_set) { Hyrax::FileSet.new }
 


### PR DESCRIPTION
### Fixes

Fixes `spec/forms/hyrax/forms/file_set_form_spec.rb` and `spec/forms/hyrax/forms/file_set_edit_form_spec.rb`.

### Summary

Marks the right form ActiveFedora only.

### Type of change (for release notes)

- `notes-valkyrie` Valkyrie Progress

@samvera/hyrax-code-reviewers
