### PR TITLE
[i1020] - correct ga4 typo that prevents download tracking

### DIFF
--- a/app/assets/javascripts/hyrax/analytics_events.js
+++ b/app/assets/javascripts/hyrax/analytics_events.js
@@ -89,11 +89,11 @@ $(document).on('click', '#file_download', function(e) {
       window.trackingTags.analytics().push([trackingTags.trackEvent(), 'work-in-collection', 'work-in-collection-download', collection]);
     });
   } else {
-    gtag('event', 'file-set-download', { 'content-type': 'file-set', 'content-id': $(this).data('label')})
-    gtag('event', 'file-set-in-work-download', { 'content-type': 'file-set-in-work', 'content-id': $(this).data('work-id')})
+    gtag('event', 'file-set-download', { 'content-type': 'file-set', 'content_id': $(this).data('label')})
+    gtag('event', 'file-set-in-work-download', { 'content-type': 'file-set-in-work', 'content_id': $(this).data('work-id')})
     $(this).data('collection-ids').forEach(function (collection) {
-      gtag('event', 'file-set-in-collection-download', { 'content-type': 'file-set-in-collection', 'content-id': collection })
-      gtag('event', 'work-in-collection-download', { 'content-type': 'work-in-collection', 'content-id': collection })
+      gtag('event', 'file-set-in-collection-download', { 'content-type': 'file-set-in-collection', 'content_id': collection })
+      gtag('event', 'work-in-collection-download', { 'content-type': 'work-in-collection', 'content_id': collection })
     });
   }
 });

--- a/app/assets/javascripts/hyrax/analytics_events.js
+++ b/app/assets/javascripts/hyrax/analytics_events.js
@@ -89,11 +89,11 @@ $(document).on('click', '#file_download', function(e) {
       window.trackingTags.analytics().push([trackingTags.trackEvent(), 'work-in-collection', 'work-in-collection-download', collection]);
     });
   } else {
-    gtag('event', 'file-set-download', { 'content-type': 'file-set', 'content_id': $(this).data('label')})
-    gtag('event', 'file-set-in-work-download', { 'content-type': 'file-set-in-work', 'content_id': $(this).data('work-id')})
+    gtag('event', 'file-set-download', { 'content_type': 'file-set', 'content_id': $(this).data('label')})
+    gtag('event', 'file-set-in-work-download', { 'content_type': 'file-set-in-work', 'content_id': $(this).data('work-id')})
     $(this).data('collection-ids').forEach(function (collection) {
-      gtag('event', 'file-set-in-collection-download', { 'content-type': 'file-set-in-collection', 'content_id': collection })
-      gtag('event', 'work-in-collection-download', { 'content-type': 'work-in-collection', 'content_id': collection })
+      gtag('event', 'file-set-in-collection-download', { 'content_type': 'file-set-in-collection', 'content_id': collection })
+      gtag('event', 'work-in-collection-download', { 'content_type': 'work-in-collection', 'content_id': collection })
     });
   }
 });


### PR DESCRIPTION
In Google Analytics we were missing the tracking for download events. This is because there was a typo in content_id.

Issue:
- https://github.com/scientist-softserv/palni-palci/issues/1020

## BEFORE

download events weren't being tracked

## AFTER

Rob was able to manually trigger this event 

![Screenshot 2024-09-03 at 2 24 29 PM](https://github.com/user-attachments/assets/4a4dff2e-2a7d-4ed8-b579-dd77d5874d0d)
