### PR TITLE
Prevent unauthenticated access to /dashboard/collections/

### DIFF
--- a/app/controllers/hyrax/dashboard/collections_controller.rb
+++ b/app/controllers/hyrax/dashboard/collections_controller.rb
@@ -26,9 +26,6 @@ module Hyrax
       # Catch permission errors
       rescue_from Hydra::AccessDenied, CanCan::AccessDenied, with: :deny_collection_access
 
-      # actions: index, create, new, edit, show, update, destroy, permissions, citation
-      before_action :authenticate_user!, except: [:index]
-
       class_attribute :presenter_class,
                       :form_class,
                       :single_item_search_builder_class,


### PR DESCRIPTION
### Fixes

https://github.com/samvera/hyrax/issues/6725

### Summary

Enables authentication for the `/dashboard/collections/` endpoint, same as for `/dashboard/my/collections/`

### Guidance for testing, such as acceptance criteria or new user interface behaviors:
* With Dassie, prior to checking out this branch, visit http://localhost:3000/dashboard/collections/ and experience the error
* Check out this branch and visit the url again, there should no longer be an error

### Type of change (for release notes)

notes-bugfix

### Detailed Description

See the issue for more details.

### Changes proposed in this pull request:
Add tests for dashboard/CatalogController#index which fail when not logged in prior to this update. Removes authentication exception for the index endpoint from this catalog controller, since it results in errors. Removing it here causes the controller to use the check from its parent class.

@samvera/hyrax-code-reviewers
