### PR TITLE
Extract fault tolerant event handling

### DIFF
--- a/app/services/hyrax/admin_set_create_service.rb
+++ b/app/services/hyrax/admin_set_create_service.rb
@@ -84,7 +84,7 @@ module Hyrax
       # Create an instance of `Hyrax::AdministrativeSet` with the suggested_id if supported.
       # @return [Hyrax::AdministrativeSet] the new admin set
       def create_admin_set(suggested_id:, title:)
-        if suggested_id.blank? || Hyrax.config.disable_wings || !Hyrax.metadata_adapter.is_a?(Wings::Valkyrie::MetadataAdapter)
+        if suggested_id.blank? || Hyrax.config.disable_wings
           # allow persister to assign id
           Hyrax::AdministrativeSet.new(title: Array.wrap(title))
         else

--- a/app/services/hyrax/listeners/object_lifecycle_listener.rb
+++ b/app/services/hyrax/listeners/object_lifecycle_listener.rb
@@ -10,7 +10,8 @@ module Hyrax
       # @param [Dry::Events::Event] event
       # @return [void]
       def on_object_deleted(event)
-        ContentDeleteEventJob.perform_later(event[:id].to_s, event[:user])
+        object_id = event[:object]&.id || event[:id]
+        ContentDeleteEventJob.perform_later(object_id.to_s, event[:user])
       end
 
       ##

--- a/app/services/hyrax/listeners/object_lifecycle_listener.rb
+++ b/app/services/hyrax/listeners/object_lifecycle_listener.rb
@@ -10,6 +10,9 @@ module Hyrax
       # @param [Dry::Events::Event] event
       # @return [void]
       def on_object_deleted(event)
+        # Accessing a non-existent key on a Dry::Events::Event will raise a KeyError; hence
+        # we cast the event to a hash
+        event = event.to_h
         object_id = event[:object]&.id || event[:id]
         ContentDeleteEventJob.perform_later(object_id.to_s, event[:user])
       end

--- a/app/services/hyrax/listeners/trophy_cleanup_listener.rb
+++ b/app/services/hyrax/listeners/trophy_cleanup_listener.rb
@@ -9,7 +9,8 @@ module Hyrax
       # @param [Dry::Events::Event] event
       # @return [void]
       def on_object_deleted(event)
-        Trophy.where(work_id: event[:id]).destroy_all
+        object_id = event[:object]&.id || event[:id]
+        Trophy.where(work_id: object_id).destroy_all
       rescue StandardError => err
         Hyrax.logger.warn "Failed to delete trophies for #{event[:id]}. " \
                           'These trophies might be orphaned.' \

--- a/app/services/hyrax/listeners/workflow_listener.rb
+++ b/app/services/hyrax/listeners/workflow_listener.rb
@@ -30,6 +30,18 @@ module Hyrax
         # don't error on known sipity error types; log instead
         Hyrax.logger.error(err)
       end
+
+      ##
+      # Called when 'object.deleted' event is published
+      # @param [Dry::Events::Event] event
+      # @return [void]
+      def on_object_deleted(event)
+        return unless event[:object]
+        gid = Hyrax::ValkyrieGlobalIdProxy.new(resource: event[:object]).to_global_id
+        return unless gid.present?
+        Sipity::Entity.where(proxy_for_global_id: gid.to_s).destroy_all
+      end
+
     end
   end
 end

--- a/app/services/hyrax/listeners/workflow_listener.rb
+++ b/app/services/hyrax/listeners/workflow_listener.rb
@@ -38,10 +38,9 @@ module Hyrax
       def on_object_deleted(event)
         return unless event[:object]
         gid = Hyrax::ValkyrieGlobalIdProxy.new(resource: event[:object]).to_global_id
-        return unless gid.present?
+        return if gid.blank?
         Sipity::Entity.where(proxy_for_global_id: gid.to_s).destroy_all
       end
-
     end
   end
 end

--- a/app/services/hyrax/listeners/workflow_listener.rb
+++ b/app/services/hyrax/listeners/workflow_listener.rb
@@ -22,6 +22,7 @@ module Hyrax
       # @param [Dry::Events::Event] event
       # @return [void]
       def on_object_deposited(event)
+        event = event.to_h
         return Hyrax.logger.warn("Skipping workflow initialization for #{event[:object]}; no user is given\n\t#{event}") if
           event[:user].blank?
 
@@ -36,6 +37,7 @@ module Hyrax
       # @param [Dry::Events::Event] event
       # @return [void]
       def on_object_deleted(event)
+        event = event.to_h
         return unless event[:object]
         gid = Hyrax::ValkyrieGlobalIdProxy.new(resource: event[:object]).to_global_id
         return if gid.blank?


### PR DESCRIPTION
## make delete listeners all take an object

c877c24d38c66704a56eba0bfdf50b0ede9e777b


## 🐛 Cast Dry::Events::Event to Hash to behave better

c4827f8f990f14ec8e23bcfffe3b512c30d49f00

Prior to this commit, when we had an event with payload keys of `:id`
and `:user`, accessing the `event[:object]` raised a KeyNotFound error.

This coercion of event to a hash helps with expectations.
