### PR TITLE
Adjust job enqueue timing

### DIFF
--- a/app/services/hyrax/valkyrie_upload.rb
+++ b/app/services/hyrax/valkyrie_upload.rb
@@ -55,12 +55,12 @@ class Hyrax::ValkyrieUpload
 
     saved_metadata = Hyrax.persister.save(resource: file_metadata)
     saved_metadata.original_filename = filename if saved_metadata.original_filename.blank?
-    Hyrax.publisher.publish("file.uploaded", metadata: saved_metadata)
 
     add_file_to_file_set(file_set: file_set,
                          file_metadata: saved_metadata,
                          user: user)
 
+    Hyrax.publisher.publish("file.uploaded", metadata: saved_metadata)
     Hyrax.publisher.publish('file.metadata.updated', metadata: saved_metadata, user: user)
 
     saved_metadata

--- a/app/services/hyrax/work_uploads_handler.rb
+++ b/app/services/hyrax/work_uploads_handler.rb
@@ -93,7 +93,10 @@ module Hyrax
         event_payloads = files.each_with_object([]) { |file, arry| arry << make_file_set_and_ingest(file) }
         @persister.save(resource: work)
         Hyrax.publisher.publish('object.metadata.updated', object: work, user: files.first.user)
-        event_payloads.each { |payload| Hyrax.publisher.publish('file.set.attached', payload) }
+        event_payloads.each do |payload|
+          payload.delete(:job).enqueue
+          Hyrax.publisher.publish('file.set.attached', payload)
+        end
       end
     end
 
@@ -114,9 +117,7 @@ module Hyrax
       file_set.permission_manager.acl.save if file_set.permission_manager.acl.pending_changes?
       append_to_work(file_set)
 
-      ValkyrieIngestJob.perform_later(file)
-
-      { file_set: file_set, user: file.user }
+      { file_set: file_set, user: file.user, job: ValkyrieIngestJob.new(file) }
     end
 
     ##

--- a/spec/jobs/attach_files_to_work_job_spec.rb
+++ b/spec/jobs/attach_files_to_work_job_spec.rb
@@ -110,7 +110,6 @@ RSpec.describe AttachFilesToWorkJob, :active_fedora, perform_enqueued: [AttachFi
     shared_examples 'a file attacher', perform_enqueued: [described_class, IngestJob] do
       it 'attaches files, copies visibility and permissions and updates the uploaded files' do
         id = generic_work.id
-        expect(ValkyrieIngestJob).to receive(:perform_later).twice
         described_class.perform_now(generic_work, [uploaded_file1, uploaded_file2])
         generic_work = Hyrax.query_service.find_by(id: id)
         file_sets = Hyrax.custom_queries.find_child_file_sets(resource: generic_work)
@@ -118,6 +117,7 @@ RSpec.describe AttachFilesToWorkJob, :active_fedora, perform_enqueued: [AttachFi
         expect(file_sets.map(&:visibility)).to all(eq 'open')
         expect(uploaded_file1.reload.file_set_uri).not_to be_nil
         expect(ImportUrlJob).not_to have_been_enqueued
+        expect(ValkyrieIngestJob).to have_been_enqueued.twice
       end
     end
 


### PR DESCRIPTION
When using the inline job queue, these jobs are run too early and encounter resources that have not yet been fully persisted. It's important to account for the inline nature of the dry-event pub/sub system and not assume that a job will actually be run later.

### Fixes

File ingest with :inline queue adapter

### Guidance for testing, such as acceptance criteria or new user interface behaviors:
* With a valkyrie app using the inline job queue, can create a work with an attached file.

@samvera/hyrax-code-reviewers
