### PR TITLE
use the `Hyrax::FileSetFileService` to determine "primary file"

### DIFF
--- a/app/controllers/hyrax/file_sets_controller.rb
+++ b/app/controllers/hyrax/file_sets_controller.rb
@@ -292,7 +292,7 @@ module Hyrax
     end
 
     def file_metadata
-      @file_metadata ||= Hyrax.query_service.custom_queries.find_file_metadata_by(id: curation_concern.original_file_id)
+      @file_metadata ||= Hyrax.config.file_set_file_service.primary_file_for(file_set: file_set)
     end
 
     # Override this method to add additional response formats to your local app

--- a/app/services/hyrax/file_set_file_service.rb
+++ b/app/services/hyrax/file_set_file_service.rb
@@ -32,7 +32,16 @@ module Hyrax
     end
 
     ##
-    # Return the Hyrax::FileMetadata which should be considered “primary” for
+    # Return the {Hyrax::FileMetadata} which should be considered “primary” for
+    # indexing and version‐tracking.
+    #
+    # @return [Hyrax::FileMetadata]
+    def self.primary_file_for(file_set:, query_service: Hyrax.query_service)
+      new(file_set: file_set, query_service: query_service).primary_file
+    end
+
+    ##
+    # Return the {Hyrax::FileMetadata} which should be considered “primary” for
     # indexing and version‐tracking.
     #
     # If +file_set.original_file_id+ is defined, it will be used; otherwise,


### PR DESCRIPTION
`Hyrax::FileSetFileService` was introduced to un-hard code the assumption that the `:original_file` PCDM Use is the "primary" file for a given file set. use it throughout the code base to avoid requiring that assumption in downstream apps.

this should allow downstream apps to wire in a new service and resolve the "primary file" for each object according to local requirements. e.g. it may be desirable for apps to treat "preservation file" or "service file" as "primary"

### Changes proposed in this pull request:
* adds support for overriding the "primary" file resolution behavior

@samvera/hyrax-code-reviewers
