### PR TITLE
🐛 Favor helper method over instance variable

### DIFF
--- a/app/controllers/hyrax/dashboard/collections_controller.rb
+++ b/app/controllers/hyrax/dashboard/collections_controller.rb
@@ -80,7 +80,6 @@ module Hyrax
 
       def edit
         form
-        collection_type
       end
 
       def after_create
@@ -274,6 +273,7 @@ module Hyrax
       def collection_type
         @collection_type ||= CollectionType.find_by_gid!(collection.collection_type_gid)
       end
+      helper_method :collection_type
 
       def link_parent_collection(parent_id)
         child = collection.respond_to?(:valkyrie_resource) ? collection.valkyrie_resource : collection

--- a/app/views/hyrax/dashboard/collections/_form_share_table.html.erb
+++ b/app/views/hyrax/dashboard/collections/_form_share_table.html.erb
@@ -2,7 +2,7 @@
                   
   <h3 class="h4"><%= t(".#{access}.title") %></h3>
   <p><%= t(".#{access}.help") %></p>
-  <p><%= t(".#{access}.help_with_works", type_title: @collection_type.title) if @collection_type.share_applies_to_new_works? && access != 'depositors' %></p>
+  <p><%= t(".#{access}.help_with_works", type_title: collection_type.title) if collection_type.share_applies_to_new_works? && access != 'depositors' %></p>
   <% if collection_permission_template_form_for(form: @form).access_grants.select(&filter).any? %>
     <table class="table table-striped share-status">
       <thead>

--- a/spec/views/hyrax/dashboard/collections/_form_share.erb_spec.rb
+++ b/spec/views/hyrax/dashboard/collections/_form_share.erb_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe 'hyrax/dashboard/collections/_form_share.html.erb', type: :view d
 
   before do
     assign(:collection, collection)
-    assign(:collection_type, collection_type)
+    allow(view).to receive(:collection_type).and_return(collection_type)
     @form = instance_double(Hyrax::Forms::CollectionForm,
                             to_model: collection,
                             permission_template: pt_form,

--- a/spec/views/hyrax/dashboard/collections/_form_share_table.html.erb_spec.rb
+++ b/spec/views/hyrax/dashboard/collections/_form_share_table.html.erb_spec.rb
@@ -14,10 +14,11 @@ RSpec.describe 'hyrax/dashboard/collections/_form_share_table.html.erb', type: :
 
   before do
     assign(:collection, collection)
-    assign(:collection_type, collection_type)
     @form = instance_double(Hyrax::Forms::CollectionForm,
                             to_model: stub_model(Collection),
                             permission_template: pt_form)
+    # A collection_type helper method normally provided by the controller
+    allow(view).to receive(:collection_type).and_return(collection_type)
     # Ignore the delete button link
     allow(view).to receive(:admin_permission_template_access_path).and_return("/admin/permission_template_accesses/123")
   end


### PR DESCRIPTION
Prior to this commit, if the `update` failed, we would not have set the
`@collection_type` instance variable.  Which would mean that we'd raise
a `NoMethodError` on `NilClass` in the
`app/views/hyrax/dashboard/collections/_form_share_table.html.erb` view.

By favoring a helper method, we no longer require that the edit (nor
create) call the collection_type method.

Below is the the only view references for `@collection_type`, so the
helper_method appears to be adequate.

```shell
❯ rg "@collection_type[\. ]" app/views
app/views/hyrax/dashboard/collections/_form_share_table.html.erb
5:  <p><%= t(".#{access}.help_with_works", type_title: @collection_type.title) if @collection_type.share_applies_to_new_works? && access != 'depositors' %></p>

app/views/hyrax/admin/collection_types/_form.html.erb
22:      <% if @collection_type.admin_set? %>
```

@samvera/hyrax-code-reviewers