### PR TITLE
Use $(document).ready instead of $(document).on("ready")

### DIFF
--- a/app/assets/javascripts/hyrax/analytics_events.js
+++ b/app/assets/javascripts/hyrax/analytics_events.js
@@ -69,7 +69,7 @@ if (typeof Turbolinks !== 'undefined') {
     setupTracking()
   })
 } else {
-  $(document).on('ready', function() {
+  $(document).ready(function() {
     setupTracking()
   })
 }


### PR DESCRIPTION
Use `$(document).ready` instead of `$(document).on("ready")` (deprecated in jQuery 1.8 and removed in jQuery 3.0, see: https://api.jquery.com/ready/).

### Summary

We noticed that after upgrading to Hyrax 4.x, we were no longer getting e.g. `work-view` analytics events in Matomo from pageviews. After extensive debugging, this was tracked down to the Hyrax `setupTracking()` function never being called.

### Type of change (for release notes)

- `notes-bugfix` Bug Fixes

### Detailed Description

Changing to `$(document).ready` should be sufficient. Turbolinks events should, I believe, still be able to use the normal events chain.

This bug affects 4.x and 5.x, and the change should probably be backported to 4.x so that people upgrading through 4.x aren't affected by a regression which causes them to miss analytics data.

Analytics events that are by default registered on click handlers instead of page views (such as `file-set-in-work-download`) are unaffected by this bug.

### Changes proposed in this pull request:

* Use `$(document).ready` instead of `$(document).on("ready")`

@samvera/hyrax-code-reviewers
