### PR TITLE
Marks `spec/presenters/hyrax/member_presenter_factory_spec.rb` as ActiveFedora-only.

### DIFF
--- a/spec/presenters/hyrax/member_presenter_factory_spec.rb
+++ b/spec/presenters/hyrax/member_presenter_factory_spec.rb
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
-RSpec.describe Hyrax::MemberPresenterFactory do
+
+# NOTE: Valkyrie has it's own factory (Hyrax::PcdmMemberPresenterFactory).
+#   This is the legacy ActiveFedora factory.
+RSpec.describe Hyrax::MemberPresenterFactory, :active_fedora do
   subject(:factory) { described_class.new(solr_document, ability, request) }
 
   let(:solr_document) { SolrDocument.new(attributes) }


### PR DESCRIPTION
### Fixes

Fixes `spec/presenters/hyrax/member_presenter_factory_spec.rb`.

### Summary

Marks `spec/presenters/hyrax/member_presenter_factory_spec.rb` as ActiveFedora-only.

### Type of change (for release notes)

- `notes-valkyrie` Valkyrie Progress

@samvera/hyrax-code-reviewers
