### PR TITLE
Adding alt attribute on thumbnail in search results list view

### DIFF
--- a/app/views/catalog/_thumbnail_list_default.html.erb
+++ b/app/views/catalog/_thumbnail_list_default.html.erb
@@ -1,10 +1,10 @@
 <% model = document.hydra_model %>
 <div class="col-md-3">
   <% if model == Hyrax::PcdmCollection || model < Hyrax::PcdmCollection %>
-    <%= document_presenter(document)&.thumbnail&.thumbnail_tag({}, suppress_link: true) %>
+    <%= document_presenter(document)&.thumbnail&.thumbnail_tag({}, suppress_link: true, alt: document.title_or_label) %>
   <% else %>
     <div class="list-thumbnail">
-      <%= document_presenter(document)&.thumbnail&.thumbnail_tag %>
+      <%= document_presenter(document)&.thumbnail&.thumbnail_tag(alt: document.title_or_label) %>
     </div>
   <% end %>
 </div>


### PR DESCRIPTION
### Fixes

Fixes #6749 - This adds alternative text on thumbnails in the search results list view but not on the gallery or masonry views. Those views currently have empty alt attributes and are passing accessibility test via SiteImprove but are not actually providing any alternative text.

### Summary

Calling up work title and using that for alternative text attribute value

### Type of change (for release notes)

- `notes-minor` Addresses accessibility-concern of missing alternative text

@samvera/hyrax-code-reviewers
