### PR TITLE
Marks ActiveFedora tests in `spec/indexers/hyrax/deep_indexing_service_spec.rb`.

### DIFF
--- a/spec/indexers/hyrax/deep_indexing_service_spec.rb
+++ b/spec/indexers/hyrax/deep_indexing_service_spec.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
-RSpec.describe Hyrax::DeepIndexingService do
+
+# Marked as AF-only, since Valkyrie work indexing is handled by Hyrax::ValkyrieWorkIndexer.
+RSpec.describe Hyrax::DeepIndexingService, :active_fedora do
   subject(:service) { described_class.new(work) }
   let(:work) { FactoryBot.build(:work) }
 


### PR DESCRIPTION
### Fixes

Fixes `spec/indexers/hyrax/deep_indexing_service_spec.rb`.

### Summary

Marks ActiveFedora tests in `spec/indexers/hyrax/deep_indexing_service_spec.rb`.

### Type of change (for release notes)

- `notes-valkyrie` Valkyrie Progress

@samvera/hyrax-code-reviewers
