### PR TITLE
Change default admin set id to `admin_set_default` to avoid issues with encoded slashes

### DIFF
--- a/app/services/hyrax/admin_set_create_service.rb
+++ b/app/services/hyrax/admin_set_create_service.rb
@@ -129,9 +129,12 @@ module Hyrax
                       Hyrax.query_service.find_by(id: 'admin_set/default')
                     rescue Ldp::BadRequest, Valkyrie::Persistence::ObjectNotFoundError
                       # Fedora 6.5+ does not support slashes in IDs, hence the need to rescue Ldp::BadRequest
-                      Hyrax.query_service.find_by(id: DEFAULT_ID)
-                    rescue Valkyrie::Persistence::ObjectNotFoundError
-                      nil
+                      # if an admin set with deprecated ID 'admin_set/default' does not exist, check again for admin set with DEFAULT_ID
+                      begin
+                        Hyrax.query_service.find_by(id: DEFAULT_ID)
+                      rescue Valkyrie::Persistence::ObjectNotFoundError
+                        nil
+                      end
                     end
 
         default_admin_set_persister.update(default_admin_set_id: admin_set.id.to_s) if admin_set.present? && save_default?


### PR DESCRIPTION
### Fixes

Fixes Fedora 6.5+ compatibility, since it does not support encoded slashes in IDs.

### Summary

We currently cannot use Fedora 6.5+ with Hyrax because it does not support encoded slashes in IDs. This leads to failure every time we perform `Hyrax.query_service.find_by(id: DEFAULT_ID)`. In this PR, I change the `DEFAULT_ID` to use underscores only, and add backwards compatibility changes to helper methods finding existing admin sets.

### Type of change (for release notes)

- `notes-bugfix` Bug Fixes

### Detailed Description

After delving into the use of `DEFAULT_ID` , it’s only ever used as an actual ID in places that have a hardcoded admin set with that ID, which is not the case for Postgres or Fedora (Fedora uses UUID). The reasoning behind my PR is, to support backwards compatibility, when we need to lookup any existing unused admin set with default id, lookup for both `admin_set/default`  and `admin_set_default`, if none exist then go forward with creating a new admin set, which will use UUID with Valkyrie. This change ensures new apps using underscores if they ever have to create a default admin set with `DEFAULT_ID` , and supports any existing apps that do not use Postgres/Fedora via Valkyrie and have an admin set with the id explicitly set to `admin_set/default`.

one edge case to this approach is, if there is a repository that has a default admin set in Fedora that has an id explicitly set to `admin_set/default` , then it will still break, because Fedora 6.5+ will break every time it looks it up. My understanding is we store the default admin set id in Fedora with UUID, and we store the UUID in the `hyrax_default_administrative_set`  on the database.

### Changes proposed in this pull request:
* change the `DEFAULT_ID` for administrative sets to use underscores only
* Change helper method `find_unsaved_default_admin_set` to lookup both `admin_set/default` and `admin_set_default` when looking for any existing unused default admin sets.

@samvera/hyrax-code-reviewers
