### PR TITLE
Adds switch for expected solr cor in `spec/valkyrie/indexing/solr/indexing_adapter_spec.rb`.

### DIFF
--- a/spec/valkyrie/indexing/solr/indexing_adapter_spec.rb
+++ b/spec/valkyrie/indexing/solr/indexing_adapter_spec.rb
@@ -8,10 +8,11 @@ RSpec.describe Valkyrie::Indexing::Solr::IndexingAdapter, :clean_index, index_ad
   let(:metadata_adapter) { Wings::Valkyrie::MetadataAdapter.new }
   let(:resource) { FactoryBot.valkyrie_create(:hyrax_resource) }
   let(:resource2) { FactoryBot.valkyrie_create(:hyrax_resource) }
+  let(:expected_solr_core) { Hyrax.config.disable_wings ? 'koppie_test' : 'valkyrie-test' }
 
   describe "#connection" do
     it "returns connection" do
-      expect(adapter.connection.uri.to_s).to include 'valkyrie-test'
+      expect(adapter.connection.uri.to_s).to include expected_solr_core
     end
   end
 


### PR DESCRIPTION
### Fixes

Fixes `spec/valkyrie/indexing/solr/indexing_adapter_spec.rb`.

### Summary

Adds switch for expected solr cor in `spec/valkyrie/indexing/solr/indexing_adapter_spec.rb`.

### Type of change (for release notes)

- `notes-valkyrie` Valkyrie Progress

@samvera/hyrax-code-reviewers
