### PR TITLE
Switches Depositor values from Creator to Depositor.

### DIFF
--- a/app/views/hyrax/admin/workflows/index.html.erb
+++ b/app/views/hyrax/admin/workflows/index.html.erb
@@ -49,7 +49,7 @@
                     <%= link_to document, [main_app, document] %>
                   </td>
                   <td>
-                    <%= safe_join(document.creator, tag(:br)) %>
+                    <%= document.depositor %>
                   </td>
                   <td>
                     <%= document.date_modified %>


### PR DESCRIPTION
### Summary

Switches Depositor values from Creator to Depositor.

### Type of change (for release notes)

Add an appropriate `notes-*` label to the PR (or indicate here) that classifies this change.

Choose from:
- `notes-minor` New Features that are backward compatible
- `notes-bugfix` Bug Fixes

### Detailed Description

Pulls the actual depositor of the Work object instead of the Creator. Creator would be an acceptable value in applications that would always consider the Creator of the Work to be the Depositor, but in archive applications using Hyrax, that's not the case.

@samvera/hyrax-code-reviewers
