### PR TITLE
Marks ActiveFedora tests in `spec/jobs/import_url_job_spec.rb`.

### DIFF
--- a/spec/jobs/import_url_job_spec.rb
+++ b/spec/jobs/import_url_job_spec.rb
@@ -28,7 +28,8 @@ RSpec.describe ImportUrlJob do
     allow(mock_retriever).to receive(:retrieve)
   end
 
-  context 'when use_valkyrie is false' do
+  # NOTE: Valkyrie processing has been marked as "TODO" in the method.
+  context 'when use_valkyrie is false', :active_fedora do
     let(:file_set) do
       FileSet.new(import_url: "http://example.org#{file_hash}",
                   label: label) do |f|


### PR DESCRIPTION
### Fixes

Fixes `spec/jobs/import_url_job_spec.rb`.

### Summary

Marks ActiveFedora tests in `spec/jobs/import_url_job_spec.rb`.

### Type of change (for release notes)

- `notes-valkyrie` Valkyrie Progress

@samvera/hyrax-code-reviewers
