### PR TITLE
Update Gemfile for bundler 2.5

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,14 @@
 # frozen_string_literal: true
 source 'https://rubygems.org'
+
 # Please see hyrax.gemspec for dependency information.
-gemspec
+# Install gems from test app
+if ENV['RAILS_ROOT']
+  test_app_gemfile_path = File.expand_path('Gemfile', ENV['RAILS_ROOT'])
+  eval_gemfile test_app_gemfile_path
+else
+  gemspec
+end
 
 group :development, :test do
   gem 'benchmark-ips'
@@ -12,10 +19,4 @@ group :development, :test do
   gem 'pry-byebug' unless ENV['CI']
   gem 'ruby-prof', require: false
   gem "simplecov", require: false
-end
-
-# Install gems from test app
-if ENV['RAILS_ROOT']
-  test_app_gemfile_path = File.expand_path('Gemfile', ENV['RAILS_ROOT'])
-  eval_gemfile test_app_gemfile_path
 end


### PR DESCRIPTION
Changes in bundler 2.5 prevent multiple gemspec calls from taking effect. We now assume the application Gemfile will correctly load the hyrax gemspec file using the RAILS_ROOT env var.

### Fixes

Mission inclusion of certain gems in the engine Gemfile.lock, manifested as missing rspec in CI.

@samvera/hyrax-code-reviewers
