### PR TITLE
Valkyrization: Fix failing test in Koppie tied to Solr collection name

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -119,7 +119,7 @@ jobs:
       HYRAX_VALKYRIE: << parameters.hyrax_valkyrie >>
       IN_DOCKER: true
       KARMA_BROWSER: remote-chromium
-      SOLR_URL: http://127.0.0.1:8985/solr/hydra-test
+      SOLR_URL: http://127.0.0.1:8985/solr/koppie_test
       VALKYRIE_SOLR_CORE: valkyrie-test
       VALKYRIE_SOLR_PORT: 8985
     steps:
@@ -130,7 +130,7 @@ jobs:
             zip -1 -r solr_conf.zip ./*
             db-wait.sh localhost:8985 # wait for solr to be available before hitting the API
             curl -H "Content-type:application/octet-stream" --data-binary @solr_conf.zip "http://solr:SolrRocks@127.0.0.1:8985/solr/admin/configs?action=UPLOAD&name=solrconfig"
-            curl -H 'Content-type: application/json' http://solr:SolrRocks@127.0.0.1:8985/api/collections/ -d '{create: {name: hydra-test, config: solrconfig, numShards: 1}}'
+            curl -H 'Content-type: application/json' http://solr:SolrRocks@127.0.0.1:8985/api/collections/ -d '{create: {name: koppie_test, config: solrconfig, numShards: 1}}'
             curl -H 'Content-type: application/json' http://solr:SolrRocks@127.0.0.1:8985/api/collections/ -d '{create: {name: valkyrie-test, config: solrconfig, numShards: 1}}'
       - ruby/rspec-test:
           app-dir: /app/samvera/hyrax-engine


### PR DESCRIPTION
### Fixes

In `spec/valkyrie/indexing/solr/indexing_adapter_spec.rb`, the failing test is expecting the Solr collection to be named `koppie_test` while it is setup with name `hydra-test`. In `docker-compose-koppie.yml`, it is setup as `koppie_test`.

![Screenshot 2024-01-24 at 12 07 18 PM](https://github.com/samvera/hyrax/assets/13107510/4e24a82a-4d1e-4a06-8ac0-38093994706a)

### Type of change (for release notes)

- `notes-valkyrie` Valkyrie Progress

### Changes proposed in this pull request:

* Change the name of the Solr collection in the CircleCI config

@samvera/hyrax-code-reviewers
