### PR TITLE
chart: add support for startupProbe

### DIFF
--- a/chart/hyrax/Chart.yaml
+++ b/chart/hyrax/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: hyrax
 description: An open-source, Samvera-powered digital repository system
 type: application
-version: 3.6.0
+version: 3.7.0
 appVersion: 5.0.0
 dependencies:
   - name: fcrepo

--- a/chart/hyrax/templates/deployment.yaml
+++ b/chart/hyrax/templates/deployment.yaml
@@ -112,6 +112,18 @@ spec:
             - name: http
               containerPort: 3000
               protocol: TCP
+          {{- if .Values.startupProbe.enabled }}
+          startupProbe:
+            initialDelaySeconds: {{ .Values.startupProbe.initialDelaySeconds | default 5 }}
+            timeoutSeconds: {{ .Values.startupProbe.timeoutSeconds | default 5 }}
+            failureThreshold: {{ .Values.startupProbe.failureThreshold | default 3 }}
+            periodSeconds: {{ .Values.startupProbe.periodSeconds | default 10}}
+            successThreshold: {{ .Values.startupProbe.successThreshold | default 1 }}
+            httpGet:
+              scheme: "HTTP"
+              path: {{ .Values.startupProbe.path | default "/" }}
+              port: 3000
+          {{- end }}
           {{- if .Values.livenessProbe.enabled }}
           livenessProbe:
             initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds | default 5 }}

--- a/chart/hyrax/values.yaml
+++ b/chart/hyrax/values.yaml
@@ -188,6 +188,16 @@ readinessProbe:
   # failureThreshold: 6
   # successThreshold: 1
 
+# consider enabling if you are experiencing slow startup times
+startupProbe:
+  enabled: false
+  # path: "/healthz"
+  # initialDelaySeconds: 30
+  # periodSeconds: 30
+  # timeoutSeconds: 5
+  # failureThreshold: 3
+  # successThreshold: 1
+
 resources: {}
 
 worker:


### PR DESCRIPTION
See
https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#define-startup-probes

This enables apps with long startups to not be killed prematurely.



@samvera/hyrax-code-reviewers
