### PR TITLE
Valkyrization: Mark `work_query_service_spec.rb` as ActiveFedora only

### DIFF
--- a/spec/services/hyrax/work_query_service_spec.rb
+++ b/spec/services/hyrax/work_query_service_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 module Hyrax
-  RSpec.describe WorkQueryService do
+  RSpec.describe WorkQueryService, :active_fedora do
     let(:user) { create(:user) }
     let(:work_id) { 'abc' }
     let(:work_relation) { double('Work Relation') }


### PR DESCRIPTION
### Fixes

Mark `spec/services/hyrax/work_query_service_spec.rb` as ActiveFedora-only since Valkyrized applications rely on `app/services/hyrax/work_resource_query_service.rb` instead. Refer to the following in `app/models/proxy_deposit_request.rb`:

```ruby
# line 10
self.work_query_service_class = Hyrax.config.use_valkyrie? ? Hyrax::WorkResourceQueryService : Hyrax::WorkQueryService
```

### Type of change (for release notes)

- `notes-valkyrie` Valkyrie Progress

### Changes proposed in this pull request:
* Mark `spec/services/hyrax/work_query_service_spec.rb` as ActiveFedora only

@samvera/hyrax-code-reviewers
