### PR TITLE
Add lonely operator for error message

### DIFF
--- a/app/services/hyrax/custom_queries/find_file_metadata.rb
+++ b/app/services/hyrax/custom_queries/find_file_metadata.rb
@@ -31,7 +31,7 @@ module Hyrax
         result = query_service.find_by(id: id)
         unless result.is_a? Hyrax::FileMetadata
           raise ::Valkyrie::Persistence::ObjectNotFoundError,
-                "Result type #{result.internal_resource} for id #{id} is not a `Hyrax::FileMetadata`"
+                "Result type #{result&.internal_resource} for id #{id} is not a `Hyrax::FileMetadata`"
         end
         result
       end
@@ -44,7 +44,7 @@ module Hyrax
         result = query_service.find_by_alternate_identifier(alternate_identifier: alternate_identifier)
         unless result.is_a? Hyrax::FileMetadata
           raise ::Valkyrie::Persistence::ObjectNotFoundError,
-                "Result type #{result.internal_resource} for alternate_identifier #{alternate_identifier} is not a `Hyrax::FileMetadata`"
+                "Result type #{result&.internal_resource} for alternate_identifier #{alternate_identifier} is not a `Hyrax::FileMetadata`"
         end
         result
       end


### PR DESCRIPTION
### Fixes

Capturing errors can sometimes result in a situation where the error message throws an error and the true error gets lost. This PR corrects this issue for the find_file_metadata queries.