### PR TITLE
🧹 Expose Hyrax.config.use_valkyrie=

### DIFF
--- a/lib/hyrax/configuration.rb
+++ b/lib/hyrax/configuration.rb
@@ -612,9 +612,11 @@ module Hyrax
     ##
     # @return [Boolean] whether to use experimental valkyrie storage features
     def use_valkyrie?
+      return @use_valkyrie unless @use_valkyrie.nil?
       return true if disable_wings # always return true if wings is disabled
       ActiveModel::Type::Boolean.new.cast(ENV.fetch('HYRAX_VALKYRIE', false))
     end
+    attr_writer :use_valkyrie
     # @!endgroup
 
     attr_writer :feature_config_path

--- a/spec/lib/hyrax/configuration_spec.rb
+++ b/spec/lib/hyrax/configuration_spec.rb
@@ -108,6 +108,8 @@ RSpec.describe Hyrax::Configuration do
   it { is_expected.to respond_to(:translate_id_to_uri) }
   it { is_expected.to respond_to(:translate_uri_to_id) }
   it { is_expected.to respond_to(:upload_path) }
+  it { is_expected.to respond_to(:use_valkyrie?) }
+  it { is_expected.to respond_to(:use_valkyrie=) }
   it { is_expected.to respond_to(:registered_ingest_dirs) }
   it { is_expected.to respond_to(:registered_ingest_dirs=) }
   it { is_expected.to respond_to(:range_for_number_of_results_to_display_per_page) }


### PR DESCRIPTION
The other configurations follow this pattern, might as well conform to that as well.

@samvera/hyrax-code-reviewers
