### PR TITLE
🐛 Fix Hyrax::ChangeSet.inspect method

### DIFF
--- a/app/models/hyrax/change_set.rb
+++ b/app/models/hyrax/change_set.rb
@@ -21,8 +21,8 @@ module Hyrax
 
       ##
       # @return [String]
-      def self.inspect
-        return "Hyrax::ChangeSet(#{model_class})" if name.blank?
+      define_singleton_method :inspect do
+        return "Hyrax::ChangeSet(#{resource_class})" if name.blank?
         super
       end
     end


### PR DESCRIPTION
Prior to this, there was no reference to `model_class` meaning that `Hyrax::ChangeSet.inspect` would raise an exception.

We need the binding of the `resource_class`, which is available during the creation of the class but not afterwards.  In other words, by using the `define_singleton_method` we can leverage the provided `resource_class` as a bound value for the return value of `.inspect`.