### PR TITLE
Make generated app use Valkyrie

### DIFF
--- a/.dassie/config/initializers/hyrax.rb
+++ b/.dassie/config/initializers/hyrax.rb
@@ -63,6 +63,11 @@ Hyrax.config do |config|
   # config.collection_model = 'Hyrax::PcdmCollection' # collection without basic metadata
   # config.collection_model = 'CollectionResource'    # collection with basic metadata
   # config.admin_set_model = 'Hyrax::AdministrativeSet'
+
+  # dassie needs legacy AF models
+  config.collection_model = '::Collection'
+  config.admin_set_model = 'AdminSet'
+  config.file_set_model = '::FileSet'
 end
 
 Date::DATE_FORMATS[:standard] = "%m/%d/%Y"

--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+# Provide plain collection model if not defined by the application.
+# Needed until Hyrax internals do not assume its existence.
+class ::Collection < Hyrax.config.collection_class; end unless '::Collection'.safe_constantize

--- a/app/models/file_set.rb
+++ b/app/models/file_set.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+# Provide plain file set model if not defined by the application.
+# Needed until Hyrax internals do not assume its existence.
+class ::FileSet < Hyrax.config.file_set_class; end unless '::FileSet'.safe_constantize

--- a/documentation/developing-your-hyrax-based-app.md
+++ b/documentation/developing-your-hyrax-based-app.md
@@ -29,6 +29,8 @@ A Hyrax-based application includes lots of dependencies. We provide a [Docker im
 
 You can also try [Running Hyrax-based application in local VM](https://github.com/samvera/hyrax/wiki/Hyrax-Development-Guide#running-hyrax-based-application-in-local-vm) which uses Ubuntu.
 
+During development, running only the dependent services in a container environment may be beneficial. This avoids potential headaches concerning file permissions and eases the use of debugging tools. The application generation instructions below use [Lando](https://lando.dev) to achieve this setup.
+
 This document contains instructions specific to setting up an app with __Hyrax
 v5.0.0.rc2__. If you are looking for instructions on installing a different
 version, be sure to select the appropriate branch or tag from the drop-down
@@ -44,8 +46,8 @@ Prerequisites are required for both creating a Hyrax\-based app and contributing
 Hyrax requires the following software to work:
 
 1. [Solr](http://lucene.apache.org/solr/) version >= 5.x (tested up to 8.11.1, which includes the log4j library update)
-1. [Fedora Commons](http://www.fedora-commons.org/) digital repository version >= 4.5.1 (tested up to 4.7.5)
-1. A SQL RDBMS (MySQL, PostgreSQL), though **note** that SQLite will be used by default if you're looking to get up and running quickly
+1. [Fedora Commons](http://www.fedora-commons.org/) digital repository version >= 4.7.6 (if not using the Valkyrie Postgres adapter)
+1. A SQL RDBMS ([PostgreSQL](https://www.postgresql.org) recommended)
 1. [Redis](http://redis.io/), a key-value store
 1. [ImageMagick](http://www.imagemagick.org/) with JPEG-2000 support
 1. [FITS](#characterization) (tested up to version 1.5.0 -- avoid version 1.1.0)
@@ -55,7 +57,12 @@ Hyrax requires the following software to work:
 **NOTE: The [Hyrax Development Guide](https://github.com/samvera/hyrax/wiki/Hyrax-Development-Guide) has instructions for installing Solr and Fedora in a development environment.**
 
 ### Characterization
+#### Servlet FITS
+FITS can be run as a web service. This has the benefit of improved performance by avoiding the slow startup time inherent to the local option below.
 
+A container image is available for this purpose: [ghcr.io/samvera/fitsservlet](https://ghcr.io/samvera/fitsservlet)
+
+#### Local FITS
 FITS can be installed on OSX using Homebrew by running the command: `brew install fits`
 
 **OR**
@@ -122,9 +129,20 @@ NOTE: [nodejs](https://nodejs.org/en/) is preinstalled on most Mac computers and
 
 NOTE: The steps need to be done in order to create a new Hyrax based app.
 
+### Development Prerequisites
+
+These instructions assume the use of [Lando](https://lando.dev) and [Docker](https://docker.io) to manage the backend services needed by your Hyrax application. Follow the Lando installation instructions before proceeding, or have alternate providers for the services listed in the generated `.lando.yml`:
+- Solr
+- Postgres
+- Redis
+- FITS servlet
+- Fedora (if not using Postgres)
+
+### Generate the application
+
 Generate a new Rails application using the template.
 
-```
+```shell
 rails _6.1.7.6_ new my_app --database=postgresql -m https://raw.githubusercontent.com/samvera/hyrax/hyrax-v5.0.0.rc2/template.rb
 ```
 
@@ -133,23 +151,65 @@ Generating a new Rails application using Hyrax's template above takes cares of a
 * Adding Hyrax (and any of its dependencies) to your application `Gemfile`, to declare that Hyrax is a dependency of your application
 * Running `bundle install`, to install Hyrax and its dependencies
 * Running Hyrax's install generator, to add a number of files that Hyrax requires within your Rails app, including e.g. database migrations
+
+### Start Services
+
+Start the background services managed by Lando. The
+
+```shell
+cd my_app
+lando start
+```
+
+### Run Migrations/Seeds
+
+This performs the following actions:
+
 * Loading all of Hyrax's database migrations into your application's database
-* Loading Hyrax's default workflows into your application's database
 * Create default collection types (e.g. Admin Set, User Collection)
+* Loading Hyrax's default workflows into your application's database
 
-### Start servers
+```shell
+rails db:migrate
+rails db:seed
+```
 
-To test-drive your new Hyrax application in development mode, spin up the servers that Hyrax needs (Solr, Fedora, and Rails):
+**NOTE**: You will want to run these commands the first time this code is deployed to a new environment as well.
+
+This creates the default administrative set -- into which all works will be deposited unless assigned to other administrative sets.
+This command also makes sure that Hyrax's built-in workflows are loaded for your application and available for the default administrative set.
+
+### Generate a work type
+
+Using Hyrax requires generating at least one type of repository object, or "work type." Hyrax allows you to generate the work types required in your application by using a Rails generator-based tool. You may generate one or more of these work types.
+
+Pass a (CamelCased) model name to Hyrax's work generator to get started, e.g.:
 
 ```
-bin/rails hydra:server
+rails generate hyrax:work_resource MovingImage
+```
+
+If your applications requires your work type to be namespaced, namespaces can be included by adding a slash to the model name which creates a new class called `MovingImage` within the `My` namespace:
+
+```shell
+rails generate hyrax:work_resource My/MovingImage
+```
+
+You may wish to [customize your work type](https://github.com/samvera/hyrax/wiki/Customizing-your-work-types) now that it's been generated.
+
+### Start Hyrax web server
+
+Test-drive your new Hyrax application in development mode:
+
+```shell
+rails s
 ```
 
 And now you should be able to browse to [localhost:3000](http://localhost:3000/) and see the application.
 
 Notes:
 * This web server is purely for development purposes. You will want to use a more fully featured [web server](https://github.com/samvera/hyrax/wiki/Hyrax-Management-Guide#web-server) for production-like environments.
-* You have the option to start each of these services individually.  More information on [solr_wrapper](https://github.com/cbeer/solr_wrapper) and [fcrepo_wrapper](https://github.com/cbeer/fcrepo_wrapper) will help you set this up.  Start rails with `rails s`.
+* For a fresh start, the data persisted in Lando can be wiped using `lando destroy`.
 
 ### Start background workers
 
@@ -163,14 +223,10 @@ Many of the services performed by Hyrax are resource intensive, and therefore ar
 
 Hyrax implements these jobs using the Rails [ActiveJob](http://edgeguides.rubyonrails.org/active_job_basics.html) framework, allowing you to choose the message queue system of your choice.
 
-For initial development, it is recommended that you change the default ActiveJob adapter from `:async` to `:inline`. This adapter will execute jobs immediately (in the foreground) as they are received. This can be accomplished by adding the following to your `config/environments/development.rb`
+For initial development, it is recommended that you change the default ActiveJob adapter from `:async` to `:inline`. This adapter will execute jobs immediately (in the foreground) as they are received. This can be accomplished by modifying the `.env` file:
 
-```
-class Application < Rails::Application
-  # ...
-  config.active_job.queue_adapter = :inline
-  # ...
-end
+```dotenv
+HYRAX_ACTIVE_JOB_QUEUE=inline
 ```
 
 For testing, it is recommended that you use the [built-in `:test` adapter](http://api.rubyonrails.org/classes/ActiveJob/QueueAdapters/TestAdapter.html) which stores enqueued and performed jobs, running only those configured to run during test setup. To do this, add the following to `config/environments/test.rb`:
@@ -185,53 +241,14 @@ end
 
 **For production applications** you will want to use a more robust message queue system such as [Sidekiq](http://sidekiq.org/). The Hyrax Development Guide has a detailed walkthrough of [installing and configuring Sidekiq](https://github.com/samvera/hyrax/wiki/Using-Sidekiq-with-Hyrax).
 
-### Create default administrative set
+### Create an Admin User
 
-**After** Fedora and Solr are running, create the default administrative set -- into which all works will be deposited unless assigned to other administrative sets -- by running the following command:
-
-```
-rails hyrax:default_admin_set:create
-```
-
-This command also makes sure that Hyrax's built-in workflows are loaded for your application and available for the default administrative set.
-
-**NOTE**: You will want to run this command the first time this code is deployed to a new environment as well.
-
-### Generate a work type
-
-Using Hyrax requires generating at least one type of repository object, or "work type." Hyrax allows you to generate the work types required in your application by using a Rails generator-based tool. You may generate one or more of these work types.
-
-Pass a (CamelCased) model name to Hyrax's work generator to get started, e.g.:
-
-```
-rails generate hyrax:work Work
-```
-
-or
-
-```
-rails generate hyrax:work MovingImage
-```
-
-If your applications requires your work type to be namespaced, namespaces can be included by adding a slash to the model name which creates a new class called `MovingImage` within the `My` namespace:
-
-```
-rails generate hyrax:work My/MovingImage
-```
-
-You may wish to [customize your work type](https://github.com/samvera/hyrax/wiki/Customizing-your-work-types) now that it's been generated.
-
-### Enable notifications
-
-Hyrax 2+ uses a WebSocket-based user notifications system, which requires Redis. To enable user notifications, make sure that you have configured ActionCable to use Redis as the adapter in your application's `config/cable.yml`. E.g., for the `development` Rails environment:
-
+To access all of Hyrax's features you must be signed in as a user in the `admin` role. The default role management system uses the `config/role_map.yml` file to assign users to roles. For example:
 ```yaml
 development:
-  adapter: redis
-  url: redis://localhost:6379
+  admin:
+    - dev@test.internal
 ```
-
-Note that the Hyrax Management Guide contains additional information on [how to configure ActionCable in production environments](https://github.com/samvera/hyrax/wiki/Hyrax-Management-Guide#notifications).
 
 ## Managing a Hyrax-based app
 

--- a/documentation/developing-your-hyrax-based-app.md
+++ b/documentation/developing-your-hyrax-based-app.md
@@ -125,7 +125,7 @@ NOTE: The steps need to be done in order to create a new Hyrax based app.
 Generate a new Rails application using the template.
 
 ```
-rails _6.1.7.6_ new my_app -m https://raw.githubusercontent.com/samvera/hyrax/hyrax-v5.0.0.rc2/template.rb
+rails _6.1.7.6_ new my_app --database=postgresql -m https://raw.githubusercontent.com/samvera/hyrax/hyrax-v5.0.0.rc2/template.rb
 ```
 
 Generating a new Rails application using Hyrax's template above takes cares of a number of steps for you, including:

--- a/lib/generators/hyrax/config_generator.rb
+++ b/lib/generators/hyrax/config_generator.rb
@@ -38,9 +38,21 @@ class Hyrax::ConfigGenerator < Rails::Generators::Base
     copy_file 'config/initializers/redis_config.rb'
   end
 
+  def configure_valkyrie
+    copy_file 'config/initializers/1_valkyrie.rb'
+  end
+
   def configure_valkyrie_index
     copy_file 'config/valkyrie_index.yml'
     copy_file 'config/solr_wrapper_valkyrie_test.yml'
+  end
+
+  def metadata_dir
+    empty_directory 'config/metadata'
+  end
+
+  def derivatives_file_services
+    copy_file 'config/initializers/file_services.rb'
   end
 
   def create_initializer_config_file

--- a/lib/generators/hyrax/install_generator.rb
+++ b/lib/generators/hyrax/install_generator.rb
@@ -198,5 +198,16 @@ module Hyrax
       rake('hyrax:universal_viewer:install')
       rake('yarn:install')
     end
+
+    def lando
+      copy_file '.lando.yml'
+    end
+
+    def dotenv
+      copy_file '.env'
+      gem_group :development, :test do
+        gem 'dotenv-rails', '~> 2.8'
+      end
+    end
   end
 end

--- a/lib/generators/hyrax/install_generator.rb
+++ b/lib/generators/hyrax/install_generator.rb
@@ -141,6 +141,12 @@ module Hyrax
       generate 'qa:local:tables'
     end
 
+    def inject_required_seeds
+      insert_into_file 'db/seeds.rb' do
+        'Hyrax::RequiredDataSeeder.new.generate_seed_data'
+      end
+    end
+
     def install_assets
       generate "hyrax:assets"
     end
@@ -180,6 +186,12 @@ module Hyrax
 
     def riiif_image_server
       generate 'hyrax:riiif' unless options[:'skip-riiif']
+    end
+
+    def insert_env_queue_adapter
+      insert_into_file 'config/application.rb', after: /config\.load_defaults [0-9.]+$/ do
+        "\n    config.active_job.queue_adapter = ENV.fetch('HYRAX_ACTIVE_JOB_QUEUE') { 'async' }.to_sym\n"
+      end
     end
 
     def universalviewer_files

--- a/lib/generators/hyrax/models_generator.rb
+++ b/lib/generators/hyrax/models_generator.rb
@@ -15,6 +15,7 @@ class Hyrax::ModelsGenerator < Rails::Generators::Base
   # Setup the database migrations
   def copy_migrations
     rake 'hyrax:install:migrations'
+    rake 'valkyrie_engine:install:migrations'
   end
 
   # Add behaviors to the user model
@@ -35,16 +36,6 @@ class Hyrax::ModelsGenerator < Rails::Generators::Base
     end
   end
   # rubocop:enable Metrics/MethodLength
-
-  def create_collection
-    copy_file 'app/models/collection.rb', 'app/models/collection.rb'
-    copy_file 'spec/models/collection_spec.rb', 'spec/models/collection_spec.rb' if rspec_installed?
-  end
-
-  def create_file_set
-    copy_file 'app/models/file_set.rb', 'app/models/file_set.rb'
-    copy_file 'spec/models/file_set_spec.rb', 'spec/models/file_set_spec.rb' if rspec_installed?
-  end
 
   # Adds clamav initializtion
   def clamav

--- a/lib/generators/hyrax/riiif_generator.rb
+++ b/lib/generators/hyrax/riiif_generator.rb
@@ -18,10 +18,6 @@ class Hyrax::RiiifGenerator < Rails::Generators::Base
 
   def add_to_gemfile
     gem 'riiif', '~> 2.1'
-
-    Bundler.with_clean_env do
-      run "bundle install"
-    end
   end
 
   def copy_initializer
@@ -30,6 +26,12 @@ class Hyrax::RiiifGenerator < Rails::Generators::Base
 
   def mount_route
     route "mount Riiif::Engine => 'images', as: :riiif if Hyrax.config.iiif_image_server?"
+  end
+
+  def enable_riiif_in_hyrax_config
+    insert_into_file 'config/initializers/hyrax.rb', before: /^  # config.iiif_image_server = false/ do
+      "  config.iiif_image_server = true\n"
+    end
   end
 
   def override_image_url_builder_in_hyrax_config

--- a/lib/generators/hyrax/templates/.env
+++ b/lib/generators/hyrax/templates/.env
@@ -1,0 +1,11 @@
+CH12N_TOOL=fits_servlet
+DATABASE_URL=postgresql://postgres@localhost:5437/hyrax-dev?pool=5
+FCREPO_URL=http://fedoraAdmin:fedoraAdmin@fcrepo:8989/fcrepo/rest
+FITS_SERVLET_URL=http://localhost:8085/fits
+HYRAX_ACTIVE_JOB_QUEUE=async
+HYRAX_SKIP_WINGS=true
+HYRAX_VALKYRIE=true
+REDIS_URL=redis://localhost:6384
+SOLR_URL=http://localhost:8988/solr/hyrax-dev
+VALKYRIE_METADATA_ADAPTER=pg_metadata
+VALKYRIE_STORAGE_ADAPTER=versioned_disk_storage

--- a/lib/generators/hyrax/templates/.env
+++ b/lib/generators/hyrax/templates/.env
@@ -3,8 +3,6 @@ DATABASE_URL=postgresql://postgres@localhost:5437/hyrax-dev?pool=5
 FCREPO_URL=http://fedoraAdmin:fedoraAdmin@fcrepo:8989/fcrepo/rest
 FITS_SERVLET_URL=http://localhost:8085/fits
 HYRAX_ACTIVE_JOB_QUEUE=async
-HYRAX_SKIP_WINGS=true
-HYRAX_VALKYRIE=true
 REDIS_URL=redis://localhost:6384
 SOLR_URL=http://localhost:8988/solr/hyrax-dev
 VALKYRIE_METADATA_ADAPTER=pg_metadata

--- a/lib/generators/hyrax/templates/.lando.yml
+++ b/lib/generators/hyrax/templates/.lando.yml
@@ -1,0 +1,50 @@
+name: hyrax-app
+app_mount: false
+services:
+  solr:
+    app_mount: false
+    type: solr:8
+    portforward: 8988
+    core: hyrax-dev
+    config:
+      dir: solr/conf
+  database:
+    app_mount: false
+    type: postgres:15
+    portforward: 5437
+    creds:
+      database: hyrax-dev
+  redis:
+    app_mount: false
+    type: redis:6
+    portforward: 6384
+    persist: true
+  fits:
+    api: 3
+    type: lando
+    app_mount: false
+    services:
+      image: ghcr.io/samvera/fitsservlet:1.6.0
+      command:
+        - "catalina.sh"
+        - "run"
+      ports:
+        - 8085:8080
+#  fedora:
+#    api: 3
+#    type: lando
+#    app_mount: false
+#    volumes:
+#      fedora6:
+#    services:
+#      image: fcrepo/fcrepo:6.4.0
+#      command:
+#        - "catalina.sh"
+#        - "run"
+#      volumes:
+#        - fedora6:/data
+#      ports:
+#        - 8989:8080
+#      environment:
+#        CATALINA_OPTS: "-Djava.awt.headless=true -Dfile.encoding=UTF-8 -server -Xms512m -Xmx1024m -XX:NewSize=256m -XX:MaxNewSize=256m -XX:PermSize=256m -XX:MaxPermSize=256m -XX:+DisableExplicitGC -Dorg.apache.tomcat.util.buf.UDecoder.ALLOW_ENCODED_SLASH=true"
+#        JAVA_OPTS: "-Dfcrepo.dynamic.jms.port=61619 -Dfcrepo.dynamic.stomp.port=61615 -Dorg.apache.tomcat.util.buf.UDecoder.ALLOW_ENCODED_SLASH=true"

--- a/lib/generators/hyrax/templates/config/initializers/1_valkyrie.rb
+++ b/lib/generators/hyrax/templates/config/initializers/1_valkyrie.rb
@@ -1,0 +1,102 @@
+# frozen_string_literal: true
+require 'faraday/multipart'
+
+# require "shrine/storage/s3"
+# require "valkyrie/storage/shrine"
+# require "valkyrie/shrine/checksum/s3"
+
+# database = ENV.fetch("METADATA_DB_NAME", "nurax_pg_metadata")
+# Rails.logger.info "Establishing connection to postgresql on: " \
+#                   "#{ENV["DB_HOST"]}:#{ENV["DB_PORT"]}.\n" \
+#                   "Using database: #{database}."
+# connection = Sequel.connect(
+#   user: ENV["DB_USERNAME"],
+#   password: ENV["DB_PASSWORD"],
+#   host: ENV["DB_HOST"],
+#   port: ENV["DB_PORT"],
+#   database: database,
+#   max_connections: ENV.fetch("DB_POOL", 5),
+#   pool_timeout: ENV.fetch("DB_TIMEOUT", 5000),
+#   adapter: :postgres
+# )
+#
+# Valkyrie::MetadataAdapter
+#   .register(Valkyrie::Sequel::MetadataAdapter.new(connection: connection),
+#             :nurax_pg_metadata_adapter)
+Valkyrie::MetadataAdapter.register(
+  Valkyrie::Persistence::Postgres::MetadataAdapter.new,
+  :pg_metadata
+)
+
+# Fedora metadata adapter
+# Valkyrie::MetadataAdapter.register(
+#   Valkyrie::Persistence::Fedora::MetadataAdapter.new(
+#     connection: ::Ldp::Client.new(Hyrax.config.fedora_connection_builder.call(
+#       ENV.fetch('FCREPO_URL') { "http://localhost:8080/fcrepo/rest" }
+#     )),
+#     base_path: Rails.env,
+#     schema: Valkyrie::Persistence::Fedora::PermissiveSchema.new(Hyrax::SimpleSchemaLoader.new.permissive_schema_for_valkrie_adapter),
+#     fedora_version: 6
+#   ), :fedora_metadata
+# )
+
+Valkyrie.config.metadata_adapter = ENV.fetch('VALKYRIE_METADATA_ADAPTER') { :pg_metadata }.to_sym
+
+# shrine_s3_options = {
+#   bucket: ENV.fetch("REPOSITORY_S3_BUCKET") { "nurax_pg#{Rails.env}" },
+#   region: ENV.fetch("REPOSITORY_S3_REGION", "us-east-1"),
+#   access_key_id: (ENV["REPOSITORY_S3_ACCESS_KEY"] || ENV["MINIO_ACCESS_KEY"]),
+#   secret_access_key: (ENV["REPOSITORY_S3_SECRET_KEY"] || ENV["MINIO_SECRET_KEY"])
+# }
+#
+# if ENV["MINIO_ENDPOINT"].present?
+#   shrine_s3_options[:endpoint] = "http://#{ENV["MINIO_ENDPOINT"]}:#{ENV.fetch("MINIO_PORT", 9000)}"
+#   shrine_s3_options[:force_path_style] = true
+# end
+#
+# Valkyrie::StorageAdapter.register(
+#   Valkyrie::Storage::Shrine.new(Shrine::Storage::S3.new(**shrine_s3_options)),
+#   :repository_s3
+# )
+#
+# Valkyrie.config.storage_adapter = :repository_s3
+
+# Fedora storage adapter
+# Valkyrie::StorageAdapter.register(
+#   Valkyrie::Storage::Fedora.new(
+#     connection: ::Ldp::Client.new(Hyrax.config.fedora_connection_builder.call(
+#       ENV.fetch('FCREPO_URL') { "http://localhost:8080/fcrepo/rest" }
+#     )),
+#     base_path: Rails.env,
+#     fedora_version: 6
+#   ), :fedora_storage
+# )
+
+Valkyrie::StorageAdapter.register(
+  Valkyrie::Storage::VersionedDisk.new(base_path: Rails.root.join("storage", "files"),
+                                       file_mover: FileUtils.method(:cp)),
+  :versioned_disk_storage
+)
+
+Valkyrie.config.storage_adapter  = ENV.fetch('VALKYRIE_STORAGE_ADAPTER') { :versioned_disk_storage }.to_sym
+
+Valkyrie.config.indexing_adapter = :solr_index
+
+custom_queries = [Hyrax::CustomQueries::Navigators::CollectionMembers,
+                  Hyrax::CustomQueries::Navigators::ChildCollectionsNavigator,
+                  Hyrax::CustomQueries::Navigators::ParentCollectionsNavigator,
+                  Hyrax::CustomQueries::Navigators::ChildFileSetsNavigator,
+                  Hyrax::CustomQueries::Navigators::ChildWorksNavigator,
+                  Hyrax::CustomQueries::Navigators::ParentWorkNavigator,
+                  Hyrax::CustomQueries::Navigators::FindFiles,
+                  Hyrax::CustomQueries::FindAccessControl,
+                  Hyrax::CustomQueries::FindCollectionsByType,
+                  Hyrax::CustomQueries::FindFileMetadata,
+                  Hyrax::CustomQueries::FindIdsByModel,
+                  Hyrax::CustomQueries::FindManyByAlternateIds,
+                  Hyrax::CustomQueries::FindModelsByAccess,
+                  Hyrax::CustomQueries::FindCountBy,
+                  Hyrax::CustomQueries::FindByDateRange]
+custom_queries.each do |handler|
+  Hyrax.query_service.custom_queries.register_query_handler(handler)
+end

--- a/lib/generators/hyrax/templates/config/initializers/file_services.rb
+++ b/lib/generators/hyrax/templates/config/initializers/file_services.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+ActiveSupport::Reloader.to_prepare do
+  Hydra::Derivatives.config.output_file_service = Hyrax::ValkyriePersistDerivatives
+  Hydra::Derivatives.config.source_file_service = Hyrax::LocalFileService
+end

--- a/lib/generators/hyrax/templates/config/initializers/hyrax.rb
+++ b/lib/generators/hyrax/templates/config/initializers/hyrax.rb
@@ -235,12 +235,12 @@ Hyrax.config do |config|
   # Identify the model class name that will be used for Collections in your app
   # (i.e. ::Collection for ActiveFedora, Hyrax::PcdmCollection for Valkyrie)
   # config.collection_model = '::Collection'
-  # config.collection_model = 'Hyrax::PcdmCollection'
+  config.collection_model = 'Hyrax::PcdmCollection'
 
   # Identify the model class name that will be used for Admin Sets in your app
   # (i.e. AdminSet for ActiveFedora, Hyrax::AdministrativeSet for Valkyrie)
   # config.admin_set_model = 'AdminSet'
-  # config.admin_set_model = 'Hyrax::AdministrativeSet'
+  config.admin_set_model = 'Hyrax::AdministrativeSet'
 
   # Identify the form that will be used for Admin Sets
   # config.administrative_set_form = Hyrax::Forms::AdministrativeSetForm
@@ -277,10 +277,10 @@ Hyrax.config do |config|
   # When your application is ready to use the valkyrie index instead of the one
   # maintained by active fedora, you will need to set this to true. You will
   # also need to update your Blacklight configuration.
-  # config.query_index_from_valkyrie = false
+  config.query_index_from_valkyrie = true
 
   ## Configure index adapter for Valkyrie::Resources to use solr readonly indexer
-  # config.index_adapter = :solr_index
+  config.index_adapter = :solr_index
 
   ## Fedora import/export tool
   #

--- a/lib/generators/hyrax/templates/config/initializers/hyrax.rb
+++ b/lib/generators/hyrax/templates/config/initializers/hyrax.rb
@@ -59,7 +59,7 @@ Hyrax.config do |config|
 
   # Hyrax uses NOIDs for files and collections instead of Fedora UUIDs
   # where NOID = 10-character string and UUID = 32-character string w/ hyphens
-  # config.enable_noids = true
+  config.enable_noids = false
 
   # Template for your repository's NOID IDs
   # config.noid_template = ".reeddeeddk"
@@ -273,6 +273,10 @@ Hyrax.config do |config|
   # config.pcdm_object_indexer_builder = lambda do |model_class|
   #   Hyrax::Indexers::PcdmObjectIndexer(model_class)
   # end
+
+  ## Enable Valkyrie only mode
+  config.use_valkyrie = true
+  config.disable_wings true
 
   # When your application is ready to use the valkyrie index instead of the one
   # maintained by active fedora, you will need to set this to true. You will

--- a/lib/generators/hyrax/templates/config/redis.yml
+++ b/lib/generators/hyrax/templates/config/redis.yml
@@ -1,9 +1,6 @@
 development:
-  host: <%= ENV.fetch('REDIS_HOST', 'localhost') %>
-  port: <%= ENV.fetch('REDIS_PORT', 6379) %>
+  url: <%= ENV.fetch('REDIS_URL', 'redis://localhost:6379/0') %>
 test:
-  host: <%= ENV.fetch('REDIS_HOST', 'localhost') %>
-  port: <%= ENV.fetch('REDIS_PORT', 6379) %>
+  url: <%= ENV.fetch('REDIS_URL', 'redis://localhost:6379/0') %>
 production:
-  host: <%= ENV.fetch('REDIS_HOST', 'localhost') %>
-  port: <%= ENV.fetch('REDIS_PORT', 6379) %>
+  url: <%= ENV.fetch('REDIS_URL', 'redis://localhost:6379/0') %>

--- a/lib/generators/hyrax/templates/config/valkyrie_index.yml
+++ b/lib/generators/hyrax/templates/config/valkyrie_index.yml
@@ -1,12 +1,7 @@
+# This is a sample config file that points to a solr server for each environment
 development:
-  host: <%= ENV['VALKYRIE_SOLR_HOST'] %>
-  port: <%= ENV['VALKYRIE_SOLR_PORT'] %>
-  core: <%= ENV['VALKYRIE_SOLR_CORE'] || 'hyrax-valkyrie-dev' %>
+  url: <%= ENV['SOLR_URL'] || "http://127.0.0.1:#{ENV.fetch('SOLR_DEVELOPMENT_PORT', 8983)}/solr/hydra-development" %>
 test:
-  host: <%= ENV['VALKYRIE_SOLR_HOST'] %>
-  port: <%= ENV['VALKYRIE_SOLR_PORT'] || 8987 %>
-  core: <%= ENV['VALKYRIE_SOLR_CORE'] || 'hyrax-valkyrie-test' %>
+  url: <%= ENV['SOLR_URL'] || "http://127.0.0.1:#{ENV.fetch('SOLR_TEST_PORT', 8985)}/solr/hydra-test" %>
 production:
-  host: <%= ENV['VALKYRIE_SOLR_HOST'] %>
-  port: <%= ENV['VALKYRIE_SOLR_PORT'] %>
-  core: <%= ENV['VALKYRIE_SOLR_CORE'] %>
+  url: <%= ENV['SOLR_URL'] || "http://your.production.server:8080/bl_solr/core0" %>

--- a/lib/hyrax/configuration.rb
+++ b/lib/hyrax/configuration.rb
@@ -170,7 +170,7 @@ module Hyrax
     #  @return [Hash] of options like {ch12n_tool: :fits_servlet}
     attr_writer :characterization_options
     def characterization_options
-      @characterization_options ||= {}
+      @characterization_options ||= { ch12n_tool: ENV.fetch('CH12N_TOOL', 'fits').to_sym }
     end
 
     ##

--- a/lib/hyrax/configuration.rb
+++ b/lib/hyrax/configuration.rb
@@ -55,7 +55,7 @@ module Hyrax
   #
   # == Valkyrie
   #
-  # *Experimental:* Options for toggling Hyrax's experimental "Wings" valkyrie
+  # Options for toggling Hyrax's "Wings" valkyrie
   # adapter and configuring valkyrie.
   #
   # @see Hyrax.config
@@ -617,14 +617,14 @@ module Hyrax
     end
 
     ##
-    # @return [Boolean] whether to use the experimental valkyrie index
+    # @return [Boolean] whether to use the valkyrie index
     def query_index_from_valkyrie
       @query_index_from_valkyrie ||= false
     end
     attr_writer :query_index_from_valkyrie
 
     ##
-    # @return [Boolean] whether to use experimental valkyrie storage features
+    # @return [Boolean] whether to use valkyrie storage features
     def use_valkyrie?
       return @use_valkyrie unless @use_valkyrie.nil?
       return true if disable_wings # always return true if wings is disabled
@@ -860,7 +860,7 @@ module Hyrax
     # @return [#constantize] a string representation of the collection
     #   model
     def collection_model
-      @collection_model ||= '::Collection'
+      @collection_model ||= 'Hyrax::PcdmCollection'
     end
 
     ##
@@ -874,7 +874,7 @@ module Hyrax
     # @return [#constantize] a string representation of the admin set
     #   model
     def admin_set_model
-      @admin_set_model ||= 'AdminSet'
+      @admin_set_model ||= 'Hyrax::AdministrativeSet'
     end
 
     ##

--- a/template.rb
+++ b/template.rb
@@ -1,6 +1,4 @@
 # frozen_string_literal: true
-# Hack for https://github.com/rails/rails/issues/35153
-gsub_file 'Gemfile', /^gem ["']sqlite3["']$/, 'gem "sqlite3", "~> 1.3.0"'
 gem 'hyrax', '5.0.0.rc2'
 run 'bundle install'
 generate 'hyrax:install', '-f'


### PR DESCRIPTION
### Summary

Updates the rails template to create a valkyrie enabled hyrax.

### Guidance for testing, such as acceptance criteria or new user interface behaviors:
* Following the updated documentation results in a plain hyrax application configured for postgres valkyrie.
* A valkyrie hyrax application that does not define `::FileSet` is functional.

### Detailed Description
Following the deprecation of Hyrax's use of ActiveFedora, Hyrax should generate a minimal usable application configured for Valkyrie.

A [Lando](https://lando.dev) config providing services for Solr, Postgres, Redis, FITSservlet, and (if needed) Fedora 6 is created, along with a `.env` file with configuration pointing to these services. It is intended that, during development, the hyrax rails server not be run in a container, but on the local workstation. This `.lando.yml` is modeled on the [one that valkyrie uses](https://github.com/samvera/valkyrie/blob/main/.lando.yml).

### Changes proposed in this pull request:
* Modify files in `lib/generators` to preconfigure valkyrie
* Provide `.lando.yml` and `.env` files to new apps
* Avoid directly referencing `::FileSet` where its absence will prevent application from loading.
* Add an ENV var to configure which characterization tool to use.

@samvera/hyrax-code-reviewers
