### PR TITLE
Marks ActiveFedora test in `spec/models/sipity_spec.rb`.

### DIFF
--- a/spec/models/sipity_spec.rb
+++ b/spec/models/sipity_spec.rb
@@ -24,7 +24,9 @@ RSpec.describe Sipity do
       it { expect(described_class.Entity(object)).to eq object }
     end
 
-    context "with a Sipity::Entity that doesn't match the globalID for a valkyrie object" do
+    # NOTE: Since this is testing an ActiveFedora object parsed into a Valkyrie object, this has been marked as
+    #   ActiveFedora-only.
+    context "with a Sipity::Entity that doesn't match the globalID for a valkyrie object", :active_fedora do
       let(:object) { FactoryBot.create(:generic_work, id: '9999').valkyrie_resource }
       let(:workflow_state) { create(:workflow_state) }
       let!(:entity) do


### PR DESCRIPTION
### Fixes

Fixes `spec/models/sipity_spec.rb`.

### Summary

Marks ActiveFedora test in `spec/models/sipity_spec.rb`.

### Type of change (for release notes)

Add an appropriate `notes-*` label to the PR (or indicate here) that classifies this change.

- `notes-valkyrie` Valkyrie Progress

@samvera/hyrax-code-reviewers
