### PR TITLE
Repurpose `MemberCleanupListener` for parent/child

### DIFF
--- a/app/services/hyrax/listeners/member_cleanup_listener.rb
+++ b/app/services/hyrax/listeners/member_cleanup_listener.rb
@@ -13,12 +13,14 @@ module Hyrax
         return unless event[:object]
 
         object = event[:object]
+        user = event[:user]
         return unless object.is_a?(Hyrax::Work)
 
         Hyrax.query_service.find_parents(resource: object).each do |parent|
           parent.member_ids -= [object.id]
           Hyrax.persister.save(resource: parent)
           Hyrax.index_adapter.save(resource: parent)
+          Hyrax.publisher.publish('object.membership.updated', object: parent, user: user)
         end
       end
 

--- a/app/services/hyrax/listeners/member_cleanup_listener.rb
+++ b/app/services/hyrax/listeners/member_cleanup_listener.rb
@@ -8,7 +8,19 @@ module Hyrax
       # Called when 'object.deleted' event is published
       # @param [Dry::Events::Event] event
       # @return [void]
-      def on_object_deleted(event); end
+      def on_object_deleted(event)
+        event = event.to_h
+        return unless event[:object]
+
+        object = event[:object]
+        return unless object.is_a?(Hyrax::Work)
+
+        Hyrax.query_service.find_parents(resource: object).each do |parent|
+          parent.member_ids -= [object.id]
+          Hyrax.persister.save(resource: parent)
+          Hyrax.index_adapter.save(resource: parent)
+        end
+      end
 
       # Called when 'collection.deleted' event is published
       # @param [Dry::Events::Event] event


### PR DESCRIPTION
This commit will repurpose the `MemberCleanupListener` to be used for cleaning up parent/child relationships.  When the child is deleted, the parent will be updated to remove the child id from its #member_ids.

@samvera/hyrax-code-reviewers
