### PR TITLE
🐛 Favor fault tolerant comparison

### DIFF
--- a/app/models/hyrax/resource.rb
+++ b/app/models/hyrax/resource.rb
@@ -150,7 +150,7 @@ module Hyrax
     end
 
     def ==(other)
-      attributes.except(:created_at, :updated_at) == other.attributes.except(:created_at, :updated_at)
+      attributes.except(:created_at, :updated_at) == other.attributes.except(:created_at, :updated_at) if other.respond_to?(:attributes)
     end
 
     def permission_manager


### PR DESCRIPTION
If the given `other` doesn't respond to `attributes` we're going to
raise an exception.  This change improves the fault tolerance.