### PR TITLE
Fix catalog search dropdown

### DIFF
--- a/app/assets/javascripts/hyrax/search.js
+++ b/app/assets/javascripts/hyrax/search.js
@@ -4,6 +4,7 @@
 
     this.init = function() {
       this.$label = this.$element.find('[data-search-element="label"]');
+      this.$visibleLabel = this.$element.find('.dropdown-toggle').find('span[aria-hidden="true"]');
       this.$items = this.$element.find('[data-search-option]');
       this.setDefault();
     }
@@ -11,7 +12,6 @@
     this.init();
     this.attachEvents();
   }
-
 
   Hyrax.Search.prototype = {
     attachEvents: function() {
@@ -43,6 +43,7 @@
 
     setLabel: function(label) {
       this.$label.html(label);
+      this.$visibleLabel.html(label);
     }
 
   }
@@ -58,8 +59,6 @@
 
 })(jQuery);
 
-
 Blacklight.onLoad(function() {
   $('#search-form-header').search();
 });
-

--- a/app/views/catalog/_search_form.html.erb
+++ b/app/views/catalog/_search_form.html.erb
@@ -20,24 +20,17 @@
             <span class="sr-only" data-search-element="label"><%= t("hyrax.search.form.option.all.label_long", application_name: application_name) %></span>
             <span aria-hidden="true"><%= t("hyrax.search.form.option.all.label_short") %></span>
           </button>
-
-          <ul class="dropdown-menu dropdown-menu-right">
-            <li class="dropdown-item">
-              <%= link_to t("hyrax.search.form.option.all.label_long", application_name: application_name), "#",
-                  data: { "search-option" => main_app.search_catalog_path, "search-label" => t("hyrax.search.form.option.all.label_short") } %>
-            </li>
-            <li class="dropdown-item">
-              <%= link_to t("hyrax.search.form.option.my_works.label_long"), "#",
-                  data: { "search-option" => hyrax.my_works_path, "search-label" => t("hyrax.search.form.option.my_works.label_short") } %>
-            </li>
-            <li class="dropdown-item">
-              <%= link_to t("hyrax.search.form.option.my_collections.label_long"), "#",
-                  data: { "search-option" => hyrax.my_collections_path, "search-label" => t("hyrax.search.form.option.my_collections.label_short") } %>
-            </li>
-          </ul>
+          <div class="dropdown-menu dropdown-menu-right">
+            <%= link_to t("hyrax.search.form.option.all.label_long", application_name: application_name), "#", class: "dropdown-item",
+                data: { "search-option" => main_app.search_catalog_path, "search-label" => t("hyrax.search.form.option.all.label_short") } %>
+            <%= link_to t("hyrax.search.form.option.my_works.label_long"), "#", class: "dropdown-item",
+                data: { "search-option" => hyrax.my_works_path, "search-label" => t("hyrax.search.form.option.my_works.label_short") } %>
+            <%= link_to t("hyrax.search.form.option.my_collections.label_long"), "#", class: "dropdown-item",
+                data: { "search-option" => hyrax.my_collections_path, "search-label" => t("hyrax.search.form.option.my_collections.label_short") } %>
+          </div>
         <% end %>
       </div><!-- /.input-group-btn -->
     </div><!-- /.input-group -->
-    
+
   </div><!-- /.form-group -->
 <% end %>


### PR DESCRIPTION
### Summary

## Fix catalog search form dropdown not changing

7a2d4768f33ea95e2f9e560dedb96e16d74cac16

On the home page when the user is logged in, the dropdown next to the
search was not changing when the user selects a different option.  This
was because the javascript was changing the data-search-element="label"
span but what is actually being shown is the aria-hidden="true" span.

Before:
```
  <span class="sr-only" data-search-element="label">All</span>
  <span aria-hidden="true">All</span>

  *user selects a different option*

  <span class="sr-only" data-search-element="label">My Works</span>
  <span aria-hidden="true">All</span>
```
After:
```
  <span class="sr-only" data-search-element="label">All</span>
  <span aria-hidden="true">All</span>

  *user selects a different option*

  <span class="sr-only" data-search-element="label">My Works</span>
  <span aria-hidden="true">My Works</span>
```

## Change html structure for search dropdown

9b2ffae723d56ba63bade38932371430a7be9f23

This change will align how Bootstrap 4 does dropdown menus.  The
exmaples that I see in the documentation show that it should be in a
<div> tag with <a> tags inside of it.


### Guidance for testing, such as acceptance criteria or new user interface behaviors:
* Sign in to Hyrax
* On the search form, click the dropdown (should say `All` by default) and choose something else
* Observe that the label changes accordingly

### Type of change (for release notes)
- `notes-bugfix` Bug Fixes

### Changes proposed in this pull request:
* Fix a bug where the label doesn't change for the search form when the user clicks it
* Change the html structure to be more Bootstrap 4 friendly

https://github.com/user-attachments/assets/784df82d-dac8-4897-98bf-dd248a0b8006

@samvera/hyrax-code-reviewers
