### PR TITLE
Install Alpine's grpc gem and use in test apps

### DIFF
--- a/.dassie/Gemfile
+++ b/.dassie/Gemfile
@@ -14,9 +14,18 @@ gem 'coffee-rails', '~> 4.2'
 gem 'dalli'
 gem 'devise'
 gem 'devise-guests', '~> 0.8'
+
+# Required because grpc and google-protobuf gem's binaries are not compatible with Alpine Linux.
+# To install the package in Alpine: `apk add ruby-grpc`
+# The pinned versions should match the version provided by the Alpine packages.
+if RUBY_PLATFORM =~ /musl/
+  path '/usr/lib/ruby/gems/3.2.0' do
+    gem 'google-protobuf', '~> 3.24.4', force_ruby_platform: true
+    gem 'grpc', '~> 1.59.3', force_ruby_platform: true
+  end
+end
+
 gemspec name: 'hyrax', path: ENV.fetch('HYRAX_ENGINE_PATH', '..')
-gem 'google-protobuf', force_ruby_platform: true # required because google-protobuf is not compatible with Alpine linux
-gem 'grpc', force_ruby_platform: true # required because google-protobuf is not compatible with Alpine linux
 gem 'jbuilder', '~> 2.5'
 gem 'jquery-rails'
 gem 'pg', '~> 1.3'

--- a/.koppie/Gemfile
+++ b/.koppie/Gemfile
@@ -14,8 +14,17 @@ gem 'coffee-rails', '~> 4.2'
 gem 'dalli'
 gem 'devise'
 gem 'devise-guests', '~> 0.8'
-gem 'google-protobuf', force_ruby_platform: true # required because google-protobuf is not compatible with Alpine linux
-gem 'grpc', force_ruby_platform: true # required because google-protobuf is not compatible with Alpine linux
+
+# Required because grpc and google-protobuf gem's binaries are not compatible with Alpine Linux.
+# To install the package in Alpine: `apk add ruby-grpc`
+# The pinned versions should match the version provided by the Alpine packages.
+if RUBY_PLATFORM =~ /musl/
+  path '/usr/lib/ruby/gems/3.2.0' do
+    gem 'google-protobuf', '~> 3.24.4', force_ruby_platform: true
+    gem 'grpc', '~> 1.59.3', force_ruby_platform: true
+  end
+end
+
 gemspec name: 'hyrax', path: ENV.fetch('HYRAX_ENGINE_PATH', '..')
 gem 'jbuilder', '~> 2.5'
 gem 'jquery-rails'

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,7 @@ RUN apk --no-cache upgrade && \
   imagemagick-tiff \
   imagemagick-webp \
   jemalloc \
+  ruby-grpc \
   tzdata \
   nodejs \
   yarn \

--- a/spec/features/work_generator_spec.rb
+++ b/spec/features/work_generator_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe 'Creating a new Work' do
 
   after do
     Rails::Generators.invoke('hyrax:work', ['Catapult', '--quiet'], behavior: :revoke, destination_root: Rails.root)
+    Hyrax::ModelRegistry.instance_variable_set(:@work_class_names, nil) # Catapult gets memoized here
   end
 
   it 'catapults should behave like generic works' do

--- a/spec/services/hyrax/quick_classification_query_spec.rb
+++ b/spec/services/hyrax/quick_classification_query_spec.rb
@@ -14,13 +14,11 @@ RSpec.describe Hyrax::QuickClassificationQuery do
     describe '#each' do
       let(:thing) { double }
 
-      before do
-        # Ensure that no other test has altered the configuration:
-        allow(Hyrax.config).to receive(:registered_curation_concern_types).and_return(['GenericWork'])
-      end
-
       it "calls the block once for every model" do
-        expect(thing).to receive(:test).with(GenericWork)
+        expect(Hyrax.config.curation_concerns.size).to be > 0
+        Hyrax.config.curation_concerns.each do |cc|
+          expect(thing).to receive(:test).with(cc)
+        end
 
         query.each { |f| thing.test(f) }
       end


### PR DESCRIPTION
### Fixes

refs #6815 

### Summary
Make the test apps use Alpine's provided grpc gem package to avoid long compilation.

### Guidance for testing, such as acceptance criteria or new user interface behaviors:
* Image build time in Actions workflow is improved

### Detailed Description

The grpc gem uses native extensions that take a long time to compile. Normally the gem can provide prebuilt binaries to avoid compilation, but Alpine Linux which we use as the base for hyrax's docker image is not compatible with those binaries. Alpine provides its own packages, but we have to match versions and specify the in-container path.

The other commits here are addressing flaky tests that made themselves known along the way.

@samvera/hyrax-code-reviewers
