### PR TITLE
Marks `spec/services/hyrax/visibility_intention_applicator_spec.rb` as ActiveFedora-only.

### DIFF
--- a/spec/services/hyrax/visibility_intention_applicator_spec.rb
+++ b/spec/services/hyrax/visibility_intention_applicator_spec.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
-RSpec.describe Hyrax::VisibilityIntentionApplicator do
+
+# NOTE: Leases and Embargoes have separate managers for Valkyrie objects.
+RSpec.describe Hyrax::VisibilityIntentionApplicator, :active_fedora do
   subject(:applicator) { described_class.new(intention: intention) }
   let(:work)           { build(:work) }
 


### PR DESCRIPTION
### Fixes

Fixes `spec/services/hyrax/visibility_intention_applicator_spec.rb`.

### Summary

Marks `spec/services/hyrax/visibility_intention_applicator_spec.rb` as ActiveFedora-only.

### Type of change (for release notes)

- `notes-valkyrie` Valkyrie Progress

@samvera/hyrax-code-reviewers
