### PR TITLE
fix blueimp file upload progress bars

### DIFF
--- a/app/assets/stylesheets/hyrax/_file_upload.scss
+++ b/app/assets/stylesheets/hyrax/_file_upload.scss
@@ -34,3 +34,9 @@
     padding-bottom: 10px;
   }
 }
+
+// fix blueimp jQuery-File-Upload display problems under Bootstrap 4+
+// found here: https://stackoverflow.com/a/48162651
+.fade.in {
+  opacity: 1
+}

--- a/app/views/hyrax/uploads/_js_templates.html.erb
+++ b/app/views/hyrax/uploads/_js_templates.html.erb
@@ -1,20 +1,20 @@
 <!-- The template to display files available for upload -->
-<% fade_class_if_not_test = Rails.env.test? ? 'show' : 'fade show' %>
+<% fade_class_if_not_test = Rails.env.test? ? '' : 'fade' %>
 <script id="template-upload" type="text/x-tmpl">
 {% for (var i=0, file; file=o.files[i]; i++) { %}
     <tr class="template-upload <%= fade_class_if_not_test %>">
-        <span>
+        <td>
             <span class="preview"></span>
-        </span>
-        <span>
+        </td>
+        <td>
             <p class="name">{%=file.name%}</p>
             <strong class="error text-danger"></strong>
-        </span>
-        <span>
+        </td>
+        <td>
             <p class="size">Processing...</p>
             <div class="progress" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="0"><div class="progress-bar progress-bar-striped progress-bar-animated bg-success" style="width:0%;"></div></div>
-        </span>
-        <span class="text-right">
+        </td>
+        <td class="text-right">
             {% if (!i && !o.options.autoUpload) { %}
                 <button class="btn btn-primary start" disabled>
                     <span class="fa fa-upload"></span>
@@ -27,7 +27,7 @@
                     <span><%= t('helpers.action.cancel') %></span>
                 </button>
             {% } %}
-        </span>
+        </td>
     </tr>
 {% } %}
 </script>

--- a/app/views/hyrax/uploads/_js_templates_branding.html.erb
+++ b/app/views/hyrax/uploads/_js_templates_branding.html.erb
@@ -1,7 +1,7 @@
 <!-- The template to display files available for upload -->
 <script id="template-upload" type="text/x-tmpl">
 {% for (var i=0, file; file=o.files[i]; i++) { %}
-    <tr class="template-upload fade show">
+    <tr class="template-upload fade">
       <td>
         <span class="preview"></span>
       </td>
@@ -37,7 +37,7 @@
 <!-- The template to display the banner once upload is complete -->
 <script id="template-download" type="text/x-tmpl">
 {% for (var i=0, file; file=o.files[i]; i++) { %}
-        <span class="template-download fade show">
+        <span class="template-download fade">
           <div id="banner">
             <div class="row branding-banner-row">
               <div class="col-sm-3">
@@ -69,7 +69,7 @@
 <!-- The template to display logo in the table once upload is complete -->
 <script id="logo-template-download" type="text/x-tmpl">
 {% for (var i=0, file; file=o.files[i]; i++) { %}
-            <span class="template-download fade show">
+            <span class="template-download fade">
             <div class="row branding-logo-row">
               <div class="col-sm-3">
                 <span class="preview">

--- a/app/views/hyrax/uploads/_js_templates_versioning.html.erb
+++ b/app/views/hyrax/uploads/_js_templates_versioning.html.erb
@@ -1,5 +1,5 @@
 <!-- The template to display files available for upload -->
-<% fade_class_if_not_test = Rails.env.test? ? 'show' : 'fade show' %>
+<% fade_class_if_not_test = Rails.env.test? ? '' : 'fade' %>
 <script id="versioning-template-upload" type="text/x-tmpl">
 {% for (var i=0, file; file=o.files[i]; i++) { %}
     <tr class="template-upload <%= fade_class_if_not_test %>">


### PR DESCRIPTION
### Fixes

Fixes #6733; refs #6733

### Summary

Gets the file upload progress bars back so that users can see what's happening.

### Guidance for testing, such as acceptance criteria or new user interface behaviors:

See screenshots on #6733

### Type of change (for release notes)

Add an appropriate `notes-*` label to the PR (or indicate here) that classifies this change.

Choose from:
- `notes-bugfix` Bug Fixes


### Detailed Description

See screenshots on #6733

This is likely to reopen #1267, as the PR for that caused the greater part of this issue.

@samvera/hyrax-code-reviewers
