### PR TITLE
Repurpose `MemberCleanupListener` for parent/child

### DIFF
--- a/app/services/hyrax/listeners/member_cleanup_listener.rb
+++ b/app/services/hyrax/listeners/member_cleanup_listener.rb
@@ -8,7 +8,16 @@ module Hyrax
       # Called when 'object.deleted' event is published
       # @param [Dry::Events::Event] event
       # @return [void]
-      def on_object_deleted(event); end
+      def on_object_deleted(event)
+        object = event[:object]
+        return unless object.is_a?(Hyrax::Work)
+
+        Hyrax.query_service.find_parents(resource: object).each do |parent|
+          parent.member_ids -= [object.id]
+          Hyrax.persister.save(resource: parent)
+          Hyrax.index_adapter.save(resource: parent)
+        end
+      end
 
       # Called when 'collection.deleted' event is published
       # @param [Dry::Events::Event] event

--- a/spec/support/simple_work.rb
+++ b/spec/support/simple_work.rb
@@ -27,4 +27,8 @@ module Hyrax
 end
 
 Wings::ModelRegistry.register(Hyrax::Test::SimpleWork, Hyrax::Test::SimpleWorkLegacy) if defined?(Wings)
-Hyrax::ValkyrieLazyMigration.migrating(Hyrax::Test::SimpleWork, from: Hyrax::Test::SimpleWorkLegacy) unless defined?(Wings)
+
+# We do not want to add the lazy migration for ActiveFedora to Valkyrie when we don't have a valid
+# Fedora end-point.  The best in test approximation of this is by way of whether or not we have
+# disabled wings; wings only makes sense when you have an ActiveFedora-based application.
+Hyrax::ValkyrieLazyMigration.migrating(Hyrax::Test::SimpleWork, from: Hyrax::Test::SimpleWorkLegacy) unless Hyrax.config.disable_wings


### PR DESCRIPTION
This commit will repurpose the `MemberCleanupListener` to be used for cleaning up parent/child relationships.  When the child is deleted, the parent will be updated to remove the child id from its #member_ids.
