### PR TITLE
Prevent sharing works and filesets with unintended groups

### DIFF
--- a/app/assets/javascripts/hyrax/permissions/control.es6
+++ b/app/assets/javascripts/hyrax/permissions/control.es6
@@ -2,6 +2,7 @@ import { Registry } from './registry'
 import { UserControls } from './user_controls'
 import { GroupControls } from './group_controls'
 import VisibilityComponent from '../save_work/visibility_component'
+import AdminSetWidget from 'hyrax/editor/admin_set_widget'
 
 export default class PermissionsControl {
   /**
@@ -14,13 +15,14 @@ export default class PermissionsControl {
     if (element.length === 0) {
       return
     }
+    this.adminSetWidget = new AdminSetWidget(element.find('select[id="admin_set_id"]'))
     this.element = element
 
     this.registry = new Registry(this.element, this.object_name(), template_id)
     this.user_controls = new UserControls(this.element, this.registry)
     this.group_controls = new GroupControls(this.element, this.registry)
     if (with_visibility_component) {
-      this.visibility_component = new VisibilityComponent(this.element)
+      this.visibility_component = new VisibilityComponent(this.element, this.adminSetWidget)
     } else {
       this.visibility_component = null
     }

--- a/app/controllers/hyrax/file_sets_controller.rb
+++ b/app/controllers/hyrax/file_sets_controller.rb
@@ -43,6 +43,7 @@ module Hyrax
 
     # GET /concern/file_sets/:id
     def edit
+      @file_set_admin_set_option = file_set_admin_set_option
       initialize_edit_form
     end
 
@@ -227,6 +228,19 @@ module Hyrax
         add_breadcrumb presenter.parent.to_s, main_app.polymorphic_path(presenter.parent) if presenter.parent.present?
         add_breadcrumb presenter.to_s, main_app.polymorphic_path(presenter)
       end
+    end
+
+    # Retrieves the admin set the file_set belongs to
+    def file_set_admin_set_option
+      return @admin_set_option if @admin_set_option
+      parent_work = parent(file_set: presenter)
+      admin_set_tesim = parent_work.solr_document[:admin_set_tesim].first
+
+      service = Hyrax::AdminSetService.new(self)
+      admin_set_option = Hyrax::AdminSetOptionsPresenter.new(service).select_options.reject do |option|
+        option[0] != admin_set_tesim
+      end
+      admin_set_option
     end
 
     def initialize_edit_form

--- a/app/helpers/hyrax/hyrax_helper_behavior.rb
+++ b/app/helpers/hyrax/hyrax_helper_behavior.rb
@@ -23,9 +23,12 @@ module Hyrax
     ##
     # @return [Array<String>] the list of all user groups
     def available_user_groups(ability:)
-      return ::User.group_service.role_names if ability.admin?
-
-      ability.user_groups
+      user_groups = ability.user_groups.dup
+      return user_groups if ability.admin?
+      # Excluding "public" and "registered" groups if non-admin user
+      user_groups.delete("public")
+      user_groups.delete("registered")
+      user_groups
     end
 
     # Which translations are available for the user to select

--- a/app/views/hyrax/file_sets/_admin_set_options.html.erb
+++ b/app/views/hyrax/file_sets/_admin_set_options.html.erb
@@ -1,0 +1,7 @@
+<!-- Including non-visible admin set dropdown to trigger VisibilityComponent JavaScript. -->
+<% if Flipflop.assign_admin_set? %>
+  <%= select_tag :admin_set_id,
+                options_for_select(@file_set_admin_set_option.map { |option| [option[0], option[1], option[2]] }),
+                include_blank: false,
+                class: 'form-control d-none' %>
+<% end %>

--- a/app/views/hyrax/file_sets/_permission.html.erb
+++ b/app/views/hyrax/file_sets/_permission.html.erb
@@ -5,6 +5,11 @@
                                 data: { param_key: file_set.model_name.param_key },
                                 class: 'nav-safety'
                               } do |f| %>
+      <div class="tab-content">
+        <div role="tabpanel" class="tab-pane show active" id="admin_sets">
+          <%= render 'admin_set_options' %>
+        </div>
+      </div>
       <%= hidden_field_tag('redirect_tab', 'permissions') %>
       <%= render "permission_form", f: f %>
       <div id="permissions_submit">

--- a/app/views/hyrax/file_sets/_permission_form.html.erb
+++ b/app/views/hyrax/file_sets/_permission_form.html.erb
@@ -49,7 +49,7 @@
     <div class="row">
       <div class="col-sm-5">
         <label for="new_group_name_skel" class="sr-only"><%= t('.new_group_name_skel') %></label>
-        <%= select_tag 'new_group_name_skel', options_for_select([t('.select_group')] + current_user.groups), class: 'form-control' %>
+        <%= select_tag 'new_group_name_skel', options_for_select([t('.select_group')] + available_user_groups(ability: current_ability)), class: 'form-control' %>
       </div>
       <div class="col-sm-4">
         <label for="new_group_permission_skel" class="sr-only"><%= t('.new_group_permission_skel') %></label>


### PR DESCRIPTION
### Fixes

Fixes #6822 

### Summary

* Non admin users are able to override visibility restrictions for an admin set for works and filesets. By following steps specified in issue #6822 works and filesets can be shared with groups that were not intended.

### Guidance for testing:

**Criteria: Users should not be able to share works to groups outside of the visibility restrictions of the admin set it belongs to**
1. As a non admin user, create a new work in Nurax.
2. Select an admin set with exclusive private visibility in the Relations tab.
3. In the sharing settings tab, ensure that "public" or "registered" are not selectable options

**Criteria: Users should not be able to share works to groups outside of the visibility restrictions of the admin set it belongs to**
1. As a non admin user, create a new work in Nurax.
2. Select an admin set with exclusive private visibility in the Relations tab.
3. Fill out the form as usual and add a file. Check the deposit agreement and click save.
4. Go to the dropdown for the file on the work page and select Edit
5. Click the permissions tab and verify that visibility restrictions for the admin set are being applied to the radio buttons (private should be the only option available)