### PR TITLE
Add form keys for bibliographic_citation

### DIFF
--- a/config/metadata/basic_metadata.yaml
+++ b/config/metadata/basic_metadata.yaml
@@ -42,6 +42,10 @@ attributes:
   bibliographic_citation:
     type: string
     multiple: true
+    form:
+      primary: false
+    index_keys:
+      - "bibliographic_citation_tesim"
     predicate: http://purl.org/dc/terms/bibliographicCitation
   contributor:
     type: string


### PR DESCRIPTION
Bibliographic citation was not showing up in the form even though it is a basic metadata property.  This commit adds it to the form.
