### PR TITLE
Fix typo for the raise statement

### DIFF
--- a/app/services/hyrax/lock_manager.rb
+++ b/app/services/hyrax/lock_manager.rb
@@ -30,8 +30,8 @@ module Hyrax
     rescue ConnectionPool::TimeoutError => err
       Hyrax.logger.error(err.message)
       raise(ConnectionPool::TimeoutError,
-            "Failed to aquire a lock from Redlock due to a Redis connection " /
-            "timeout: #{err}. If you are using Redis via `ConnectionPool` " /
+            "Failed to acquire a lock from Redlock due to a Redis connection " \
+            "timeout: #{err}. If you are using Redis via `ConnectionPool` " \
             "you may wish to increase the pool size.")
     end
 


### PR DESCRIPTION
This commit fixes a typo in the raise statement. In Bulkrax, the error seen was

```
NoMethodError - undefined method `/' for "Failed to aquire a lock from Redlock due to a Redis connection ":String
```