### PR TITLE
Marks `spec/lib/hyrax/resource_sync/resource_list_writer_spec.rb` as ActiveFedora-only.

### DIFF
--- a/spec/lib/hyrax/resource_sync/resource_list_writer_spec.rb
+++ b/spec/lib/hyrax/resource_sync/resource_list_writer_spec.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
-RSpec.describe Hyrax::ResourceSync::ResourceListWriter, :clean_repo do
+
+# NOTE: This uses methods, such as `#delegated_attributes`, that inherit from ActiveFedora::Relation.
+RSpec.describe Hyrax::ResourceSync::ResourceListWriter, :active_fedora, :clean_repo do
   subject(:writer) do
     described_class.new(resource_host: 'example.com', capability_list_url: capability_list)
   end


### PR DESCRIPTION
### Fixes

Fixes `spec/lib/hyrax/resource_sync/resource_list_writer_spec.rb`.

### Summary

Marks `spec/lib/hyrax/resource_sync/resource_list_writer_spec.rb` as ActiveFedora-only.

### Type of change (for release notes)

- `notes-valkyrie` Valkyrie Progress

@samvera/hyrax-code-reviewers
