### PR TITLE
Change && to if

### DIFF
--- a/app/models/concerns/hyrax/solr_document_behavior.rb
+++ b/app/models/concerns/hyrax/solr_document_behavior.rb
@@ -82,9 +82,9 @@ module Hyrax
 
     # Method to return the model
     def hydra_model(classifier: nil)
-      ((first('has_model_ssim')&.+ 'Resource')&.safe_constantize && Hyrax.config.valkyrie_transition) ||
-        first('has_model_ssim')&.safe_constantize ||
-        model_classifier(classifier).classifier(self).best_model
+      model = first('has_model_ssim')&.safe_constantize
+      model = (first('has_model_ssim')&.+ 'Resource')&.safe_constantize if Hyrax.config.valkyrie_transition?
+      model || model_classifier(classifier).classifier(self).best_model
     end
 
     def depositor(default = '')

--- a/spec/lib/freyja/persister_spec.rb
+++ b/spec/lib/freyja/persister_spec.rb
@@ -7,7 +7,7 @@ require 'valkyrie/specs/shared_specs'
 require 'wings'
 require 'freyja/metadata_adapter'
 
-RSpec.describe Freyja::Persister, :active_fedora do
+RSpec.describe Freyja::Persister, :active_fedora, :clean_repo do
   subject(:persister) { described_class.new(adapter: adapter) }
   let(:adapter) { Freyja::MetadataAdapter.new }
   let(:query_service) { adapter.query_service }
@@ -268,7 +268,7 @@ RSpec.describe Freyja::Persister, :active_fedora do
         .to raise_error Valkyrie::Persistence::ObjectNotFoundError
     end
 
-    it "can delete all objects but only from postgers" do
+    it "can delete all objects but only from postgres" do
       resource2 = resource_class.new
 
       persister.save_all(resources: [resource, resource2])


### PR DESCRIPTION
In the case of a `GenericWorkResource` the `#hydra_model` method would still return `GenericWork` because the first condition evaluated to `true` instead.
