### PR TITLE
Issue 6755

### DIFF
--- a/app/assets/stylesheets/_bootstrap-default-overrides.scss
+++ b/app/assets/stylesheets/_bootstrap-default-overrides.scss
@@ -18,7 +18,7 @@ $warning: #565653 !default;
 // * Darkens the text for disabled pagination buttons on every page.
 $breadcrumb-active-color: #4c4c4c;
 $pagination-disabled-color: #4c4c4c;
-$primary: #0056B3 !default;
+$blue: #0056B3 !default;
 
 // Date picker on safari placeholder text was misaligned
 @media screen {

--- a/app/assets/stylesheets/_bootstrap-default-overrides.scss
+++ b/app/assets/stylesheets/_bootstrap-default-overrides.scss
@@ -18,6 +18,7 @@ $warning: #565653 !default;
 // * Darkens the text for disabled pagination buttons on every page.
 $breadcrumb-active-color: #4c4c4c;
 $pagination-disabled-color: #4c4c4c;
+$primary: #0056B3 !default;
 
 // Date picker on safari placeholder text was misaligned
 @media screen {


### PR DESCRIPTION
### Fixes

Adds override for blue background color used by Bootstrap to use a blue with color contrast greater than 7:1. This passes [WCAG 2.2 Level AAA](https://www.w3.org/TR/WCAG22/#contrast-minimum) requirements.

Fixes #6755 

### Summary

Based on [Bootstrap 4.6.2 variable styles](https://github.com/twbs/bootstrap/blob/v4.6.2/scss/_variables.scss) in use with current Hyrax, there are known accessibility problems with some color contrasts. Overriding the color assigned to this blue variable makes sure anything using that color (primary class, at least) will contrast enough for accessibility.

### Type of change (for release notes)

- `notes-minor` Accessibility fix

@samvera/hyrax-code-reviewers
