### PR TITLE
Address valkyrie derivative issues

### DIFF
--- a/app/indexers/hyrax/indexers/file_set_indexer.rb
+++ b/app/indexers/hyrax/indexers/file_set_indexer.rb
@@ -104,7 +104,7 @@ module Hyrax
 
           # support for derivatives download
           derivatives = resource.extensions_and_mime_types
-          solr_doc['extensions_and_mime_types_ssm'] = derivatives if derivatives.present?
+          solr_doc['extensions_and_mime_types_ssm'] = derivatives.to_json if derivatives.present?
         end
       end
 

--- a/app/indexers/hyrax/indexers/file_set_indexer.rb
+++ b/app/indexers/hyrax/indexers/file_set_indexer.rb
@@ -101,6 +101,9 @@ module Hyrax
 
           # attributes set by fits for video
           solr_doc['aspect_ratio_tesim']      = file_metadata.aspect_ratio if file_metadata.aspect_ratio.present?
+
+          # support for derivatives download
+          solr_doc['extensions_and_mime_types_ssim'] = resource.extensions_and_mime_types.to_json if resource.extensions_and_mime_types.present?
         end
       end
 

--- a/app/indexers/hyrax/indexers/file_set_indexer.rb
+++ b/app/indexers/hyrax/indexers/file_set_indexer.rb
@@ -103,7 +103,8 @@ module Hyrax
           solr_doc['aspect_ratio_tesim']      = file_metadata.aspect_ratio if file_metadata.aspect_ratio.present?
 
           # support for derivatives download
-          solr_doc['extensions_and_mime_types_ssim'] = resource.extensions_and_mime_types.to_json if resource.extensions_and_mime_types.present?
+          derivatives = resource.extensions_and_mime_types
+          solr_doc['extensions_and_mime_types_ssm'] = derivatives if derivatives.present?
         end
       end
 

--- a/app/models/concerns/hyrax/solr_document_behavior.rb
+++ b/app/models/concerns/hyrax/solr_document_behavior.rb
@@ -135,6 +135,12 @@ module Hyrax
       self['visibility_ssi'] == indexed_lease_visibility
     end
 
+    def extensions_and_mime_types
+      if self['extensions_and_mime_types_ssim']
+        JSON.parse(self['extensions_and_mime_types_ssim'].first).map(&:with_indifferent_access)
+      end
+    end
+
     private
 
     def model_classifier(classifier)

--- a/app/models/concerns/hyrax/solr_document_behavior.rb
+++ b/app/models/concerns/hyrax/solr_document_behavior.rb
@@ -136,9 +136,7 @@ module Hyrax
     end
 
     def extensions_and_mime_types
-      if self['extensions_and_mime_types_ssim']
-        JSON.parse(self['extensions_and_mime_types_ssim'].first).map(&:with_indifferent_access)
-      end
+      JSON.parse(self['extensions_and_mime_types_ssim'].first).map(&:with_indifferent_access) if self['extensions_and_mime_types_ssim']
     end
 
     private

--- a/app/models/concerns/hyrax/solr_document_behavior.rb
+++ b/app/models/concerns/hyrax/solr_document_behavior.rb
@@ -136,7 +136,7 @@ module Hyrax
     end
 
     def extensions_and_mime_types
-      JSON.parse(self['extensions_and_mime_types_ssim'].first).map(&:with_indifferent_access) if self['extensions_and_mime_types_ssim']
+      JSON.parse(self['extensions_and_mime_types_ssm'].first).map(&:with_indifferent_access) if self['extensions_and_mime_types_ssm']
     end
 
     private

--- a/app/models/hyrax/file_set.rb
+++ b/app/models/hyrax/file_set.rb
@@ -107,6 +107,28 @@ module Hyrax
     end
 
     ##
+    # @return [Array] All ids, extensions, mime types, names, and uses
+    # @example
+    #   [{:id=>"123", :extension=>"pdf", :mime_type=>"application/pdf", :name=>nil, :use=>"OriginalFile"},
+    #    {:id=>"234", :extension=>"jpeg", :mime_type=>"application/octet-stream", :name=>"thumbnail", :use=>"ThumbnailImage"}]
+    def extensions_and_mime_types
+      Hyrax.query_service.find_many_by_ids(ids: file_ids).each_with_object([]) do |fm, arr|
+        extension = File.extname(fm.original_filename)
+        next if extension.empty?
+
+        use = fm.pcdm_use.first.to_s.split("#").last
+        name = use == 'OriginalFile' ? nil : File.basename(fm.original_filename, extension).split('-').last
+        arr << {
+          id: fm.id.to_s,
+          extension: extension[1..], # remove leading '.'
+          mime_type: fm.mime_type,
+          name: name,
+          use: use
+        }
+      end
+    end
+
+    ##
     # @return [Valkyrie::ID]
     def representative_id
       id

--- a/app/models/hyrax/file_set.rb
+++ b/app/models/hyrax/file_set.rb
@@ -113,7 +113,7 @@ module Hyrax
     #    {:id=>"234", :extension=>"jpeg", :mime_type=>"application/octet-stream", :name=>"thumbnail", :use=>"ThumbnailImage"}]
     # rubocop:disable Metrics/MethodLength
     def extensions_and_mime_types
-      return {} if file_ids.empty?
+      return [] if file_ids.empty?
       Hyrax.query_service.find_many_by_ids(ids: file_ids).each_with_object([]) do |fm, arr|
         next unless fm.original_filename
         extension = File.extname(fm.original_filename)

--- a/app/models/hyrax/file_set.rb
+++ b/app/models/hyrax/file_set.rb
@@ -111,8 +111,11 @@ module Hyrax
     # @example
     #   [{:id=>"123", :extension=>"pdf", :mime_type=>"application/pdf", :name=>nil, :use=>"OriginalFile"},
     #    {:id=>"234", :extension=>"jpeg", :mime_type=>"application/octet-stream", :name=>"thumbnail", :use=>"ThumbnailImage"}]
+    # rubocop:disable Metrics/MethodLength
     def extensions_and_mime_types
+      return {} if file_ids.empty?
       Hyrax.query_service.find_many_by_ids(ids: file_ids).each_with_object([]) do |fm, arr|
+        next unless fm.original_filename
         extension = File.extname(fm.original_filename)
         next if extension.empty?
 
@@ -126,6 +129,7 @@ module Hyrax
           use: use
         }
       end
+      # rubocop:enable Metrics/MethodLength
     end
 
     ##

--- a/app/presenters/hyrax/file_set_presenter.rb
+++ b/app/presenters/hyrax/file_set_presenter.rb
@@ -20,7 +20,8 @@ module Hyrax
 
     # CurationConcern methods
     delegate :stringify_keys, :human_readable_type, :collection?, :image?, :video?,
-             :audio?, :pdf?, :office_document?, :representative_id, :to_s, to: :solr_document
+             :audio?, :pdf?, :office_document?, :representative_id, :to_s,
+             :extensions_and_mime_types, to: :solr_document
 
     # Methods used by blacklight helpers
     delegate :has?, :first, :fetch, to: :solr_document

--- a/app/views/hyrax/file_sets/_actions.html.erb
+++ b/app/views/hyrax/file_sets/_actions.html.erb
@@ -45,8 +45,15 @@
                     class: "download",
                     data: { label: file_set.id, work_id: @presenter.id, collection_ids: @presenter.member_of_collection_ids } %>
       </li>
+      <% file_set.extensions_and_mime_types&.each do |hash| %>
+        <% next unless hash[:name] %>
+        <li class ="dropdown-item" role="menuitem" tabindex="-1">
+          <a href="<%= "/downloads/#{file_set.id}?locale=en&file=#{hash[:name]}&mime_type=#{hash[:mime_type]}" %>" download>
+            Download <em>(as <%= hash[:name] %>)</em>
+          </a>
+        </li>
+      <% end %>
     <% end %>
-
     </ul>
   </div>
   <% end %>

--- a/app/views/hyrax/file_sets/_actions.html.erb
+++ b/app/views/hyrax/file_sets/_actions.html.erb
@@ -49,7 +49,7 @@
       <% file_set.extensions_and_mime_types&.each do |hash| %>
         <% next unless hash[:name] %>
         <li class ="dropdown-item" role="menuitem" tabindex="-1">
-          <a href="<%= "/downloads/#{file_set.id}?locale=en&file=#{hash[:name]}&mime_type=#{hash[:mime_type]}" %>" download>
+          <a href="<%= download_url(id: file_set.id, locale: 'en', file: hash[:name], mime_type: hash[:mime_type]) %>" download>
             Download <em>(as <%= hash[:name] %>)</em>
           </a>
         </li>

--- a/app/views/hyrax/file_sets/_actions.html.erb
+++ b/app/views/hyrax/file_sets/_actions.html.erb
@@ -45,6 +45,7 @@
                     class: "download",
                     data: { label: file_set.id, work_id: @presenter.id, collection_ids: @presenter.member_of_collection_ids } %>
       </li>
+
       <% file_set.extensions_and_mime_types&.each do |hash| %>
         <% next unless hash[:name] %>
         <li class ="dropdown-item" role="menuitem" tabindex="-1">

--- a/spec/models/hyrax/file_set_spec.rb
+++ b/spec/models/hyrax/file_set_spec.rb
@@ -13,4 +13,32 @@ RSpec.describe Hyrax::FileSet do
       expect(file_set.human_readable_type).to eq 'File Set'
     end
   end
+
+  describe '#extensions_and_mime_types' do
+    let(:original_file) do
+      FactoryBot.valkyrie_create(:hyrax_file_metadata,
+      file_identifier: 'disk:///app/samvera/hyrax-webapp/storage/files/path/to/my_file.pdf',
+      mime_type: "application/pdf",
+      original_filename: 'my_file.pdf')
+    end
+    let(:thumbnail) do
+      FactoryBot.valkyrie_create(:hyrax_file_metadata,
+      use: :thumbnail_file,
+      file_identifier: 'disk:///app/samvera/hyrax-webapp/storage/files/path/to/thumbnail_file.jpg',
+      mime_type: "image/jpeg",
+      original_filename: 'thumbnail_file.jpg')
+    end
+    let(:files) { [original_file, thumbnail] }
+    let(:file_ids) { files.map(&:id) }
+    let(:results_array) do
+      [{ id: thumbnail.id.to_s, extension: "jpg", mime_type: "image/jpeg", name: "thumbnail_file", use: "ThumbnailImage" },
+       { id: original_file.id.to_s, extension: "pdf", mime_type: "application/pdf", name: nil, use: "OriginalFile" }]
+    end
+
+    before { file_set.file_ids = file_ids }
+
+    it 'builds an array of extensions_and_mime_types' do
+      expect(file_set.extensions_and_mime_types).to match_array results_array
+    end
+  end
 end


### PR DESCRIPTION
Valkyrie derivatives sort of work but only by accident. We need to access them via the storage adapter, rather than assuming we will find them on the file system. This begins the process of accessing derivatives appropriately.

The idea is to always include the options to download derivatives on the actions dropdown. 

The actions download menu does not have a Hyrax::FileSet object... it has a Hyrax::IiifAv::IiifFileSetPresenter object (at least when we are using IiifPrint). The `extensions_and_mime_types` method we added to the fileset gives us an array of hashes that we can use for the actions dropdown:
```
 [{:id=>"123", :extension=>"pdf", :mime_type=>"application/pdf", :name=>nil, :use=>"OriginalFile"},
    #    {:id=>"234", :extension=>"jpeg", :mime_type=>"application/octet-stream", :name=>"thumbnail", :use=>"ThumbnailImage"}]
``` 

<details>
<summary> Screenshots </summary>

![Screenshot 2024-05-15 at 4 42 42 PM](https://github.com/samvera/hyrax/assets/17851674/d94317a4-4988-4413-8658-4224af361ded)

![Screenshot 2024-05-15 at 4 42 51 PM](https://github.com/samvera/hyrax/assets/17851674/810e146c-97b5-481d-854b-943d843c2ebd)


</details>
