### PR TITLE
ability to skip the logo on save

### DIFF
--- a/.regen
+++ b/.regen
@@ -1,2 +1,2 @@
 # When updating CI regen seed, set to current date.
-2023-08-09T14:34:59
+2024-09-09T14:34:59

--- a/app/controllers/hyrax/dashboard/collections_controller.rb
+++ b/app/controllers/hyrax/dashboard/collections_controller.rb
@@ -231,7 +231,9 @@ module Hyrax
                                                                             banner_unchanged_indicator: params["banner_unchanged"] },
                           'collection_resource.save_collection_logo' => { update_logo_file_ids: params["logo_files"],
                                                                           alttext_values: params["alttext"],
-                                                                          linkurl_values: params["linkurl"] }
+                                                                          linkurl_values: params["linkurl"],
+                                                                          logo_unchanged_indicator: false
+                                                                        }
                         )
                  .call(form)
         @collection = result.value_or { return after_update_errors(result.failure.first) }

--- a/app/controllers/hyrax/dashboard/collections_controller.rb
+++ b/app/controllers/hyrax/dashboard/collections_controller.rb
@@ -232,8 +232,7 @@ module Hyrax
                           'collection_resource.save_collection_logo' => { update_logo_file_ids: params["logo_files"],
                                                                           alttext_values: params["alttext"],
                                                                           linkurl_values: params["linkurl"],
-                                                                          logo_unchanged_indicator: false
-                                                                        }
+                                                                          logo_unchanged_indicator: false }
                         )
                  .call(form)
         @collection = result.value_or { return after_update_errors(result.failure.first) }

--- a/lib/hyrax/transactions/steps/save_collection_logo.rb
+++ b/lib/hyrax/transactions/steps/save_collection_logo.rb
@@ -19,7 +19,8 @@ module Hyrax
         #
         # @return [Dry::Monads::Result] `Failure` if the work fails to save;
         #   `Success(input)`, otherwise.
-        def call(collection_resource, update_logo_file_ids: nil, alttext_values: nil, linkurl_values: nil)
+        def call(collection_resource, update_logo_file_ids: nil, alttext_values: nil, linkurl_values: nil, logo_unchanged_indicator: true)
+          return Success(collection_resource) if ActiveModel::Type::Boolean.new.cast(logo_unchanged_indicator)
           collection_id = collection_resource.id.to_s
           process_logo_input(collection_id: collection_id, update_logo_file_ids: update_logo_file_ids, alttext_values: alttext_values, linkurl_values: linkurl_values)
           Success(collection_resource)

--- a/spec/hyrax/transactions/steps/save_collection_logo_spec.rb
+++ b/spec/hyrax/transactions/steps/save_collection_logo_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Hyrax::Transactions::Steps::SaveCollectionLogo do
     let(:uploaded) { FactoryBot.create(:uploaded_file) }
 
     it 'saves logo metadata' do
-      expect(step.call(collection, update_logo_file_ids: [uploaded.id.to_s], alttext_values: ["Logo alt Text"], linkurl_values: ["http://abc.com"])).to be_success
+      expect(step.call(collection, update_logo_file_ids: [uploaded.id.to_s], alttext_values: ["Logo alt Text"], linkurl_values: ["http://abc.com"], logo_unchanged_indicator: false)).to be_success
 
       expect(CollectionBrandingInfo
                .where(collection_id: collection.id.to_s,
@@ -25,7 +25,7 @@ RSpec.describe Hyrax::Transactions::Steps::SaveCollectionLogo do
     end
 
     it 'does not save linkurl containing html; target_url is empty' do
-      expect(step.call(collection, update_logo_file_ids: [uploaded.id.to_s], alttext_values: ["Logo alt Text"], linkurl_values: ["<script>remove_me</script>"])).to be_success
+      expect(step.call(collection, update_logo_file_ids: [uploaded.id.to_s], alttext_values: ["Logo alt Text"], linkurl_values: ["<script>remove_me</script>"], logo_unchanged_indicator: false)).to be_success
 
       expect(
         CollectionBrandingInfo.where(
@@ -36,7 +36,7 @@ RSpec.describe Hyrax::Transactions::Steps::SaveCollectionLogo do
     end
 
     it 'does not save linkurl containing dodgy protocol; target_url is empty' do
-      expect(step.call(collection, update_logo_file_ids: [uploaded.id.to_s], alttext_values: ["Logo alt Text"], linkurl_values: ['javascript:alert("remove_me")'])).to be_success
+      expect(step.call(collection, update_logo_file_ids: [uploaded.id.to_s], alttext_values: ["Logo alt Text"], linkurl_values: ['javascript:alert("remove_me")'], logo_unchanged_indicator: false)).to be_success
 
       expect(
         CollectionBrandingInfo.where(

--- a/spec/hyrax/transactions/steps/save_collection_logo_spec.rb
+++ b/spec/hyrax/transactions/steps/save_collection_logo_spec.rb
@@ -13,7 +13,11 @@ RSpec.describe Hyrax::Transactions::Steps::SaveCollectionLogo do
     let(:uploaded) { FactoryBot.create(:uploaded_file) }
 
     it 'saves logo metadata' do
-      expect(step.call(collection, update_logo_file_ids: [uploaded.id.to_s], alttext_values: ["Logo alt Text"], linkurl_values: ["http://abc.com"], logo_unchanged_indicator: false)).to be_success
+      expect(step.call(collection,
+                       update_logo_file_ids: [uploaded.id.to_s],
+                       alttext_values: ["Logo alt Text"],
+                       linkurl_values: ["http://abc.com"],
+                       logo_unchanged_indicator: false)).to be_success
 
       expect(CollectionBrandingInfo
                .where(collection_id: collection.id.to_s,
@@ -25,7 +29,11 @@ RSpec.describe Hyrax::Transactions::Steps::SaveCollectionLogo do
     end
 
     it 'does not save linkurl containing html; target_url is empty' do
-      expect(step.call(collection, update_logo_file_ids: [uploaded.id.to_s], alttext_values: ["Logo alt Text"], linkurl_values: ["<script>remove_me</script>"], logo_unchanged_indicator: false)).to be_success
+      expect(step.call(collection,
+                       update_logo_file_ids: [uploaded.id.to_s],
+                       alttext_values: ["Logo alt Text"],
+                       linkurl_values: ["<script>remove_me</script>"],
+                       logo_unchanged_indicator: false)).to be_success
 
       expect(
         CollectionBrandingInfo.where(
@@ -36,7 +44,11 @@ RSpec.describe Hyrax::Transactions::Steps::SaveCollectionLogo do
     end
 
     it 'does not save linkurl containing dodgy protocol; target_url is empty' do
-      expect(step.call(collection, update_logo_file_ids: [uploaded.id.to_s], alttext_values: ["Logo alt Text"], linkurl_values: ['javascript:alert("remove_me")'], logo_unchanged_indicator: false)).to be_success
+      expect(step.call(collection,
+                       update_logo_file_ids: [uploaded.id.to_s],
+                       alttext_values: ["Logo alt Text"],
+                       linkurl_values: ['javascript:alert("remove_me")'],
+                       logo_unchanged_indicator: false)).to be_success
 
       expect(
         CollectionBrandingInfo.where(


### PR DESCRIPTION
### Fixes

Any time the collection is saved via the form, if logo ids are not sent to the form, the logo are cleared from the collection AND the logos are deleted.

### Summary

This change makes the default use of the form safer. It does not change the current view save behavior, but makes updating collections via Bulkrax, via alternate controller / forms, via rake tasks, and via the console much safer.

### Guidance for testing, such as acceptance criteria or new user interface behaviors:
* Create a collection via the UI, add a logo and a banner
* On the console, run the following to update the collection
```
        res = Hyrax.query_service.find_by(id: COLLECTION_ID)
        # start with a form for the resource
        fm = form_for(model:).constantize.new(resource: res)
        result = Hyrax::Transactions::Container[collection_model_event_mapping[model]].call(fm)
```

* See that the logo is still present on the collection when the page is refreshed.

@samvera/hyrax-code-reviewers
