### PR TITLE
Marks `spec/services/hyrax/graph_exporter_spec.rb` as ActiveFedora-only.

### DIFF
--- a/spec/services/hyrax/graph_exporter_spec.rb
+++ b/spec/services/hyrax/graph_exporter_spec.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
-RSpec.describe Hyrax::GraphExporter do
+
+# NOTE: This service focuses solely on interacting with ActiveFedora methods and connections.
+RSpec.describe Hyrax::GraphExporter, :active_fedora do
   subject(:service) { described_class.new(document, hostname: 'localhost') }
   let(:work) { FactoryBot.create(:work_with_one_file, visibility: 'open') }
   let(:document) { double(id: work.id) }


### PR DESCRIPTION
### Fixes

Fixes `spec/services/hyrax/graph_exporter_spec.rb`.

### Summary

Marks `spec/services/hyrax/graph_exporter_spec.rb` as ActiveFedora-only.

### Type of change (for release notes)

- `notes-valkyrie` Valkyrie Progress

@samvera/hyrax-code-reviewers
