### PR TITLE
Valkyrization: Fix inconsistent test in `lease_expiry_job_spec.rb`

### DIFF
--- a/spec/jobs/lease_expiry_job_spec.rb
+++ b/spec/jobs/lease_expiry_job_spec.rb
@@ -3,14 +3,16 @@ RSpec.describe LeaseExpiryJob, :clean_repo do
   subject { described_class }
 
   context 'with Valkyrie resources' do
-    let(:leased_work) { valkyrie_create(:hyrax_work, :under_lease) }
-    let(:work_with_expired_lease) { valkyrie_create(:hyrax_work, :with_expired_enforced_lease) }
-    let(:file_set_with_expired_lease) { valkyrie_create(:hyrax_file_set, :with_expired_enforced_lease) }
+    let!(:leased_work) { valkyrie_create(:hyrax_work, :under_lease) }
+    let!(:work_with_expired_lease) { valkyrie_create(:hyrax_work, :with_expired_enforced_lease) }
+    let!(:file_set_with_expired_lease) { valkyrie_create(:hyrax_file_set, :with_expired_enforced_lease) }
 
     describe '#records_with_expired_leases' do
       it 'returns all records with expired leases' do
-        records = [work_with_expired_lease.id, file_set_with_expired_lease.id]
-        expect(described_class.new.records_with_expired_leases.map(&:id)).to eq(records)
+        record_ids = described_class.new.records_with_expired_leases.map(&:id)
+        expect(record_ids.count).to eq(2)
+        expect(record_ids).to include(work_with_expired_lease.id)
+        expect(record_ids).to include(file_set_with_expired_lease.id)
       end
     end
 


### PR DESCRIPTION
### Fixes

I noticed in Koppie CI that the following test in `spec/jobs/lease_expiry_job_spec.rb` fails when items are not returned in the expected order:

![Screenshot 2024-01-24 at 11 06 06 AM](https://github.com/samvera/hyrax/assets/13107510/5f743f7b-4a09-4ccb-aebd-bdea8c8ad007)

In this PR, I edit the test to remove the reliance on the ordering of the expected items.

### Type of change (for release notes)

- `notes-valkyrie` Valkyrie Progress

### Changes proposed in this pull request:
* Change the test to check for the existence of the expected items individually instead of comparing arrays in any particular order

@samvera/hyrax-code-reviewers
