### PR TITLE
Marks `spec/views/hyrax/batch_uploads/_form.html.erb_spec.rb` as ActiveFedora-only.

### DIFF
--- a/spec/views/hyrax/batch_uploads/_form.html.erb_spec.rb
+++ b/spec/views/hyrax/batch_uploads/_form.html.erb_spec.rb
@@ -1,5 +1,10 @@
 # frozen_string_literal: true
-RSpec.describe 'hyrax/batch_uploads/_form.html.erb', type: :view do
+
+# Hyrax::BatchUploadsController's form class is Hyrax::Forms::BatchUploadForm, which inherits from
+#   Hyrax::Forms::WorkForm that utilizes app/services/hydra_editor/field_metadata_service.rb.
+#   That service calls #reflect_on_association on the Work class. This is an ActiveFedora-specific
+#   method that doesn't translate to Valkyrie Work behavior.
+RSpec.describe 'hyrax/batch_uploads/_form.html.erb', :active_fedora, type: :view do
   let(:work) { GenericWork.new }
   let(:ability) { double('ability', current_user: user) }
   let(:controller_class) { Hyrax::BatchUploadsController }


### PR DESCRIPTION
### Fixes

Fixes `spec/views/hyrax/batch_uploads/_form.html.erb_spec.rb`.

### Summary

Marks `spec/views/hyrax/batch_uploads/_form.html.erb_spec.rb` as ActiveFedora-only.

### Type of change (for release notes)

- `notes-valkyrie` Valkyrie Progress

@samvera/hyrax-code-reviewers
