### PR TITLE
Marks `spec/models/concerns/hyrax/solr_document/ordered_members_spec.rb` as ActiveFedora-only.

### DIFF
--- a/spec/models/concerns/hyrax/solr_document/ordered_members_spec.rb
+++ b/spec/models/concerns/hyrax/solr_document/ordered_members_spec.rb
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
-RSpec.describe Hyrax::SolrDocument::OrderedMembers do
+
+# NOTE: This class specifically queries `ordered_targets_ssim`, which is only
+#   indexed within Dassie.
+RSpec.describe Hyrax::SolrDocument::OrderedMembers, :active_fedora do
   subject(:decorated) { described_class.decorate(document) }
   let(:data) { { id: parent_id } }
   let(:document) { SolrDocument.new(data) }


### PR DESCRIPTION
### Fixes

Fixes `spec/models/concerns/hyrax/solr_document/ordered_members_spec.rb`.

### Summary

Marks `spec/models/concerns/hyrax/solr_document/ordered_members_spec.rb` as ActiveFedora-only.

### Type of change (for release notes)

- `notes-valkyrie` Valkyrie Progress

@samvera/hyrax-code-reviewers
