### PR TITLE
Explicitly cast metrics from Matomo to be integers

### DIFF
--- a/app/services/hyrax/analytics/matomo.rb
+++ b/app/services/hyrax/analytics/matomo.rb
@@ -165,9 +165,9 @@ module Hyrax
             if result[1].empty?
               results.push([result[0].to_date, 0])
             elsif result[1].is_a?(Array)
-              results.push([result[0].to_date, result[1].first[metric]])
+              results.push([result[0].to_date, result[1].first[metric].to_i])
             else
-              results.push([result[0].to_date, result[1][metric].presence || 0])
+              results.push([result[0].to_date, result[1][metric].presence.to_i])
             end
           end
           Hyrax::Analytics::Results.new(results)


### PR DESCRIPTION
Explicitly cast metrics from Matomo to be integers. See: https://github.com/matomo-org/matomo/issues/21978

### Summary

The above bug in Matomo introduces some analytics events with metrics recorded as Strings instead of Integers, e.g. `"1"` instead of `1`. Much of `Hyrax::Analytics` depends on these metrics being numbers instead of strings, so this results in exceptions once Hyrax tries to parse and transform the analytics data.

### Type of change (for release notes)

- `notes-bugfix` Bug Fixes

### Detailed Description

Any object that has associated analytics events which are/were affected by the Matomo bug above will result in a "Something Went Wrong" exception when you try to view their usage stats, e.g.:

```
app_1              | F, [2024-06-10T16:21:18.687334 #18] FATAL -- : [e34f85c6-402e-4c37-9ba8-6f31d156b0ac]   
app_1              | [e34f85c6-402e-4c37-9ba8-6f31d156b0ac] ActionView::Template::Error (String can't be coerced into Integer):
app_1              | [e34f85c6-402e-4c37-9ba8-6f31d156b0ac]     13:     <div class="alert alert-info">
app_1              | [e34f85c6-402e-4c37-9ba8-6f31d156b0ac]     14:       <span class="fa fa-signal large-icon"></span>
app_1              | [e34f85c6-402e-4c37-9ba8-6f31d156b0ac]     15:         <%= t('total_view', count: @pageviews.range(Hyrax.config.analytics_start_date.to_date, Time.zone.today)) %>
app_1              | [e34f85c6-402e-4c37-9ba8-6f31d156b0ac]     16:         <%= t('download', count: @downloads.range(Hyrax.config.analytics_start_date.to_date, Time.zone.today)) %>
app_1              | [e34f85c6-402e-4c37-9ba8-6f31d156b0ac]     17:     </div>
app_1              | [e34f85c6-402e-4c37-9ba8-6f31d156b0ac]     18: 
app_1              | [e34f85c6-402e-4c37-9ba8-6f31d156b0ac]     19:     <div class="stats-container">
app_1              | [e34f85c6-402e-4c37-9ba8-6f31d156b0ac]   
app_1              | [e34f85c6-402e-4c37-9ba8-6f31d156b0ac] hyrax (5.0.0) app/services/hyrax/analytics/results.rb:62:in `+'
```

### Changes proposed in this pull request:

Normalize all metrics from Matomo with an explicit call to `.to_i` at read-time.

NB: we can safely simplify `.presence.to_i || 0` to `.presence.to_i` here because `nil.to_i` evaluates to `0`.

@samvera/hyrax-code-reviewers
