### PR TITLE
GH Actions workflow improvements

### DIFF
--- a/.github/workflows/build-test-lint.yml
+++ b/.github/workflows/build-test-lint.yml
@@ -129,6 +129,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           path: artifacts
+          pattern: "*report*"
       - name: Publish Test Report
         uses: EnricoMi/publish-unit-test-result-action@v2
         with:

--- a/.github/workflows/build-test-lint.yml
+++ b/.github/workflows/build-test-lint.yml
@@ -75,6 +75,12 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+      - name: Setup tmate debug session
+        uses: mxschmitt/action-tmate@v3
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.debug_enabled }}
+        with:
+          limit-access-to-actor: true
+          detached: true
       - name: Download built image artifact
         uses: actions/download-artifact@v4
         with:
@@ -110,11 +116,6 @@ jobs:
         with:
           name: spec-reports-${{ matrix.ci_node_index }}
           path: '**/rspec*.xml'
-      - name: Setup tmate session
-        uses: mxschmitt/action-tmate@v3
-        if: failure()
-        with:
-          limit-access-to-actor: true
 
   report:
     needs: test


### PR DESCRIPTION
### Summary

Only run debug step by request.
Only copy reports when fetching reports.