### PR TITLE
Fix “::Collection” definition with autoloading

### DIFF
--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -2,4 +2,16 @@
 
 # Provide plain collection model if not defined by the application.
 # Needed until Hyrax internals do not assume its existence.
-class ::Collection < Hyrax.config.collection_class; end unless '::Collection'.safe_constantize
+class ::Collection < Hyrax.config.collection_class; end unless ActiveSupport::Dependencies.then do |deps|
+  # In autoloading environments, when referencing +::Collection+ from the
+  # initializer, make sure that +safe_constantize+ wouldn’t just try loading
+  # this file again (which would produce a runtime error). Do this by manually
+  # searching for the file which should define +::Collection+ and checking if it
+  # is the one being currently loaded.
+  break true if Object.const_defined?(:Collection)
+  file_path = deps.search_for_file("collection")
+  expanded = File.expand_path(file_path)
+  expanded.delete_suffix!(".rb")
+  break false if deps.loading.include?(expanded)
+  '::Collection'.safe_constantize
+end


### PR DESCRIPTION
In autoloaded environments which reference `::Collection` in an initializer, `safe_constantize` will create a recursive autoloading loop. We can hook into `ActiveSupport::Dependencies` to check whether this is going to happen, and pre·emptively return `false` in that case (so that `::Collection` is defined properly), without changing behaviour where `::Collection` is getting `safe_constantize`d from somewhere else.

### Fixes

Fixes #6736