### PR TITLE
Valkyrization: Fix Collection Type Deletion Bug

### DIFF
--- a/app/services/hyrax/custom_queries/find_collections_by_type.rb
+++ b/app/services/hyrax/custom_queries/find_collections_by_type.rb
@@ -30,7 +30,7 @@ module Hyrax
       # @return [Enumerable<PcdmCollection>]
       def find_collections_by_type(global_id:)
         query_service
-          .find_all_of_model(model: Hyrax.config.collection_model)
+          .find_all_of_model(model: Hyrax.config.collection_model.safe_constantize)
           .select { |collection| collection.collection_type_gid == global_id }
       end
     end

--- a/app/services/hyrax/custom_queries/find_collections_by_type.rb
+++ b/app/services/hyrax/custom_queries/find_collections_by_type.rb
@@ -30,7 +30,7 @@ module Hyrax
       # @return [Enumerable<PcdmCollection>]
       def find_collections_by_type(global_id:)
         query_service
-          .find_all_of_model(model: PcdmCollection)
+          .find_all_of_model(model: Hyrax.config.collection_model)
           .select { |collection| collection.collection_type_gid == global_id }
       end
     end

--- a/spec/controllers/hyrax/admin/collection_types_controller_spec.rb
+++ b/spec/controllers/hyrax/admin/collection_types_controller_spec.rb
@@ -307,7 +307,7 @@ RSpec.describe Hyrax::Admin::CollectionTypesController, type: :controller, clean
       end
 
       context "when collections exist of this type" do
-        let!(:collection) { valkyrie_create(:pcdm_collection, collection_type_gid: collection_type_to_destroy.to_global_id.to_s) }
+        let!(:collection) { valkyrie_create(:hyrax_collection, collection_type_gid: collection_type_to_destroy.to_global_id.to_s) }
 
         it "doesn't delete the collection type or collection" do
           delete :destroy, params: { id: collection_type_to_destroy }

--- a/spec/features/collection_type_spec.rb
+++ b/spec/features/collection_type_spec.rb
@@ -241,7 +241,7 @@ RSpec.describe 'collection_type', type: :feature do
 
     context 'when collections exist of this type' do
       let!(:collection1) do
-        FactoryBot.valkyrie_create(:pcdm_collection, :public, user: create(:user), collection_type_gid: exhibit_collection_type.to_global_id)
+        FactoryBot.valkyrie_create(:hyrax_collection, :public, user: create(:user), collection_type_gid: exhibit_collection_type.to_global_id)
       end
 
       before do
@@ -340,7 +340,7 @@ RSpec.describe 'collection_type', type: :feature do
       include_examples 'tests the inability to delete collection types that are associated to persisted collections'
     end
 
-    context 'when collections exist of this type (Valkyrie)', pending: "This test should work after resolving https://github.com/samvera/hyrax/issues/6611" do
+    context 'when collections exist of this type (Valkyrie)' do
       include_examples 'tests the inability to delete collection types that are associated to persisted collections' if Hyrax.config.disable_wings
     end
   end

--- a/spec/forms/hyrax/forms/admin/collection_type_form_spec.rb
+++ b/spec/forms/hyrax/forms/admin/collection_type_form_spec.rb
@@ -6,7 +6,9 @@ RSpec.describe Hyrax::Forms::Admin::CollectionTypeForm, :clean_repo do
   shared_context 'with a collection' do
     let(:collection_type) { FactoryBot.create(:collection_type) }
 
-    FactoryBot.valkyrie_create(:hyrax_collection, collection_type_gid: collection_type.to_global_id)
+    before do
+      FactoryBot.valkyrie_create(:hyrax_collection, collection_type_gid: collection_type.to_global_id)
+    end
   end
 
   it { is_expected.to delegate_method(:title).to(:collection_type) }

--- a/spec/forms/hyrax/forms/admin/collection_type_form_spec.rb
+++ b/spec/forms/hyrax/forms/admin/collection_type_form_spec.rb
@@ -6,12 +6,7 @@ RSpec.describe Hyrax::Forms::Admin::CollectionTypeForm, :clean_repo do
   shared_context 'with a collection' do
     let(:collection_type) { FactoryBot.create(:collection_type) }
 
-    # NOTE: Changed collection object to :pcdm_collection because the query used to find a collection_type's
-    #   collections is tied to Hyrax::PcdmCollection, which :hyrax_collection doesn't parse to when that type
-    #   of collection is created via FactoryBot.
-    before do
-      FactoryBot.valkyrie_create(:pcdm_collection, collection_type_gid: collection_type.to_global_id)
-    end
+    FactoryBot.valkyrie_create(:hyrax_collection, collection_type_gid: collection_type.to_global_id)
   end
 
   it { is_expected.to delegate_method(:title).to(:collection_type) }

--- a/spec/models/hyrax/collection_type_spec.rb
+++ b/spec/models/hyrax/collection_type_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Hyrax::CollectionType, type: :model do
 
   shared_context 'with a collection' do
     let(:collection_type) { FactoryBot.create(:collection_type) }
-    let!(:collection) { FactoryBot.valkyrie_create(:pcdm_collection, collection_type_gid: collection_type.to_global_id.to_s) }
+    let!(:collection) { FactoryBot.valkyrie_create(:hyrax_collection, collection_type_gid: collection_type.to_global_id.to_s) }
   end
 
   describe "validations", :clean_repo do
@@ -155,7 +155,7 @@ RSpec.describe Hyrax::CollectionType, type: :model do
       end
 
       context 'when use_valkyrie is true' do
-        let!(:pcdm_collection) { valkyrie_create(:pcdm_collection, collection_type_gid: collection_type.to_global_id.to_s) }
+        let!(:pcdm_collection) { valkyrie_create(:hyrax_collection, collection_type_gid: collection_type.to_global_id.to_s) }
 
         it 'returns pcdm collections of this collection type' do
           expect(collection_type.collections(use_valkyrie: true).to_a).to include pcdm_collection

--- a/spec/services/hyrax/custom_queries/find_collections_by_type_spec.rb
+++ b/spec/services/hyrax/custom_queries/find_collections_by_type_spec.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-RSpec.describe Hyrax::CustomQueries::FindCollectionsByType, valkyrie_adapter: :test_adapter do
+RSpec.describe Hyrax::CustomQueries::FindCollectionsByType, valkyrie_adapter: :test_adapter, skip: !Hyrax.config.use_valkyrie? || !Hyrax.config.disable_wings do
   subject(:query_handler) { described_class.new(query_service: query_service) }
   let(:adapter)           { Valkyrie::MetadataAdapter.find(:test_adapter) }
   let(:collection_type)   { FactoryBot.create(:collection_type) }


### PR DESCRIPTION
### Fixes

Fix #6611 

### Summary

In Koppie, when querying for collections that are of a certain collection type, we are using a fixed type `PcdmCollection` instead of using the type assigned in the configuration of the application, `Hyrax.config.collection_model`. When checking if there are any collections associated with a specific collection type, the application runs the following query in Koppie:

```
Valkyrie::Persistence::Postgres::ORM::Resource Load (0.7ms)  SELECT "orm_resources".* FROM "orm_resources" WHERE "orm_resources"."internal_resource" = $1 ORDER BY "orm_resources"."id" ASC LIMIT $2  [["internal_resource", "CollectionResource"], ["LIMIT", 1000]]
```

Since Koppie is configured with `config.collection_model = 'CollectionResource'`, all collections created have `internal_resource` set to `CollectionResource` instead of `PcdmCollection`, hence why the query returns no records of collections associated with a specific type, even if they do exist.

### Guidance for testing, such as acceptance criteria or new user interface behaviors:
1. Log in as admin in the Koppie environment.
2. Visit `Dashboard` (click on user email in upper right corner).
3. Choose `Settings` and then `Collection Types` on the left side of the screen.
4. Click `Create new collection type` on the upper right corner of the screen.
5. Fill in `Type name` with anything and `Save`.
6. Select `Collections` on the left side of the window and then choose `Add New Collection`.
7. For `Select type of collection`, choose the collection type you just created and click `Create collection`.
8. After that collection persists,  go back to Collection Types (`Settings` -> `Collection Types`).
9. Find the collection type you created and click `Delete`; confirm collection type cannot be deleted in the pop-up.

### Type of change (for release notes)

- `notes-valkyrie` Valkyrie Progress

### Changes proposed in this pull request:
* Edit `app/services/hyrax/custom_queries/find_collections_by_type.rb` to use `Hyrax.config.collection_model` instead of `PcdmCollection` in the query used to check if a collection type has any collections associated with it
* Edit test files to account for the change in `app/services/hyrax/custom_queries/find_collections_by_type.rb`

@samvera/hyrax-code-reviewers
