### PR TITLE
🧹 Removing low-value spec

### DIFF
--- a/spec/presenters/hyrax/work_show_presenter_spec.rb
+++ b/spec/presenters/hyrax/work_show_presenter_spec.rb
@@ -342,13 +342,6 @@ RSpec.describe Hyrax::WorkShowPresenter do
       expect(presenter.file_set_presenters.map(&:id)).to eq obj.member_ids
     end
 
-    context "solr query" do
-      it "requests >10 rows" do
-        expect(Hyrax::SolrService).to receive(:post).with(hash_including(rows: 10_000)).and_call_original
-        presenter.file_set_presenters
-      end
-    end
-
     context "when some of the members are not file sets" do
       let(:obj) { FactoryBot.valkyrie_create(:hyrax_work, :with_file_and_work) }
       let(:solr_document) { SolrDocument.new(Hyrax::ValkyrieIndexer.for(resource: obj).to_solr) }


### PR DESCRIPTION
This spec doesn't test methods in the `described_class`, but instead asserts behavior in a delegated method's low-level implementation.

The spec could be more appropriate in the delegated object's unit tests.

Further, the logic for determining the delegate has branching logic; and with this single test likely means we were only testing one of the branches.