### PR TITLE
Points Hyrax::EditPermissionsService.build_service_object_from to Hyrax configuration variable.

### DIFF
--- a/app/services/hyrax/edit_permissions_service.rb
+++ b/app/services/hyrax/edit_permissions_service.rb
@@ -41,7 +41,7 @@ module Hyrax
         # (+Hyrax::Forms::FileSetForm+), +:in_works_ids+ is prepopulated onto
         # the form object itself. For +Hyrax::Forms::FileSetEditForm+, the
         # +:in_works+ method is present on the wrapped +:model+.
-        if form.object.is_a?(Hyrax::Forms::FileSetForm)
+        if form.object.is_a?(Hyrax.config.file_set_form)
           object_id = form.object.in_works_ids.first
           new(object: Hyrax.query_service.find_by(id: object_id), ability: ability)
         else


### PR DESCRIPTION
### Summary

Points Hyrax::EditPermissionsService.build_service_object_from to Hyrax configuration variable.

### Guidance for testing, such as acceptance criteria or new user interface behaviors:
*This change should not alter any tested processing.

### Type of change (for release notes)

- `notes-bugfix` Bug Fixes
- `notes-valkyrie` Valkyrie Progress

### Detailed Description

For L#44, the `if` test's subject is hard-coded and unaware of any customized form class that the Hyrax Engine's implementers could create and set inside the Engine's configuration. This swaps to the configuration variable that defaults to the same hard-coded class (`Hyrax::Forms::FileSetForm`).

@samvera/hyrax-code-reviewers
