### PR TITLE
chart: fcrepo updates, version bumps

### DIFF
--- a/chart/hyrax/Chart.yaml
+++ b/chart/hyrax/Chart.yaml
@@ -6,7 +6,7 @@ version: 3.5.1
 appVersion: 3.3.0
 dependencies:
   - name: fcrepo
-    version: 1.0.0
+    version: 2.0.0
     repository: oci://ghcr.io/samvera
     condition: fcrepo.enabled
   - name: memcached

--- a/chart/hyrax/Chart.yaml
+++ b/chart/hyrax/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: hyrax
 description: An open-source, Samvera-powered digital repository system
 type: application
-version: 3.5.1
-appVersion: 3.3.0
+version: 3.6.0
+appVersion: 5.0.0
 dependencies:
   - name: fcrepo
     version: 2.0.0

--- a/chart/hyrax/values.yaml
+++ b/chart/hyrax/values.yaml
@@ -226,7 +226,7 @@ fcrepo:
     enabled: false
     image:
       repository: bitnami/postgresql
-      tag: 12.11.0-debian-11-r12
+      tag: 12.17.0-debian-11-r28
 
 # configuration for an external/existing fits service;
 #   ignored if `fits.enabled` is true


### PR DESCRIPTION
the fcrepo chart is itself a major version bump, but by default we don't use the now-removed subchart variables, so i don't think a major bump is necessary here.

@samvera/hyrax-code-reviewers
