### PR TITLE
♻️ Remove bug when no date given; and improve error messaging

### DIFF
--- a/lib/hyrax/transactions/steps/save.rb
+++ b/lib/hyrax/transactions/steps/save.rb
@@ -40,7 +40,7 @@ module Hyrax
             save_lease_or_embargo(unsaved)
             saved = @persister.save(resource: unsaved)
           rescue StandardError => err
-            return Failure(["Failed save on #{change_set}\n\t#{err.message}", change_set.resource])
+            return Failure.new(["Failed save on #{change_set}\n\t#{err.message}", change_set.resource], err.backtrace.first)
           end
 
           # if we have a permission manager, it's acting as a local cache of another resource.
@@ -58,6 +58,7 @@ module Hyrax
         private
 
         def valid_future_date?(item, attribute)
+          return true if item.fields[attribute].blank?
           raise StandardError, "#{item.model} must use a future date" if item.fields[attribute] < Time.zone.now
         end
 

--- a/lib/hyrax/transactions/steps/set_user_as_creator.rb
+++ b/lib/hyrax/transactions/steps/set_user_as_creator.rb
@@ -23,7 +23,7 @@ module Hyrax
 
           Success(change_set)
         rescue NoMethodError => err
-          Failure([err.message, change_set])
+          Failure.new([err.message, change_set], err.backtrace.first)
         end
 
         ##


### PR DESCRIPTION
This commit is a minor change to include backtrace information in the
Failure and also catch a case where we're comparing `nil <
Time.zone.now`.

@samvera/hyrax-code-reviewers