### PR TITLE
Marks `spec/services/hyrax/import_url_failure_service_spec.rb` as ActiveFedora-only.

### DIFF
--- a/spec/services/hyrax/import_url_failure_service_spec.rb
+++ b/spec/services/hyrax/import_url_failure_service_spec.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
-RSpec.describe Hyrax::ImportUrlFailureService do
+# NOTE: This class deals with accessing a FileSet's #errors attribute,
+#   which isn't a defined attribute in Valkyrie objects.
+RSpec.describe Hyrax::ImportUrlFailureService, :active_fedora do
   let!(:depositor) { create(:user) }
   let(:inbox) { depositor.mailbox.inbox }
   let(:file) do


### PR DESCRIPTION
### Fixes

Fixes `spec/services/hyrax/import_url_failure_service_spec.rb`.

### Summary

Marks `spec/services/hyrax/import_url_failure_service_spec.rb` as ActiveFedora-only.

### Type of change (for release notes)

- `notes-valkyrie` Valkyrie Progress

@samvera/hyrax-code-reviewers
