### PR TITLE
♻️ Add downstream configurability of factories

### DIFF
--- a/lib/hyrax/specs/factory_name.rb
+++ b/lib/hyrax/specs/factory_name.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+module Hyrax
+  module Specs
+    ##
+    # This configuration serves the goal of exposing Hyrax's factories to downstream
+    # implementations, allowing for greater re-use of these complicated and foundational testing
+    # tools.
+    #
+    # One envisioned scenario is that a downstream application wants to extend two factories
+    # (e.g. admin_set and permission_template).  Given that Hyrax's :admin_set factory references
+    # :permission_template factory, it would be convenient to provide a means to change that factory
+    # name.
+    #
+    # The implementation pattern is as follows:
+    #
+    # - Define a factory using a "hard-coded" symbol.
+    # - Within a factory, when referencing another factory, do so by way of this class.
+    # - Within a spec, reference a factory by a "hard-coded" symbol.
+    #
+    # Downstream implementations can adjust the Hyrax::Specs::FactoryName, which in turn means that
+    # the factories defined in Hyrax and re-used downstream, will use those newly specified
+    # factories.  Those newly specified factories *might* inherit from the default factory.
+    class FactoryName
+      class_attribute :admin_set, default: :admin_set
+      class_attribute :admin_set_lw, default: :admin_set_lw
+      class_attribute :adminset_lw, default: :adminset_lw
+      class_attribute :collection, default: :collection
+      class_attribute :collection_lw, default: :collection_lw
+      class_attribute :collection_lw_type, default: :collection_lw_type
+      class_attribute :collection_type, default: :collection_type
+      class_attribute :collection_type_participant, default: :collection_type_participant
+      class_attribute :default_adminset, default: :default_adminset
+      class_attribute :embargoed_work, default: :embargoed_work
+      class_attribute :file_set, default: :file_set
+      class_attribute :hyrax_admin_set, default: :hyrax_admin_set
+      class_attribute :hyrax_collection, default: :hyrax_collection
+      class_attribute :hyrax_embargo, default: :hyrax_embargo
+      class_attribute :hyrax_file_set, default: :hyrax_file_set
+      class_attribute :hyrax_lease, default: :hyrax_lease
+      class_attribute :hyrax_resource, default: :hyrax_resource
+      class_attribute :hyrax_work, default: :hyrax_work
+      class_attribute :leased_work, default: :leased_work
+      class_attribute :monograph, default: :monograph
+      class_attribute :permission, default: :permission
+      class_attribute :permission_template, default: :permission_template
+      class_attribute :permission_template_access, default: :permission_template_access
+      class_attribute :typeless_collection, default: :typeless_collection
+      class_attribute :uploaded_file, default: :uploaded_file
+      class_attribute :user, default: :user
+      class_attribute :user_collection_type, default: :user_collection_type
+      class_attribute :work, default: :work
+      class_attribute :workflow, default: :workflow
+      class_attribute :workflow_action, default: :workflow_action
+    end
+  end
+end

--- a/spec/factories/access_control.rb
+++ b/spec/factories/access_control.rb
@@ -1,12 +1,12 @@
 # frozen_string_literal: true
 FactoryBot.define do
   factory :access_control, class: Hyrax::AccessControl do
-    permissions { build(:permission) }
+    permissions { build(Hyrax::Specs::FactoryName.permission) }
 
     trait :with_target do
-      access_to { valkyrie_create(:hyrax_resource).id }
+      access_to { valkyrie_create(Hyrax::Specs::FactoryName.hyrax_resource).id }
 
-      permissions { build(:permission, access_to: access_to) }
+      permissions { build(Hyrax::Specs::FactoryName.permission, access_to: access_to) }
     end
   end
 end

--- a/spec/factories/admin_sets.rb
+++ b/spec/factories/admin_sets.rb
@@ -14,7 +14,7 @@ FactoryBot.define do
         attributes = evaluator.with_permission_template.merge(attributes) if evaluator.with_permission_template.respond_to?(:merge)
         # There is a unique constraint on permission_templates.source_id; I don't want to
         # create a permission template if one already exists for this admin_set
-        create(:permission_template, attributes) unless Hyrax::PermissionTemplate.find_by(source_id: admin_set.id)
+        create(Hyrax::Specs::FactoryName.permission_template, attributes) unless Hyrax::PermissionTemplate.find_by(source_id: admin_set.id)
       end
     end
 

--- a/spec/factories/admin_sets_lw.rb
+++ b/spec/factories/admin_sets_lw.rb
@@ -57,7 +57,7 @@ FactoryBot.define do
 
   factory :adminset_lw, class: AdminSet do
     transient do
-      user { create(:user) }
+      user { create(Hyrax::Specs::FactoryName.user) }
 
       with_permission_template { false }
       with_solr_document { false }
@@ -105,7 +105,7 @@ FactoryBot.define do
     # Builds a pre-Hyrax 2.1.0 adminset without edit/view grants on the admin set.
     # Do not use with create because the save will cause the solr grants to be created.
     transient do
-      user { create(:user) }
+      user { create(Hyrax::Specs::FactoryName.user) }
       with_permission_template { true }
       with_solr_document { true }
     end
@@ -184,7 +184,7 @@ FactoryBot.define do
       attributes = { source_id: adminset.id }
       attributes[:manage_users] = user_managers(evaluator.with_permission_template, evaluator.user)
       attributes = evaluator.with_permission_template.merge(attributes) if evaluator.with_permission_template.respond_to?(:merge)
-      FactoryBot.create(:permission_template, attributes) unless Hyrax::PermissionTemplate.find_by(source_id: adminset.id)
+      FactoryBot.create(Hyrax::Specs::FactoryName.permission_template, attributes) unless Hyrax::PermissionTemplate.find_by(source_id: adminset.id)
     end
 
     # Process the with_solr_document transient property such that...

--- a/spec/factories/administrative_sets.rb
+++ b/spec/factories/administrative_sets.rb
@@ -5,7 +5,7 @@ FactoryBot.define do
 
     transient do
       with_permission_template { false }
-      user { create(:user) }
+      user { create(Hyrax::Specs::FactoryName.user) }
       access_grants { [] }
       with_index { true }
     end

--- a/spec/factories/collection_types.rb
+++ b/spec/factories/collection_types.rb
@@ -101,7 +101,7 @@ FactoryBot.define do
                          access: Hyrax::CollectionTypeParticipant::CREATE_ACCESS,
                          agent_id: user,
                          agent_type: Hyrax::CollectionTypeParticipant::USER_TYPE }
-          FactoryBot.create(:collection_type_participant, attributes)
+          FactoryBot.create(Hyrax::Specs::FactoryName.collection_type_participant, attributes)
         end
       end
 
@@ -111,7 +111,7 @@ FactoryBot.define do
                          access: Hyrax::CollectionTypeParticipant::CREATE_ACCESS,
                          agent_id: group,
                          agent_type: Hyrax::CollectionTypeParticipant::GROUP_TYPE }
-          FactoryBot.create(:collection_type_participant, attributes)
+          FactoryBot.create(Hyrax::Specs::FactoryName.collection_type_participant, attributes)
         end
       end
 
@@ -121,7 +121,7 @@ FactoryBot.define do
                          access: Hyrax::CollectionTypeParticipant::MANAGE_ACCESS,
                          agent_id: user,
                          agent_type: Hyrax::CollectionTypeParticipant::USER_TYPE }
-          FactoryBot.create(:collection_type_participant, attributes)
+          FactoryBot.create(Hyrax::Specs::FactoryName.collection_type_participant, attributes)
         end
       end
 
@@ -132,7 +132,7 @@ FactoryBot.define do
                        access: Hyrax::CollectionTypeParticipant::MANAGE_ACCESS,
                        agent_id: group,
                        agent_type: Hyrax::CollectionTypeParticipant::GROUP_TYPE }
-        FactoryBot.create(:collection_type_participant, attributes)
+        FactoryBot.create(Hyrax::Specs::FactoryName.collection_type_participant, attributes)
       end
     end
   end

--- a/spec/factories/collections.rb
+++ b/spec/factories/collections.rb
@@ -74,7 +74,7 @@ FactoryBot.define do
 
   factory :collection_lw, class: Collection do
     transient do
-      user { create(:user) }
+      user { create(Hyrax::Specs::FactoryName.user) }
 
       collection_type { nil }
       collection_type_settings { nil }
@@ -135,8 +135,8 @@ FactoryBot.define do
 
   factory :user_collection_lw, class: Collection do
     transient do
-      user { create(:user) }
-      collection_type { create(:user_collection_type) }
+      user { create(Hyrax::Specs::FactoryName.user) }
+      collection_type { create(Hyrax::Specs::FactoryName.user_collection_type) }
     end
 
     sequence(:title) { |n| ["User Collection Title #{n}"] }
@@ -148,10 +148,10 @@ FactoryBot.define do
 
   factory :typeless_collection_lw, class: Collection do
     # To create a pre-Hyrax 2.1.0 collection without a collection type gid...
-    #   col = build(:typeless_collection, ...)
+    #   col = build(Hyrax::Specs::FactoryName.typeless_collection, ...)
     #   col.save(validate: false)
     transient do
-      user { create(:user) }
+      user { create(Hyrax::Specs::FactoryName.user) }
       with_permission_template { false }
       do_save { false }
     end
@@ -165,7 +165,7 @@ FactoryBot.define do
         attributes = { source_id: collection.id }
         attributes[:manage_users] = [evaluator.user]
         attributes = evaluator.with_permission_template.merge(attributes) if evaluator.with_permission_template.respond_to?(:merge)
-        create(:permission_template, attributes) unless Hyrax::PermissionTemplate.find_by(source_id: collection.id)
+        create(Hyrax::Specs::FactoryName.permission_template, attributes) unless Hyrax::PermissionTemplate.find_by(source_id: collection.id)
       end
     end
   end
@@ -229,9 +229,9 @@ FactoryBot.define do
     # @param [Class] evaluator holding the transient properties for the current build/creation process
     def self.process_collection_type_settings(collection, evaluator)
       if evaluator.collection_type_settings.present?
-        collection.collection_type = FactoryBot.create(:collection_type, *evaluator.collection_type_settings)
+        collection.collection_type = FactoryBot.create(Hyrax::Specs::FactoryName.collection_type, *evaluator.collection_type_settings)
       elsif collection.collection_type_gid.blank?
-        collection.collection_type = FactoryBot.create(:user_collection_type)
+        collection.collection_type = FactoryBot.create(Hyrax::Specs::FactoryName.user_collection_type)
       end
     end
 
@@ -249,7 +249,7 @@ FactoryBot.define do
       attributes = { source_id: collection.id }
       attributes[:manage_users] = user_managers(evaluator.with_permission_template, evaluator.user)
       attributes = evaluator.with_permission_template.merge(attributes) if evaluator.with_permission_template.respond_to?(:merge)
-      FactoryBot.create(:permission_template, attributes) unless Hyrax::PermissionTemplate.find_by(source_id: collection.id)
+      FactoryBot.create(Hyrax::Specs::FactoryName.permission_template, attributes) unless Hyrax::PermissionTemplate.find_by(source_id: collection.id)
     end
 
     # Process the with_solr_document transient property such that...

--- a/spec/factories/collections_factory.rb
+++ b/spec/factories/collections_factory.rb
@@ -5,11 +5,11 @@ FactoryBot.define do
     # light weight collection factory.  DO NOT ADD tests using this factory.
     #
     # rubocop:disable Layout/LineLength
-    # @example let(:collection) { build(:collection, collection_type_settings: [:not_nestable, :discoverable, :sharable, :allow_multiple_membership]) }
+    # @example let(:collection) { build(Hyrax::Specs::FactoryName.collection, collection_type_settings: [:not_nestable, :discoverable, :sharable, :allow_multiple_membership]) }
     # rubocop:enable Layout/LineLength
 
     transient do
-      user { create(:user) }
+      user { create(Hyrax::Specs::FactoryName.user) }
       # allow defaulting to default user collection
       collection_type_settings { nil }
       with_permission_template { false }
@@ -20,9 +20,9 @@ FactoryBot.define do
     after(:build) do |collection, evaluator|
       collection.apply_depositor_metadata(evaluator.user.user_key)
       if evaluator.collection_type_settings.present?
-        collection.collection_type = create(:collection_type, *evaluator.collection_type_settings)
+        collection.collection_type = create(Hyrax::Specs::FactoryName.collection_type, *evaluator.collection_type_settings)
       elsif collection.collection_type_gid.nil?
-        collection.collection_type = create(:user_collection_type)
+        collection.collection_type = create(Hyrax::Specs::FactoryName.user_collection_type)
       end
     end
 
@@ -32,7 +32,7 @@ FactoryBot.define do
         attributes = { source_id: collection.id }
         attributes[:manage_users] = CollectionFactoryHelper.user_managers(evaluator.with_permission_template, evaluator.user, evaluator.create_access)
         attributes = evaluator.with_permission_template.merge(attributes) if evaluator.with_permission_template.respond_to?(:merge)
-        create(:permission_template, attributes) unless Hyrax::PermissionTemplate.find_by(source_id: collection.id)
+        create(Hyrax::Specs::FactoryName.permission_template, attributes) unless Hyrax::PermissionTemplate.find_by(source_id: collection.id)
         collection.permission_template.reset_access_controls_for(collection: collection, interpret_visibility: true)
       end
     end
@@ -59,8 +59,8 @@ FactoryBot.define do
 
   factory :user_collection, class: Collection do
     transient do
-      user { create(:user) }
-      collection_type { create(:user_collection_type) }
+      user { create(Hyrax::Specs::FactoryName.user) }
+      collection_type { create(Hyrax::Specs::FactoryName.user_collection_type) }
     end
 
     sequence(:title) { |n| ["User Collection Title #{n}"] }
@@ -72,10 +72,10 @@ FactoryBot.define do
 
   factory :typeless_collection, class: Collection do
     # To create a pre-Hyrax 2.1.0 collection without a collection type gid...
-    #   col = build(:typeless_collection, ...)
+    #   col = build(Hyrax::Specs::FactoryName.typeless_collection, ...)
     #   col.save(validate: false)
     transient do
-      user { create(:user) }
+      user { create(Hyrax::Specs::FactoryName.user) }
       with_permission_template { false }
       create_access { false }
       do_save { false }
@@ -90,7 +90,7 @@ FactoryBot.define do
         attributes = { source_id: collection.id }
         attributes[:manage_users] = [evaluator.user] if evaluator.create_access
         attributes = evaluator.with_permission_template.merge(attributes) if evaluator.with_permission_template.respond_to?(:merge)
-        create(:permission_template, attributes) unless Hyrax::PermissionTemplate.find_by(source_id: collection.id)
+        create(Hyrax::Specs::FactoryName.permission_template, attributes) unless Hyrax::PermissionTemplate.find_by(source_id: collection.id)
       end
     end
   end

--- a/spec/factories/file_sets.rb
+++ b/spec/factories/file_sets.rb
@@ -2,7 +2,7 @@
 FactoryBot.define do
   factory :file_set do
     transient do
-      user { create(:user) }
+      user { create(Hyrax::Specs::FactoryName.user) }
       content { nil }
     end
     after(:build) do |fs, evaluator|
@@ -38,7 +38,7 @@ FactoryBot.define do
       end
       after(:create) do |file, evaluator|
         Hydra::Works::UploadFileToFileSet.call(file, evaluator.content) if evaluator.content
-        create(:work, user: evaluator.user).members << file
+        create(Hyrax::Specs::FactoryName.work, user: evaluator.user).members << file
       end
     end
   end

--- a/spec/factories/generic_works.rb
+++ b/spec/factories/generic_works.rb
@@ -3,7 +3,7 @@
 FactoryBot.define do
   factory :work, aliases: [:generic_work, :private_generic_work], class: 'GenericWork' do
     transient do
-      user { create(:user) }
+      user { create(Hyrax::Specs::FactoryName.user) }
       # Set to true (or a hash) if you want to create an admin set
       with_admin_set { false }
     end
@@ -15,7 +15,7 @@ FactoryBot.define do
         attributes = {}
         attributes[:id] = work.admin_set_id if work.admin_set_id.present?
         attributes = evaluator.with_admin_set.merge(attributes) if evaluator.with_admin_set.respond_to?(:merge)
-        admin_set = create(:admin_set, attributes)
+        admin_set = create(Hyrax::Specs::FactoryName.admin_set, attributes)
         work.admin_set_id = admin_set.id
       end
     end
@@ -51,55 +51,55 @@ FactoryBot.define do
 
     factory :work_with_one_file do
       before(:create) do |work, evaluator|
-        work.ordered_members << create(:file_set, user: evaluator.user, title: ['A Contained FileSet'], label: 'filename.pdf')
+        work.ordered_members << create(Hyrax::Specs::FactoryName.file_set, user: evaluator.user, title: ['A Contained FileSet'], label: 'filename.pdf')
       end
     end
 
     factory :work_with_files do
-      before(:create) { |work, evaluator| 2.times { work.ordered_members << create(:file_set, user: evaluator.user) } }
+      before(:create) { |work, evaluator| 2.times { work.ordered_members << create(Hyrax::Specs::FactoryName.file_set, user: evaluator.user) } }
     end
 
     factory :work_with_image_files do
-      before(:create) { |work, evaluator| 2.times { work.ordered_members << create(:file_set, :image, user: evaluator.user) } }
+      before(:create) { |work, evaluator| 2.times { work.ordered_members << create(Hyrax::Specs::FactoryName.file_set, :image, user: evaluator.user) } }
     end
 
     factory :work_with_ordered_files do
       before(:create) do |work, evaluator|
-        work.ordered_members << create(:file_set, user: evaluator.user)
-        work.ordered_member_proxies.insert_target_at(0, create(:file_set, user: evaluator.user))
+        work.ordered_members << create(Hyrax::Specs::FactoryName.file_set, user: evaluator.user)
+        work.ordered_member_proxies.insert_target_at(0, create(Hyrax::Specs::FactoryName.file_set, user: evaluator.user))
       end
     end
 
     factory :work_with_one_child do
       before(:create) do |work, evaluator|
-        work.ordered_members << create(:work, user: evaluator.user, title: ['A Contained Work'])
+        work.ordered_members << create(Hyrax::Specs::FactoryName.work, user: evaluator.user, title: ['A Contained Work'])
       end
     end
 
     factory :work_with_two_children do
       before(:create) do |work, evaluator|
-        work.ordered_members << create(:work, user: evaluator.user, title: ['A Contained Work'], id: "BlahBlah1")
-        work.ordered_members << create(:work, user: evaluator.user, title: ['Another Contained Work'], id: "BlahBlah2")
+        work.ordered_members << create(Hyrax::Specs::FactoryName.work, user: evaluator.user, title: ['A Contained Work'], id: "BlahBlah1")
+        work.ordered_members << create(Hyrax::Specs::FactoryName.work, user: evaluator.user, title: ['Another Contained Work'], id: "BlahBlah2")
       end
     end
 
     factory :work_with_representative_file do
       before(:create) do |work, evaluator|
-        work.ordered_members << create(:file_set, user: evaluator.user, title: ['A Contained FileSet'])
+        work.ordered_members << create(Hyrax::Specs::FactoryName.file_set, user: evaluator.user, title: ['A Contained FileSet'])
         work.representative_id = work.members[0].id
       end
     end
 
     factory :work_with_file_and_work do
       before(:create) do |work, evaluator|
-        work.ordered_members << create(:file_set, user: evaluator.user)
-        work.ordered_members << create(:work, user: evaluator.user)
+        work.ordered_members << create(Hyrax::Specs::FactoryName.file_set, user: evaluator.user)
+        work.ordered_members << create(Hyrax::Specs::FactoryName.work, user: evaluator.user)
       end
     end
 
     factory :with_embargo_date do
       # build with defaults:
-      # let(:work) { create(:embargoed_work) }
+      # let(:work) { create(Hyrax::Specs::FactoryName.embargoed_work) }
 
       # build with specific values:
       # let(:embargo_attributes) do
@@ -107,7 +107,7 @@ FactoryBot.define do
       #     current_state: Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE,
       #     future_state: Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC }
       # end
-      # let(:work) { create(:embargoed_work, with_embargo_attributes: embargo_attributes) }
+      # let(:work) { create(Hyrax::Specs::FactoryName.embargoed_work, with_embargo_attributes: embargo_attributes) }
 
       transient do
         with_embargo_attributes { false }
@@ -140,13 +140,13 @@ FactoryBot.define do
                                evaluator.future_state)
           end
         end
-        after(:create) { |work, evaluator| 2.times { work.ordered_members << create(:file_set, user: evaluator.user) } }
+        after(:create) { |work, evaluator| 2.times { work.ordered_members << create(Hyrax::Specs::FactoryName.file_set, user: evaluator.user) } }
       end
     end
 
     factory :with_lease_date do
       # build with defaults:
-      # let(:work) { create(:leased_work) }
+      # let(:work) { create(Hyrax::Specs::FactoryName.leased_work) }
 
       # build with specific values:
       # let(:lease_attributes) do
@@ -154,7 +154,7 @@ FactoryBot.define do
       #     current_state: Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC,
       #     future_state: Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED }
       # end
-      # let(:work) { create(:leased_work, with_lease_attributes: lease_attributes) }
+      # let(:work) { create(Hyrax::Specs::FactoryName.leased_work, with_lease_attributes: lease_attributes) }
 
       transient do
         with_lease_attributes { false }
@@ -187,7 +187,7 @@ FactoryBot.define do
                              evaluator.future_state)
           end
         end
-        after(:create) { |work, evaluator| 2.times { work.ordered_members << create(:file_set, user: evaluator.user) } }
+        after(:create) { |work, evaluator| 2.times { work.ordered_members << create(Hyrax::Specs::FactoryName.file_set, user: evaluator.user) } }
       end
     end
   end
@@ -195,6 +195,6 @@ FactoryBot.define do
   # Doesn't set up any edit_users
   factory :work_without_access, class: 'GenericWork' do
     title { ['Test title'] }
-    depositor { create(:user).user_key }
+    depositor { create(Hyrax::Specs::FactoryName.user).user_key }
   end
 end

--- a/spec/factories/hyrax_collection.rb
+++ b/spec/factories/hyrax_collection.rb
@@ -11,7 +11,7 @@ FactoryBot.define do
       with_permission_template { true }
       collection_type { nil }
       with_index { true }
-      user { create(:user) }
+      user { create(Hyrax::Specs::FactoryName.user) }
       edit_groups { [] }
       edit_users { [] }
       read_groups { [] }
@@ -56,25 +56,25 @@ FactoryBot.define do
 
     trait :with_member_works do
       transient do
-        members { [valkyrie_create(:hyrax_work), valkyrie_create(:hyrax_work)] }
+        members { [valkyrie_create(Hyrax::Specs::FactoryName.hyrax_work), valkyrie_create(Hyrax::Specs::FactoryName.hyrax_work)] }
       end
     end
 
     trait :with_member_collections do
       transient do
-        members { [valkyrie_create(:hyrax_collection), valkyrie_create(:hyrax_collection)] }
+        members { [valkyrie_create(Hyrax::Specs::FactoryName.hyrax_collection), valkyrie_create(Hyrax::Specs::FactoryName.hyrax_collection)] }
       end
     end
 
     trait :as_collection_member do
-      member_of_collection_ids { [valkyrie_create(:hyrax_collection).id] }
+      member_of_collection_ids { [valkyrie_create(Hyrax::Specs::FactoryName.hyrax_collection).id] }
     end
 
     trait :as_member_of_multiple_collections do
       member_of_collection_ids do
-        [valkyrie_create(:hyrax_collection).id,
-         valkyrie_create(:hyrax_collection).id,
-         valkyrie_create(:hyrax_collection).id]
+        [valkyrie_create(Hyrax::Specs::FactoryName.hyrax_collection).id,
+         valkyrie_create(Hyrax::Specs::FactoryName.hyrax_collection).id,
+         valkyrie_create(Hyrax::Specs::FactoryName.hyrax_collection).id]
       end
     end
 

--- a/spec/factories/hyrax_file_metadata.rb
+++ b/spec/factories/hyrax_file_metadata.rb
@@ -62,9 +62,9 @@ FactoryBot.define do
 
     trait :with_file do
       transient do
-        file { FactoryBot.create(:uploaded_file, file: File.open(Hyrax::Engine.root + 'spec/fixtures/world.png')) }
-        file_set { FactoryBot.valkyrie_create(:hyrax_file_set) }
-        user { FactoryBot.create(:user) }
+        file { FactoryBot.create(Hyrax::Specs::FactoryName.uploaded_file, file: File.open(Hyrax::Engine.root + 'spec/fixtures/world.png')) }
+        file_set { FactoryBot.valkyrie_create(Hyrax::Specs::FactoryName.hyrax_file_set) }
+        user { FactoryBot.create(Hyrax::Specs::FactoryName.user) }
       end
 
       after(:build) do |file_metadata, evaluator|

--- a/spec/factories/hyrax_file_set.rb
+++ b/spec/factories/hyrax_file_set.rb
@@ -59,7 +59,7 @@ FactoryBot.define do
 
     trait :with_expired_enforced_embargo do
       after(:build) do |fs, _evaluator|
-        fs.embargo = FactoryBot.valkyrie_create(:hyrax_embargo, :expired)
+        fs.embargo = FactoryBot.valkyrie_create(Hyrax::Specs::FactoryName.hyrax_embargo, :expired)
       end
 
       after(:create) do |fs, _evaluator|
@@ -81,7 +81,7 @@ FactoryBot.define do
 
     trait :with_expired_enforced_lease do
       after(:build) do |fs, _evaluator|
-        fs.lease = FactoryBot.valkyrie_create(:hyrax_lease, :expired)
+        fs.lease = FactoryBot.valkyrie_create(Hyrax::Specs::FactoryName.hyrax_lease, :expired)
       end
 
       after(:create) do |fs, _evaluator|
@@ -119,7 +119,7 @@ FactoryBot.define do
 
     trait :in_work do
       transient do
-        work { build(:hyrax_work) }
+        work { build(Hyrax::Specs::FactoryName.hyrax_work) }
       end
 
       after(:create) do |file_set, evaluator|

--- a/spec/factories/hyrax_resource.rb
+++ b/spec/factories/hyrax_resource.rb
@@ -5,11 +5,11 @@
 FactoryBot.define do
   factory :hyrax_resource, class: "Hyrax::Resource" do
     trait :under_embargo do
-      embargo_id { FactoryBot.create(:hyrax_embargo).id }
+      embargo_id { FactoryBot.create(Hyrax::Specs::FactoryName.hyrax_embargo).id }
     end
 
     trait :under_lease do
-      lease_id { FactoryBot.create(:hyrax_lease).id }
+      lease_id { FactoryBot.create(Hyrax::Specs::FactoryName.hyrax_lease).id }
     end
   end
 end

--- a/spec/factories/hyrax_work.rb
+++ b/spec/factories/hyrax_work.rb
@@ -15,7 +15,7 @@ FactoryBot.define do
 
     trait :with_expired_enforced_embargo do
       after(:build) do |work, _evaluator|
-        work.embargo = FactoryBot.valkyrie_create(:hyrax_embargo, :expired)
+        work.embargo = FactoryBot.valkyrie_create(Hyrax::Specs::FactoryName.hyrax_embargo, :expired)
       end
 
       after(:create) do |work, _evaluator|
@@ -37,7 +37,7 @@ FactoryBot.define do
 
     trait :with_expired_enforced_lease do
       after(:build) do |work, _evaluator|
-        work.lease = FactoryBot.valkyrie_create(:hyrax_lease, :expired)
+        work.lease = FactoryBot.valkyrie_create(Hyrax::Specs::FactoryName.hyrax_lease, :expired)
       end
 
       after(:create) do |work, _evaluator|
@@ -112,7 +112,7 @@ FactoryBot.define do
 
     trait :with_admin_set do
       transient do
-        admin_set { valkyrie_create(:hyrax_admin_set) }
+        admin_set { valkyrie_create(Hyrax::Specs::FactoryName.hyrax_admin_set) }
       end
 
       after(:build) do |work, evaluator|
@@ -130,7 +130,7 @@ FactoryBot.define do
           # If you set a depositor on the containing work, propogate that into these members
           additional_attributes = {}
           additional_attributes[:depositor] = depositor if depositor
-          [valkyrie_create(:hyrax_work, additional_attributes), valkyrie_create(:hyrax_work, additional_attributes)]
+          [valkyrie_create(Hyrax::Specs::FactoryName.hyrax_work, additional_attributes), valkyrie_create(Hyrax::Specs::FactoryName.hyrax_work, additional_attributes)]
         end
       end
     end
@@ -141,7 +141,7 @@ FactoryBot.define do
           # If you set a depositor on the containing work, propogate that into these members
           additional_attributes = {}
           additional_attributes[:depositor] = depositor if depositor
-          [valkyrie_create(:hyrax_file_set, additional_attributes), valkyrie_create(:hyrax_work, additional_attributes)]
+          [valkyrie_create(Hyrax::Specs::FactoryName.hyrax_file_set, additional_attributes), valkyrie_create(Hyrax::Specs::FactoryName.hyrax_work, additional_attributes)]
         end
       end
     end
@@ -152,7 +152,7 @@ FactoryBot.define do
           # If you set a depositor on the containing work, propogate that into this member
           additional_attributes = {}
           additional_attributes[:depositor] = depositor if depositor
-          [valkyrie_create(:hyrax_file_set, additional_attributes)]
+          [valkyrie_create(Hyrax::Specs::FactoryName.hyrax_file_set, additional_attributes)]
         end
       end
     end
@@ -163,7 +163,7 @@ FactoryBot.define do
           # If you set a depositor on the containing work, propogate that into these members
           additional_attributes = {}
           additional_attributes[:depositor] = depositor if depositor
-          [valkyrie_create(:hyrax_file_set, additional_attributes), valkyrie_create(:hyrax_file_set, additional_attributes)]
+          [valkyrie_create(Hyrax::Specs::FactoryName.hyrax_file_set, additional_attributes), valkyrie_create(Hyrax::Specs::FactoryName.hyrax_file_set, additional_attributes)]
         end
       end
     end
@@ -171,7 +171,7 @@ FactoryBot.define do
     trait :with_thumbnail do
       thumbnail_id do
         file_set = members.find(&:file_set?) ||
-                   valkyrie_create(:hyrax_file_set)
+                   valkyrie_create(Hyrax::Specs::FactoryName.hyrax_file_set)
         file_set.id
       end
     end
@@ -179,7 +179,7 @@ FactoryBot.define do
     trait :with_representative do
       representative_id do
         file_set = members&.find(&:file_set?) ||
-                   valkyrie_create(:hyrax_file_set)
+                   valkyrie_create(Hyrax::Specs::FactoryName.hyrax_file_set)
         file_set.id
       end
     end
@@ -187,20 +187,20 @@ FactoryBot.define do
     trait :with_renderings do
       rendering_ids do
         file_set = members.find(&:file_set?) ||
-                   valkyrie_create(:hyrax_file_set)
+                   valkyrie_create(Hyrax::Specs::FactoryName.hyrax_file_set)
         file_set.id
       end
     end
 
     trait :as_collection_member do
-      member_of_collection_ids { [valkyrie_create(:hyrax_collection).id] }
+      member_of_collection_ids { [valkyrie_create(Hyrax::Specs::FactoryName.hyrax_collection).id] }
     end
 
     trait :as_member_of_multiple_collections do
       member_of_collection_ids do
-        [valkyrie_create(:hyrax_collection).id,
-         valkyrie_create(:hyrax_collection).id,
-         valkyrie_create(:hyrax_collection).id]
+        [valkyrie_create(Hyrax::Specs::FactoryName.hyrax_collection).id,
+         valkyrie_create(Hyrax::Specs::FactoryName.hyrax_collection).id,
+         valkyrie_create(Hyrax::Specs::FactoryName.hyrax_collection).id]
       end
     end
 
@@ -213,7 +213,7 @@ FactoryBot.define do
 
       trait :with_member_works do
         transient do
-          members { [valkyrie_create(:monograph), valkyrie_create(:monograph)] }
+          members { [valkyrie_create(Hyrax::Specs::FactoryName.monograph), valkyrie_create(Hyrax::Specs::FactoryName.monograph)] }
         end
       end
     end

--- a/spec/factories/permission.rb
+++ b/spec/factories/permission.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 FactoryBot.define do
   factory :permission, class: "Hyrax::Permission" do
-    agent { create(:user).user_key.to_s }
+    agent { create(Hyrax::Specs::FactoryName.user).user_key.to_s }
     mode  { :read }
   end
 end

--- a/spec/factories/permission_templates.rb
+++ b/spec/factories/permission_templates.rb
@@ -25,10 +25,10 @@ FactoryBot.define do
             begin
               Collection.find(source_id)
             rescue ActiveFedora::ObjectNotFoundError
-              create(:collection, id: source_id)
+              create(Hyrax::Specs::FactoryName.collection, id: source_id)
             end
           else
-            create(:collection)
+            create(Hyrax::Specs::FactoryName.collection)
           end
         permission_template.source_id = collection.id
       end
@@ -40,8 +40,8 @@ FactoryBot.define do
         Sipity::Workflow.activate!(permission_template: permission_template, workflow_id: permission_template.available_workflows.pick(:id))
       end
       if evaluator.with_active_workflow
-        workflow = create(:workflow, active: true, permission_template: permission_template)
-        create(:workflow_action, workflow: workflow) # Need to create a single action that can be taken
+        workflow = create(Hyrax::Specs::FactoryName.workflow, active: true, permission_template: permission_template)
+        create(Hyrax::Specs::FactoryName.workflow_action, workflow: workflow) # Need to create a single action that can be taken
       end
       AccessHelper.create_access(permission_template, 'user', :manage, evaluator.manage_users) if evaluator.manage_users.present?
       AccessHelper.create_access(permission_template, 'group', :manage, evaluator.manage_groups) if evaluator.manage_groups.present?
@@ -68,7 +68,7 @@ FactoryBot.define do
   class AccessHelper
     def self.create_access(permission_template_id, agent_type, access, agent_ids)
       agent_ids.each do |agent_id|
-        FactoryBot.create(:permission_template_access,
+        FactoryBot.create(Hyrax::Specs::FactoryName.permission_template_access,
                           access,
                           permission_template: permission_template_id,
                           agent_type: agent_type,
@@ -87,10 +87,10 @@ FactoryBot.define do
         begin
           AdminSet.find(source_id)
         rescue ActiveFedora::ObjectNotFoundError
-          FactoryBot.create(:admin_set, id: source_id)
+          FactoryBot.create(Hyrax::Specs::FactoryName.admin_set, id: source_id)
         end
       else
-        FactoryBot.create(:admin_set)
+        FactoryBot.create(Hyrax::Specs::FactoryName.admin_set)
       end
     end
 
@@ -101,10 +101,10 @@ FactoryBot.define do
         rescue Valkyrie::Persistence::ObjectNotFoundError
           # Creating an Administrative set with a pre-determined id will not work for all adapters
           # so we're letting the adapter assign the id
-          FactoryBot.valkyrie_create(:hyrax_admin_set)
+          FactoryBot.valkyrie_create(Hyrax::Specs::FactoryName.hyrax_admin_set)
         end
       else
-        FactoryBot.valkyrie_create(:hyrax_admin_set)
+        FactoryBot.valkyrie_create(Hyrax::Specs::FactoryName.hyrax_admin_set)
       end
     end
   end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -6,7 +6,7 @@ FactoryBot.define do
 
     transient do
       # Allow for custom groups when a user is instantiated.
-      # @example create(:user, groups: 'avacado')
+      # @example create(Hyrax::Specs::FactoryName.user, groups: 'avacado')
       groups { [] }
     end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -76,6 +76,7 @@ WebMock.disable_net_connect!(allow_localhost: true, allow: allowed_hosts)
 require 'i18n/debug' if ENV['I18N_DEBUG']
 require 'byebug' unless ci_build?
 
+require 'hyrax/specs/factory_name'
 require 'hyrax/specs/shared_specs/factories/strategies/json_strategy'
 require 'hyrax/specs/shared_specs/factories/strategies/valkyrie_resource'
 FactoryBot.register_strategy(:valkyrie_create, ValkyrieCreateStrategy)


### PR DESCRIPTION
From the code comment:

> This configuration serves the goal of exposing Hyrax's factories to
> downstream implementations, allowing for greater re-use of these
> complicated and foundational testing tools.
>
> One envisioned scenario is that a downstream application wants to
> extend two factories (e.g. admin_set and permission_template).  Given
> that Hyrax's :admin_set factory references :permission_template
> factory, it would be convenient to provide a means to change that
> factory name.
>
> The implementation pattern is as follows:
>
> - Define a factory using a "hard-coded" symbol.
> - Within a factory, when referencing another factory, do so by way of
>   this class.
> - Within a spec, reference a factory by a "hard-coded" symbol.
>
> Downstream implementations can adjust the Hyrax::Specs::FactoryName,
> which in turn means that the factories defined in Hyrax and re-used
> downstream, will use those newly specified factories.  Those newly
> specified factories *might* inherit from the default factory.

@samvera/hyrax-code-reviewers