### PR TITLE
Marks `spec/jobs/attach_files_to_work_with_ordered_members_job_spec.rb` as ActiveFedora-only.

### DIFF
--- a/spec/jobs/attach_files_to_work_with_ordered_members_job_spec.rb
+++ b/spec/jobs/attach_files_to_work_with_ordered_members_job_spec.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
-RSpec.describe AttachFilesToWorkWithOrderedMembersJob, perform_enqueued: [AttachFilesToWorkWithOrderedMembersJob] do
+
+# NOTE: This job initiates the Actor Stack with ActiveFedora objects.
+RSpec.describe AttachFilesToWorkWithOrderedMembersJob, :active_fedora, perform_enqueued: [AttachFilesToWorkWithOrderedMembersJob] do
   let(:file1) { File.open(fixture_path + '/world.png') }
   let(:file2) { File.open(fixture_path + '/image.jp2') }
   let(:uploaded_file1) { build(:uploaded_file, file: file1) }


### PR DESCRIPTION
### Fixes

Fixes `spec/jobs/attach_files_to_work_with_ordered_members_job_spec.rb`.

### Summary

Marks `spec/jobs/attach_files_to_work_with_ordered_members_job_spec.rb` as ActiveFedora-only.

### Type of change (for release notes)

- `notes-valkyrie` Valkyrie Progress

@samvera/hyrax-code-reviewers
