### PR TITLE
🧹 Favor explicit FactoryBot.create

### DIFF
--- a/spec/factories/admin_sets_lw.rb
+++ b/spec/factories/admin_sets_lw.rb
@@ -57,7 +57,7 @@ FactoryBot.define do
 
   factory :adminset_lw, class: AdminSet do
     transient do
-      user { create(:user) }
+      user { FactoryBot.create(:user) }
 
       with_permission_template { false }
       with_solr_document { false }
@@ -105,7 +105,7 @@ FactoryBot.define do
     # Builds a pre-Hyrax 2.1.0 adminset without edit/view grants on the admin set.
     # Do not use with create because the save will cause the solr grants to be created.
     transient do
-      user { create(:user) }
+      user { FactoryBot.create(:user) }
       with_permission_template { true }
       with_solr_document { true }
     end

--- a/spec/factories/administrative_sets.rb
+++ b/spec/factories/administrative_sets.rb
@@ -15,7 +15,7 @@ FactoryBot.define do
 
     transient do
       with_permission_template { false }
-      user { create(:user) }
+      user { FactoryBot.create(:user) }
       access_grants { [] }
       with_index { true }
     end

--- a/spec/factories/collections.rb
+++ b/spec/factories/collections.rb
@@ -74,7 +74,7 @@ FactoryBot.define do
 
   factory :collection_lw, class: Collection do
     transient do
-      user { create(:user) }
+      user { FactoryBot.create(:user) }
 
       collection_type { nil }
       collection_type_settings { nil }
@@ -135,7 +135,7 @@ FactoryBot.define do
 
   factory :user_collection_lw, class: Collection do
     transient do
-      user { create(:user) }
+      user { FactoryBot.create(:user) }
       collection_type { create(:user_collection_type) }
     end
 
@@ -151,7 +151,7 @@ FactoryBot.define do
     #   col = build(:typeless_collection, ...)
     #   col.save(validate: false)
     transient do
-      user { create(:user) }
+      user { FactoryBot.create(:user) }
       with_permission_template { false }
       do_save { false }
     end

--- a/spec/factories/collections_factory.rb
+++ b/spec/factories/collections_factory.rb
@@ -9,7 +9,7 @@ FactoryBot.define do
     # rubocop:enable Layout/LineLength
 
     transient do
-      user { create(:user) }
+      user { FactoryBot.create(:user) }
       # allow defaulting to default user collection
       collection_type_settings { nil }
       with_permission_template { false }
@@ -59,7 +59,7 @@ FactoryBot.define do
 
   factory :user_collection, class: Collection do
     transient do
-      user { create(:user) }
+      user { FactoryBot.create(:user) }
       collection_type { create(:user_collection_type) }
     end
 
@@ -75,7 +75,7 @@ FactoryBot.define do
     #   col = build(:typeless_collection, ...)
     #   col.save(validate: false)
     transient do
-      user { create(:user) }
+      user { FactoryBot.create(:user) }
       with_permission_template { false }
       create_access { false }
       do_save { false }

--- a/spec/factories/file_sets.rb
+++ b/spec/factories/file_sets.rb
@@ -2,7 +2,7 @@
 FactoryBot.define do
   factory :file_set do
     transient do
-      user { create(:user) }
+      user { FactoryBot.create(:user) }
       content { nil }
     end
     after(:build) do |fs, evaluator|

--- a/spec/factories/generic_works.rb
+++ b/spec/factories/generic_works.rb
@@ -3,7 +3,7 @@
 FactoryBot.define do
   factory :work, aliases: [:generic_work, :private_generic_work], class: 'GenericWork' do
     transient do
-      user { create(:user) }
+      user { FactoryBot.create(:user) }
       # Set to true (or a hash) if you want to create an admin set
       with_admin_set { false }
     end

--- a/spec/factories/hyrax_collection.rb
+++ b/spec/factories/hyrax_collection.rb
@@ -19,7 +19,7 @@ FactoryBot.define do
       with_permission_template { true }
       collection_type { nil }
       with_index { true }
-      user { create(:user) }
+      user { FactoryBot.create(:user) }
       edit_groups { [] }
       edit_users { [] }
       read_groups { [] }


### PR DESCRIPTION
In cases where we have `Factory A` that uses the
`FactoryBot.valkyrie_create` strategy, and it calls `create(:user)`, the
`create(:user)` uses the `valkyrie_create` strategy; which causes
problems.

This change favors the explicit `FactoryBot.create` call to be specific
about the strategy instead of implicit.