### PR TITLE
WIP - Address valkyrie derivative issues (includes double_combo... do not merge)

### DIFF
--- a/app/indexers/hyrax/indexers/file_set_indexer.rb
+++ b/app/indexers/hyrax/indexers/file_set_indexer.rb
@@ -101,6 +101,9 @@ module Hyrax
 
           # attributes set by fits for video
           solr_doc['aspect_ratio_tesim']      = file_metadata.aspect_ratio if file_metadata.aspect_ratio.present?
+
+          # support for derivatives download
+          solr_doc['extensions_and_mime_types_ssim'] = resource.extensions_and_mime_types.to_json if resource.extensions_and_mime_types.present?
         end
       end
 

--- a/app/models/concerns/hyrax/solr_document_behavior.rb
+++ b/app/models/concerns/hyrax/solr_document_behavior.rb
@@ -142,9 +142,7 @@ module Hyrax
     end
 
     def extensions_and_mime_types
-      if self['extensions_and_mime_types_ssim']
-        JSON.parse(self['extensions_and_mime_types_ssim'].first).map(&:with_indifferent_access)
-      end
+      JSON.parse(self['extensions_and_mime_types_ssim'].first).map(&:with_indifferent_access) if self['extensions_and_mime_types_ssim']
     end
 
     private

--- a/app/models/concerns/hyrax/solr_document_behavior.rb
+++ b/app/models/concerns/hyrax/solr_document_behavior.rb
@@ -141,6 +141,12 @@ module Hyrax
       self['visibility_ssi'] == indexed_lease_visibility
     end
 
+    def extensions_and_mime_types
+      if self['extensions_and_mime_types_ssim']
+        JSON.parse(self['extensions_and_mime_types_ssim'].first).map(&:with_indifferent_access)
+      end
+    end
+
     private
 
     def model_classifier(classifier)

--- a/app/models/hyrax/file_set.rb
+++ b/app/models/hyrax/file_set.rb
@@ -113,7 +113,7 @@ module Hyrax
     #    {:id=>"234", :extension=>"jpeg", :mime_type=>"application/octet-stream", :name=>"thumbnail", :use=>"ThumbnailImage"}]
     # rubocop:disable Metrics/MethodLength
     def extensions_and_mime_types
-      return {} if file_ids.empty?
+      return [] if file_ids.empty?
       Hyrax.query_service.find_many_by_ids(ids: file_ids).each_with_object([]) do |fm, arr|
         next unless fm.original_filename
         extension = File.extname(fm.original_filename)

--- a/app/models/hyrax/file_set.rb
+++ b/app/models/hyrax/file_set.rb
@@ -107,14 +107,25 @@ module Hyrax
     end
 
     ##
-    # @return [Hash] All extensions & their mime types
+    # @return [Array] All ids, extensions, mime types, names, and uses
+    # @example
+    #   [{:id=>"123", :extension=>"pdf", :mime_type=>"application/pdf", :name=>nil, :use=>"OriginalFile"},
+    #    {:id=>"234", :extension=>"jpeg", :mime_type=>"application/octet-stream", :name=>"thumbnail", :use=>"ThumbnailImage"}]
     def extensions_and_mime_types
-      @extensions_and_mime_types = {}
-      file_ids.each do |file_id|
-       fm = Hyrax.query_service.find_by(id: file_id)
-       @extensions_and_mime_types[fm.mime_type] = File.extname(fm.original_filename)[1..]
+      Hyrax.query_service.find_many_by_ids(ids: file_ids).each_with_object([]) do |fm, arr|
+        extension = File.extname(fm.original_filename)
+        next if extension.empty?
+
+        use = fm.pcdm_use.first.to_s.split("#").last
+        name = use == 'OriginalFile' ? nil : File.basename(fm.original_filename, extension).split('-').last
+        arr << {
+          id: fm.id.to_s,
+          extension: extension[1..], # remove leading '.'
+          mime_type: fm.mime_type,
+          name: name,
+          use: use
+        }
       end
-      @extensions_and_mime_types
     end
 
     ##

--- a/app/models/hyrax/file_set.rb
+++ b/app/models/hyrax/file_set.rb
@@ -111,8 +111,11 @@ module Hyrax
     # @example
     #   [{:id=>"123", :extension=>"pdf", :mime_type=>"application/pdf", :name=>nil, :use=>"OriginalFile"},
     #    {:id=>"234", :extension=>"jpeg", :mime_type=>"application/octet-stream", :name=>"thumbnail", :use=>"ThumbnailImage"}]
+    # rubocop:disable Metrics/MethodLength
     def extensions_and_mime_types
+      return {} if file_ids.empty?
       Hyrax.query_service.find_many_by_ids(ids: file_ids).each_with_object([]) do |fm, arr|
+        next unless fm.original_filename
         extension = File.extname(fm.original_filename)
         next if extension.empty?
 
@@ -126,6 +129,7 @@ module Hyrax
           use: use
         }
       end
+      # rubocop:enable Metrics/MethodLength
     end
 
     ##

--- a/app/models/hyrax/file_set.rb
+++ b/app/models/hyrax/file_set.rb
@@ -107,6 +107,17 @@ module Hyrax
     end
 
     ##
+    # @return [Hash] All extensions & their mime types
+    def extensions_and_mime_types
+      @extensions_and_mime_types = {}
+      file_ids.each do |file_id|
+       fm = Hyrax.query_service.find_by(id: file_id)
+       @extensions_and_mime_types[fm.mime_type] = File.extname(fm.original_filename)[1..]
+      end
+      @extensions_and_mime_types
+    end
+
+    ##
     # @return [Valkyrie::ID]
     def representative_id
       id

--- a/app/presenters/hyrax/file_set_presenter.rb
+++ b/app/presenters/hyrax/file_set_presenter.rb
@@ -20,7 +20,8 @@ module Hyrax
 
     # CurationConcern methods
     delegate :stringify_keys, :human_readable_type, :collection?, :image?, :video?,
-             :audio?, :pdf?, :office_document?, :representative_id, :to_s, to: :solr_document
+             :audio?, :pdf?, :office_document?, :representative_id, :to_s,
+             :extensions_and_mime_types, to: :solr_document
 
     # Methods used by blacklight helpers
     delegate :has?, :first, :fetch, to: :solr_document

--- a/app/views/hyrax/file_sets/_actions.html.erb
+++ b/app/views/hyrax/file_sets/_actions.html.erb
@@ -45,7 +45,7 @@
                     class: "download",
                     data: { label: file_set.id, work_id: @presenter.id, collection_ids: @presenter.member_of_collection_ids } %>
       </li>
-      <%# @TODO: This needs to be updated to find the derivatives appropriately %>
+
       <% file_set.extensions_and_mime_types&.each do |hash| %>
         <% next unless hash[:name] %>
         <li class ="dropdown-item" role="menuitem" tabindex="-1">

--- a/app/views/hyrax/file_sets/_actions.html.erb
+++ b/app/views/hyrax/file_sets/_actions.html.erb
@@ -46,16 +46,15 @@
                     data: { label: file_set.id, work_id: @presenter.id, collection_ids: @presenter.member_of_collection_ids } %>
       </li>
       <%# @TODO: This needs to be updated to find the derivatives appropriately %>
-      <% work_deriv = IiifPrint::Data::WorkDerivatives.new(fileset: file_set) %>
-      <% work_deriv.keys.each do |name| %>
-        <li role="menuitem" tabindex="-1">
-          <a href="<%= "/downloads/#{file_set.id}?locale=en&file=#{name}" %>" download>
-            Download <em>(as <%= name %>)</em>
+      <% file_set.extensions_and_mime_types&.each do |hash| %>
+        <% next unless hash[:name] %>
+        <li class ="dropdown-item" role="menuitem" tabindex="-1">
+          <a href="<%= "/downloads/#{file_set.id}?locale=en&file=#{hash[:name]}&mime_type=#{hash[:mime_type]}" %>" download>
+            Download <em>(as <%= hash[:name] %>)</em>
           </a>
         </li>
       <% end %>
     <% end %>
-
     </ul>
   </div>
   <% end %>

--- a/app/views/hyrax/file_sets/_actions.html.erb
+++ b/app/views/hyrax/file_sets/_actions.html.erb
@@ -1,5 +1,5 @@
 <% if (can?(:download, file_set.id) || can?(:destroy, file_set.id) || can?(:edit, file_set.id)) && !workflow_restriction?(@parent) %>
-  <% if can?(:download, file_set.id) && !(can?(:edit, file_set.id) || can?(:destroy, file_set.id)) %>
+  <% if Hyrax.config.display_media_download_link? && (can?(:download, file_set.id) && !(can?(:edit, file_set.id) || can?(:destroy, file_set.id))) %>
   <%= link_to t('.download'),
               hyrax.download_path(file_set),
               class: 'btn btn-secondary btn-sm',
@@ -35,7 +35,7 @@
       </li>
     <% end %>
 
-    <% if can?(:download, file_set.id) %>
+    <% if Hyrax.config.display_media_download_link? && can?(:download, file_set.id) %>
       <li class="dropdown-item" role="menuitem" tabindex="-1">
         <%= link_to t('.download'),
                     hyrax.download_path(file_set),
@@ -45,6 +45,15 @@
                     class: "download",
                     data: { label: file_set.id, work_id: @presenter.id, collection_ids: @presenter.member_of_collection_ids } %>
       </li>
+      <%# @TODO: This needs to be updated to find the derivatives appropriately %>
+      <% work_deriv = IiifPrint::Data::WorkDerivatives.new(fileset: file_set) %>
+      <% work_deriv.keys.each do |name| %>
+        <li role="menuitem" tabindex="-1">
+          <a href="<%= "/downloads/#{file_set.id}?locale=en&file=#{name}" %>" download>
+            Download <em>(as <%= name %>)</em>
+          </a>
+        </li>
+      <% end %>
     <% end %>
 
     </ul>


### PR DESCRIPTION
**Keeping this in draft mode... This PR will be canceled once the other PR is merged into main, and then main is merged into double_combo.** 

Valkyrie derivatives sort of work but only by accident. We need to access them via the storage adapter, rather than assuming we will find them on the file system. This begins the process of accessing derivatives appropriately.

The idea is to always include the options to download derivatives on the actions dropdown. 

The actions download menu does not have a Hyrax::FileSet object... it has a Hyrax::IiifAv::IiifFileSetPresenter object (at least when we are using IiifPrint). The `extensions_and_mime_types` method we added to the fileset gives us an array of hashes that we can use for the actions dropdown:
```
 [{:id=>"123", :extension=>"pdf", :mime_type=>"application/pdf", :name=>nil, :use=>"OriginalFile"},
    #    {:id=>"234", :extension=>"jpeg", :mime_type=>"application/octet-stream", :name=>"thumbnail", :use=>"ThumbnailImage"}]
``` 
