### PR TITLE
generalize Sipity::Entity() test for solr documents over classes

### DIFF
--- a/spec/models/sipity_spec.rb
+++ b/spec/models/sipity_spec.rb
@@ -45,9 +45,15 @@ RSpec.describe Sipity do
 
     context "with a SolrDocument" do
       let(:object) { SolrDocument.new(id: '9999', has_model_ssim: ["GenericWork"]) }
-      let(:workflow_state) { create(:workflow_state) }
+      let(:workflow_state) { FactoryBot.create(:workflow_state) }
       let!(:entity) do
-        Sipity::Entity.create(proxy_for_global_id: "gid://#{GlobalID.app}/GenericWork/9999",
+        gid_class_string = if GenericWork < Valkyrie::Resource
+                             "Hyrax::ValkyrieGlobalIdProxy"
+                           else
+                             "GenericWork"
+                           end
+
+        Sipity::Entity.create(proxy_for_global_id: "gid://#{GlobalID.app}/#{gid_class_string}/9999",
                               workflow_state: workflow_state,
                               workflow: workflow_state.workflow)
       end


### PR DESCRIPTION
since Valkyrie doesn't support `#to_global_id`, we use a `ValkyrieGlobalIdProxy` class for all `Valkyrie::ID` identified objects. hard coding the gid string to include "GenericWork" in this test breaks for this reason when "GenericWork" is a `Valkyrie::Resource`. to make it pass, we could build an actual work resource and cast it using `Hyrax::GleobalID(resource)`, but since this test avoids real models, we opt to just switch the expected entity match based on the model's ancestry.

@samvera/hyrax-code-reviewers
