### PR TITLE
Set valkyrie models as default in Hyrax.config

### DIFF
--- a/.dassie/config/initializers/hyrax.rb
+++ b/.dassie/config/initializers/hyrax.rb
@@ -63,6 +63,11 @@ Hyrax.config do |config|
   # config.collection_model = 'Hyrax::PcdmCollection' # collection without basic metadata
   # config.collection_model = 'CollectionResource'    # collection with basic metadata
   # config.admin_set_model = 'Hyrax::AdministrativeSet'
+
+  # dassie needs legacy AF models
+  config.collection_model = '::Collection'
+  config.admin_set_model = 'AdminSet'
+  config.file_set_model = '::FileSet'
 end
 
 Date::DATE_FORMATS[:standard] = "%m/%d/%Y"

--- a/lib/hyrax/configuration.rb
+++ b/lib/hyrax/configuration.rb
@@ -55,7 +55,7 @@ module Hyrax
   #
   # == Valkyrie
   #
-  # *Experimental:* Options for toggling Hyrax's experimental "Wings" valkyrie
+  # Options for toggling Hyrax's "Wings" valkyrie
   # adapter and configuring valkyrie.
   #
   # @see Hyrax.config
@@ -617,14 +617,14 @@ module Hyrax
     end
 
     ##
-    # @return [Boolean] whether to use the experimental valkyrie index
+    # @return [Boolean] whether to use the valkyrie index
     def query_index_from_valkyrie
       @query_index_from_valkyrie ||= false
     end
     attr_writer :query_index_from_valkyrie
 
     ##
-    # @return [Boolean] whether to use experimental valkyrie storage features
+    # @return [Boolean] whether to use valkyrie storage features
     def use_valkyrie?
       return @use_valkyrie unless @use_valkyrie.nil?
       return true if disable_wings # always return true if wings is disabled
@@ -860,7 +860,7 @@ module Hyrax
     # @return [#constantize] a string representation of the collection
     #   model
     def collection_model
-      @collection_model ||= '::Collection'
+      @collection_model ||= 'Hyrax::PcdmCollection'
     end
 
     ##
@@ -874,7 +874,7 @@ module Hyrax
     # @return [#constantize] a string representation of the admin set
     #   model
     def admin_set_model
-      @admin_set_model ||= 'AdminSet'
+      @admin_set_model ||= 'Hyrax::AdministrativeSet'
     end
 
     ##


### PR DESCRIPTION
file_set_model is already the valkyrie model by default. .dassie continues to use the AF models. Existing hyrax applications continuing to use AF will need to set a similar config.

@samvera/hyrax-code-reviewers
