### PR TITLE
Fix subtle background gradient on featured works

### DIFF
--- a/app/assets/stylesheets/hyrax/_nestable.scss
+++ b/app/assets/stylesheets/hyrax/_nestable.scss
@@ -82,7 +82,7 @@ tr.dd-item {
     background: #fafafa;
     background: -webkit-linear-gradient(top, #fafafa 0%, #eee 100%);
     background:    -moz-linear-gradient(top, #fafafa 0%, #eee 100%);
-    background:         linear-gradient(top, #fafafa 0%, #eee 100%);
+    background:         linear-gradient(to bottom, #fafafa 0%, #eee 100%);
     -webkit-border-radius: 3px;
             border-radius: 3px;
     box-sizing: border-box; -moz-box-sizing: border-box;


### PR DESCRIPTION
### Summary
The gradient was throwing an invalid property value error which should be fixed now.

### Guidance for testing, such as acceptance criteria or new user interface behaviors:
* Take a look at the featured work when logged in as an admin user.
* Notice that there is a very subtle gradient on the background

### Type of change (for release notes)
- `notes-bugfix` Bug Fixes

### Before
<img width="604" alt="image" src="https://github.com/user-attachments/assets/2484e451-ef86-423c-9a22-a6481a3711a2">

### After
<img width="567" alt="image" src="https://github.com/user-attachments/assets/2d49b441-7cb7-419e-989e-d22a030feaa8">

@samvera/hyrax-code-reviewers
