### PR TITLE
Enabling pairtree paths for Fedora 6 in Sirenia

### DIFF
--- a/.koppie/config/initializers/1_valkyrie.rb
+++ b/.koppie/config/initializers/1_valkyrie.rb
@@ -34,7 +34,9 @@ Valkyrie::MetadataAdapter.register(
       ENV.fetch('FCREPO_URL') { "http://localhost:8080/fcrepo/rest" })),
     base_path: Rails.env,
     schema: Valkyrie::Persistence::Fedora::PermissiveSchema.new(Hyrax::SimpleSchemaLoader.new.permissive_schema_for_valkrie_adapter),
-    fedora_version: 6
+    fedora_version: 6.5,
+    fedora_pairtree_count: 4,
+    fedora_pairtree_length: 2
   ), :fedora_metadata
 )
 
@@ -64,7 +66,9 @@ Valkyrie::StorageAdapter.register(
     connection: ::Ldp::Client.new(Hyrax.config.fedora_connection_builder.call(
       ENV.fetch('FCREPO_URL') { "http://localhost:8080/fcrepo/rest" })),
     base_path: Rails.env,
-    fedora_version: 6
+    fedora_version: 6.5,
+    fedora_pairtree_count: 4,
+    fedora_pairtree_length: 2
   ), :fedora_storage
 )
 

--- a/docker-compose-sirenia.yml
+++ b/docker-compose-sirenia.yml
@@ -134,7 +134,8 @@ services:
         CATALINA_OPTS=-Dfcrepo.home=/fcrepo-home -Djava.awt.headless=true -Dfile.encoding=UTF-8
         -server -Xms512m -Xmx1024m -XX:NewSize=256m -XX:MaxNewSize=256m -XX:PermSize=256m
         -XX:MaxPermSize=256m -XX:+DisableExplicitGC -Dorg.apache.tomcat.util.buf.UDecoder.ALLOW_ENCODED_SLASH=true
-      - JAVA_OPTS=-Dorg.apache.tomcat.util.buf.UDecoder.ALLOW_ENCODED_SLASH=true
+        -Dfcrepo.pid.minter.length=2 -Dfcrepo.pid.minter.count=4
+      - JAVA_OPTS=-Dorg.apache.tomcat.util.buf.UDecoder.ALLOW_ENCODED_SLASH=true -Dfcrepo.pid.minter.length=2 -Dfcrepo.pid.minter.count=4
     volumes:
       - fcrepo:/fcrepo-home
     ports:

--- a/hyrax.gemspec
+++ b/hyrax.gemspec
@@ -85,7 +85,7 @@ SUMMARY
   spec.add_dependency 'retriable', '>= 2.9', '< 4.0'
   spec.add_dependency 'signet'
   spec.add_dependency 'tinymce-rails', '~> 5.10'
-  spec.add_dependency 'valkyrie', '~> 3.1.1'
+  spec.add_dependency 'valkyrie', '~> 3.3'
   spec.add_dependency 'view_component', '~> 2.74.1' # Pin until blacklight is updated with workaround for https://github.com/ViewComponent/view_component/issues/1565
   spec.add_dependency 'sprockets', '3.7.2' # 3.7.3 fails feature specs
   spec.add_dependency 'sass-rails', '~> 6.0'

--- a/lib/generators/hyrax/templates/config/initializers/1_valkyrie.rb
+++ b/lib/generators/hyrax/templates/config/initializers/1_valkyrie.rb
@@ -36,7 +36,9 @@ Valkyrie::MetadataAdapter.register(
 #     )),
 #     base_path: Rails.env,
 #     schema: Valkyrie::Persistence::Fedora::PermissiveSchema.new(Hyrax::SimpleSchemaLoader.new.permissive_schema_for_valkrie_adapter),
-#     fedora_version: 6
+#     fedora_version: 6.5,
+#     fedora_pairtree_count: 4,
+#     fedora_pairtree_length: 2
 #   ), :fedora_metadata
 # )
 
@@ -68,7 +70,9 @@ Valkyrie.config.metadata_adapter = ENV.fetch('VALKYRIE_METADATA_ADAPTER') { :pg_
 #       ENV.fetch('FCREPO_URL') { "http://localhost:8080/fcrepo/rest" }
 #     )),
 #     base_path: Rails.env,
-#     fedora_version: 6
+#     fedora_version: 6.5,
+#     fedora_pairtree_count: 4,
+#     fedora_pairtree_length: 2
 #   ), :fedora_storage
 # )
 


### PR DESCRIPTION
**NOTE**: this PR depends on changes in [this Valkyrie PR](https://github.com/samvera/valkyrie/pull/957). 

Fedora 6.5 now supports automatic creation of "pairtree" IDs, which means that identifiers are stored in a hashed directory structure to avoid excessive child nodes directly in the root node.

However, unlike Fedora 4 where this was the default behavior, it has to be enabled via options in 6.5. Since doing so requires configuring both the count and length of the pairtree algorithm, it needs to be configurable in the Valkyrie Fedora adapters so that both sides match.

This PR sets the `fcrepo` image to run 6.5 in the Sirenia compose file and sets JVM runtime options to enable automatic creation of pairtree paths.  The corresponding values are then set in the Valkyrie adapter initialization so that ID to URI translations are correct.

For example, if an ID of `AaBbCcDd` in Fedora was created under the root node as `/Aa/Bb/Cc/Dd/AaBbCcDd`, then setting count and length to 4 and 2 in the Fedora adapters ensures that the same path will be calculated and returned.

Note that the configuration above is not required for pairtree paths to work correctly in Fedora 4, and automatic pairtree creation is not supported under Fedora 5 or Fedora 6 < 6.5.