### PR TITLE
🐛 Use configured class instead of hard-coded

### DIFF
--- a/app/presenters/hyrax/pcdm_member_presenter_factory.rb
+++ b/app/presenters/hyrax/pcdm_member_presenter_factory.rb
@@ -98,9 +98,9 @@ module Hyrax
     def presenter_for(document:, ability:)
       case document['has_model_ssim'].first
       when *Hyrax::ModelRegistry.file_set_rdf_representations
-        Hyrax::FileSetPresenter.new(document, ability)
+        file_presenter_class.new(document, ability)
       else
-        Hyrax::WorkShowPresenter.new(document, ability)
+        work_presenter_class.new(document, ability)
       end
     end
 

--- a/app/presenters/hyrax/work_show_presenter.rb
+++ b/app/presenters/hyrax/work_show_presenter.rb
@@ -63,10 +63,10 @@ module Hyrax
 
     # @return [Boolean] render a IIIF viewer
     def iiif_viewer?
-      representative_id.present? &&
+      Hyrax.config.iiif_image_server? &&
+        representative_id.present? &&
         representative_presenter.present? &&
         representative_presenter.image? &&
-        Hyrax.config.iiif_image_server? &&
         members_include_viewable_image?
     end
 


### PR DESCRIPTION
The baseline configuration for the `Hyrax::PcdmMemberPresenterFactory` allows for us to specify the `file_presenter_class` and the `work_presenter_class`.  However, in the case of `presenter_for` we were not leveraging that configurability.

This commit rectifies that behavior.

Tagging along with this commit is a minor performance improvement. Namely, check a simple boolean before we begin checking elements that might require additional queries and/or loading additional objects.

@samvera/hyrax-code-reviewers
