### PR TITLE
✂ Remove useless test

### DIFF
--- a/spec/controllers/hyrax/homepage_controller_spec.rb
+++ b/spec/controllers/hyrax/homepage_controller_spec.rb
@@ -39,13 +39,6 @@ RSpec.describe Hyrax::HomepageController, type: :controller do
       end
     end
 
-    it "does not include other user's private documents in recent documents" do
-      get :index
-      expect(response).to be_successful
-      titles = assigns(:recent_documents).map { |d| d['title_tesim'][0] }
-      expect(titles).not_to include('Test Private Document')
-    end
-
     it "includes only Work objects in recent documents" do
       get :index
       expect(assigns(:recent_documents).all?(&:work?)).to eq true


### PR DESCRIPTION
Nowhere in the code, aside from what we're removing, does the phrase `"Test Private Document"` show up.  Also, there's no setup for this test, meaning we aren't creating documents and were likely once upon a time relying on another spec to run and not clean itself up.

It was [1743c7b569b3][1] that removed any creation of documents.

Below is a Ripgrep search looking for any possible matches:

```
❯ rg "Test.*Document" -i spec
spec/controllers/hyrax/generic_works_controller_spec.rb
13:  describe 'integration test for suppressed documents' do
31:  describe 'integration test for depositor of a suppressed documents without a workflow role' do

spec/controllers/hyrax/file_sets_controller_spec.rb
507:    describe 'integration test for suppressed documents' do
937:    describe 'integration test for suppressed documents' do

spec/features/browse_dashboard_works_spec.rb
19:                               title: ["Test Document MP3"],
60:      expect(page).to have_link("Display all details of Test Document MP3",
```

[1]: https://github.com/samvera/hyrax/commit/1743c7b569b3#diff-85199f339ea08f1dcaa588f9d29c68cd1209956fef816a8e1c92221bd0f6af45L9

@samvera/hyrax-code-reviewers
