### PR TITLE
♻️ Favor Hyrax.query_service over method chaining

### DIFF
--- a/lib/wings/model_transformer.rb
+++ b/lib/wings/model_transformer.rb
@@ -83,8 +83,25 @@ module Wings
       # otherwise, we can just rely on the `access_control_ids`.
       return unless resource.respond_to?(:permission_manager)
 
-      resource.permission_manager.acl.permissions =
-        pcdm_object.access_control.valkyrie_resource.permissions
+      # When the pcdm_object has an access_control (see above) but there's no access_control_id, we
+      # need to rely on the computed access_control object.  Why?  There are tests that fail.
+      acl = if pcdm_object.access_control_id.nil?
+              pcdm_object.access_control.valkyrie_resource
+            else
+              begin
+                # Given that we have an access_control AND an access_control_id, we want to ensure
+                # that we fetch the access_control from persistence.  Why?  Because when we update
+                # an ACL and are using those adapters, we will write the ACL to the Valkyrie adapter
+                # without writing the work to the Valkyrie adapter.  This might be a failing, but
+                # migrations in place are hard.
+                acl_id = pcdm_object.access_control_id
+                acl_id = ::Valkyrie::ID.new(acl_id) unless acl_id.is_a?(::Valkyrie::ID)
+                Hyrax.query_service.find_by(id: acl_id)
+              rescue ::Valkyrie::Persistence::ObjectNotFoundError
+                pcdm_object.access_control.valkyrie_resource
+              end
+            end
+      resource.permission_manager.acl.permissions = acl.permissions
     end
 
     ##

--- a/spec/services/hyrax/admin_set_create_service_spec.rb
+++ b/spec/services/hyrax/admin_set_create_service_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Hyrax::AdminSetCreateService do
                                                     .and_raise(Valkyrie::Persistence::ObjectNotFoundError)
         end
         expect(described_class).to receive(:create_default_admin_set!).and_call_original
-        expect(query_service).to receive(:find_by).with(id: anything).and_call_original # permission template
+        expect(query_service).to receive(:find_by).with(id: anything).at_least(1).times.and_call_original # permission template
         admin_set = described_class.find_or_create_default_admin_set
         expect(admin_set.title).to eq described_class::DEFAULT_TITLE
       end


### PR DESCRIPTION
*NOTE: This is part of the looming Double Combo work for the lazy migration for Hyrax, but I figure having this reviewed separately eases the review of a chunky PR.*

See [Access Control List (ACL) Considerations in the Hyku wiki](https://github.com/samvera/hyku/wiki/Updating-Hyku-6-with-Hyrax-5-Developer-Notes#access-control-list-acl-considerations).

Prior to this commit we relied on the access_control object to "self convert" via the `#valkyrie_resource` method.  However, that method circumvents the `Hyrax.query_service` which provides a more up to date version of the permissions.

This is subtle bug is most notable when we have composite adapters; those modeled in the `double_combo` branch.

How it manifests is as follows:

- I have a Work and ACL in Fedora.
- I update the ACL to Postgres.
  - When I fetch the Work, it's in Fedora and grabs the ACL from Fedora which is not the most current.

This relates to:

- 0de7df6d2ee05f2d43b25acc3788349891a948d4
- https://github.com/samvera/hyrax/pull/6670

@samvera/hyrax-code-reviewers
