### PR TITLE
Allows pending test that passes in CI but fails locally (`spec/services/hyrax/statistics/collections/over_time_spec.rb`).

### DIFF
--- a/spec/services/hyrax/statistics/collections/over_time_spec.rb
+++ b/spec/services/hyrax/statistics/collections/over_time_spec.rb
@@ -5,24 +5,10 @@ RSpec.describe Hyrax::Statistics::Collections::OverTime do
   describe "#points", :clean_repo do
     before { FactoryBot.valkyrie_create(:hyrax_collection) }
 
-    shared_examples('test list of points') do
-      it "is a list of points" do
-        expect(service.points.size).to eq 5
-        expect(service.points.first[1]).to eq 0
-        expect(service.points.to_a.last[1]).to eq 1
-      end
-    end
-
-    context 'ActiveFedora environment', :active_fedora do
-      include_examples 'test list of points'
-    end
-
-    # NOTE: Hyrax::AbstractTypeRelation inherits from ActiveFedora::Relation. When the code attempts to run
-    #   `AbstractTypeRelation.new(allowable_types: [Hyrax.config.collection_class])` in a Valkyrie environment,
-    #   it quietly fails with `#<NoMethodError: undefined method `solr_query_handler' for Monograph:Class> rescued
-    #   during inspection` and returns nil.
-    context 'Valkyrie environment', pending: 'undefined method solr_query_handler' do
-      include_examples 'test list of points' if Hyrax.config.disable_wings
+    it "is a list of points" do
+      expect(service.points.size).to eq 5
+      expect(service.points.first[1]).to eq 0
+      expect(service.points.to_a.last[1]).to eq 1
     end
   end
 end


### PR DESCRIPTION
### Fixes

Fixes `spec/services/hyrax/statistics/collections/over_time_spec.rb`.

### Summary

Allows pending test that passes in CI but fails locally (`spec/services/hyrax/statistics/collections/over_time_spec.rb`).

### Type of change (for release notes)

- `notes-valkyrie` Valkyrie Progress

@samvera/hyrax-code-reviewers
