### PR TITLE
Allow removal of Location fields, and related QOL fixes

### DIFF
--- a/app/assets/javascripts/hyrax/autocomplete/linked_data.es6
+++ b/app/assets/javascripts/hyrax/autocomplete/linked_data.es6
@@ -18,6 +18,9 @@ export default class LinkedData {
     let result = this.element.select2("data")
     this.element.select2("destroy")
     this.element.val(result.label).attr("readonly", "readonly")
+    // Adding d-block class to the remove button to show it after a selection is made.
+    let removeButton = this.element.closest('.field-wrapper').find('.input-group-btn.field-controls .remove')
+    removeButton.addClass('d-block')
     this.setIdentifier(result.id)
   }
 

--- a/app/assets/stylesheets/hyrax/controlled_vocabulary.scss
+++ b/app/assets/stylesheets/hyrax/controlled_vocabulary.scss
@@ -1,7 +1,7 @@
 .controlled_vocabulary {
   @extend .multi_value;
 
-  .listing li:only-of-type .remove {
-    display: block;
+  .listing li .remove {
+    display: none;
   }
 }


### PR DESCRIPTION
### Fixes

https://github.com/samvera/hyrax/issues/6719

### Summary

Fixes issue with the Location field (as described in [6719](https://github.com/samvera/hyrax/issues/6719)), that prevents removal of the first location field. Fixes a few other issues and gets the display a little more consistent.

Work was done by @davidcam-src

### Guidance for testing, such as acceptance criteria or new user interface behaviors:

See the linked ticket. It's helpful to add and remove locations at the same time for both new and existing works, and then verifying the expected locations show up on the work.

To test in Dassie, you'll need to update the `.dassie/.env` file to add a `GEONAMES_USERNAME=` entry with a valid geonames username.

### Type of change (for release notes)

notes-bugfix

### Detailed Description

Resolves an additional issue when creating a new work, where adding and then removing a location will result in the removed location appearing on the created work.

Adds in placeholder text for inputs after the first one (with the same placeholder text as the first input)

Some additional complications arose when deleting entries on existing works due to index collisions between delete and newly added entries.

### Changes proposed in this pull request:
* Updates to javascript to get the Remove button to appear all the time and work with all location entries

@samvera/hyrax-code-reviewers
