### PR TITLE
♻️ Leverage more of Blacklight's Solr URL

### DIFF
--- a/lib/valkyrie/indexing/solr/indexing_adapter.rb
+++ b/lib/valkyrie/indexing/solr/indexing_adapter.rb
@@ -66,9 +66,14 @@ module Valkyrie
             return {}
           end
 
-          { 'host' => bl_index.host,
+          {
+            'host' => bl_index.host,
+            'user' => bl_index.user,
+            'password' => bl_index.password,
+            'scheme' => bl_index.scheme,
             'port' => bl_index.port,
-            'core' => 'hyrax-valkyrie' }
+            'core' => bl_index.path.split("/")[2] || 'hyrax-valkyrie'
+          }.compact
         end
 
         def connection_url
@@ -78,12 +83,17 @@ module Valkyrie
                      {}
                    end
 
-          # if any configuration is missing, derive it from Blacklight
-          config = blacklight_based_config.with_indifferent_access.merge(config)
-
+          # Given how we're building blacklight_based_config, there won't be a URL.  So let's avoid
+          # that whole logic path.
           return config['url'] if config['url'].present?
 
-          "http://#{config['host']}:#{config['port']}/solr/#{config['core']}"
+          # Derive any missing configuration from Blacklight.
+          config = blacklight_based_config.with_indifferent_access.merge(config)
+
+          url = "#{config.fetch('scheme', 'http')}://"
+          url = "#{url}#{config['user']}:#{config['password']}@" if config.key?('user') && config.key?('password')
+
+          "#{url}#{config['host']}:#{config['port']}/solr/#{config['core']}"
         end
 
         def default_connection


### PR DESCRIPTION
Prior to this commit, our defaults were not considering scheme, core, password, nor user from the Blacklight URL.

What this meant was that the generated URL could strip away useful information from the configured URL; in particular the user and password information.

With this change, we utilize more of the underlying Blacklight configuration; a net positive.