### PR TITLE
The helm chart says it evaluates extraEnvVars but it was not actually doing so

### DIFF
--- a/chart/hyrax/templates/_tmplvalues.tpl
+++ b/chart/hyrax/templates/_tmplvalues.tpl
@@ -1,0 +1,38 @@
+{{/*
+Copyright VMware, Inc.
+SPDX-License-Identifier: APACHE-2.0
+*/}}
+
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Renders a value that contains template perhaps with scope if the scope is present.
+Usage:
+{{ include "common.tplvalues.render" ( dict "value" .Values.path.to.the.Value "context" $ ) }}
+{{ include "common.tplvalues.render" ( dict "value" .Values.path.to.the.Value "context" $ "scope" $app ) }}
+*/}}
+{{- define "common.tplvalues.render" -}}
+{{- $value := typeIs "string" .value | ternary .value (.value | toYaml) }}
+{{- if contains "{{" (toJson .value) }}
+  {{- if .scope }}
+      {{- tpl (cat "{{- with $.RelativeScope -}}" $value "{{- end }}") (merge (dict "RelativeScope" .scope) .context) }}
+  {{- else }}
+    {{- tpl $value .context }}
+  {{- end }}
+{{- else }}
+    {{- $value }}
+{{- end }}
+{{- end -}}
+
+{{/*
+Merge a list of values that contains template after rendering them.
+Merge precedence is consistent with http://masterminds.github.io/sprig/dicts.html#merge-mustmerge
+Usage:
+{{ include "common.tplvalues.merge" ( dict "values" (list .Values.path.to.the.Value1 .Values.path.to.the.Value2) "context" $ ) }}
+*/}}
+{{- define "common.tplvalues.merge" -}}
+{{- $dst := dict -}}
+{{- range .values -}}
+{{- $dst = include "common.tplvalues.render" (dict "value" . "context" $.context "scope" $.scope) | fromYaml | merge $dst -}}
+{{- end -}}
+{{ $dst | toYaml }}
+{{- end -}}

--- a/chart/hyrax/templates/_tmplvalues.tpl
+++ b/chart/hyrax/templates/_tmplvalues.tpl
@@ -7,10 +7,10 @@ SPDX-License-Identifier: APACHE-2.0
 {{/*
 Renders a value that contains template perhaps with scope if the scope is present.
 Usage:
-{{ include "common.tplvalues.render" ( dict "value" .Values.path.to.the.Value "context" $ ) }}
-{{ include "common.tplvalues.render" ( dict "value" .Values.path.to.the.Value "context" $ "scope" $app ) }}
+{{ include "hyrax.tplvalues.render" ( dict "value" .Values.path.to.the.Value "context" $ ) }}
+{{ include "hyrax.tplvalues.render" ( dict "value" .Values.path.to.the.Value "context" $ "scope" $app ) }}
 */}}
-{{- define "common.tplvalues.render" -}}
+{{- define "hyrax.tplvalues.render" -}}
 {{- $value := typeIs "string" .value | ternary .value (.value | toYaml) }}
 {{- if contains "{{" (toJson .value) }}
   {{- if .scope }}
@@ -27,12 +27,12 @@ Usage:
 Merge a list of values that contains template after rendering them.
 Merge precedence is consistent with http://masterminds.github.io/sprig/dicts.html#merge-mustmerge
 Usage:
-{{ include "common.tplvalues.merge" ( dict "values" (list .Values.path.to.the.Value1 .Values.path.to.the.Value2) "context" $ ) }}
+{{ include "hyrax.tplvalues.merge" ( dict "values" (list .Values.path.to.the.Value1 .Values.path.to.the.Value2) "context" $ ) }}
 */}}
-{{- define "common.tplvalues.merge" -}}
+{{- define "hyrax.tplvalues.merge" -}}
 {{- $dst := dict -}}
 {{- range .values -}}
-{{- $dst = include "common.tplvalues.render" (dict "value" . "context" $.context "scope" $.scope) | fromYaml | merge $dst -}}
+{{- $dst = include "hyrax.tplvalues.render" (dict "value" . "context" $.context "scope" $.scope) | fromYaml | merge $dst -}}
 {{- end -}}
 {{ $dst | toYaml }}
 {{- end -}}

--- a/chart/hyrax/templates/deployment-worker.yaml
+++ b/chart/hyrax/templates/deployment-worker.yaml
@@ -30,7 +30,7 @@ spec:
                 name: {{ template "hyrax.fullname" . }}
           env:
             {{- if .Values.extraEnvVars }}
-            {{- include "common.tplvalues.render" (dict "value" .Values.extraEnvVars "context" $) | nindent 12 }}
+            {{- include "hyrax.tplvalues.render" (dict "value" .Values.extraEnvVars "context" $) | nindent 12 }}
             {{- end }}
           command:
             - sh
@@ -66,7 +66,7 @@ spec:
             {{- end }}
           env:
             {{- if .Values.extraEnvVars }}
-            {{- include "common.tplvalues.render" (dict "value" .Values.extraEnvVars "context" $) | nindent 12 }}
+            {{- include "hyrax.tplvalues.render" (dict "value" .Values.extraEnvVars "context" $) | nindent 12 }}
             {{- end }}
           {{- if .Values.worker.readinessProbe.enabled }}
           readinessProbe:

--- a/chart/hyrax/templates/deployment-worker.yaml
+++ b/chart/hyrax/templates/deployment-worker.yaml
@@ -29,7 +29,9 @@ spec:
             - secretRef:
                 name: {{ template "hyrax.fullname" . }}
           env:
-            {{- toYaml .Values.worker.extraEnvVars | nindent 12 }}
+            {{- if .Values.extraEnvVars }}
+            {{- include "common.tplvalues.render" (dict "value" .Values.extraEnvVars "context" $) | nindent 12 }}
+            {{- end }}
           command:
             - sh
             - -c
@@ -63,7 +65,9 @@ spec:
               {{- toYaml . | nindent 12 }}
             {{- end }}
           env:
-            {{- toYaml .Values.worker.extraEnvVars | nindent 12 }}
+            {{- if .Values.extraEnvVars }}
+            {{- include "common.tplvalues.render" (dict "value" .Values.extraEnvVars "context" $) | nindent 12 }}
+            {{- end }}
           {{- if .Values.worker.readinessProbe.enabled }}
           readinessProbe:
             exec:

--- a/chart/hyrax/templates/deployment.yaml
+++ b/chart/hyrax/templates/deployment.yaml
@@ -38,7 +38,9 @@ spec:
                 name: {{ .Values.solrExistingSecret }}
             {{- end }}
           env:
-            {{- toYaml .Values.extraEnvVars | nindent 12 }}
+            {{- if .Values.extraEnvVars }}
+            {{- include "common.tplvalues.render" (dict "value" .Values.extraEnvVars "context" $) | nindent 12 }}
+            {{- end }}
           command:
             - sh
             - -c
@@ -66,7 +68,9 @@ spec:
               {{- toYaml . | nindent 12 }}
             {{- end }}
           env:
-            {{- toYaml .Values.extraEnvVars | nindent 12 }}
+            {{- if .Values.extraEnvVars }}
+            {{- include "common.tplvalues.render" (dict "value" .Values.extraEnvVars "context" $) | nindent 12 }}
+            {{- end }}
           command:
             - sh
             - -c
@@ -101,7 +105,9 @@ spec:
               {{- toYaml . | nindent 12 }}
             {{- end }}
           env:
-            {{- toYaml .Values.extraEnvVars | nindent 12 }}
+            {{- if .Values.extraEnvVars }}
+            {{- include "common.tplvalues.render" (dict "value" .Values.extraEnvVars "context" $) | nindent 12 }}
+            {{- end }}
           ports:
             - name: http
               containerPort: 3000

--- a/chart/hyrax/templates/deployment.yaml
+++ b/chart/hyrax/templates/deployment.yaml
@@ -39,7 +39,7 @@ spec:
             {{- end }}
           env:
             {{- if .Values.extraEnvVars }}
-            {{- include "common.tplvalues.render" (dict "value" .Values.extraEnvVars "context" $) | nindent 12 }}
+            {{- include "hyrax.tplvalues.render" (dict "value" .Values.extraEnvVars "context" $) | nindent 12 }}
             {{- end }}
           command:
             - sh
@@ -69,7 +69,7 @@ spec:
             {{- end }}
           env:
             {{- if .Values.extraEnvVars }}
-            {{- include "common.tplvalues.render" (dict "value" .Values.extraEnvVars "context" $) | nindent 12 }}
+            {{- include "hyrax.tplvalues.render" (dict "value" .Values.extraEnvVars "context" $) | nindent 12 }}
             {{- end }}
           command:
             - sh
@@ -106,7 +106,7 @@ spec:
             {{- end }}
           env:
             {{- if .Values.extraEnvVars }}
-            {{- include "common.tplvalues.render" (dict "value" .Values.extraEnvVars "context" $) | nindent 12 }}
+            {{- include "hyrax.tplvalues.render" (dict "value" .Values.extraEnvVars "context" $) | nindent 12 }}
             {{- end }}
           ports:
             - name: http


### PR DESCRIPTION
### Summary
Help text was taking from Bitnami helm charts but the actual functionality was not.  This PR remedies that. It allows for things like

```yaml
extraEnvVars:
  - name: SOMETHING
     value: { .Values.some_value }
```
 
or

```yaml
extraEnvVars:
  - name: SOMETHING
     value: text

worker:
  extraEnvVars: |
      {{- toYaml .Values.extraEnvVars }}
      - name: WORKER_SOMETHING
         value: text
```

### Changes proposed in this pull request:
* Add the template parser for envVars as promised in the docs
* Does not change the existing functionality or require people to change their values files

@samvera/hyrax-code-reviewers
