### PR TITLE
Do not require custom cops in the engine

### DIFF
--- a/lib/hyrax/engine.rb
+++ b/lib/hyrax/engine.rb
@@ -34,7 +34,6 @@ module Hyrax
     require 'hyrax/transactions'
     require 'hyrax/errors'
     require 'hyrax/valkyrie_simple_path_generator'
-    require 'hyrax/rubocop/custom_cops'
 
     # Force these models to be added to Legato's registry in development mode
     config.eager_load_paths += %W[

--- a/spec/lib/hyrax/rubocop/custom_cops_spec.rb
+++ b/spec/lib/hyrax/rubocop/custom_cops_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+require 'hyrax/rubocop/custom_cops'
 
 RSpec.describe Hyrax::RuboCop::CustomCops::ArResource do
   subject(:cop) { described_class.new }


### PR DESCRIPTION
This broke builds that do not install the rubocop gem. Loading of this custom cop is handled by rubocop.yml

### Fixes

Nurax failing to build due to rubocop gem not included.
