### PR TITLE
Valkyrization: Mark `persist_directly_contained_output_file_service_spec.rb` as ActiveFedora only

### DIFF
--- a/spec/services/hyrax/persist_directly_contained_output_file_service_spec.rb
+++ b/spec/services/hyrax/persist_directly_contained_output_file_service_spec.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-RSpec.describe Hyrax::PersistDirectlyContainedOutputFileService do
+RSpec.describe Hyrax::PersistDirectlyContainedOutputFileService, :active_fedora do
   # PersistDirectlyContainedOutputFileService is used by FullTextExtract.output_file_service
   let(:file_set) { create(:file_set, user: user) }
   let(:user) { build(:user) }


### PR DESCRIPTION
### Fixes

Mark `persist_directly_contained_output_file_service_spec.rb` as ActiveFedora only, since Valkyrized applications rely on `app/services/hyrax/valkyrie_persist_derivatives.rb`, as shown in `app/models/concerns/hyrax/file_set/derivatives.rb`:

```ruby
Hydra::Derivatives.source_file_service = Hyrax::LocalFileService
Hydra::Derivatives.output_file_service = Hyrax::ValkyriePersistDerivatives
# Hydra::Derivatives::FullTextExtract.output_file_service = Hyrax::PersistDirectlyContainedOutputFileService
Hydra::Derivatives::FullTextExtract.output_file_service = Hyrax::ValkyriePersistDerivatives
```

### Type of change (for release notes)

- `notes-valkyrie` Valkyrie Progress

### Changes proposed in this pull request:
* Mark `persist_directly_contained_output_file_service_spec.rb` as ActiveFedora only.

@samvera/hyrax-code-reviewers
