### PR TITLE
:bug:Account for Valkyrie ID in location indexer

### DIFF
--- a/app/services/hyrax/location_service.rb
+++ b/app/services/hyrax/location_service.rb
@@ -19,7 +19,7 @@ module Hyrax
 
     def extract_id(obj)
       uri = case obj
-            when String
+            when String, Valkyrie::ID
               URI(obj)
             when URI
               obj


### PR DESCRIPTION
Without passing a string, we get an error when based_near is nil. This was discovered when testing Bulkrax in a valkyrized app. When we uploaded a CSV with no based_near defined, I was getting an error `*** ArgumentError Exception: g410220 is not a valid type` from the #extract_id method. 

- [ ] https://github.com/samvera/hyrax/issues/6775

```ruby
    def based_near_prepopulator
      self.based_near = based_near.map do |loc|
        uri = RDF::URI.parse(loc)
        if uri
          Hyrax::ControlledVocabularies::Location.new(uri)
        else
          loc
        end
      end
```
**based_near => [#<Valkyrie::ID:0x0000ffff5f734970 @id="g410220">]**

This is because at this point, obj is a neither a string or a URI. It's a Valkyrie::ID.

```ruby
    def extract_id(obj)
      uri = case obj
            when String
              URI(obj)
            when URI
              obj
            else
              raise ArgumentError, "#{obj} is not a valid type"
            end
      uri.path.split('/').last
    end
```

@samvera/hyrax-code-reviewers
