### PR TITLE
Move clean_repo before hook after :index_adapter

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -282,14 +282,6 @@ RSpec.configure do |config|
   #   skip("Don't test Wings") if Hyrax.config.disable_wings
   # end
 
-  config.before(:example, :clean_repo) do
-    clean_active_fedora_repository unless Hyrax.config.disable_wings
-    Hyrax::RedisEventStore.instance.then(&:flushdb)
-    # Not needed to clean the Solr core used by ActiveFedora since
-    # clean_active_fedora_repository will wipe that core
-    Hyrax::SolrService.wipe! if Hyrax.config.query_index_from_valkyrie
-  end
-
   # Use this example metadata when you want to perform jobs inline during testing.
   #
   #   describe '#my_method`, :perform_enqueued do
@@ -329,6 +321,14 @@ RSpec.configure do |config|
     allow(Hyrax)
       .to receive(:index_adapter)
       .and_return(Valkyrie::IndexingAdapter.find(adapter_name))
+  end
+
+  config.before(:example, :clean_repo) do
+    clean_active_fedora_repository unless Hyrax.config.disable_wings
+    Hyrax::RedisEventStore.instance.then(&:flushdb)
+    # Not needed to clean the Solr core used by ActiveFedora since
+    # clean_active_fedora_repository will wipe that core
+    Hyrax::SolrService.wipe! if Hyrax.config.query_index_from_valkyrie
   end
 
   config.after(:example, :index_adapter) do |example|


### PR DESCRIPTION
### Summary

Fixes flakiness in by_format_spec.rb

### Detailed Description
If an rspec example specified both :clean_repo and :index_adapter, the incorrect solr adapter would be cleaned leading to sporadic test failures.

Flakiness seen when 
`spec/controllers/hyrax/file_sets_controller_spec.rb[1:1:1:4:1:1]`
ran prior to 
`spec/services/hyrax/statistics/file_sets/by_format_spec.rb[1:1:1]`

### Changes proposed in this pull request:
* Reordering of rspec before hooks

@samvera/hyrax-code-reviewers
