### PR TITLE
Use faster solr faceting for dashboard stats

### DIFF
--- a/app/models/hyrax/statistic.rb
+++ b/app/models/hyrax/statistic.rb
@@ -27,29 +27,20 @@ module Hyrax
 
       def query_works(query)
         models = Hyrax::ModelRegistry.work_rdf_representations.map { |m| "\"#{m}\"" }
-        Hyrax::SolrService.query("has_model_ssim:(#{models.join(' OR ')})", fl: query, rows: 100_000)
+        response = Hyrax::SolrService.get(fq: "has_model_ssim:(#{models.join(' OR ')})", 'facet.field': query, 'facet.missing': true, rows: 0)
+        Hash[*response['facet_counts']['facet_fields'][query]]
       end
 
       def work_types
-        results = query_works("human_readable_type_tesim")
-        results.group_by { |result| result['human_readable_type_tesim']&.join('') || "Unknown" }.transform_values(&:count)
+        types = query_works("human_readable_type_sim")
+        types['Unknown'] = types.delete(nil)
+        types
       end
 
       def resource_types
-        results = query_works("resource_type_tesim")
-        resource_types = []
-        results.each do |y|
-          if y["resource_type_tesim"].nil? || (y["resource_type_tesim"] == [""])
-            resource_types.push("Unknown")
-          elsif y["resource_type_tesim"].count > 1
-            y["resource_type_tesim"].each do |t|
-              resource_types.push(t)
-            end
-          else
-            resource_types.push(y["resource_type_tesim"].join(""))
-          end
-        end
-        resource_types.group_by { |rt| rt }.transform_values(&:count)
+        types = query_works("resource_type_sim")
+        types['Unknown'] = types.delete(nil)
+        types
       end
 
       private


### PR DESCRIPTION
### Summary
The main dashboard statistics loads slowly the more works, work types, and resource type values in solr. This can lead to timeouts in severe cases.

### Guidance for testing, such as acceptance criteria or new user interface behaviors:
* With a large number of works (25k+) and different resource type values (50+) visit the dashboard `/dashboard`
* Record the time to page load before and after fix
* Check for no discrepancies between displayed statistics

### Type of change (for release notes)
- `notes-bugfix` Bug Fixes

### Detailed Description
The stats graphic on the dashboard was built using large solr responses and several calls to looping methods (`#each`, `#group_by`?, `#transform_values`). Obviously, loops are very slow over large arrays/hashes. Solr can do this sort of data massaging for us with its facet API in constant time.

This change uses Solr Facets to calculate the number of works grouped by any solr field, in particular `human_readable_type_sim` for work types and `resource_type_sim` for resource types. Note this uses `*_sim` rather than `*_tesim` so the keys aren't mangled (string vs text). This can be done on a 0-row Solr query (opposed to the arbitrary 100k, which breaks on repos w/ more than 100k works).

The most interesting line: `Hash[*response['facet_counts']['facet_fields'][query]]` is a technique to turn the Solr facet response, an array in the form ['key', 'value, 'key', value...] into the appropriate hash {key: value, key: value...}. This is also resilient to `nil` or some empty values if the facet response isn't right.

### Changes proposed in this pull request:
* Replace large solr query and repetitive looping with faster Solr Facet data

@samvera/hyrax-code-reviewers