### PR TITLE
 Explicitly cast metrics from Matomo to be integers

### DIFF
--- a/app/services/hyrax/analytics/matomo.rb
+++ b/app/services/hyrax/analytics/matomo.rb
@@ -165,9 +165,9 @@ module Hyrax
             if result[1].empty?
               results.push([result[0].to_date, 0])
             elsif result[1].is_a?(Array)
-              results.push([result[0].to_date, result[1].first[metric]])
+              results.push([result[0].to_date, result[1].first[metric].to_i])
             else
-              results.push([result[0].to_date, result[1][metric].presence || 0])
+              results.push([result[0].to_date, result[1][metric].presence.to_i])
             end
           end
           Hyrax::Analytics::Results.new(results)


### PR DESCRIPTION
Same as #6831 moved to a non-fork branch.

@ryanfb The new Actions CI reporting is not yet working for PRs from forks, so I duplicated the commit here.