### PR TITLE
🐛 Remove subtle timing error in ActorStack coercion

### DIFF
--- a/app/actors/hyrax/actors/base_actor.rb
+++ b/app/actors/hyrax/actors/base_actor.rb
@@ -69,10 +69,13 @@ module Hyrax
       end
 
       def save(env, use_valkyrie: false)
-        return env.curation_concern.save unless use_valkyrie
+        # NOTE: You must call env.curation_concern.save before you attempt to coerce the curation
+        # concern into a valkyrie resource.
+        is_valid = env.curation_concern.save
+        return is_valid unless use_valkyrie
 
         # don't run validations again on the converted object if they've already passed
-        resource = valkyrie_save(resource: env.curation_concern.valkyrie_resource, is_valid: env.curation_concern.save)
+        resource = valkyrie_save(resource: env.curation_concern.valkyrie_resource, is_valid: is_valid)
 
         # we need to manually set the id and reload, because the actor stack requires
         # `env.curation_concern` to be the exact same instance throughout.
@@ -83,7 +86,7 @@ module Hyrax
         # for now, just hit the validation error again
         # later we should capture the _err.obj and pass it back
         # through the environment
-        env.curation_concern.save
+        is_valid
       end
 
       def apply_save_data_to_curation_concern(env)


### PR DESCRIPTION
Prior to this commit, the order of operations was:

1. Coerce the curation_concern to a valkyrie_resource
2. Save the curation concern (which changes the curation_concern object and thus would change the valkyrie_resource were we to again run `env.curation_concern.valkyrie_resource`)

The subtle bug is that the curation_concern's valkyrie resource would have an out of sync access control.  Why, because we're relying on logic elsewhere (e.g. Hyrax::ModelConverter) to assign the permissions.

In v5.0.0 and prior we're copying the current curation concern's permissions to the valkyrie permission; this happens before we save. [See implementation][1].

However, this can create issues depending on metadata adapter configuration; in particular when we update the ACL object for a record without updating the record; something that we see happening in the Frigg and Freyja adapters, but is also not limited to those adapters.

Also, consider that we likely want to remove a timing of parameters; because when reading method call, we (or at least I) mentally treat the parameters we pass as order independent.  Put another way, the parameters we pass should likely not change state of each other.

[1]: https://github.com/samvera/hyrax/commit/bcf3ab05d0acf211d4694f7ef0d165319667d6e7

@samvera/hyrax-code-reviewers
