### PR TITLE
🐛 internal_resource and to_rdf_representation are assumptive

### DIFF
--- a/app/models/admin_set.rb
+++ b/app/models/admin_set.rb
@@ -28,7 +28,26 @@ class AdminSet < ActiveFedora::Base
   DEFAULT_WORKFLOW_NAME = Hyrax.config.default_active_workflow_name
 
   validates_with Hyrax::HasOneTitleValidator
+
+  ##
+  # @!group Class Attributes
+  #
+  # @!attribute internal_resource
+  #   @return [String]
+  class_attribute :internal_resource, default: "AdminSet"
+
   class_attribute :human_readable_short_description
+  # @!endgroup Class Attributes
+  ##
+
+  def self.to_rdf_representation
+    internal_resource
+  end
+
+  def to_rdf_representation
+    internal_resource
+  end
+
   self.indexer = Hyrax::AdminSetIndexer
 
   property :title,             predicate: ::RDF::Vocab::DC.title

--- a/app/models/concerns/hyrax/collection_behavior.rb
+++ b/app/models/concerns/hyrax/collection_behavior.rb
@@ -17,7 +17,15 @@ module Hyrax
 
       self.indexer = Hyrax::CollectionIndexer
 
+      ##
+      # @!group Class Attributes
+      #
+      # @!attribute internal_resource
+      #   @return [String]
+      class_attribute :internal_resource, default: "Collection"
+
       class_attribute :index_collection_type_gid_as, instance_writer: false
+      ##
       self.index_collection_type_gid_as = [:symbol]
 
       property :collection_type_gid, predicate: ::RDF::Vocab::SCHEMA.additionalType, multiple: false do |index|

--- a/lib/wings/valkyrie/query_service.rb
+++ b/lib/wings/valkyrie/query_service.rb
@@ -23,7 +23,7 @@ module Wings
       def count_all_of_model(model:)
         ActiveFedora::Base
           .where(has_model_ssim: [model_class_for(model).to_rdf_representation,
-                                  model.new.internal_resource.to_s])
+                                  model.to_rdf_representation])
           .count
       end
 
@@ -63,6 +63,9 @@ module Wings
       #
       # @param model [Class]
       # @return [Array<Valkyrie::Resource>]
+      #
+      # @note Due to implementation details, .find_all_of_model and .count_all_of_model may not
+      #       return the same number of results.  Is that a bug?  Probably.
       def find_all_of_model(model:)
         model_class_for(model).all.map do |obj|
           resource_factory.to_resource(object: obj)

--- a/spec/models/admin_set_spec.rb
+++ b/spec/models/admin_set_spec.rb
@@ -8,6 +8,9 @@ RSpec.describe AdminSet, :active_fedora, type: :model do
 
   subject { described_class.new(title: ['Some title']) }
 
+  its(:internal_resource) { is_expected.to eq('AdminSet') }
+  its(:to_rdf_representation) { is_expected.to eq('AdminSet') }
+
   describe '#active_workflow' do
     it 'leverages Sipity::Workflow.find_active_workflow_for' do
       admin_set = build(:admin_set, id: 1234)

--- a/spec/wings/valkyrie/query_service_spec.rb
+++ b/spec/wings/valkyrie/query_service_spec.rb
@@ -89,6 +89,30 @@ RSpec.describe Wings::Valkyrie::QueryService, :active_fedora, :clean_repo do
       persister.save(resource: Monograph.new)
       expect(query_service.count_all_of_model(model: Monograph)).to eq(2)
     end
+
+    it "can count AdminSet" do
+      expect(query_service.count_all_of_model(model: AdminSet)).to eq(0)
+    end
+
+    it "can count Hyrax::AdministrativeSet" do
+      expect(query_service.count_all_of_model(model: Hyrax::AdministrativeSet)).to eq(0)
+    end
+
+    it "can count the configured Hyrax.config.admin_set_model" do
+      expect(query_service.count_all_of_model(model: Hyrax.config.admin_set_class)).to eq(0)
+    end
+
+    it "can count Collection" do
+      expect(query_service.count_all_of_model(model: Collection)).to eq(0)
+    end
+
+    it "can count Hyrax::PcdmCollection" do
+      expect(query_service.count_all_of_model(model: Hyrax::PcdmCollection)).to eq(0)
+    end
+
+    it "can count the configured Hyrax.config.admin_set_model" do
+      expect(query_service.count_all_of_model(model: Hyrax.config.collection_class)).to eq(0)
+    end
   end
 
   describe ".find_all", clean_repo: true do


### PR DESCRIPTION
Prior to this commit, when we attempted to query for all of the collection models and admin set models, we'd see a mix of errors depending on how we configured Wings; and regardless of configuring Wings.

First, without a to_rdf_representation, we'd see an error like:

```
NoMethodError:
       undefined method `schema' for AdminSet:Class
```

Were we to configure Wings to handle an AdminSet, we'd then see

```
NoMethodError:
       undefined method `internal_resource' for #<AdminSet id: nil,
```

With this change, we're removing those errors.

@samvera/hyrax-code-reviewers
