### PR TITLE
Valkyrization: Mark `move_all_works_to_admin_set_spec.rb` as ActiveFedora only

### DIFF
--- a/spec/lib/hyrax/move_all_works_to_admin_set_spec.rb
+++ b/spec/lib/hyrax/move_all_works_to_admin_set_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require 'hyrax/move_all_works_to_admin_set'
 
-RSpec.describe MoveAllWorksToAdminSet, :clean_repo do
+RSpec.describe MoveAllWorksToAdminSet, :active_fedora, :clean_repo do
   subject { described_class.run(admin_set) }
 
   let(:admin_set) { create(:admin_set) }


### PR DESCRIPTION
### Fixes

Mark `spec/lib/hyrax/move_all_works_to_admin_set_spec.rb` as ActiveFedora only, since it relies on `Hyrax::WorkRelation` which is also ActiveFedora only.

### Type of change (for release notes)

- `notes-valkyrie` Valkyrie Progress

### Changes proposed in this pull request:
* Mark `spec/lib/hyrax/move_all_works_to_admin_set_spec.rb` as ActiveFedora only.

@samvera/hyrax-code-reviewers
