### PR TITLE
Adds active_fedora tag to AF-specific tests in `spec/hyrax/transactions/steps/set_default_admin_set_spec.rb`.

### DIFF
--- a/spec/hyrax/transactions/steps/set_default_admin_set_spec.rb
+++ b/spec/hyrax/transactions/steps/set_default_admin_set_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe Hyrax::Transactions::Steps::SetDefaultAdminSet do
       end
     end
 
-    context 'with an active fedora object' do
+    context 'with an active fedora object', :active_fedora do
       let(:work) { build(:generic_work) }
 
       it 'is success' do


### PR DESCRIPTION
### Fixes

Fixes `spec/hyrax/transactions/steps/set_default_admin_set_spec.rb`.

### Summary

Adds active_fedora tag to AF-specific tests in `spec/hyrax/transactions/steps/set_default_admin_set_spec.rb`.

### Type of change (for release notes)

- `notes-valkyrie` Valkyrie Progress

@samvera/hyrax-code-reviewers
