### PR TITLE
🐛 Favor Hyrax::SolrService where possible

### DIFF
--- a/app/controllers/hyrax/admin/analytics/work_reports_controller.rb
+++ b/app/controllers/hyrax/admin/analytics/work_reports_controller.rb
@@ -41,11 +41,11 @@ module Hyrax
         def accessible_works
           models = Hyrax.config.curation_concerns.map { |m| "\"#{m}\"" }
           if current_user.ability.admin?
-            ActiveFedora::SolrService.query("has_model_ssim:(#{models.join(' OR ')})",
+            Hyrax::SolrService.query("has_model_ssim:(#{models.join(' OR ')})",
               fl: 'title_tesim, id, member_of_collections',
               rows: 50_000)
           else
-            ActiveFedora::SolrService.query(
+            Hyrax::SolrService.query(
               "edit_access_person_ssim:#{current_user} AND has_model_ssim:(#{models.join(' OR ')})",
               fl: 'title_tesim, id, member_of_collections',
               rows: 50_000
@@ -55,13 +55,13 @@ module Hyrax
 
         def accessible_file_sets
           if current_user.ability.admin?
-            ActiveFedora::SolrService.query(
+            Hyrax::SolrService.query(
               "has_model_ssim:FileSet",
               fl: 'title_tesim, id',
               rows: 50_000
             )
           else
-            ActiveFedora::SolrService.query(
+            Hyrax::SolrService.query(
               "edit_access_person_ssim:#{current_user} AND has_model_ssim:FileSet",
               fl: 'title_tesim, id',
               rows: 50_000

--- a/app/models/hyrax/statistic.rb
+++ b/app/models/hyrax/statistic.rb
@@ -43,7 +43,7 @@ module Hyrax
 
       def query_works(query)
         models = Hyrax.config.curation_concerns.map { |m| "\"#{m}\"" }
-        ActiveFedora::SolrService.query("has_model_ssim:(#{models.join(' OR ')})", fl: query, rows: 100_000)
+        Hyrax::SolrService.query("has_model_ssim:(#{models.join(' OR ')})", fl: query, rows: 100_000)
       end
 
       def work_types

--- a/app/services/hyrax/solr_service.rb
+++ b/app/services/hyrax/solr_service.rb
@@ -17,7 +17,7 @@ module Hyrax
     delegate :commit, to: :connection
 
     def initialize(use_valkyrie: Hyrax.config.query_index_from_valkyrie)
-      @old_service = ActiveFedora::SolrService
+      @old_service = ActiveFedora::SolrService # What hopefully will be the lone reference to ActiveFedora::SolrService
       @use_valkyrie = use_valkyrie
     end
 

--- a/lib/wings/services/custom_queries/find_ids_by_model.rb
+++ b/lib/wings/services/custom_queries/find_ids_by_model.rb
@@ -29,7 +29,7 @@ module Wings
         model_name = ModelRegistry.lookup(model).model_name
 
         solr_query = "_query_:\"{!raw f=has_model_ssim}#{model_name}\""
-        solr_response = ActiveFedora::SolrService.get(solr_query, fl: 'id', rows: @query_rows)['response']
+        solr_response = Hyrax::SolrService.get(solr_query, fl: 'id', rows: @query_rows)['response']
 
         loop do
           response_docs = solr_response['docs']
@@ -38,7 +38,7 @@ module Wings
           response_docs.each { |doc| yield doc['id'] }
 
           break if (solr_response['start'] + solr_response['docs'].count) >= solr_response['numFound']
-          solr_response = ActiveFedora::SolrService.get(solr_query, fl: 'id', rows: @query_rows, start: solr_response['start'] + @query_rows)['response']
+          solr_response = Hyrax::SolrService.get(solr_query, fl: 'id', rows: @query_rows, start: solr_response['start'] + @query_rows)['response']
         end
       end
     end


### PR DESCRIPTION
We need one remaining `ActiveFedora::SolrService` reference to tie into that not yet removed class.

@samvera/hyrax-code-reviewers
