### PR TITLE
Fix search results for works with matching fileset keywords

### DIFF
--- a/app/search_builders/hyrax/catalog_search_builder.rb
+++ b/app/search_builders/hyrax/catalog_search_builder.rb
@@ -80,6 +80,6 @@ class Hyrax::CatalogSearchBuilder < Hyrax::SearchBuilder
 
   # join from file id to work relationship solrized member_ids_ssim
   def join_for_works_from_files
-    "{!join from=#{Hyrax.config.id_field} to=member_ids_ssim}{!terms f=has_model_ssim}FileSet,Hyrax::FileSet#{dismax_query}"
+    "{!join from=#{Hyrax.config.id_field} to=member_ids_ssim v=has_model_ssim:*FileSet}#{dismax_query}"
   end
 end

--- a/spec/search_builders/hyrax/catalog_search_builder_spec.rb
+++ b/spec/search_builders/hyrax/catalog_search_builder_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Hyrax::CatalogSearchBuilder do
       it "creates a valid solr join for works and files" do
         subject
         expect(solr_params[:user_query]).to eq user_query
-        expect(solr_params[:q]).to eq '{!lucene}_query_:"{!dismax v=$user_query}" _query_:"{!join from=id to=member_ids_ssim}{!terms f=has_model_ssim}FileSet,Hyrax::FileSet{!dismax v=$user_query}"'
+        expect(solr_params[:q]).to eq '{!lucene}_query_:"{!dismax v=$user_query}" _query_:"{!join from=id to=member_ids_ssim v=has_model_ssim:*FileSet}{!dismax v=$user_query}"'
       end
     end
 


### PR DESCRIPTION
### Summary

Fixes catalog controller spec in koppie and display of works where only the Hyrax::FileSet matches the query.

### Guidance for testing, such as acceptance criteria or new user interface behaviors:
* Given a work where only an attached fileset contains metadata matching the search query, the work is displayed in the catalog controller search results.

### Detailed Description
The previous attempt to add `Hyrax::FileSet` to the existing requirement of "`FileSet` by way of the `!terms` query did not work properly, perhaps not filtering at all.

### Changes proposed in this pull request:
* Modify this solr query to allow has_model_ssim to match on any value ending in "FileSet"
* 
*

@samvera/hyrax-code-reviewers
