### PR TITLE
use `find_files(file_set: file_set)` in various specs

### DIFF
--- a/spec/controllers/hyrax/file_sets_controller_spec.rb
+++ b/spec/controllers/hyrax/file_sets_controller_spec.rb
@@ -542,7 +542,7 @@ RSpec.describe Hyrax::FileSetsController do
       let(:file) { fixture_file_upload('/world.png', 'image/png') }
       let(:work) { FactoryBot.valkyrie_create(:hyrax_work, title: "test title", uploaded_files: [FactoryBot.create(:uploaded_file, user: work_user)], edit_users: [work_user]) }
       let(:file_set) { query_service.find_members(resource: work).first }
-      let(:file_metadata) { query_service.custom_queries.find_file_metadata_by(id: file_set.file_ids.first) }
+      let(:file_metadata) { query_service.custom_queries.find_files(file_set: file_set).first }
       let(:uploaded) { storage_adapter.find_by(id: file_metadata.file_identifier) }
       let(:query_service) { Hyrax.query_service }
       let(:storage_adapter) { Hyrax.storage_adapter }

--- a/spec/hyrax/transactions/file_set_destroy_spec.rb
+++ b/spec/hyrax/transactions/file_set_destroy_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe Hyrax::Transactions::FileSetDestroy do
     context "with attached files" do
       let(:work) { FactoryBot.valkyrie_create(:hyrax_work, uploaded_files: [FactoryBot.create(:uploaded_file)], edit_users: [user]) }
       let(:file_set) { query_service.find_members(resource: work).first }
-      let(:file_metadata) { query_service.custom_queries.find_file_metadata_by(id: file_set.file_ids.first) }
+      let(:file_metadata) { query_service.custom_queries.find_files(file_set: file_set).first }
       let(:uploaded) { storage_adapter.find_by(id: file_metadata.file_identifier) }
       let(:storage_adapter) { Hyrax.storage_adapter }
       let(:query_service) { Hyrax.query_service }

--- a/spec/hyrax/transactions/work_destroy_spec.rb
+++ b/spec/hyrax/transactions/work_destroy_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe Hyrax::Transactions::WorkDestroy do
     context "with attached files" do
       let(:work) { FactoryBot.valkyrie_create(:hyrax_work, uploaded_files: [FactoryBot.create(:uploaded_file)], edit_users: [user]) }
       let(:file_set) { query_service.find_members(resource: work).first }
-      let(:file_metadata) { query_service.custom_queries.find_file_metadata_by(id: file_set.file_ids.first) }
+      let(:file_metadata) { query_service.custom_queries.find_files(file_set: file_set).first }
       let(:uploaded) { storage_adapter.find_by(id: file_metadata.file_identifier) }
       let(:storage_adapter) { Hyrax.storage_adapter }
       let(:query_service) { Hyrax.query_service }

--- a/spec/presenters/hyrax/version_list_presenter_spec.rb
+++ b/spec/presenters/hyrax/version_list_presenter_spec.rb
@@ -80,7 +80,7 @@ RSpec.describe Hyrax::VersionListPresenter do
     let(:file) { fixture_file_upload('/world.png', 'image/png') }
     let(:work) { FactoryBot.valkyrie_create(:hyrax_work, uploaded_files: [FactoryBot.create(:uploaded_file)]) }
     let(:file_set) { query_service.find_members(resource: work).first }
-    let(:file_metadata) { query_service.custom_queries.find_file_metadata_by(id: file_set.file_ids.first) }
+    let(:file_metadata) { query_service.custom_queries.find_files(file_set: file_set).first }
     let(:uploaded) { storage_adapter.find_by(id: file_metadata.file_identifier) }
     let(:query_service) { Hyrax.query_service }
     let(:storage_adapter) { Hyrax.storage_adapter }


### PR DESCRIPTION
avoid `query_service.custom_queries.find_file_metadata_by(id: file_set.file_ids.first)` where `find_files` is better.


@samvera/hyrax-code-reviewers
