### PR TITLE
Cleans ID array attributes before persisting with pair-tree Valkyrie Fedora.

### DIFF
--- a/app/models/hyrax/change_set.rb
+++ b/app/models/hyrax/change_set.rb
@@ -45,5 +45,12 @@ module Hyrax
     def self.for(resource)
       Hyrax::ChangeSet(resource.class).new(resource)
     end
+
+    def clean_id_fields_before_sync
+      id_fields = fields.keys.select { |k| k.include?('_id') }
+      multiple_id_fields_with_empties = id_fields.select { |f| fields[f].is_a?(Array) && fields[f].any?(&:empty?) }
+
+      multiple_id_fields_with_empties.each { |f| fields[f] = fields[f].reject(&:empty?) }
+    end
   end
 end

--- a/lib/hyrax/transactions/steps/save.rb
+++ b/lib/hyrax/transactions/steps/save.rb
@@ -35,6 +35,7 @@ module Hyrax
             valid_future_date?(change_set.lease, 'lease_expiration_date') if change_set.respond_to?(:lease) && change_set.lease
             valid_future_date?(change_set.embargo, 'embargo_release_date') if change_set.respond_to?(:embargo) && change_set.embargo
             new_collections = changed_collection_membership(change_set)
+            change_set.clean_id_fields_before_sync
 
             unsaved = change_set.sync
             save_lease_or_embargo(unsaved)


### PR DESCRIPTION
### Fixes

Fixes #6874 

### Summary

Cleans ID array attributes before persisting with pair-tree Valkyrie Fedora.

### Guidance for testing, such as acceptance criteria or new user interface behaviors:

1. Run a local build of Sirenia using Docker
2. Log in and navigate to Dashboard -> Works
3. Click on the title of a work that you've already deposited (or deposit a new one if you don't have any works)
4. Click Edit
5. Select a different visibility setting (I went from Public to Institution) and click Save Changes
6. A message saying `Failed save on # undefined method split' for nil:NilClass` should not appear, replaced with a success message.

### Type of change (for release notes)

- `notes-bugfix` Bug Fixes
- `notes-valkyrie` Valkyrie Progress

### Changes proposed in this pull request:
* app/models/hyrax/change_set.rb: creates a method that cleans multi-valued id attributes if they contain empty strings.
* lib/hyrax/transactions/steps/save.rb: calls the new method before `sync`ing, where instances of `Valkyrie:ID` with empty ID values could be created.
* spec/models/hyrax/change_set_spec.rb: tests the method created.

@samvera/hyrax-code-reviewers
