### PR TITLE
move file related listeners to their own space

### DIFF
--- a/app/services/hyrax/listeners/file_listener.rb
+++ b/app/services/hyrax/listeners/file_listener.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+module Hyrax
+  module Listeners
+    ##
+    # Listens for events related to Files ({Valkyrie::StorageAdapter::File})
+    class FileListener
+      ##
+      # Called when 'file.characterized' event is published;
+      # allows post-characterization handling, like derivatives generation.
+      #
+      # @param [Dry::Events::Event] event
+      # @return [void]
+      def on_file_characterized(event)
+        file_set = event[:file_set]
+
+        case file_set
+        when ActiveFedora::Base # ActiveFedora
+          CreateDerivativesJob
+            .perform_later(file_set, event[:file_id], event[:path_hint])
+        else
+          ValkyrieCreateDerivativesJob
+            .perform_later(file_set.id.to_s, event[:file_id])
+        end
+      end
+
+      ##
+      # Called when 'file.uploaded' event is published
+      # @param [Dry::Events::Event] event
+      # @return [void]
+      def on_file_uploaded(event)
+        # Run characterization for original file only
+        return unless event[:metadata]&.original_file?
+
+        ValkyrieCharacterizationJob.perform_later(event[:metadata].id.to_s)
+      end
+    end
+  end
+end

--- a/app/services/hyrax/listeners/file_metadata_listener.rb
+++ b/app/services/hyrax/listeners/file_metadata_listener.rb
@@ -6,25 +6,6 @@ module Hyrax
     # Listens for events related to {Hyrax::FileMetadata}
     class FileMetadataListener
       ##
-      # Called when 'file.characterized' event is published;
-      # allows post-characterization handling, like derivatives generation.
-      #
-      # @param [Dry::Events::Event] event
-      # @return [void]
-      def on_file_characterized(event)
-        file_set = event[:file_set]
-
-        case file_set
-        when ActiveFedora::Base # ActiveFedora
-          CreateDerivativesJob
-            .perform_later(file_set, event[:file_id], event[:path_hint])
-        else
-          ValkyrieCreateDerivativesJob
-            .perform_later(file_set.id.to_s, event[:file_id])
-        end
-      end
-
-      ##
       # Called when 'file.metadata.updated' event is published; reindexes a
       # {Hyrax::FileSet} when a file claiming to be its `pcdm_use:OriginalFile`
       #
@@ -40,17 +21,6 @@ module Hyrax
                           "in response to an event of type #{event.id} but " \
                           "encountered an error #{err.message}. should this " \
                           "object be in a FileSet #{event[:metadata]}"
-      end
-
-      ##
-      # Called when 'file.uploaded' event is published
-      # @param [Dry::Events::Event] event
-      # @return [void]
-      def on_file_uploaded(event)
-        # Run characterization for original file only
-        return unless event[:metadata]&.original_file?
-
-        ValkyrieCharacterizationJob.perform_later(event[:metadata].id.to_s)
       end
     end
   end

--- a/lib/hyrax/publisher.rb
+++ b/lib/hyrax/publisher.rb
@@ -124,6 +124,16 @@ module Hyrax
 
     # @since 3.5.0
     # @macro a_registered_event
+    #   @note this event SHOULD be published file is characteried by the
+    #     characterization service. Normally, this should happen close to
+    #     when the `file.metadata.updated` event (since characterization
+    #     typically involves updating the metadata). Listeners that intend
+    #     to track updates to file metadata should listen on that event
+    #     topic.
+    #     The event payload MUST include a `:file_set` ({Hyrax::FileSet}),
+    #     a `:file_id` (the id of the {Valkyrie::StorageAdapter::File}),
+    #     and MAY have a `path_hint` for a local path / cache for the
+    #     file.
     register_event('file.characterized')
 
     # @since 3.3.0
@@ -208,6 +218,7 @@ module Hyrax
       @default_listeners ||=
         [Hyrax::Listeners::ACLIndexListener.new,
          Hyrax::Listeners::BatchNotificationListener.new,
+         Hyrax::Listener::FileListener.new,
          Hyrax::Listeners::FileMetadataListener.new,
          Hyrax::Listeners::FileSetLifecycleListener.new,
          Hyrax::Listeners::FileSetLifecycleNotificationListener.new,

--- a/lib/hyrax/publisher.rb
+++ b/lib/hyrax/publisher.rb
@@ -218,7 +218,7 @@ module Hyrax
       @default_listeners ||=
         [Hyrax::Listeners::ACLIndexListener.new,
          Hyrax::Listeners::BatchNotificationListener.new,
-         Hyrax::Listener::FileListener.new,
+         Hyrax::Listeners::FileListener.new,
          Hyrax::Listeners::FileMetadataListener.new,
          Hyrax::Listeners::FileSetLifecycleListener.new,
          Hyrax::Listeners::FileSetLifecycleNotificationListener.new,


### PR DESCRIPTION
these listener methods don't have to do with `FileMetadata`, so they should be reorganized out into their own class. this makes it easier for downstream apps to override behaviors that are only related to files.


@samvera/hyrax-code-reviewers
