### PR TITLE
Marks `spec/jobs/fixity_check_job_spec.rb` as ActiveFedora-only.

### DIFF
--- a/spec/jobs/fixity_check_job_spec.rb
+++ b/spec/jobs/fixity_check_job_spec.rb
@@ -1,4 +1,6 @@
 # frozen_string_literal: true
+
+# NOTE: A Valkyrie-compliant Fixity Check service needs to be created.
 RSpec.describe FixityCheckJob, :active_fedora do
   let(:user) { create(:user) }
 

--- a/spec/jobs/fixity_check_job_spec.rb
+++ b/spec/jobs/fixity_check_job_spec.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-RSpec.describe FixityCheckJob do
+RSpec.describe FixityCheckJob, :active_fedora do
   let(:user) { create(:user) }
 
   let(:file_set) do


### PR DESCRIPTION
### Fixes

Fixes `spec/jobs/fixity_check_job_spec.rb`.

### Summary

Marks `spec/jobs/fixity_check_job_spec.rb` as ActiveFedora-only.

### Type of change (for release notes)

- `notes-valkyrie` Valkyrie Progress

@samvera/hyrax-code-reviewers
