### PR TITLE
Rescue exception when collection is missing

### DIFF
--- a/app/helpers/hyrax/hyrax_helper_behavior.rb
+++ b/app/helpers/hyrax/hyrax_helper_behavior.rb
@@ -294,6 +294,8 @@ module Hyrax
       solr_field = solr_docs.first["title_tesim"]
       return nil if solr_field.nil?
       solr_field.first
+    rescue Blacklight::Exceptions::RecordNotFound
+      nil
     end
 
     ##

--- a/spec/helpers/hyrax_helper_spec.rb
+++ b/spec/helpers/hyrax_helper_spec.rb
@@ -375,6 +375,7 @@ RSpec.describe HyraxHelper, type: :helper do
       allow(repository).to receive(:find).with("abcd12345").and_return(solr_response)
       allow(repository).to receive(:find).with("efgh67890").and_return(bad_solr_response)
       allow(repository).to receive(:find).with("bad-id").and_return(empty_solr_response)
+      allow(repository).to receive(:find).with("error-id").and_raise(Blacklight::Exceptions::RecordNotFound)
     end
 
     it "returns the first title of the collection" do
@@ -387,6 +388,10 @@ RSpec.describe HyraxHelper, type: :helper do
 
     it "returns nil if collection not found" do
       expect(helper.collection_title_by_id("bad-id")).to eq nil
+    end
+
+    it "returns nil if RecordNotFound is raised" do
+      expect(helper.collection_title_by_id("error-id")).to eq nil
     end
   end
 


### PR DESCRIPTION
### Fixes

Fixes #6649

### Summary

Rescues RecordNotFound error when collection is not found.

### Guidance for testing, such as acceptance criteria or new user interface behaviors:
* A work with a missing collection does not raise an error in catalog controller search results.

### Detailed Description
Rescuing this error makes this method behave the same as when the collection does not have a title field. In theory this situation is protected against by checks when deleting a collection, but in case "Life Finds a Way" this should prevent painful error screens.

@samvera/hyrax-code-reviewers
