### PR TITLE
Marks `spec/forms/hyrax/forms/batch_edit_form_spec.rb` as ActiveFedora-only.

### DIFF
--- a/spec/forms/hyrax/forms/batch_edit_form_spec.rb
+++ b/spec/forms/hyrax/forms/batch_edit_form_spec.rb
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
-RSpec.describe Hyrax::Forms::BatchEditForm do
+
+# NOTE: Valkyrie has it's own form class (Hyrax::Forms::ResourceBatchEditForm).
+#   This is the legacy ActiveFedora form.
+RSpec.describe Hyrax::Forms::BatchEditForm, :active_fedora do
   let(:model) { GenericWork.new }
   let(:work1) do
     create :generic_work,


### PR DESCRIPTION
### Fixes

Fixes `spec/forms/hyrax/forms/batch_edit_form_spec.rb`.

### Summary

Marks `spec/forms/hyrax/forms/batch_edit_form_spec.rb` as ActiveFedora-only.

### Type of change (for release notes)

- `notes-valkyrie` Valkyrie Progress

@samvera/hyrax-code-reviewers
