### PR TITLE
🧹 Avoid direct `allow(File).to receive(:exist?)`

### DIFF
--- a/spec/services/hyrax/thumbnail_path_service_spec.rb
+++ b/spec/services/hyrax/thumbnail_path_service_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe Hyrax::ThumbnailPathService do
     context "that has a thumbnail" do
       let(:original_file) { mock_file_factory(mime_type: 'image/jpeg') }
 
-      before { allow(File).to receive(:exist?).and_return(true) }
+      before { allow(described_class).to receive(:thumbnail?).and_return(true) }
       it { is_expected.to eq '/downloads/999?file=thumbnail' }
     end
 
@@ -68,7 +68,8 @@ RSpec.describe Hyrax::ThumbnailPathService do
       let(:original_file)  { mock_file_factory(mime_type: 'image/jpeg') }
 
       before do
-        allow(File).to receive(:exist?).and_return(true)
+        allow(described_class).to receive(:thumbnail?).and_return(true)
+        allow(ActiveFedora::Base).to receive(:find)
         allow(ActiveFedora::Base).to receive(:find).with('999').and_return(representative)
         allow(representative).to receive(:original_file).and_return(original_file)
       end


### PR DESCRIPTION
If you stub `File.exist?` to return `true` you cannot use a debugger.

Why?  Because the debugger will check if `.byebugrc` exists (which is stubbed to be true) and then attempt to open that file, which will probably fail.

@samvera/hyrax-code-reviewers
