### PR TITLE
Prevent AF loading members or files unless members or files are being loaded in the outer Valkyrie object

### DIFF
--- a/lib/wings/active_fedora_converter.rb
+++ b/lib/wings/active_fedora_converter.rb
@@ -156,10 +156,9 @@ module Wings
         af_object.try(:members)&.replace(members)
       end
 
-      if converted_attrs.keys.include?(:files)
-        files = converted_attrs.delete(:files)
-        af_object.files.build_or_set(files) if files
-      end
+      return unless converted_attrs.keys.include?(:files)
+      files = converted_attrs.delete(:files)
+      af_object.files.build_or_set(files) if files
     end
 
     def create_extrated_text(af_object)

--- a/lib/wings/active_fedora_converter.rb
+++ b/lib/wings/active_fedora_converter.rb
@@ -145,15 +145,21 @@ module Wings
 
     def parse_attributes(af_object)
       converted_attrs = normal_attributes
-      members = Array.wrap(converted_attrs.delete(:members))
-      files = converted_attrs.delete(:files)
-      af_object.attributes = converted_attrs
+      af_object.attributes = converted_attrs.except(:members, :files)
       af_object.extracted_text = create_extrated_text(af_object) if resource.attributes[:extracted_text_id].present?
       perform_lease_conversion(af_object: af_object, resource: resource)
       perform_embargo_conversion(af_object: af_object, resource: resource)
-      members.empty? ? af_object.try(:ordered_members)&.clear : af_object.try(:ordered_members=, members)
-      af_object.try(:members)&.replace(members)
-      af_object.files.build_or_set(files) if files
+
+      if converted_attrs.keys.include?(:members)
+        members = Array.wrap(converted_attrs.delete(:members))
+        members.empty? ? af_object.try(:ordered_members)&.clear : af_object.try(:ordered_members=, members)
+        af_object.try(:members)&.replace(members)
+      end
+
+      if converted_attrs.keys.include?(:files)
+        files = converted_attrs.delete(:files)
+        af_object.files.build_or_set(files) if files
+      end
     end
 
     def create_extrated_text(af_object)


### PR DESCRIPTION
This speeds up AdministrativeSet and Collection actions that do not require touching the members.

### Fixes

Fixes #6772 

### Summary

We currently load the AF members of collections and admin sets when ever we run the AFConverter on them. This causes very long load times for data we then discard.

@samvera/hyrax-code-reviewers
