### PR TITLE
Marks `spec/search_builders/hyrax/work_relation_spec.rb` as ActiveFedora-only.

### DIFF
--- a/spec/search_builders/hyrax/work_relation_spec.rb
+++ b/spec/search_builders/hyrax/work_relation_spec.rb
@@ -1,5 +1,11 @@
 # frozen_string_literal: true
-RSpec.describe Hyrax::WorkRelation, :clean_repo do
+
+# NOTE: This is an ActiveFedora query service that is currently being used
+#   in the following classes/modules:
+#   Hyrax::SingularSubresourceController, Hyrax::WorkUsage, Hyrax::UserStatImporter,
+#   Hyrax::WorkQueryService, Hyrax::Statistics::QueryService, Hyrax::Statistics::Works::OverTime,
+#   MoveAllWorksToAdminSet, and Hyrax::ResourceSync::ResourceListWriter
+RSpec.describe Hyrax::WorkRelation, :active_fedora, :clean_repo do
   let!(:work) { create(:generic_work) }
   let!(:file_set) { create(:file_set) }
   let!(:collection) { build(:collection_lw) }


### PR DESCRIPTION
### Fixes

Fixes `spec/search_builders/hyrax/work_relation_spec.rb`.

### Summary

Marks `spec/search_builders/hyrax/work_relation_spec.rb` as ActiveFedora-only.

### Type of change (for release notes)

- `notes-valkyrie` Valkyrie Progress

@samvera/hyrax-code-reviewers
