### PR TITLE
Some more frontend fixes

### DIFF
--- a/app/assets/stylesheets/hyrax/_card.scss
+++ b/app/assets/stylesheets/hyrax/_card.scss
@@ -2,6 +2,10 @@
   margin-bottom: 20px;
 }
 
+#featured_works .card {
+  margin-bottom: 5px;
+}
+
 .card-title {
   margin-top: 0;
   margin-bottom: 0;

--- a/app/assets/stylesheets/hyrax/_catalog.scss
+++ b/app/assets/stylesheets/hyrax/_catalog.scss
@@ -23,6 +23,16 @@
     }
   }
 
+  .search-results-title-row {
+    .badge {
+      margin-bottom: 6px;
+    }
+
+    .search-result-title {
+      margin-right: 16px;
+    }
+  }
+
   .collection-icon-search {
     padding-bottom: 20px;
   }

--- a/app/assets/stylesheets/hyrax/_facets.scss
+++ b/app/assets/stylesheets/hyrax/_facets.scss
@@ -3,6 +3,18 @@
     width: 100%;
 }
 
+.facet-field-heading button.collapsed::after {
+    transition: transform 0.25s ease;
+}
+
+.facet-field-heading button::after {
+    transition: transform 0.25s ease;
+}
+
+.collapsing {
+    transition: height 0.25s ease;
+}
+
 .facets-header > .navbar-toggler {
     display: none;
 }

--- a/app/assets/stylesheets/hyrax/_featured.scss
+++ b/app/assets/stylesheets/hyrax/_featured.scss
@@ -44,3 +44,7 @@ ol#featured_works {
   padding: 1em 0;
   border-bottom: 1px dotted $gray-lighter;
 }
+
+.dd-handle.dd3-handle {
+  z-index: 1;
+}

--- a/app/assets/stylesheets/hyrax/_nestable.scss
+++ b/app/assets/stylesheets/hyrax/_nestable.scss
@@ -47,12 +47,12 @@ tr.dd-item {
 
 .dd-placeholder,
 .dd-empty { margin: 5px 0; padding: 0; min-height: 30px; border: 1px dashed #b6bcbf; box-sizing: border-box; -moz-box-sizing: border-box; }
-.dd-empty { border: 1px dashed #bbb; min-height: 100px; 
-    background-image: -webkit-linear-gradient(45deg, #fff 25%, transparent 25%, transparent 75%, #fff 75%, #fff), 
+.dd-empty { border: 1px dashed #bbb; min-height: 100px;
+    background-image: -webkit-linear-gradient(45deg, #fff 25%, transparent 25%, transparent 75%, #fff 75%, #fff),
                       -webkit-linear-gradient(45deg, #fff 25%, transparent 25%, transparent 75%, #fff 75%, #fff);
-    background-image:    -moz-linear-gradient(45deg, #fff 25%, transparent 25%, transparent 75%, #fff 75%, #fff), 
+    background-image:    -moz-linear-gradient(45deg, #fff 25%, transparent 25%, transparent 75%, #fff 75%, #fff),
                          -moz-linear-gradient(45deg, #fff 25%, transparent 25%, transparent 75%, #fff 75%, #fff);
-    background-image:         linear-gradient(45deg, #fff 25%, transparent 25%, transparent 75%, #fff 75%, #fff), 
+    background-image:         linear-gradient(45deg, #fff 25%, transparent 25%, transparent 75%, #fff 75%, #fff),
                               linear-gradient(45deg, #fff 25%, transparent 25%, transparent 75%, #fff 75%, #fff);
     background-size: 60px 60px;
     background-position: 0 0, 30px 30px;
@@ -95,15 +95,16 @@ tr.dd-item {
 
 .dd3-item > button { margin-left: 30px; }
 
-.dd3-handle { 
+.dd3-handle {
     position: absolute; margin: 0; left: 0; top: 0; cursor: pointer; width: 30px;
     text-indent: 100px;
     white-space: nowrap; overflow: hidden;
     border: 1px solid #aaa;
     background: #ddd;
     background: -webkit-linear-gradient(top, #ddd 0%, #bbb 100%);
-    background:    -moz-linear-gradient(top, #ddd 0%, #bbb 100%);
-    background:         linear-gradient(top, #ddd 0%, #bbb 100%);
+    background: -moz-linear-gradient(top, #ddd 0%, #bbb 100%);
+    background: -o-linear-gradient(to bottom, #ddd 0%, #bbb 100%);
+    background: linear-gradient(to bottom, #ddd 0%, #bbb 100%);
     border-top-right-radius: 0;
     border-bottom-right-radius: 0;
 }

--- a/app/presenters/hyrax/menu_presenter.rb
+++ b/app/presenters/hyrax/menu_presenter.rb
@@ -33,7 +33,7 @@ module Hyrax
     def nav_link(options, also_active_for: nil, **link_html_options)
       active_urls = [options, also_active_for].compact
       list_options = active_urls.any? { |url| current_page?(url) } ? { class: 'active nav-item' } : { class: 'nav-item' }
-      tag.li(list_options) do
+      tag.li(**list_options) do
         link_to(options, link_html_options) do
           yield
         end

--- a/app/views/hyrax/dashboard/_sidebar.html.erb
+++ b/app/views/hyrax/dashboard/_sidebar.html.erb
@@ -12,7 +12,7 @@
         </div>
       </div>
     </li>
-    <li class="nav-item">
+    <li class="nav-item <%= 'active' if current_page?(hyrax.dashboard_path) %>">
       <%= link_to hyrax.dashboard_path, class: "nav-link", title: t('hyrax.admin.sidebar.dashboard') do %>
         <span class="fa fa-home" aria-hidden="true"></span> <span class="sidebar-action-text"><%= t('hyrax.admin.sidebar.dashboard') %></span>
       <% end %>


### PR DESCRIPTION
### Summary

These are a few more frontend fixes.

### Guidance for testing, such as acceptance criteria or new user interface behaviors:
* Navigate to the catalog results page (ensure there are faceted terms available)
* Click the facets and note the collapse animation is present

### Type of change (for release notes)
- `notes-bugfix` (Perhaps?  Not sure if the animation was intentionally removed or not, if so, disregard this PR)

### Detailed Description

## Bring back the animation for the facet menu

7d180371f97c975c793840a12ef81d2c22e2a744

This commit will bring back the collapse animation for the facet menu on
the catalog search results page.  For a sutble touch, I've made the
speed of the ">" icon rotation at the same speed as the menu collapse.

#### Before
https://github.com/samvera/hyrax/assets/19597776/9a835881-0d65-4cc3-aef5-d3e766f1184a

#### After
https://github.com/samvera/hyrax/assets/19597776/3245f957-33ef-4d67-b90a-06caedf08bc3

## Align collection badge

4f9ceec41b292f7efebb2b9675e28051fd97a721

This commit will align the collection badge mainly with a bigger margin
on the right so the badge doesn't look so close to the title.

#### Before
<img width="952" alt="image" src="https://github.com/samvera/hyrax/assets/19597776/7b147505-9bd4-4c59-961c-a82af151610f">


#### After
<img width="1026" alt="image" src="https://github.com/samvera/hyrax/assets/19597776/f9335fcb-9e10-4f36-b1d1-712b30fd0109">


## Even out spacing on featured works

cb89d21c40a3291382ddf7fb8d9bb33a7e241918

This commit will even the spacing out on the featured works on the
homepage.  Also moving the handle index up so it looks like the old
version.

## Ensure gradient is applied to featured works drag

fa1bffccdc36ef8de2a386ff11ea9035f63d0780

This commit will update the way the CSS gradient is called so that it is
applied.

#### Before
<img width="1008" alt="image" src="https://github.com/samvera/hyrax/assets/19597776/b4a22826-f456-4fdf-8796-e841fd611100">

#### After
<img width="817" alt="image" src="https://github.com/samvera/hyrax/assets/19597776/aaee72b9-c4a2-4856-aaec-c531870d2d8f">

## Fix #li for views

bea69bdf9814b0a78bf2bd95ca0317bae7a46ceb

Not sure when this changed but without adding the ** infront of
list_options we get a hash printed out instead of the class attribute:
```
list_options
{:class=>"nav-item"}

(ruby) tag.li(list_options)
"<li>{:class=&gt;&quot;nav-item&quot;}</li>"

(ruby) tag.li(**list_options)
"<li class=\"nav-item\"></li>"
```

This commit should fix the active class not being added to the active
menu item.  Also it fixes the way it stacks when the sidebar is closed.

#### Before

https://github.com/samvera/hyrax/assets/19597776/faa2922d-f27e-4c6d-a474-00db7ae27ff5

#### After

https://github.com/samvera/hyrax/assets/19597776/af509b4e-b2d3-4c56-ae87-57121bdc6e74

## Add active class to Dashboard <li>

4dd04435619ddb335e6dcec5c7bed226e3635756

This commit will align the dashboard <li> behavior with the other
sidebar items.  When the user is on the dashboard, the dashboard <li>
will have the active class.

#### Before

https://github.com/samvera/hyrax/assets/19597776/3abd1137-e5c4-477b-8f95-775b97bb108e

#### After

https://github.com/samvera/hyrax/assets/19597776/a1731f89-7253-40dd-b85a-90caaebca677


@samvera/hyrax-code-reviewers