### PR TITLE
New query strategy to join FileSet solr documents

### DIFF
--- a/app/search_builders/hyrax/catalog_search_builder.rb
+++ b/app/search_builders/hyrax/catalog_search_builder.rb
@@ -80,6 +80,12 @@ class Hyrax::CatalogSearchBuilder < Hyrax::SearchBuilder
 
   # join from file id to work relationship solrized member_ids_ssim
   def join_for_works_from_files
-    "{!join from=#{Hyrax.config.id_field} to=member_ids_ssim v=has_model_ssim:*FileSet}#{dismax_query}"
+    "{!join from=#{Hyrax.config.id_field} to=member_ids_ssim}#{file_set_filter}#{dismax_query}"
+  end
+
+  # Query segment to filter out non-FileSet documents
+  # A wildcard * is used to avoid attempting to escape the :: in Hyrax::FileSet
+  def file_set_filter
+    "{!lucene q.op=AND}has_model_ssim:*FileSet"
   end
 end

--- a/spec/search_builders/hyrax/catalog_search_builder_spec.rb
+++ b/spec/search_builders/hyrax/catalog_search_builder_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Hyrax::CatalogSearchBuilder do
       it "creates a valid solr join for works and files" do
         subject
         expect(solr_params[:user_query]).to eq user_query
-        expect(solr_params[:q]).to eq '{!lucene}_query_:"{!dismax v=$user_query}" _query_:"{!join from=id to=member_ids_ssim v=has_model_ssim:*FileSet}{!dismax v=$user_query}"'
+        expect(solr_params[:q]).to eq '{!lucene}_query_:"{!dismax v=$user_query}" _query_:"{!join from=id to=member_ids_ssim}{!lucene q.op=AND}has_model_ssim:*FileSet{!dismax v=$user_query}"'
       end
     end
 


### PR DESCRIPTION
### Fixes

Fixes #6724

### Summary

The previous attempt to join FileSet documents in the catalog search query failed to actually filter results. Due to a bad or outdated test, this was not detected when running specs.

Updates the "term search" catalog controller spec to use the `all_fields` search. Prior to this change the spec did not follow a code path to `join_for_works_from_files`. `all_fields` appears to be set for all queries originating from the hyrax web interface (others are defined but unused in an unmodified CatalogController), so other specs that specify a `q` param have had `all_fields` added.

Furthermore, the {!join} query did not have any effect when no FileSet documents are present in the solr index. Without a FileSet in the mix, bad query results caused by the join were not detected by the spec.

### Guidance for testing, such as acceptance criteria or new user interface behaviors:
* Searching for terms in the catalog controller returns only matching works, or works with matching filesets

### Changes proposed in this pull request:
* Use new solr query style when joining FileSet documents
* Improve the catalog controller spec to detect this failure
*

@samvera/hyrax-code-reviewers
