### PR TITLE
Cast provided `id` to string

### DIFF
--- a/lib/hyrax/configuration.rb
+++ b/lib/hyrax/configuration.rb
@@ -952,7 +952,7 @@ module Hyrax
     attr_writer :translate_id_to_uri
     def translate_id_to_uri
       @translate_id_to_uri ||= lambda do |id|
-        "#{ActiveFedora.fedora.host}#{ActiveFedora.fedora.base_path}/#{::Noid::Rails.treeify(id)}"
+        "#{ActiveFedora.fedora.host}#{ActiveFedora.fedora.base_path}/#{::Noid::Rails.treeify(id.to_s)}"
       end
     end
 


### PR DESCRIPTION
Prior to this commit, we were seeing the following issues:

```
NoMethodError:
  undefined method `split' for #<Valkyrie::ID:0x0000ffffa5f04bc8 @id="admin_set/default">
```

The string interpolation (e.g. `#{ }`) did not use the `#to_s` method of the identifier.  With this change, we treat the `Valkyrie::ID` as something we can "Noidify".

