### PR TITLE
♻️ Favor using to_rdf_representation

### DIFF
--- a/lib/hyrax/specs/shared_specs/indexers.rb
+++ b/lib/hyrax/specs/shared_specs/indexers.rb
@@ -18,7 +18,7 @@ RSpec.shared_examples 'a Hyrax::Resource indexer' do
   describe '#to_solr' do
     it 'indexes base resource fields' do
       expect(indexer.to_solr)
-        .to include(has_model_ssim: resource.class.name,
+        .to include(has_model_ssim: resource.to_rdf_representation,
                     human_readable_type_tesim: resource.human_readable_type,
                     alternate_ids_sim: a_collection_containing_exactly(*ids))
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -66,6 +66,25 @@ Valkyrie::StorageAdapter.register(
   :fixture_disk
 )
 
+# Because we're relying on shared specs from Valkyrie, and assuming that all of the classes will
+# respond to #to_rdf_representation and the base Valkyrie::Resource does not do that nor does the
+# dynamic classes generated for the shared specs; we need the following coercion.
+module Hyrax::Resource::Coercible
+  extend ActiveSupport::Concern
+
+  class_methods do
+    def to_rdf_representation
+      name.to_s
+    end
+  end
+
+  def to_rdf_representation
+    self.class.to_rdf_representation
+  end
+end
+
+Valkyrie::Resource.include(Hyrax::Resource::Coercible)
+
 # Require supporting ruby files from spec/support/ and subdirectories.  Note: engine, not Rails.root context.
 Dir[File.join(File.dirname(__FILE__), "support/**/*.rb")].each { |f| require f }
 


### PR DESCRIPTION
We're more and more using the to_rdf_representation as the baseline
conceptual class that we're persisting.  It is different from
generic_type in that in the case of Pcdm::Work, the
`to_rdf_representation` represents the specific implemented work model
and the generic_type remains `Work`.