### PR TITLE
Use compact, not flatten, in the model registry

### DIFF
--- a/app/models/hyrax/model_registry.rb
+++ b/app/models/hyrax/model_registry.rb
@@ -99,7 +99,7 @@ module Hyrax
     end
 
     def self.classes_from(strings)
-      strings.map(&:safe_constantize).flatten.uniq
+      strings.map(&:safe_constantize).compact.uniq
     end
     private_class_method :classes_from
 

--- a/spec/models/hyrax/model_registry_spec.rb
+++ b/spec/models/hyrax/model_registry_spec.rb
@@ -29,4 +29,11 @@ RSpec.describe Hyrax::ModelRegistry do
       it { is_expected.to all(be_kind_of(String)) }
     end
   end
+
+  describe ".classes_from" do
+    subject { described_class.send("classes_from", ["DefinitelyNotARealClass", "Hyrax"]) }
+
+    it { is_expected.to be_a(Array) }
+    it { is_expected.not_to include(nil) }
+  end
 end


### PR DESCRIPTION
`#safe_constantize` shouldn’t ever return an Array, so there shouldn’t be any need for flattening. It may, however, return `nil`. `#compact` will get rid of that, and likely is what was intended here.