### PR TITLE
Flexible views

### DIFF
--- a/.dassie/config/metadata_profiles/m3_profile.yaml
+++ b/.dassie/config/metadata_profiles/m3_profile.yaml
@@ -4,7 +4,7 @@ profile:
   date_modified: '2024-06-01'
   responsibility: https://samvera.org
   responsibility_statement: Hyrax Initial Profile
-  type:
+  type: Initial Profile
   version: 1
 classes:
   GenericWork:
@@ -25,6 +25,8 @@ classes:
     display_label: PcdmCollection
   Hyrax::FileSet:
     display_label: FileSet
+  Hyrax::PcdmCollection:
+    display_label: PcdmCollection
 contexts:
   flexible_context:
     display_label: Flexible Metadata Example
@@ -50,6 +52,7 @@ properties:
       - GenericWorkResource
       - Wings(Hyrax::Resource)
       - GenericWork
+      - Monograph
     cardinality:
       minimum: 1
     multi_value: true
@@ -58,15 +61,14 @@ properties:
       sources:
       - 'null'
     definition:
-      default: Enter a standardized title for display. If only one
-        title is needed, transcribe the title from the source
-        itself.
+      default: Enter a standardized title for display. If only one title is needed,
+        transcribe the title from the source itself.
     display_label:
       default: Title
     index_documentation: displayable, searchable
     indexing:
-    - 'title_sim'
-    - 'title_tesim'
+    - title_sim
+    - title_tesim
     form:
       required: true
       primary: true
@@ -91,6 +93,7 @@ properties:
       - GenericWorkResource
       - Wings(Hyrax::Resource)
       - GenericWork
+      - Monograph
     cardinality:
       minimum: 0
       maximum: 1
@@ -100,7 +103,17 @@ properties:
     property_uri: http://purl.org/dc/terms/modified
     range: http://www.w3.org/2001/XMLSchema#dateTime
     sample_values:
-    - "2024-06-06 21:06:51 +0000"
+    - '2024-06-06 21:06:51 +0000'
+    view:
+      label:
+        de: 'Zuletzt geändert'
+        en: 'Last modified'
+        es: 'Última modificación'
+        fr: 'Dernière modification'
+        it: 'Ultima modifica'
+        pt-BR: 'Última modificação'
+        zh: '最新修改'
+      html_dl: true
   date_uploaded:
     available_on:
       class:
@@ -111,6 +124,7 @@ properties:
       - GenericWorkResource
       - Wings(Hyrax::Resource)
       - GenericWork
+      - Monograph
     cardinality:
       minimum: 0
       maximum: 1
@@ -120,7 +134,7 @@ properties:
     property_uri: http://purl.org/dc/terms/dateSubmitted
     range: http://www.w3.org/2001/XMLSchema#dateTime
     sample_values:
-    - "2024-06-06 21:06:51 +0000"
+    - '2024-06-06 21:06:51 +0000'
   depositor:
     available_on:
       class:
@@ -131,6 +145,7 @@ properties:
       - GenericWorkResource
       - Wings(Hyrax::Resource)
       - GenericWork
+      - Monograph
     cardinality:
       minimum: 0
       maximum: 1
@@ -143,7 +158,7 @@ properties:
       default: Depositor
     index_documentation: searchable
     indexing:
-    - 'depositor_tesim'
+    - depositor_tesim
     property_uri: http://id.loc.gov/vocabulary/relators/dpt
     range: http://www.w3.org/2001/XMLSchema#string
     sample_values:
@@ -151,6 +166,8 @@ properties:
   creator:
     available_on:
       class:
+      - AdminSet
+      - AdminSetResource
       - Hyrax::FileSet
       - CollectionResource
       - GenericWorkResource
@@ -168,8 +185,8 @@ properties:
       default: Creator
     index_documentation: displayable, searchable
     indexing:
-    - 'creator_sim'
-    - 'creator_tesim'
+    - creator_sim
+    - creator_tesim
     form:
       required: true
       primary: true
@@ -177,6 +194,9 @@ properties:
     range: http://www.w3.org/2001/XMLSchema#string
     sample_values:
     - Julie Allinson
+    view:
+      render_as: "faceted"
+      html_dl: true
   license:
     available_on:
       class:
@@ -197,14 +217,17 @@ properties:
       default: License
     index_documentation: displayable, searchable
     indexing:
-    - 'license_sim'
-    - 'license_tesim'
+    - license_sim
+    - license_tesim
     form:
       primary: false
     property_uri: http://purl.org/dc/terms/license
     range: http://www.w3.org/2001/XMLSchema#string
     sample_values:
     - http://creativecommons.org/licenses/by/3.0/us/
+    view:
+      render_as: "external_link"
+      html_dl: true
   abstract:
     available_on:
       class:
@@ -225,14 +248,16 @@ properties:
       default: Abstract
     index_documentation: displayable, searchable
     indexing:
-    - 'abstract_sim'
-    - 'abstract_tesim'
+    - abstract_sim
+    - abstract_tesim
     form:
       primary: false
     property_uri: http://purl.org/dc/terms/abstract
     range: http://www.w3.org/2001/XMLSchema#string
     sample_values:
     - This is an abstract.
+    view:
+      html_dl: true
   access_right:
     available_on:
       class:
@@ -252,17 +277,21 @@ properties:
       default: Access Right
     index_documentation: displayable, searchable
     indexing:
-    - 'access_right_sim'
-    - 'access_right_tesim'
+    - access_right_sim
+    - access_right_tesim
     form:
       primary: false
     property_uri: http://purl.org/dc/terms/accessRights
     range: http://www.w3.org/2001/XMLSchema#string
     sample_values:
     - Open Access
+    view:
+      html_dl: true
   alternative_title:
     available_on:
       class:
+      - AdminSet
+      - AdminSetResource
       - CollectionResource
       - GenericWorkResource
       - Wings(Hyrax::Resource)
@@ -279,14 +308,19 @@ properties:
       default: Alternative Title
     index_documentation: displayable, searchable
     indexing:
-    - 'alternative_title_sim'
-    - 'alternative_title_tesim'
+    - alternative_title_sim
+    - alternative_title_tesim
     form:
       primary: false
     property_uri: http://purl.org/dc/terms/alternative
     range: http://www.w3.org/2001/XMLSchema#string
     sample_values:
     - Alternate Title Example
+    view:
+      label:
+        en: 'Alternative Title'
+        es: 'Título Alternativo'
+      html_dl: true
   arkivo_checksum:
     available_on:
       class:
@@ -331,14 +365,17 @@ properties:
       default: Location
     index_documentation: displayable, searchable
     indexing:
-    - 'based_near_sim'
-    - 'based_near_tesim'
+    - based_near_sim
+    - based_near_tesim
     form:
       primary: false
     property_uri: http://xmlns.com/foaf/0.1/based_near
     range: http://www.w3.org/2001/XMLSchema#string
     sample_values:
     - San Diego, California, United States
+    view:
+      label: Based Near
+      html_dl: true
   bibliographic_citation:
     available_on:
       class:
@@ -358,14 +395,16 @@ properties:
       default: Bibliographic Citation
     index_documentation: displayable, searchable
     indexing:
-    - 'bibliographic_citation_sim'
-    - 'bibliographic_citation_tesim'
+    - bibliographic_citation_sim
+    - bibliographic_citation_tesim
     form:
       primary: false
     property_uri: http://purl.org/dc/terms/bibliographicCitation
     range: http://www.w3.org/2001/XMLSchema#string
     sample_values:
-    - "Doe, J. (2024). Example Citation. Journal of Examples, 12(3), 45-67."
+    - Doe, J. (2024). Example Citation. Journal of Examples, 12(3), 45-67.
+    view:
+      html_dl: true
   contributor:
     available_on:
       class:
@@ -386,14 +425,17 @@ properties:
       default: Contributor
     index_documentation: displayable, searchable
     indexing:
-    - 'contributor_tesim'
-    - 'contributor_sim'
+    - contributor_tesim
+    - contributor_sim
     form:
       primary: false
     property_uri: http://purl.org/dc/elements/1.1/contributor
     range: http://www.w3.org/2001/XMLSchema#string
     sample_values:
     - Julie Allinson
+    view:
+      render_as: "faceted"
+      html_dl: true
   date_created:
     available_on:
       class:
@@ -414,18 +456,23 @@ properties:
       default: Date Created
     index_documentation: displayable, searchable
     indexing:
-    - 'date_created_sim'
-    - 'date_created_tesim'
+    - date_created_sim
+    - date_created_tesim
     form:
       primary: false
     property_uri: http://purl.org/dc/terms/created
     range: http://www.w3.org/2001/XMLSchema#dateTime
     sample_values:
-    sample_values:
-    - "2024-06-06 21:06:51 +0000"
+    - '2024-06-06 21:06:51 +0000'
+    view:
+      render_as: "linked"
+      search_field: 'date_created_tesim'
+      html_dl: true
   description:
     available_on:
       class:
+      - AdminSet
+      - AdminSetResource
       - Hyrax::FileSet
       - CollectionResource
       - GenericWorkResource
@@ -443,8 +490,8 @@ properties:
       default: Description
     index_documentation: displayable, searchable
     indexing:
-    - 'description_sim'
-    - 'description_tesim'
+    - description_sim
+    - description_tesim
     form:
       primary: false
     property_uri: http://purl.org/dc/elements/1.1/description
@@ -471,14 +518,18 @@ properties:
       default: Identifier
     index_documentation: displayable, searchable
     indexing:
-    - 'identifier_sim'
-    - 'identifier_tesim'
+    - identifier_sim
+    - identifier_tesim
     form:
       primary: false
     property_uri: http://purl.org/dc/terms/identifier
     range: http://www.w3.org/2001/XMLSchema#string
     sample_values:
     - abc123
+    view:
+      render_as: "linked"
+      search_field: 'identifier_tesim'
+      html_dl: true
   import_url:
     available_on:
       class:
@@ -521,8 +572,8 @@ properties:
       default: Keyword
     index_documentation: displayable, searchable
     indexing:
-    - 'keyword_sim'
-    - 'keyword_tesim'
+    - keyword_sim
+    - keyword_tesim
     form:
       primary: false
     property_uri: http://schema.org/keywords
@@ -530,6 +581,9 @@ properties:
     sample_values:
     - Metadata
     - Repository
+    view:
+      render_as: "faceted"
+      html_dl: true
   label:
     available_on:
       class:
@@ -551,8 +605,8 @@ properties:
       default: Label
     index_documentation: displayable, searchable
     indexing:
-    - 'label_sim'
-    - 'label_tesim'
+    - label_sim
+    - label_tesim
     form:
       primary: false
     property_uri: info:fedora/fedora-system:def/model#downloadFilename
@@ -579,8 +633,8 @@ properties:
       default: Language
     index_documentation: displayable, searchable
     indexing:
-    - 'language_sim'
-    - 'language_tesim'
+    - language_sim
+    - language_tesim
     form:
       primary: false
     property_uri: http://purl.org/dc/elements/1.1/language
@@ -588,6 +642,9 @@ properties:
     sample_values:
     - English
     - Spanish
+    view:
+      render_as: "faceted"
+      html_dl: true
   publisher:
     available_on:
       class:
@@ -608,14 +665,17 @@ properties:
       default: Publisher
     index_documentation: displayable, searchable
     indexing:
-    - 'publisher_sim'
-    - 'publisher_tesim'
+    - publisher_sim
+    - publisher_tesim
     form:
       primary: false
     property_uri: http://purl.org/dc/elements/1.1/publisher
     range: http://www.w3.org/2001/XMLSchema#string
     sample_values:
     - Scholastic
+    view:
+      render_as: "faceted"
+      html_dl: true
   related_url:
     available_on:
       class:
@@ -636,14 +696,17 @@ properties:
       default: Related URL
     index_documentation: displayable, searchable
     indexing:
-    - 'related_url_sim'
-    - 'related_url_tesim'
+    - related_url_sim
+    - related_url_tesim
     form:
       primary: false
     property_uri: http://www.w3.org/2000/01/rdf-schema#seeAlso
     range: http://www.w3.org/2001/XMLSchema#string
     sample_values:
     - http://example.com/resource1
+    view:
+      render_as: "external_link"
+      html_dl: true
   relative_path:
     available_on:
       class:
@@ -666,7 +729,7 @@ properties:
     property_uri: http://scholarsphere.psu.edu/ns#relativePath
     range: http://www.w3.org/2001/XMLSchema#string
     sample_values:
-    - /path/to/resource
+    - "/path/to/resource"
   resource_type:
     available_on:
       class:
@@ -687,8 +750,8 @@ properties:
       default: Resource Type
     index_documentation: displayable, searchable
     indexing:
-    - 'resource_type_sim'
-    - 'resource_type_tesim'
+    - resource_type_sim
+    - resource_type_tesim
     form:
       primary: false
     property_uri: http://purl.org/dc/terms/type
@@ -696,6 +759,9 @@ properties:
     sample_values:
     - Article
     - Conference Proceeding
+    view:
+      render_as: "faceted"
+      html_dl: true
   rights_notes:
     available_on:
       class:
@@ -716,14 +782,16 @@ properties:
       default: Rights Notes
     index_documentation: displayable, searchable
     indexing:
-    - 'rights_notes_sim'
-    - 'rights_notes_tesim'
+    - rights_notes_sim
+    - rights_notes_tesim
     form:
       primary: false
     property_uri: http://purl.org/dc/elements/1.1/rights
     range: http://www.w3.org/2001/XMLSchema#string
     sample_values:
     - Creative Commons license.
+    view:
+      html_dl: true
   rights_statement:
     available_on:
       class:
@@ -744,14 +812,17 @@ properties:
       default: Rights Statement
     index_documentation: displayable, searchable
     indexing:
-    - 'rights_statement_sim'
-    - 'rights_statement_tesim'
+    - rights_statement_sim
+    - rights_statement_tesim
     form:
       primary: true
     property_uri: http://www.europeana.eu/schemas/edm/rights
     range: http://www.w3.org/2001/XMLSchema#string
     sample_values:
     - http://rightsstatements.org/vocab/InC/1.0/
+    view:
+      html_dl: true
+      render_as: "rights_statement"
   source:
     available_on:
       class:
@@ -772,8 +843,8 @@ properties:
       default: Source
     index_documentation: displayable, searchable
     indexing:
-    - 'source_sim'
-    - 'source_tesim'
+    - source_sim
+    - source_tesim
     form:
       primary: false
     property_uri: http://purl.org/dc/terms/source
@@ -781,6 +852,8 @@ properties:
     sample_values:
     - Original Manuscript
     - Digital Archive
+    view:
+      html_dl: true
   subject:
     available_on:
       class:
@@ -801,8 +874,8 @@ properties:
       default: Subject
     index_documentation: displayable, searchable
     indexing:
-    - 'subject_sim'
-    - 'subject_tesim'
+    - subject_sim
+    - subject_tesim
     form:
       primary: false
     property_uri: http://purl.org/dc/elements/1.1/subject
@@ -810,10 +883,14 @@ properties:
     sample_values:
     - Art
     - Science
+    view:
+      render_as: "faceted"
+      html_dl: true
   target_audience:
     available_on:
       class:
       - CollectionResource
+      - Monograph
     cardinality:
       minimum: 0
     multi_value: true
@@ -906,7 +983,7 @@ properties:
       default: Record Info
     index_documentation: searchable
     indexing:
-    - 'record_info_tesim'
+    - record_info_tesim
     form:
       required: true
       primary: true
@@ -976,26 +1053,6 @@ properties:
     range: http://www.w3.org/2001/XMLSchema#string
     sample_values:
     - Example Series Title
-  target_audience:
-    available_on:
-      class:
-      - Monograph
-    cardinality:
-      minimum: 0
-    multi_value: true
-    controlled_values:
-      format: http://www.w3.org/2001/XMLSchema#string
-      sources:
-      - 'null'
-    display_label:
-      default: Target Audience
-    form:
-      multiple: true
-    property_uri: http://hyrax-example.com/target_audience
-    range: http://www.w3.org/2001/XMLSchema#string
-    sample_values:
-    - Researchers
-    - Students
   table_of_contents:
     available_on:
       class:
@@ -1033,4 +1090,4 @@ properties:
     property_uri: http://hyrax-example.com/date_of_issuance
     range: http://www.w3.org/2001/XMLSchema#string
     sample_values:
-    - "2024-06-06 21:06:51 +0000"
+    - '2024-06-06 21:06:51 +0000'

--- a/.koppie/config/metadata_profiles/m3_profile.yaml
+++ b/.koppie/config/metadata_profiles/m3_profile.yaml
@@ -4,7 +4,7 @@ profile:
   date_modified: '2024-06-01'
   responsibility: https://samvera.org
   responsibility_statement: Hyrax Initial Profile
-  type: Flexible with Views
+  type: Initial Profile
   version: 1
 classes:
   GenericWork:
@@ -17,6 +17,8 @@ classes:
     display_label: PcdmCollection
   Hyrax::FileSet:
     display_label: FileSet
+  Hyrax::PcdmCollection:
+    display_label: PcdmCollection
 contexts:
   flexible_context:
     display_label: Flexible Metadata Example
@@ -39,6 +41,7 @@ properties:
       - Hyrax::FileSet
       - CollectionResource
       - GenericWork
+      - Monograph
     cardinality:
       minimum: 1
     multi_value: true
@@ -81,6 +84,7 @@ properties:
       - Hyrax::FileSet
       - CollectionResource
       - GenericWork
+      - Monograph
     cardinality:
       minimum: 0
       maximum: 1
@@ -92,7 +96,14 @@ properties:
     sample_values:
     - '2024-06-06 21:06:51 +0000'
     view:
-      label: Date Modified
+      label:
+        de: 'Zuletzt geändert'
+        en: 'Last modified'
+        es: 'Última modificación'
+        fr: 'Dernière modification'
+        it: 'Ultima modifica'
+        pt-BR: 'Última modificação'
+        zh: '最新修改'
       html_dl: true
   date_uploaded:
     available_on:
@@ -111,8 +122,6 @@ properties:
     range: http://www.w3.org/2001/XMLSchema#dateTime
     sample_values:
     - '2024-06-06 21:06:51 +0000'
-    view:
-      html_dl: true
   depositor:
     available_on:
       class:
@@ -120,6 +129,7 @@ properties:
       - Hyrax::FileSet
       - CollectionResource
       - GenericWork
+      - Monograph
     cardinality:
       minimum: 0
       maximum: 1
@@ -137,11 +147,10 @@ properties:
     range: http://www.w3.org/2001/XMLSchema#string
     sample_values:
     - Julie Allinson
-    view:
-      html_dl: true
   creator:
     available_on:
       class:
+      - Hyrax::AdministrativeSet
       - Hyrax::FileSet
       - CollectionResource
       - GenericWork
@@ -167,6 +176,7 @@ properties:
     sample_values:
     - Julie Allinson
     view:
+      render_as: "faceted"
       html_dl: true
   license:
     available_on:
@@ -195,6 +205,7 @@ properties:
     sample_values:
     - http://creativecommons.org/licenses/by/3.0/us/
     view:
+      render_as: "external_link"
       html_dl: true
   abstract:
     available_on:
@@ -254,6 +265,7 @@ properties:
   alternative_title:
     available_on:
       class:
+      - Hyrax::AdministrativeSet
       - CollectionResource
       - GenericWork
       - Monograph
@@ -277,6 +289,9 @@ properties:
     sample_values:
     - Alternate Title Example
     view:
+      label:
+        en: 'Alternative Title'
+        es: 'Título Alternativo'
       html_dl: true
   arkivo_checksum:
     available_on:
@@ -300,8 +315,6 @@ properties:
     range: http://www.w3.org/2001/XMLSchema#string
     sample_values:
     - c0855931b7f1aefedb91d31af76873c0
-    view:
-      html_dl: true
   based_near:
     available_on:
       class:
@@ -329,6 +342,7 @@ properties:
     sample_values:
     - San Diego, California, United States
     view:
+      label: Based Near
       html_dl: true
   bibliographic_citation:
     available_on:
@@ -384,6 +398,7 @@ properties:
     sample_values:
     - Julie Allinson
     view:
+      render_as: "faceted"
       html_dl: true
   date_created:
     available_on:
@@ -412,6 +427,8 @@ properties:
     sample_values:
     - '2024-06-06 21:06:51 +0000'
     view:
+      render_as: "linked"
+      search_field: 'date_created_tesim'
       html_dl: true
   description:
     available_on:
@@ -439,8 +456,6 @@ properties:
     range: http://www.w3.org/2001/XMLSchema#string
     sample_values:
     - This is a description.
-    view:
-      html_dl: true
   identifier:
     available_on:
       class:
@@ -468,6 +483,8 @@ properties:
     sample_values:
     - abc123
     view:
+      render_as: "linked"
+      search_field: 'identifier_tesim'
       html_dl: true
   import_url:
     available_on:
@@ -489,8 +506,6 @@ properties:
     range: http://www.w3.org/2001/XMLSchema#string
     sample_values:
     - http://example.com/resource1
-    view:
-      html_dl: true
   keyword:
     available_on:
       class:
@@ -519,6 +534,7 @@ properties:
     - Metadata
     - Repository
     view:
+      render_as: "faceted"
       html_dl: true
   label:
     available_on:
@@ -547,8 +563,6 @@ properties:
     range: http://www.w3.org/2001/XMLSchema#string
     sample_values:
     - file_label.txt
-    view:
-      html_dl: true
   language:
     available_on:
       class:
@@ -577,6 +591,7 @@ properties:
     - English
     - Spanish
     view:
+      render_as: "faceted"
       html_dl: true
   publisher:
     available_on:
@@ -605,6 +620,7 @@ properties:
     sample_values:
     - Scholastic
     view:
+      render_as: "faceted"
       html_dl: true
   related_url:
     available_on:
@@ -633,6 +649,7 @@ properties:
     sample_values:
     - http://example.com/resource1
     view:
+      render_as: "external_link"
       html_dl: true
   relative_path:
     available_on:
@@ -655,8 +672,6 @@ properties:
     range: http://www.w3.org/2001/XMLSchema#string
     sample_values:
     - "/path/to/resource"
-    view:
-      html_dl: true
   resource_type:
     available_on:
       class:
@@ -685,6 +700,7 @@ properties:
     - Article
     - Conference Proceeding
     view:
+      render_as: "faceted"
       html_dl: true
   rights_notes:
     available_on:
@@ -742,6 +758,7 @@ properties:
     - http://rightsstatements.org/vocab/InC/1.0/
     view:
       html_dl: true
+      render_as: "rights_statement"
   source:
     available_on:
       class:
@@ -799,6 +816,7 @@ properties:
     - Art
     - Science
     view:
+      render_as: "faceted"
       html_dl: true
   target_audience:
     available_on:

--- a/.koppie/config/metadata_profiles/m3_profile.yaml
+++ b/.koppie/config/metadata_profiles/m3_profile.yaml
@@ -4,7 +4,7 @@ profile:
   date_modified: '2024-06-01'
   responsibility: https://samvera.org
   responsibility_statement: Hyrax Initial Profile
-  type:
+  type: Flexible with Views
   version: 1
 classes:
   GenericWork:
@@ -39,7 +39,6 @@ properties:
       - Hyrax::FileSet
       - CollectionResource
       - GenericWork
-      - Monograph
     cardinality:
       minimum: 1
     multi_value: true
@@ -48,15 +47,14 @@ properties:
       sources:
       - 'null'
     definition:
-      default: Enter a standardized title for display. If only one
-        title is needed, transcribe the title from the source
-        itself.
+      default: Enter a standardized title for display. If only one title is needed,
+        transcribe the title from the source itself.
     display_label:
       default: Title
     index_documentation: displayable, searchable
     indexing:
-    - 'title_sim'
-    - 'title_tesim'
+    - title_sim
+    - title_tesim
     form:
       required: true
       primary: true
@@ -71,6 +69,11 @@ properties:
     requirement: required
     sample_values:
     - Pencil drawn portrait study of woman
+    view:
+      label:
+        en: 'Title'
+        es: 'Título'
+      html_dl: true
   date_modified:
     available_on:
       class:
@@ -78,7 +81,6 @@ properties:
       - Hyrax::FileSet
       - CollectionResource
       - GenericWork
-      - Monograph
     cardinality:
       minimum: 0
       maximum: 1
@@ -88,7 +90,10 @@ properties:
     property_uri: http://purl.org/dc/terms/modified
     range: http://www.w3.org/2001/XMLSchema#dateTime
     sample_values:
-    - "2024-06-06 21:06:51 +0000"
+    - '2024-06-06 21:06:51 +0000'
+    view:
+      label: Date Modified
+      html_dl: true
   date_uploaded:
     available_on:
       class:
@@ -96,7 +101,6 @@ properties:
       - Hyrax::FileSet
       - CollectionResource
       - GenericWork
-      - Monograph
     cardinality:
       minimum: 0
       maximum: 1
@@ -106,7 +110,9 @@ properties:
     property_uri: http://purl.org/dc/terms/dateSubmitted
     range: http://www.w3.org/2001/XMLSchema#dateTime
     sample_values:
-    - "2024-06-06 21:06:51 +0000"
+    - '2024-06-06 21:06:51 +0000'
+    view:
+      html_dl: true
   depositor:
     available_on:
       class:
@@ -114,7 +120,6 @@ properties:
       - Hyrax::FileSet
       - CollectionResource
       - GenericWork
-      - Monograph
     cardinality:
       minimum: 0
       maximum: 1
@@ -127,11 +132,13 @@ properties:
       default: Depositor
     index_documentation: searchable
     indexing:
-    - 'depositor_tesim'
+    - depositor_tesim
     property_uri: http://id.loc.gov/vocabulary/relators/dpt
     range: http://www.w3.org/2001/XMLSchema#string
     sample_values:
     - Julie Allinson
+    view:
+      html_dl: true
   creator:
     available_on:
       class:
@@ -150,8 +157,8 @@ properties:
       default: Creator
     index_documentation: displayable, searchable
     indexing:
-    - 'creator_sim'
-    - 'creator_tesim'
+    - creator_sim
+    - creator_tesim
     form:
       required: true
       primary: true
@@ -159,6 +166,8 @@ properties:
     range: http://www.w3.org/2001/XMLSchema#string
     sample_values:
     - Julie Allinson
+    view:
+      html_dl: true
   license:
     available_on:
       class:
@@ -177,14 +186,16 @@ properties:
       default: License
     index_documentation: displayable, searchable
     indexing:
-    - 'license_sim'
-    - 'license_tesim'
+    - license_sim
+    - license_tesim
     form:
       primary: false
     property_uri: http://purl.org/dc/terms/license
     range: http://www.w3.org/2001/XMLSchema#string
     sample_values:
     - http://creativecommons.org/licenses/by/3.0/us/
+    view:
+      html_dl: true
   abstract:
     available_on:
       class:
@@ -203,14 +214,16 @@ properties:
       default: Abstract
     index_documentation: displayable, searchable
     indexing:
-    - 'abstract_sim'
-    - 'abstract_tesim'
+    - abstract_sim
+    - abstract_tesim
     form:
       primary: false
     property_uri: http://purl.org/dc/terms/abstract
     range: http://www.w3.org/2001/XMLSchema#string
     sample_values:
     - This is an abstract.
+    view:
+      html_dl: true
   access_right:
     available_on:
       class:
@@ -228,14 +241,16 @@ properties:
       default: Access Right
     index_documentation: displayable, searchable
     indexing:
-    - 'access_right_sim'
-    - 'access_right_tesim'
+    - access_right_sim
+    - access_right_tesim
     form:
       primary: false
     property_uri: http://purl.org/dc/terms/accessRights
     range: http://www.w3.org/2001/XMLSchema#string
     sample_values:
     - Open Access
+    view:
+      html_dl: true
   alternative_title:
     available_on:
       class:
@@ -253,14 +268,16 @@ properties:
       default: Alternative Title
     index_documentation: displayable, searchable
     indexing:
-    - 'alternative_title_sim'
-    - 'alternative_title_tesim'
+    - alternative_title_sim
+    - alternative_title_tesim
     form:
       primary: false
     property_uri: http://purl.org/dc/terms/alternative
     range: http://www.w3.org/2001/XMLSchema#string
     sample_values:
     - Alternate Title Example
+    view:
+      html_dl: true
   arkivo_checksum:
     available_on:
       class:
@@ -283,6 +300,8 @@ properties:
     range: http://www.w3.org/2001/XMLSchema#string
     sample_values:
     - c0855931b7f1aefedb91d31af76873c0
+    view:
+      html_dl: true
   based_near:
     available_on:
       class:
@@ -301,14 +320,16 @@ properties:
       default: Location
     index_documentation: displayable, searchable
     indexing:
-    - 'based_near_sim'
-    - 'based_near_tesim'
+    - based_near_sim
+    - based_near_tesim
     form:
       primary: false
     property_uri: http://xmlns.com/foaf/0.1/based_near
     range: http://www.w3.org/2001/XMLSchema#string
     sample_values:
     - San Diego, California, United States
+    view:
+      html_dl: true
   bibliographic_citation:
     available_on:
       class:
@@ -326,14 +347,16 @@ properties:
       default: Bibliographic Citation
     index_documentation: displayable, searchable
     indexing:
-    - 'bibliographic_citation_sim'
-    - 'bibliographic_citation_tesim'
+    - bibliographic_citation_sim
+    - bibliographic_citation_tesim
     form:
       primary: false
     property_uri: http://purl.org/dc/terms/bibliographicCitation
     range: http://www.w3.org/2001/XMLSchema#string
     sample_values:
-    - "Doe, J. (2024). Example Citation. Journal of Examples, 12(3), 45-67."
+    - Doe, J. (2024). Example Citation. Journal of Examples, 12(3), 45-67.
+    view:
+      html_dl: true
   contributor:
     available_on:
       class:
@@ -352,14 +375,16 @@ properties:
       default: Contributor
     index_documentation: displayable, searchable
     indexing:
-    - 'contributor_tesim'
-    - 'contributor_sim'
+    - contributor_tesim
+    - contributor_sim
     form:
       primary: false
     property_uri: http://purl.org/dc/elements/1.1/contributor
     range: http://www.w3.org/2001/XMLSchema#string
     sample_values:
     - Julie Allinson
+    view:
+      html_dl: true
   date_created:
     available_on:
       class:
@@ -378,15 +403,16 @@ properties:
       default: Date Created
     index_documentation: displayable, searchable
     indexing:
-    - 'date_created_sim'
-    - 'date_created_tesim'
+    - date_created_sim
+    - date_created_tesim
     form:
       primary: false
     property_uri: http://purl.org/dc/terms/created
     range: http://www.w3.org/2001/XMLSchema#dateTime
     sample_values:
-    sample_values:
-    - "2024-06-06 21:06:51 +0000"
+    - '2024-06-06 21:06:51 +0000'
+    view:
+      html_dl: true
   description:
     available_on:
       class:
@@ -405,14 +431,16 @@ properties:
       default: Description
     index_documentation: displayable, searchable
     indexing:
-    - 'description_sim'
-    - 'description_tesim'
+    - description_sim
+    - description_tesim
     form:
       primary: false
     property_uri: http://purl.org/dc/elements/1.1/description
     range: http://www.w3.org/2001/XMLSchema#string
     sample_values:
     - This is a description.
+    view:
+      html_dl: true
   identifier:
     available_on:
       class:
@@ -431,14 +459,16 @@ properties:
       default: Identifier
     index_documentation: displayable, searchable
     indexing:
-    - 'identifier_sim'
-    - 'identifier_tesim'
+    - identifier_sim
+    - identifier_tesim
     form:
       primary: false
     property_uri: http://purl.org/dc/terms/identifier
     range: http://www.w3.org/2001/XMLSchema#string
     sample_values:
     - abc123
+    view:
+      html_dl: true
   import_url:
     available_on:
       class:
@@ -459,6 +489,8 @@ properties:
     range: http://www.w3.org/2001/XMLSchema#string
     sample_values:
     - http://example.com/resource1
+    view:
+      html_dl: true
   keyword:
     available_on:
       class:
@@ -477,8 +509,8 @@ properties:
       default: Keyword
     index_documentation: displayable, searchable
     indexing:
-    - 'keyword_sim'
-    - 'keyword_tesim'
+    - keyword_sim
+    - keyword_tesim
     form:
       primary: false
     property_uri: http://schema.org/keywords
@@ -486,6 +518,8 @@ properties:
     sample_values:
     - Metadata
     - Repository
+    view:
+      html_dl: true
   label:
     available_on:
       class:
@@ -505,14 +539,16 @@ properties:
       default: Label
     index_documentation: displayable, searchable
     indexing:
-    - 'label_sim'
-    - 'label_tesim'
+    - label_sim
+    - label_tesim
     form:
       primary: false
     property_uri: info:fedora/fedora-system:def/model#downloadFilename
     range: http://www.w3.org/2001/XMLSchema#string
     sample_values:
     - file_label.txt
+    view:
+      html_dl: true
   language:
     available_on:
       class:
@@ -531,8 +567,8 @@ properties:
       default: Language
     index_documentation: displayable, searchable
     indexing:
-    - 'language_sim'
-    - 'language_tesim'
+    - language_sim
+    - language_tesim
     form:
       primary: false
     property_uri: http://purl.org/dc/elements/1.1/language
@@ -540,6 +576,8 @@ properties:
     sample_values:
     - English
     - Spanish
+    view:
+      html_dl: true
   publisher:
     available_on:
       class:
@@ -558,14 +596,16 @@ properties:
       default: Publisher
     index_documentation: displayable, searchable
     indexing:
-    - 'publisher_sim'
-    - 'publisher_tesim'
+    - publisher_sim
+    - publisher_tesim
     form:
       primary: false
     property_uri: http://purl.org/dc/elements/1.1/publisher
     range: http://www.w3.org/2001/XMLSchema#string
     sample_values:
     - Scholastic
+    view:
+      html_dl: true
   related_url:
     available_on:
       class:
@@ -584,14 +624,16 @@ properties:
       default: Related URL
     index_documentation: displayable, searchable
     indexing:
-    - 'related_url_sim'
-    - 'related_url_tesim'
+    - related_url_sim
+    - related_url_tesim
     form:
       primary: false
     property_uri: http://www.w3.org/2000/01/rdf-schema#seeAlso
     range: http://www.w3.org/2001/XMLSchema#string
     sample_values:
     - http://example.com/resource1
+    view:
+      html_dl: true
   relative_path:
     available_on:
       class:
@@ -612,7 +654,9 @@ properties:
     property_uri: http://scholarsphere.psu.edu/ns#relativePath
     range: http://www.w3.org/2001/XMLSchema#string
     sample_values:
-    - /path/to/resource
+    - "/path/to/resource"
+    view:
+      html_dl: true
   resource_type:
     available_on:
       class:
@@ -631,8 +675,8 @@ properties:
       default: Resource Type
     index_documentation: displayable, searchable
     indexing:
-    - 'resource_type_sim'
-    - 'resource_type_tesim'
+    - resource_type_sim
+    - resource_type_tesim
     form:
       primary: false
     property_uri: http://purl.org/dc/terms/type
@@ -640,6 +684,8 @@ properties:
     sample_values:
     - Article
     - Conference Proceeding
+    view:
+      html_dl: true
   rights_notes:
     available_on:
       class:
@@ -658,14 +704,16 @@ properties:
       default: Rights Notes
     index_documentation: displayable, searchable
     indexing:
-    - 'rights_notes_sim'
-    - 'rights_notes_tesim'
+    - rights_notes_sim
+    - rights_notes_tesim
     form:
       primary: false
     property_uri: http://purl.org/dc/elements/1.1/rights
     range: http://www.w3.org/2001/XMLSchema#string
     sample_values:
     - Creative Commons license.
+    view:
+      html_dl: true
   rights_statement:
     available_on:
       class:
@@ -684,14 +732,16 @@ properties:
       default: Rights Statement
     index_documentation: displayable, searchable
     indexing:
-    - 'rights_statement_sim'
-    - 'rights_statement_tesim'
+    - rights_statement_sim
+    - rights_statement_tesim
     form:
       primary: true
     property_uri: http://www.europeana.eu/schemas/edm/rights
     range: http://www.w3.org/2001/XMLSchema#string
     sample_values:
     - http://rightsstatements.org/vocab/InC/1.0/
+    view:
+      html_dl: true
   source:
     available_on:
       class:
@@ -710,8 +760,8 @@ properties:
       default: Source
     index_documentation: displayable, searchable
     indexing:
-    - 'source_sim'
-    - 'source_tesim'
+    - source_sim
+    - source_tesim
     form:
       primary: false
     property_uri: http://purl.org/dc/terms/source
@@ -719,6 +769,8 @@ properties:
     sample_values:
     - Original Manuscript
     - Digital Archive
+    view:
+      html_dl: true
   subject:
     available_on:
       class:
@@ -737,8 +789,8 @@ properties:
       default: Subject
     index_documentation: displayable, searchable
     indexing:
-    - 'subject_sim'
-    - 'subject_tesim'
+    - subject_sim
+    - subject_tesim
     form:
       primary: false
     property_uri: http://purl.org/dc/elements/1.1/subject
@@ -746,10 +798,12 @@ properties:
     sample_values:
     - Art
     - Science
+    view:
+      html_dl: true
   target_audience:
     available_on:
       class:
-      - CollectionResource
+      - Monograph
     cardinality:
       minimum: 0
     multi_value: true
@@ -760,13 +814,14 @@ properties:
     display_label:
       default: Target Audience
     form:
-      primary: true
       multiple: true
     property_uri: http://hyrax-example.com/target_audience
     range: http://www.w3.org/2001/XMLSchema#string
     sample_values:
     - Researchers
     - Students
+    view:
+      html_dl: true
   department:
     available_on:
       class:
@@ -788,6 +843,8 @@ properties:
     sample_values:
     - Mathematics
     - History
+    view:
+      html_dl: true
   course:
     available_on:
       class:
@@ -808,6 +865,8 @@ properties:
     range: http://www.w3.org/2001/XMLSchema#string
     sample_values:
     - Computer Science 50
+    view:
+      html_dl: true
   monograph_title:
     available_on:
       class:
@@ -826,6 +885,8 @@ properties:
     range: http://www.w3.org/2001/XMLSchema#string
     sample_values:
     - Example Monograph Title
+    view:
+      html_dl: true
   record_info:
     available_on:
       class:
@@ -842,7 +903,7 @@ properties:
       default: Record Info
     index_documentation: searchable
     indexing:
-    - 'record_info_tesim'
+    - record_info_tesim
     form:
       required: true
       primary: true
@@ -850,6 +911,8 @@ properties:
     range: http://www.w3.org/2001/XMLSchema#string
     sample_values:
     - Example Record Info
+    view:
+      html_dl: true
   place_of_publication:
     available_on:
       class:
@@ -871,6 +934,8 @@ properties:
     range: http://www.w3.org/2001/XMLSchema#string
     sample_values:
     - Example Place of Publication
+    view:
+      html_dl: true
   genre:
     available_on:
       class:
@@ -892,6 +957,8 @@ properties:
     sample_values:
     - Fiction
     - Non-Fiction
+    view:
+      html_dl: true
   series_title:
     available_on:
       class:
@@ -912,26 +979,8 @@ properties:
     range: http://www.w3.org/2001/XMLSchema#string
     sample_values:
     - Example Series Title
-  target_audience:
-    available_on:
-      class:
-      - Monograph
-    cardinality:
-      minimum: 0
-    multi_value: true
-    controlled_values:
-      format: http://www.w3.org/2001/XMLSchema#string
-      sources:
-      - 'null'
-    display_label:
-      default: Target Audience
-    form:
-      multiple: true
-    property_uri: http://hyrax-example.com/target_audience
-    range: http://www.w3.org/2001/XMLSchema#string
-    sample_values:
-    - Researchers
-    - Students
+    view:
+      html_dl: true
   table_of_contents:
     available_on:
       class:
@@ -952,6 +1001,8 @@ properties:
     range: http://www.w3.org/2001/XMLSchema#string
     sample_values:
     - Example Table of Contents
+    view:
+      html_dl: true
   date_of_issuance:
     available_on:
       class:
@@ -969,4 +1020,6 @@ properties:
     property_uri: http://hyrax-example.com/date_of_issuance
     range: http://www.w3.org/2001/XMLSchema#string
     sample_values:
-    - "2024-06-06 21:06:51 +0000"
+    - '2024-06-06 21:06:51 +0000'
+    view:
+      html_dl: true

--- a/app/helpers/hyrax/attributes_helper.rb
+++ b/app/helpers/hyrax/attributes_helper.rb
@@ -5,9 +5,11 @@ module Hyrax
     def view_options_for(presenter)
       model_name = presenter.model.model_name.name
 
-      # @todo: decide if views should be based on current_version or the work's version (presenter.schema_version)
+      # @todo: decide if views should instead be based on the work's stored version (presenter.schema_version)
+      # => using current means dropped terms from schema could be missing even if they exist on the work (but they'd already be missing on the edit view anyway)
+      # => using saved means that any view changes can't take effect unless the work(s) needing them are edited & saved
       if Hyrax.config.flexible?
-        Hyrax::Schema.default_schema_loader.view_definitions_for(schema: model_name, version: Hyrax::FlexibleSchema.order("created_at asc").last.id)
+        Hyrax::Schema.default_schema_loader.view_definitions_for(schema: model_name, version: Hyrax::FlexibleSchema.current_schema_id)
       else
         schema = model_name.constantize.schema || (model_name + 'Resource').safe_constantize.schema
         Hyrax::Schema.default_schema_loader.view_definitions_for(schema:)
@@ -15,7 +17,7 @@ module Hyrax
     end
 
     # @param [String] field name
-    # @param [Hash<Hash] {:label=>{"en"=>"Title", "es"=>"Título"}, :html_dl=>true}
+    # @param [Hash<Hash>] a nested hash of view options... {:label=>{"en"=>"Title", "es"=>"Título"}, :html_dl=>true}
     def conform_options(field_name, options_hash)
       options = HashWithIndifferentAccess.new(options_hash)
       hash_of_locales = HashWithIndifferentAccess.new(options)['label'] || {}
@@ -24,9 +26,9 @@ module Hyrax
       unless hash_of_locales.present?
         options[:label] = field_to_label(field_name.to_s)
         return options
-      end     
+      end    
 
-      return options_hash if hash_of_locales.is_a?(String)
+      return options_hash if hash_of_locales.is_a?(String) || hash_of_locales.empty?
 
       # If the params locale is found in the hash of locales, use that value
       if hash_of_locales[current_locale].present?
@@ -41,6 +43,8 @@ module Hyrax
 
       options
     end
+
+    private
 
     def field_to_label(input_string)
       # Split the input string by underscores

--- a/app/models/hyrax/flexible_schema.rb
+++ b/app/models/hyrax/flexible_schema.rb
@@ -6,6 +6,10 @@ class Hyrax::FlexibleSchema < ApplicationRecord
     order("created_at asc").last.profile
   end
 
+  def self.current_schema_id
+    order("created_at asc").last.id
+  end
+
   def title
     "#{profile['profile']['responsibility_statement']} - version #{id}"
   end

--- a/app/presenters/hyrax/work_show_presenter.rb
+++ b/app/presenters/hyrax/work_show_presenter.rb
@@ -30,6 +30,10 @@ module Hyrax
     # most all objects implicitly implicitly implement #to_s
     delegate :to_s, to: :solr_document
 
+    def schema_version
+      solr_document[:schema_version_ssi]
+    end
+
     def page_title
       "#{human_readable_type} | #{title.first} | ID: #{id} | #{I18n.t('hyrax.product_name')}"
     end

--- a/app/services/hyrax/m3_schema_loader.rb
+++ b/app/services/hyrax/m3_schema_loader.rb
@@ -8,6 +8,14 @@ module Hyrax
   #
   # @see config/metadata_profiles/m3_profile.yaml for an example configuration
   class M3SchemaLoader < Hyrax::SchemaLoader
+    def view_definitions_for(schema:, version: 1)
+      definitions(schema, version).each_with_object({}) do |definition, hash|
+        next if definition.view_options.empty?
+
+        hash[definition.name] = definition.view_options
+      end
+    end
+
     private
 
     ##

--- a/app/services/hyrax/schema_loader.rb
+++ b/app/services/hyrax/schema_loader.rb
@@ -45,14 +45,6 @@ module Hyrax
       end
     end
 
-    def view_definitions_for(schema:, version: 1)
-      definitions(schema, version).each_with_object({}) do |definition, hash|
-        next if definition.view_options.empty?
-
-        hash[definition.name] = definition.view_options
-      end
-    end
-
     ##
     # @api private
     class AttributeDefinition

--- a/app/services/hyrax/simple_schema_loader.rb
+++ b/app/services/hyrax/simple_schema_loader.rb
@@ -8,7 +8,7 @@ module Hyrax
   #
   # @see config/metadata/basic_metadata.yaml for an example configuration
   class SimpleSchemaLoader < Hyrax::SchemaLoader
-    def view_definitions_for(schema:, version: 1)
+    def view_definitions_for(schema:, _version: 1)
       schema.each_with_object({}) do |property, metadata|
         view_options = property.meta['view']
         metadata[property.name.to_s] = view_options unless view_options.nil?

--- a/app/services/hyrax/simple_schema_loader.rb
+++ b/app/services/hyrax/simple_schema_loader.rb
@@ -8,6 +8,13 @@ module Hyrax
   #
   # @see config/metadata/basic_metadata.yaml for an example configuration
   class SimpleSchemaLoader < Hyrax::SchemaLoader
+    def view_definitions_for(schema:, version: 1)
+      schema.each_with_object({}) do |property, metadata|
+        view_options = property.meta['view']
+        metadata[property.name.to_s] = view_options unless view_options.nil?
+      end
+    end
+
     def permissive_schema_for_valkrie_adapter
       metadata_files.each_with_object({}) do |schema_name, ret_hsh|
         predicate_pairs(ret_hsh, schema_name)

--- a/app/views/hyrax/base/_attribute_rows.html.erb
+++ b/app/views/hyrax/base/_attribute_rows.html.erb
@@ -1,3 +1,3 @@
 <% view_options_for(presenter).each do |field, options| %>
-  <%= presenter.attribute_to_html(field.to_sym, conform_options(options)) %>
+  <%= presenter.attribute_to_html(field.to_sym, conform_options(field, options)) %>
 <% end %>

--- a/config/metadata_profiles/m3_profile.yaml
+++ b/config/metadata_profiles/m3_profile.yaml
@@ -4,7 +4,7 @@ profile:
   date_modified: '2024-06-01'
   responsibility: https://samvera.org
   responsibility_statement: Hyrax Initial Profile
-  type:
+  type: Initial Profile
   version: 1
 classes:
   Hyrax::Work:
@@ -45,15 +45,14 @@ properties:
       sources:
       - 'null'
     definition:
-      default: Enter a standardized title for display. If only one
-        title is needed, transcribe the title from the source
-        itself.
+      default: Enter a standardized title for display. If only one title is needed,
+        transcribe the title from the source itself.
     display_label:
       default: Title
     index_documentation: displayable, searchable
     indexing:
-    - 'title_sim'
-    - 'title_tesim'
+    - title_sim
+    - title_tesim
     form:
       required: true
       primary: true
@@ -84,7 +83,17 @@ properties:
     property_uri: http://purl.org/dc/terms/modified
     range: http://www.w3.org/2001/XMLSchema#dateTime
     sample_values:
-    - "2024-06-06 21:06:51 +0000"
+    - '2024-06-06 21:06:51 +0000'
+    view:
+      label:
+        de: 'Zuletzt geändert'
+        en: 'Last modified'
+        es: 'Última modificación'
+        fr: 'Dernière modification'
+        it: 'Ultima modifica'
+        pt-BR: 'Última modificação'
+        zh: '最新修改'
+      html_dl: true
   date_uploaded:
     available_on:
       class:
@@ -101,7 +110,7 @@ properties:
     property_uri: http://purl.org/dc/terms/dateSubmitted
     range: http://www.w3.org/2001/XMLSchema#dateTime
     sample_values:
-    - "2024-06-06 21:06:51 +0000"
+    - '2024-06-06 21:06:51 +0000'
   depositor:
     available_on:
       class:
@@ -121,7 +130,7 @@ properties:
       default: Depositor
     index_documentation: searchable
     indexing:
-    - 'depositor_tesim'
+    - depositor_tesim
     property_uri: http://id.loc.gov/vocabulary/relators/dpt
     range: http://www.w3.org/2001/XMLSchema#string
     sample_values:
@@ -129,7 +138,10 @@ properties:
   creator:
     available_on:
       class:
+      - Hyrax::AdministrativeSet
       - Hyrax::FileSet
+      - Hyrax::PcdmCollection
+      - Hyrax::Work
     cardinality:
       minimum: 1
     multi_value: true
@@ -141,8 +153,8 @@ properties:
       default: Creator
     index_documentation: displayable, searchable
     indexing:
-    - 'creator_sim'
-    - 'creator_tesim'
+    - creator_sim
+    - creator_tesim
     form:
       required: true
       primary: true
@@ -150,10 +162,16 @@ properties:
     range: http://www.w3.org/2001/XMLSchema#string
     sample_values:
     - Julie Allinson
+    view:
+      render_as: "faceted"
+      html_dl: true
   license:
     available_on:
       class:
+      - Hyrax::AdministrativeSet
       - Hyrax::FileSet
+      - Hyrax::PcdmCollection
+      - Hyrax::Work
     cardinality:
       minimum: 0
     multi_value: true
@@ -163,20 +181,27 @@ properties:
       - 'null'
     display_label:
       default: License
-    index_documentation: searchable
+    index_documentation: displayable, searchable
     indexing:
-    - 'license_tesim'
+    - license_sim
+    - license_tesim
     form:
       required: false
-      primary: true
+      primary: false
     property_uri: http://purl.org/dc/terms/license
     range: http://www.w3.org/2001/XMLSchema#string
     sample_values:
     - http://creativecommons.org/licenses/by/3.0/us/
+    view:
+      render_as: "external_link"
+      html_dl: true
   abstract:
     available_on:
       class:
+      - Hyrax::AdministrativeSet
       - Hyrax::FileSet
+      - Hyrax::PcdmCollection
+      - Hyrax::Work
     cardinality:
       minimum: 0
     multi_value: true
@@ -186,17 +211,104 @@ properties:
       - 'null'
     display_label:
       default: Abstract
-    index_documentation: searchable
+    index_documentation: displayable, searchable
     indexing:
-    - 'abstract_tesim'
+    - abstract_sim
+    - abstract_tesim
+    form:
+      primary: false
     property_uri: http://purl.org/dc/terms/abstract
     range: http://www.w3.org/2001/XMLSchema#string
     sample_values:
     - This is an abstract.
+    view:
+      html_dl: true
+  access_right:
+    available_on:
+      class:
+      - Hyrax::AdministrativeSet
+      - Hyrax::PcdmCollection
+      - Hyrax::Work
+    cardinality:
+      minimum: 0
+    multi_value: true
+    controlled_values:
+      format: http://www.w3.org/2001/XMLSchema#string
+      sources:
+      - 'null'
+    display_label:
+      default: Access Right
+    index_documentation: displayable, searchable
+    indexing:
+    - access_right_sim
+    - access_right_tesim
+    form:
+      primary: false
+    property_uri: http://purl.org/dc/terms/accessRights
+    range: http://www.w3.org/2001/XMLSchema#string
+    sample_values:
+    - Open Access
+    view:
+      html_dl: true
+  alternative_title:
+    available_on:
+      class:
+      - Hyrax::AdministrativeSet
+      - Hyrax::PcdmCollection
+      - Hyrax::Work
+    cardinality:
+      minimum: 0
+    multi_value: true
+    controlled_values:
+      format: http://www.w3.org/2001/XMLSchema#string
+      sources:
+      - 'null'
+    display_label:
+      default: Alternative Title
+    index_documentation: displayable, searchable
+    indexing:
+    - alternative_title_sim
+    - alternative_title_tesim
+    form:
+      primary: false
+    property_uri: http://purl.org/dc/terms/alternative
+    range: http://www.w3.org/2001/XMLSchema#string
+    sample_values:
+    - Alternate Title Example
+    view:
+      label:
+        en: 'Alternative Title'
+        es: 'Título Alternativo'
+      html_dl: true
+  arkivo_checksum:
+    available_on:
+      class:
+      - Hyrax::AdministrativeSet
+      - Hyrax::PcdmCollection
+      - Hyrax::Work
+    cardinality:
+      minimum: 0
+      maximum: 1
+    multi_value: false
+    controlled_values:
+      format: http://www.w3.org/2001/XMLSchema#string
+      sources:
+      - 'null'
+    display_label:
+      default: Arkivo Checksum
+    form:
+      primary: false
+    property_uri: http://scholarsphere.psu.edu/ns#arkivoChecksum
+    range: http://www.w3.org/2001/XMLSchema#string
+    sample_values:
+    - c0855931b7f1aefedb91d31af76873c0
   based_near:
     available_on:
       class:
+      - Hyrax::AdministrativeSet
       - Hyrax::FileSet
+      - Hyrax::PcdmCollection
+      - Hyrax::Work
     cardinality:
       minimum: 0
     multi_value: true
@@ -208,18 +320,51 @@ properties:
       default: Location
     index_documentation: displayable, searchable
     indexing:
-    - 'based_near_sim'
-    - 'based_near_tesim'
+    - based_near_sim
+    - based_near_tesim
     form:
       primary: false
     property_uri: http://xmlns.com/foaf/0.1/based_near
     range: http://www.w3.org/2001/XMLSchema#string
     sample_values:
     - San Diego, California, United States
+    view:
+      label: Based Near
+      html_dl: true
+  bibliographic_citation:
+    available_on:
+      class:
+      - Hyrax::AdministrativeSet
+      - Hyrax::PcdmCollection
+      - Hyrax::Work
+    cardinality:
+      minimum: 0
+    multi_value: true
+    controlled_values:
+      format: http://www.w3.org/2001/XMLSchema#string
+      sources:
+      - 'null'
+    display_label:
+      default: Bibliographic Citation
+    index_documentation: displayable, searchable
+    indexing:
+    - bibliographic_citation_sim
+    - bibliographic_citation_tesim
+    form:
+      primary: false
+    property_uri: http://purl.org/dc/terms/bibliographicCitation
+    range: http://www.w3.org/2001/XMLSchema#string
+    sample_values:
+    - Doe, J. (2024). Example Citation. Journal of Examples, 12(3), 45-67.
+    view:
+      html_dl: true
   contributor:
     available_on:
       class:
+      - Hyrax::AdministrativeSet
       - Hyrax::FileSet
+      - Hyrax::PcdmCollection
+      - Hyrax::Work
     cardinality:
       minimum: 0
     multi_value: true
@@ -229,19 +374,26 @@ properties:
       - 'null'
     display_label:
       default: Contributor
-    index_documentation: searchable
+    index_documentation: displayable, searchable
     indexing:
-    - 'contributor_tesim'
+    - contributor_tesim
+    - contributor_sim
     form:
       primary: false
     property_uri: http://purl.org/dc/elements/1.1/contributor
     range: http://www.w3.org/2001/XMLSchema#string
     sample_values:
     - Julie Allinson
+    view:
+      render_as: "faceted"
+      html_dl: true
   date_created:
     available_on:
       class:
+      - Hyrax::AdministrativeSet
       - Hyrax::FileSet
+      - Hyrax::PcdmCollection
+      - Hyrax::Work
     cardinality:
       minimum: 0
     multi_value: true
@@ -251,19 +403,27 @@ properties:
       - 'null'
     display_label:
       default: Date Created
-    index_documentation: searchable
+    index_documentation: displayable, searchable
     indexing:
-    - 'date_created_tesim'
+    - date_created_sim
+    - date_created_tesim
     form:
       primary: false
     property_uri: http://purl.org/dc/terms/created
     range: http://www.w3.org/2001/XMLSchema#dateTime
     sample_values:
-    - "2024-06-06 21:06:51 +0000"
+    - '2024-06-06 21:06:51 +0000'
+    view:
+      render_as: "linked"
+      search_field: 'date_created_tesim'
+      html_dl: true
   description:
     available_on:
       class:
+      - Hyrax::AdministrativeSet
       - Hyrax::FileSet
+      - Hyrax::PcdmCollection
+      - Hyrax::Work
     cardinality:
       minimum: 0
     multi_value: true
@@ -273,9 +433,10 @@ properties:
       - 'null'
     display_label:
       default: Description
-    index_documentation: searchable
+    index_documentation: displayable, searchable
     indexing:
-    - 'description_tesim'
+    - description_sim
+    - description_tesim
     form:
       primary: false
     property_uri: http://purl.org/dc/elements/1.1/description
@@ -285,7 +446,10 @@ properties:
   identifier:
     available_on:
       class:
+      - Hyrax::AdministrativeSet
       - Hyrax::FileSet
+      - Hyrax::PcdmCollection
+      - Hyrax::Work
     cardinality:
       minimum: 0
     multi_value: true
@@ -295,19 +459,47 @@ properties:
       - 'null'
     display_label:
       default: Identifier
-    index_documentation: searchable
+    index_documentation: displayable, searchable
     indexing:
-    - 'identifier_tesim'
+    - identifier_sim
+    - identifier_tesim
     form:
       primary: false
     property_uri: http://purl.org/dc/terms/identifier
     range: http://www.w3.org/2001/XMLSchema#string
     sample_values:
     - abc123
+    view:
+      render_as: "linked"
+      search_field: 'identifier_tesim'
+      html_dl: true
+  import_url:
+    available_on:
+      class:
+      - Hyrax::AdministrativeSet
+      - Hyrax::PcdmCollection
+      - Hyrax::Work
+    cardinality:
+      minimum: 0
+      maximum: 1
+    multi_value: false
+    controlled_values:
+      format: http://www.w3.org/2001/XMLSchema#string
+      sources:
+      - 'null'
+    display_label:
+      default: Import URL
+    property_uri: http://scholarsphere.psu.edu/ns#importUrl
+    range: http://www.w3.org/2001/XMLSchema#string
+    sample_values:
+    - http://example.com/resource1
   keyword:
     available_on:
       class:
+      - Hyrax::AdministrativeSet
       - Hyrax::FileSet
+      - Hyrax::PcdmCollection
+      - Hyrax::Work
     cardinality:
       minimum: 0
     multi_value: true
@@ -319,8 +511,8 @@ properties:
       default: Keyword
     index_documentation: displayable, searchable
     indexing:
-    - 'keyword_sim'
-    - 'keyword_tesim'
+    - keyword_sim
+    - keyword_tesim
     form:
       primary: false
     property_uri: http://schema.org/keywords
@@ -328,6 +520,9 @@ properties:
     sample_values:
     - Metadata
     - Repository
+    view:
+      render_as: "faceted"
+      html_dl: true
   label:
     available_on:
       class:
@@ -342,6 +537,12 @@ properties:
       - 'null'
     display_label:
       default: Label
+    index_documentation: displayable, searchable
+    indexing:
+    - label_sim
+    - label_tesim
+    form:
+      primary: false
     property_uri: info:fedora/fedora-system:def/model#downloadFilename
     range: http://www.w3.org/2001/XMLSchema#string
     sample_values:
@@ -349,7 +550,10 @@ properties:
   language:
     available_on:
       class:
+      - Hyrax::AdministrativeSet
       - Hyrax::FileSet
+      - Hyrax::PcdmCollection
+      - Hyrax::Work
     cardinality:
       minimum: 0
     multi_value: true
@@ -359,9 +563,10 @@ properties:
       - 'null'
     display_label:
       default: Language
+    index_documentation: displayable, searchable
     indexing:
-    - 'language_tesim'
-    index_documentation: searchable
+    - language_sim
+    - language_tesim
     form:
       primary: false
     property_uri: http://purl.org/dc/elements/1.1/language
@@ -369,10 +574,16 @@ properties:
     sample_values:
     - English
     - Spanish
+    view:
+      render_as: "faceted"
+      html_dl: true
   publisher:
     available_on:
       class:
+      - Hyrax::AdministrativeSet
       - Hyrax::FileSet
+      - Hyrax::PcdmCollection
+      - Hyrax::Work
     cardinality:
       minimum: 0
     multi_value: true
@@ -382,19 +593,26 @@ properties:
       - 'null'
     display_label:
       default: Publisher
+    index_documentation: displayable, searchable
     indexing:
-    - 'publisher_tesim'
-    index_documentation: searchable
+    - publisher_sim
+    - publisher_tesim
     form:
       primary: false
     property_uri: http://purl.org/dc/elements/1.1/publisher
     range: http://www.w3.org/2001/XMLSchema#string
     sample_values:
     - Scholastic
+    view:
+      render_as: "faceted"
+      html_dl: true
   related_url:
     available_on:
       class:
+      - Hyrax::AdministrativeSet
       - Hyrax::FileSet
+      - Hyrax::PcdmCollection
+      - Hyrax::Work
     cardinality:
       minimum: 0
     multi_value: true
@@ -404,19 +622,26 @@ properties:
       - 'null'
     display_label:
       default: Related URL
-    index_documentation: searchable
+    index_documentation: displayable, searchable
     indexing:
-    - 'related_url_tesim'
+    - related_url_sim
+    - related_url_tesim
     form:
       primary: false
     property_uri: http://www.w3.org/2000/01/rdf-schema#seeAlso
     range: http://www.w3.org/2001/XMLSchema#string
     sample_values:
     - http://example.com/resource1
+    view:
+      render_as: "external_link"
+      html_dl: true
   relative_path:
     available_on:
       class:
+      - Hyrax::AdministrativeSet
       - Hyrax::FileSet
+      - Hyrax::PcdmCollection
+      - Hyrax::Work
     cardinality:
       minimum: 0
       maximum: 1
@@ -430,11 +655,14 @@ properties:
     property_uri: http://scholarsphere.psu.edu/ns#relativePath
     range: http://www.w3.org/2001/XMLSchema#string
     sample_values:
-    - /path/to/resource
+    - '/path/to/resource'
   resource_type:
     available_on:
       class:
+      - Hyrax::AdministrativeSet
       - Hyrax::FileSet
+      - Hyrax::PcdmCollection
+      - Hyrax::Work
     cardinality:
       minimum: 0
     multi_value: true
@@ -446,17 +674,25 @@ properties:
       default: Resource Type
     index_documentation: displayable, searchable
     indexing:
-    - 'resource_type_sim'
-    - 'resource_type_tesim'
+    - resource_type_sim
+    - resource_type_tesim
+    form:
+      primary: false
     property_uri: http://purl.org/dc/terms/type
     range: http://www.w3.org/2001/XMLSchema#string
     sample_values:
     - Article
     - Conference Proceeding
+    view:
+      render_as: "faceted"
+      html_dl: true
   rights_notes:
     available_on:
       class:
+      - Hyrax::AdministrativeSet
       - Hyrax::FileSet
+      - Hyrax::PcdmCollection
+      - Hyrax::Work
     cardinality:
       minimum: 0
     multi_value: true
@@ -466,17 +702,25 @@ properties:
       - 'null'
     display_label:
       default: Rights Notes
+    index_documentation: displayable, searchable
     indexing:
-    - 'rights_notes_tesim'
-    index_documentation: searchable
+    - rights_notes_sim
+    - rights_notes_tesim
+    form:
+      primary: false
     property_uri: http://purl.org/dc/elements/1.1/rights
     range: http://www.w3.org/2001/XMLSchema#string
     sample_values:
     - Creative Commons license.
+    view:
+      html_dl: true
   rights_statement:
     available_on:
       class:
+      - Hyrax::AdministrativeSet
       - Hyrax::FileSet
+      - Hyrax::PcdmCollection
+      - Hyrax::Work
     cardinality:
       minimum: 0
     multi_value: true
@@ -486,17 +730,26 @@ properties:
       - 'null'
     display_label:
       default: Rights Statement
-    index_documentation: searchable
+    index_documentation: displayable, searchable
     indexing:
-    - 'rights_statement_tesim'
+    - rights_statement_sim
+    - rights_statement_tesim
+    form:
+      primary: true
     property_uri: http://www.europeana.eu/schemas/edm/rights
     range: http://www.w3.org/2001/XMLSchema#string
     sample_values:
     - http://rightsstatements.org/vocab/InC/1.0/
+    view:
+      html_dl: true
+      render_as: "rights_statement"
   source:
     available_on:
       class:
+      - Hyrax::AdministrativeSet
       - Hyrax::FileSet
+      - Hyrax::PcdmCollection
+      - Hyrax::Work
     cardinality:
       minimum: 0
     multi_value: true
@@ -506,18 +759,26 @@ properties:
       - 'null'
     display_label:
       default: Source
-    index_documentation: searchable
+    index_documentation: displayable, searchable
     indexing:
-    - 'source_tesim'
+    - source_sim
+    - source_tesim
+    form:
+      primary: false
     property_uri: http://purl.org/dc/terms/source
     range: http://www.w3.org/2001/XMLSchema#string
     sample_values:
     - Original Manuscript
     - Digital Archive
+    view:
+      html_dl: true
   subject:
     available_on:
       class:
+      - Hyrax::AdministrativeSet
       - Hyrax::FileSet
+      - Hyrax::PcdmCollection
+      - Hyrax::Work
     cardinality:
       minimum: 0
     multi_value: true
@@ -529,8 +790,8 @@ properties:
       default: Subject
     index_documentation: displayable, searchable
     indexing:
-    - 'subject_sim'
-    - 'subject_tesim'
+    - subject_sim
+    - subject_tesim
     form:
       primary: false
     property_uri: http://purl.org/dc/elements/1.1/subject
@@ -538,3 +799,7 @@ properties:
     sample_values:
     - Art
     - Science
+    view:
+      render_as: "faceted"
+      html_dl: true
+ 

--- a/lib/hyrax/schema.rb
+++ b/lib/hyrax/schema.rb
@@ -65,21 +65,6 @@ module Hyrax
     end
 
     ##
-    # @param [Hyrax::Resource] work_type
-    #
-    # @example Hyrax::Schema.schema_to_hash(Monograph)
-    #
-    # @return [Hash{String => Hash}]
-    def self.schema_to_hash_for(work_type)
-      return unless work_type.respond_to?(:schema)
-
-      schema = work_type.schema
-      schema.each_with_object({}) do |property, metadata|
-        metadata[property.name.to_s] = property.meta
-      end
-    end
-
-    ##
     # @param [Symbol] schema_name
     #
     # @note use Hyrax::Schema(:my_schema) instead


### PR DESCRIPTION
Refs
- https://github.com/scientist-softserv/amigos/issues/30
- https://github.com/scientist-softserv/amigos/issues/31

### Summary

Building on prior work to dynamically render attributes for the simple schema, this implements a very basic view of attributes on a resource's show view for flexible schemas.  More detail is needed in the sample m3 profile to fill in other options (such as `render_as` and locale details)

I currently have it set up to use the most recent schema for view definition, since we don't want to have to edit, save, and index every work if we change something regarding views.

As long as a term has a basic `view:` definition section in the schema, it will render from the attributes partial:
- if a `label:` string is provided, the label will be rendered
- if a label instead has a list of locales, the label will be rendered using locale logic
- if there is no label, the term name will be formatted as a label. This is consistent with current behavior, and explicitly filling in the label is needed to prevent the default behavior from rendering the label without being bold.

```
# sample view definition:
    view:
      label:
        en: 'Alternative Title'
        es: 'Título Alternativo'
      html_dl: true
```

<details>

<summary>Screenshots</summary>

![Screenshot 2024-06-28 at 1 52 50 PM](https://github.com/samvera/hyrax/assets/17851674/f4b65b07-9074-4745-ab18-4c61c4cce948)

![Screenshot 2024-06-28 at 1 53 18 PM](https://github.com/samvera/hyrax/assets/17851674/0a508e96-359f-48bc-a730-fc21038d38ce)

</details>
