### PR TITLE
Corrects the sharing of predicates between date_created and created_at.

### DIFF
--- a/config/metadata/hyrax_internal_metadata.yaml
+++ b/config/metadata/hyrax_internal_metadata.yaml
@@ -14,7 +14,7 @@ attributes:
   compression:
     predicate: http://vocabulary.samvera.org/ns#compressionScheme
   created_at:
-    predicate: http://purl.org/dc/terms/created
+    predicate: http://vocabulary.samvera.org/ns#created_at
   file_identifier:
     predicate: http://vocabulary.samvera.org/ns#fileIdentifier
   file_ids:


### PR DESCRIPTION
### Summary

Corrects the sharing of predicates between `date_created` and `created_at`.

### Type of change (for release notes)

- `notes-valkyrie` Valkyrie Progress

@samvera/hyrax-code-reviewers
