### PR TITLE
Valkyrization: Fix failing tests in `spec/valkyrie/indexing/solr/indexing_adapter_spec.rb`

### DIFF
--- a/.koppie/.env
+++ b/.koppie/.env
@@ -43,6 +43,6 @@ SOLR_CORES=koppie
 SOLR_HOST=solr
 SOLR_PORT=8983
 SOLR_URL=http://solr:8983/solr/koppie
-SOLR_TEST_URL=http://solr:8983/solr/koppie_test
+SOLR_TEST_URL=http://solr:8983/solr/hydra-test
 VALKYRIE_METADATA_ADAPTER=pg_metadata
 VALKYRIE_STORAGE_ADAPTER=versioned_disk_storage

--- a/docker-compose-koppie.yml
+++ b/docker-compose-koppie.yml
@@ -145,7 +145,7 @@ services:
     command:
       - sh
       - "-c"
-      - "precreate-core koppie_test /opt/solr/server/configsets/hyraxconf; solr-precreate koppie /opt/solr/server/configsets/hyraxconf"
+      - "precreate-core hydra-test /opt/solr/server/configsets/hyraxconf; solr-precreate koppie /opt/solr/server/configsets/hyraxconf"
     volumes:
       - solr_home:/var/solr/data:cached
       - .koppie/solr/conf:/opt/solr/server/configsets/hyraxconf

--- a/docker-compose-sirenia.yml
+++ b/docker-compose-sirenia.yml
@@ -129,8 +129,8 @@ services:
     image: fcrepo/fcrepo:6.4.0
     environment:
       - >-
-        CATALINA_OPTS=-Dfcrepo.home=/fcrepo-home -Djava.awt.headless=true -Dfile.encoding=UTF-8 
-        -server -Xms512m -Xmx1024m -XX:NewSize=256m -XX:MaxNewSize=256m -XX:PermSize=256m 
+        CATALINA_OPTS=-Dfcrepo.home=/fcrepo-home -Djava.awt.headless=true -Dfile.encoding=UTF-8
+        -server -Xms512m -Xmx1024m -XX:NewSize=256m -XX:MaxNewSize=256m -XX:PermSize=256m
         -XX:MaxPermSize=256m -XX:+DisableExplicitGC -Dorg.apache.tomcat.util.buf.UDecoder.ALLOW_ENCODED_SLASH=true
       - JAVA_OPTS=-Dorg.apache.tomcat.util.buf.UDecoder.ALLOW_ENCODED_SLASH=true
     volumes:
@@ -170,7 +170,7 @@ services:
     command:
       - sh
       - "-c"
-      - "precreate-core koppie_test /opt/solr/server/configsets/hyraxconf; solr-precreate koppie /opt/solr/server/configsets/hyraxconf"
+      - "precreate-core hydra-test /opt/solr/server/configsets/hyraxconf; solr-precreate koppie /opt/solr/server/configsets/hyraxconf"
     volumes:
       - solr_home:/var/solr/data:cached
       - .koppie/solr/conf:/opt/solr/server/configsets/hyraxconf

--- a/spec/valkyrie/indexing/solr/indexing_adapter_spec.rb
+++ b/spec/valkyrie/indexing/solr/indexing_adapter_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Valkyrie::Indexing::Solr::IndexingAdapter, :clean_index, index_ad
   let(:metadata_adapter) { Wings::Valkyrie::MetadataAdapter.new }
   let(:resource) { FactoryBot.valkyrie_create(:hyrax_resource) }
   let(:resource2) { FactoryBot.valkyrie_create(:hyrax_resource) }
-  let(:expected_solr_core) { Hyrax.config.disable_wings ? 'koppie_test' : 'valkyrie-test' }
+  let(:expected_solr_core) { Hyrax.config.disable_wings ? 'hydra-test' : 'valkyrie-test' }
 
   describe "#connection" do
     it "returns connection" do


### PR DESCRIPTION
### Fixes

Fix failing tests in `spec/valkyrie/indexing/solr/indexing_adapter_spec.rb` due to difference in Solr core name between Koppie docker and CircleCI setup. Per @dlpierce's recommendation, I am changing the Solr core name for Koppie to `hydra-test`.


### Type of change (for release notes)

- `notes-valkyrie` Valkyrie Progress

### Changes proposed in this pull request:

* Change Solr core name for Koppie to `hydra-test`

@samvera/hyrax-code-reviewers
