### PR TITLE
Add configuration for config_search_paths

### DIFF
--- a/app/services/hyrax/simple_schema_loader.rb
+++ b/app/services/hyrax/simple_schema_loader.rb
@@ -158,7 +158,7 @@ module Hyrax
     end
 
     def config_search_paths
-      [Rails.root, Hyrax::Engine.root]
+      Hyrax.config.simple_schema_loader_config_search_paths
     end
 
     def metadata_files

--- a/lib/hyrax/configuration.rb
+++ b/lib/hyrax/configuration.rb
@@ -1154,6 +1154,24 @@ module Hyrax
       @visibility_map ||= Hyrax::VisibilityMap.instance
     end
 
+    attr_writer :simple_schema_loader_config_search_paths
+    # A configuration for modifying the SimpleSchemaLoader#config_search_paths
+    # which will allow gems to add their own metadata yaml files and easily keep
+    # them within the gem.
+    #
+    # @return [Array<Pathname>]
+    # @see Hyrax::SimpleSchemaLoader#config_search_paths
+    # @example
+    #   Hyrax.config do |config|
+    #     config.simple_schema_loader_config_search_paths.unshift(HykuKnapsack::Engine.root)
+    #   end
+    #
+    #   Hyrax.config.simple_schema_loader_config_search_paths
+    #   => [#<Pathname:/app/samvera>, #<Pathname:/app/samvera/hyrax-webapp>, #<Pathname:/app/samvera/hyrax-webapp/gems/hyrax>]
+    def simple_schema_loader_config_search_paths
+      @simple_schema_loader_config_search_paths ||= [Rails.root, Hyrax::Engine.root]
+    end
+
     private
 
     # @param [Symbol, #to_s] model_name - symbol representing the model

--- a/spec/lib/hyrax/configuration_spec.rb
+++ b/spec/lib/hyrax/configuration_spec.rb
@@ -115,6 +115,7 @@ RSpec.describe Hyrax::Configuration do
   it { is_expected.to respond_to(:range_for_number_of_results_to_display_per_page) }
   it { is_expected.to respond_to(:range_for_number_of_results_to_display_per_page=) }
   it { is_expected.to respond_to(:work_requires_files?) }
+  it { is_expected.to respond_to(:simple_schema_loader_config_search_paths) }
 
   describe "#registered_ingest_dirs" do
     it "provides the Rails tmp directory for temporary downloads for cloud files" do


### PR DESCRIPTION
### Summary

This commit will allow gems to override the `SimpleSchemaLoader#config_search_paths` easily.

### Type of change (for release notes)
- `notes-minor` New Features that are backward compatible

### Detailed Description

In gems that introduce a metadata yaml file, it would be nice to have a way to keep the yaml in the gem but add the path of the yaml to be loaded by the SimpleSchemaLoader.

### Changes proposed in this pull request:
* Add a configuration for the SimpleSchemaLoader to add different search paths.

@samvera/hyrax-code-reviewers
