### PR TITLE
🧹 Add autoload for Forms

### DIFF
--- a/lib/hyrax.rb
+++ b/lib/hyrax.rb
@@ -41,6 +41,7 @@ module Hyrax
     autoload :Configuration
     autoload :ControlledVocabularies
     autoload :EventStore
+    autoload :Forms
     autoload :RedisEventStore
     autoload :ResourceSync
     autoload :Zotero


### PR DESCRIPTION
With moving the Hyrax::Forms class methods to hyrax/forms.rb we're
seeing cases where the methods are not found.

I suspect we need to declare the autoload for that module.  Especially
since these are our converter functions.