### PR TITLE
Fix save button remaining inactive after upload completes (with passive deposit agreements)

### DIFF
--- a/app/assets/javascripts/hyrax/save_work/uploaded_files.es6
+++ b/app/assets/javascripts/hyrax/save_work/uploaded_files.es6
@@ -3,7 +3,15 @@ export class UploadedFiles {
   constructor(form, callback) {
     this.form = form
     this.element = $('#fileupload')
-    this.element.on('fileuploadcompleted', callback)
+    this.uploadsInProgress = 0
+    this.element.on('fileuploadadded', (e, data) => {
+      this.uploadsInProgress += 1
+      callback(e, data)
+    })
+    this.element.on('fileuploadcompleted', (e, data) => {
+      this.uploadsInProgress -= 1
+      callback(e, data)
+    })
     this.element.on('fileuploaddestroyed', callback)
   }
 
@@ -13,7 +21,7 @@ export class UploadedFiles {
   }
 
   get inProgress() {
-    return this.element.fileupload('active') > 0
+    return this.uploadsInProgress > 0;
   }
 
   get hasFiles() {

--- a/spec/features/deposit_agreements_spec.rb
+++ b/spec/features/deposit_agreements_spec.rb
@@ -28,10 +28,14 @@ RSpec.describe 'Deposit Agreement options', :js, :workflow, :clean_repo do
     end
 
     it "allows saving work when active deposit agreement is off" do
+      expect(find('input[name="save_with_files"]')[:disabled]).to eq('true')
+
       # Fill in required metadata
       fill_in('Title', with: 'My Test Work')
       fill_in('Creator', with: 'Doe, Jane')
       select('In Copyright', from: 'Rights statement')
+
+      expect(find('input[name="save_with_files"]')[:disabled]).to eq('false')
 
       # Add a file
       click_link "Files"
@@ -40,9 +44,7 @@ RSpec.describe 'Deposit Agreement options', :js, :workflow, :clean_repo do
       end
 
       expect(page).not_to have_selector('#agreement')
-      click_on('Save')
-      expect(page).to have_content('My Test Work')
-      expect(page).to have_content "Your files are being processed by #{I18n.t('hyrax.product_name')} in the background."
+      expect(find('input[name="save_with_files"]')[:disabled]).to eq('true')
     end
   end
 end

--- a/spec/features/deposit_agreements_spec.rb
+++ b/spec/features/deposit_agreements_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+RSpec.describe 'Deposit Agreement options', :js, :workflow, :clean_repo do
+  let(:user) { create(:user) }
+  let(:admin_user) { create(:admin) }
+  # let(:adminset) { create(:admin_set) }
+  let!(:ability) { ::Ability.new(user) }
+  let(:permission_template) { create(:permission_template, with_admin_set: true, with_active_workflow: true) }
+
+  before do
+    # Grant the user access to deposit into an admin set.
+    create(:permission_template_access, :deposit, permission_template: permission_template, agent_type: 'user', agent_id: user.user_key)
+    # stub out characterization
+    allow(CharacterizeJob).to receive(:perform_later)
+  end
+
+  context "with activate deposit agreement off" do
+    before do
+      sign_in admin_user
+      # Disable active agreements
+      visit "/admin/features"
+      first("tr[data-feature='active-deposit-agreement-acceptance'] input[value='off']").click
+
+      sign_in user
+      click_link 'Works'
+      find('#add-new-work-button').click
+      choose "payload_concern", option: "GenericWork"
+      click_button 'Create work'
+    end
+
+    it "allows saving work when active deposit agreement is off" do
+      # Fill in required metadata
+      fill_in('Title', with: 'My Test Work')
+      fill_in('Creator', with: 'Doe, Jane')
+      select('In Copyright', from: 'Rights statement')
+
+      # Add a file
+      click_link "Files"
+      within('div#add-files') do
+        attach_file("files[]", "#{Hyrax::Engine.root}/spec/fixtures/image.jp2", visible: false)
+      end
+
+      expect(page).not_to have_selector('#agreement')
+      click_on('Save')
+      expect(page).to have_content('My Test Work')
+      expect(page).to have_content "Your files are being processed by #{I18n.t('hyrax.product_name')} in the background."
+    end
+  end
+end

--- a/spec/features/deposit_agreements_spec.rb
+++ b/spec/features/deposit_agreements_spec.rb
@@ -28,14 +28,14 @@ RSpec.describe 'Deposit Agreement options', :js, :workflow, :clean_repo do
     end
 
     it "allows saving work when active deposit agreement is off" do
-      expect(find('input[name="save_with_files"]')[:disabled]).to eq('true')
+      expect(page).to have_selector('input[name="save_with_files"][disabled]')
 
       # Fill in required metadata
       fill_in('Title', with: 'My Test Work')
       fill_in('Creator', with: 'Doe, Jane')
       select('In Copyright', from: 'Rights statement')
 
-      expect(find('input[name="save_with_files"]')[:disabled]).to eq('false')
+      expect(page).to have_selector('input[name="save_with_files"]:not([disabled])')
 
       # Add a file
       click_link "Files"
@@ -44,7 +44,7 @@ RSpec.describe 'Deposit Agreement options', :js, :workflow, :clean_repo do
       end
 
       expect(page).not_to have_selector('#agreement')
-      expect(find('input[name="save_with_files"]')[:disabled]).to eq('true')
+      expect(page).to have_selector('input[name="save_with_files"]:not([disabled])')
     end
   end
 end


### PR DESCRIPTION
### Fixes

https://github.com/samvera/hyrax/issues/6517

### Summary

Fixes issue where the "Save" button on the work page is disabled after an upload completes even if all requirements have been met.

### Guidance for testing, such as acceptance criteria or new user interface behaviors:
See the linked issue for how to replicate the issue.

### Type of change (for release notes)
notes-bugfix

### Detailed Description

The issue appears to be that the fileupload('active') value is still "1" at the time that the `fileuploadcompleted` or `fileuploaddone` events are fired. It is being retrieved here:
https://github.com/samvera/hyrax/blob/main/app/assets/javascripts/hyrax/save_work/uploaded_files.es6#L16
which is used for deciding if the "Save" button should be disabled. So when the completed event fires, it checks to see if there are any active uploads, and there still are since the plugin doesn't seem to have cleared them yet.

Since 'active' doesn't seem reliable for this purpose, I switched to externally tracking when an upload was started and ended. There is also a 'progress' attribute which records the number of bytes uploaded that might be usable for this, which we could try if that's preferred.

For what its worth, it looks like the jquery.fileupload plugin was archived in May 2023. Some parts also don't seem to be working, like the "Cancel upload" button is disabled for me and doesn't work, plus it doesn't show in progress uploads, the file just eventually appears on the list once the upload finishes. I'm guessing we need to replace it at some point, which might already be in the backlog.

### Changes proposed in this pull request:
* Uses an external counter for number of uploads in progress rather than the internal one, since it does not update in time for reevaluating the save button.
* Adds a test to demonstrate the bug and check for passive deposit agreement behavior

@samvera/hyrax-code-reviewers
