### PR TITLE
♻️ Ensure setting permission template for work factories

### DIFF
--- a/spec/factories/hyrax_work.rb
+++ b/spec/factories/hyrax_work.rb
@@ -66,7 +66,7 @@ FactoryBot.define do
           .assign_access_for(visibility: evaluator.visibility_setting)
       end
 
-      if evaluator.admin_set
+      if evaluator.respond_to?(:admin_set) && evaluator.admin_set.present?
         template = Hyrax::PermissionTemplate.find_by(source_id: evaluator.admin_set.id)
         Hyrax::PermissionTemplateApplicator.apply(template).to(model: work) if template
       end
@@ -86,7 +86,7 @@ FactoryBot.define do
           .assign_access_for(visibility: evaluator.visibility_setting)
       end
 
-      if evaluator.admin_set
+      if evaluator.respond_to?(:admin_set) && evaluator.admin_set.present?
         template = Hyrax::PermissionTemplate.find_by(source_id: evaluator.admin_set.id)
         Hyrax::PermissionTemplateApplicator.apply(template).to(model: work) if template
       end

--- a/spec/factories/hyrax_work.rb
+++ b/spec/factories/hyrax_work.rb
@@ -66,6 +66,11 @@ FactoryBot.define do
           .assign_access_for(visibility: evaluator.visibility_setting)
       end
 
+      if evaluator.admin_set
+        template = Hyrax::PermissionTemplate.find_by(source_id: evaluator.admin_set.id)
+        Hyrax::PermissionTemplateApplicator.apply(template).to(model: work) if template
+      end
+
       work.permission_manager.edit_groups = work.permission_manager.edit_groups.to_a + evaluator.edit_groups
       work.permission_manager.edit_users  = work.permission_manager.edit_users.to_a + evaluator.edit_users
       work.permission_manager.read_users  = work.permission_manager.read_users.to_a + evaluator.read_users
@@ -80,6 +85,12 @@ FactoryBot.define do
           .new(resource: work)
           .assign_access_for(visibility: evaluator.visibility_setting)
       end
+
+      if evaluator.admin_set
+        template = Hyrax::PermissionTemplate.find_by(source_id: evaluator.admin_set.id)
+        Hyrax::PermissionTemplateApplicator.apply(template).to(model: work) if template
+      end
+
       work.permission_manager.edit_groups = work.permission_manager.edit_groups.to_a + evaluator.edit_groups
       work.permission_manager.edit_users  = work.permission_manager.edit_users.to_a + evaluator.edit_users
       work.permission_manager.read_users  = work.permission_manager.read_users.to_a + evaluator.read_users


### PR DESCRIPTION
Prior to this commit, even if we specified an admin_set as part of creation, we would not use that set's permission template.  This could result in inconsistent behavior.

With this commit, we have normalized the behavior.

@samvera/hyrax-code-reviewers
