### PR TITLE
Lazy migrate characterization along with file

### DIFF
--- a/app/jobs/migrate_files_to_valkyrie_job.rb
+++ b/app/jobs/migrate_files_to_valkyrie_job.rb
@@ -12,6 +12,7 @@ class MigrateFilesToValkyrieJob < Hyrax::ApplicationJob
     migrate_files!(resource: resource)
   end
 
+  # rubocop:disable Metrics/MethodLength
   def attribute_mapping
     return @attribute_mapping if @attribute_mapping
     @attribute_mapping = %w[
@@ -64,6 +65,7 @@ class MigrateFilesToValkyrieJob < Hyrax::ApplicationJob
     @attribute_mapping['checksum'] = 'original_checksum'
     @attribute_mapping
   end
+  # rubocop:enable Metrics/MethodLength
 
   private
 

--- a/app/jobs/migrate_files_to_valkyrie_job.rb
+++ b/app/jobs/migrate_files_to_valkyrie_job.rb
@@ -12,60 +12,20 @@ class MigrateFilesToValkyrieJob < Hyrax::ApplicationJob
     migrate_files!(resource: resource)
   end
 
-  # rubocop:disable Metrics/MethodLength
   def attribute_mapping
     return @attribute_mapping if @attribute_mapping
     @attribute_mapping = %w[
-      aspect_ratio
-      bit_depth
-      bit_rate
-      byte_order
-      capture_device
-      channels
-      character_count
-      character_set
-      checksum
-      color_map
-      color_space
-      compression
-      creator
-      data_format
-      duration
-      exif_version
-      file_title
-      fits_version
-      format_label
-      frame_rate
-      gps_timestamp
-      graphics_count
-      height
-      image_producer
-      language
-      latitude
-      line_count
-      longitude
-      markup_basis
-      markup_language
-      offset
-      orientation
-      page_count
-      paragraph_count
-      profile_name
-      profile_version
-      recorded_size
-      sample_rate
-      scanning_software
-      table_count
-      well_formed
-      width
-      word_count
-    ].inject({}) { |j, i| j[i] = i; j}
+      aspect_ratio bit_depth bit_rate byte_order capture_device channels character_count character_set
+      checksum color_map color_space compression creator data_format duration exif_version file_title
+      fits_version format_label frame_rate gps_timestamp graphics_count height image_producer language
+      latitude line_count longitude markup_basis markup_language offset orientation page_count
+      paragraph_count profile_name profile_version recorded_size sample_rate scanning_software
+      table_count well_formed width word_count ].inject({}) { |j, i| j[i] = i; j}
     @attribute_mapping['recorded_size'] = 'file_size'
     @attribute_mapping['channels'] = 'alpha_channels'
     @attribute_mapping['checksum'] = 'original_checksum'
     @attribute_mapping
   end
-  # rubocop:enable Metrics/MethodLength
 
   private
 

--- a/lib/freyja/persister.rb
+++ b/lib/freyja/persister.rb
@@ -32,7 +32,9 @@ module Freyja
 
     def convert_and_migrate_resource(orm_object)
       new_resource = resource_factory.to_resource(object: orm_object)
-      MigrateFilesToValkyrieJob.perform_later(new_resource) if new_resource.is_a?(Hyrax::FileSet) && new_resource.file_ids.size == 1 && new_resource.file_ids.first.id.to_s.match('/files/')
+      if Hyrax.config.valkyrie_transition? && new_resource.is_a?(Hyrax::FileSet) && new_resource.file_ids.size == 1 && new_resource.file_ids.first.id.to_s.match('/files/')
+        MigrateFilesToValkyrieJob.perform_later(new_resource)
+      end
       new_resource
     end
   end

--- a/lib/goddess/query.rb
+++ b/lib/goddess/query.rb
@@ -146,6 +146,29 @@ module Goddess
     # @param [QueryService] query_service
     def initialize(*services)
       @services = services
+      setup_custom_queries
+    end
+
+    def setup_custom_queries
+      # load all the sql based custom queries
+      [
+        Hyrax::CustomQueries::Navigators::CollectionMembers,
+        Hyrax::CustomQueries::Navigators::ChildCollectionsNavigator,
+        Hyrax::CustomQueries::Navigators::ParentCollectionsNavigator,
+        Hyrax::CustomQueries::Navigators::ChildFileSetsNavigator,
+        Hyrax::CustomQueries::Navigators::ChildWorksNavigator,
+        Hyrax::CustomQueries::Navigators::FindFiles,
+        Hyrax::CustomQueries::FindAccessControl,
+        Hyrax::CustomQueries::FindCollectionsByType,
+        Hyrax::CustomQueries::FindFileMetadata,
+        Hyrax::CustomQueries::FindIdsByModel,
+        Hyrax::CustomQueries::FindManyByAlternateIds,
+        Hyrax::CustomQueries::FindModelsByAccess,
+        Hyrax::CustomQueries::FindCountBy,
+        Hyrax::CustomQueries::FindByDateRange
+      ].each do |handler|
+        services[0].custom_queries.register_query_handler(handler)
+      end
     end
   end
 end

--- a/lib/goddess/query.rb
+++ b/lib/goddess/query.rb
@@ -149,6 +149,7 @@ module Goddess
       setup_custom_queries
     end
 
+    # rubocop:disable Metrics/MethodLength
     def setup_custom_queries
       # load all the sql based custom queries
       [
@@ -170,5 +171,6 @@ module Goddess
         services[0].custom_queries.register_query_handler(handler)
       end
     end
+    # rubocop:enable Metrics/MethodLength
   end
 end

--- a/lib/wings.rb
+++ b/lib/wings.rb
@@ -115,7 +115,9 @@ end
 
 Valkyrie.config.resource_class_resolver = lambda do |resource_klass_name|
   klass_name = resource_klass_name.gsub(/Resource$/, '')
-  klass = klass_name.constantize
+  # Second one should throw a name error because we do not know what you want if
+  # it isn't one of these two options
+  klass = klass_name.safe_constantize || resource_klass_name.constantize
   Wings::ModelRegistry.reverse_lookup(klass) || klass
 end
 

--- a/lib/wings.rb
+++ b/lib/wings.rb
@@ -113,6 +113,12 @@ rescue NameError, Hyrax::SimpleSchemaLoader::UndefinedSchemaError => err
   :noop
 end
 
+Valkyrie.config.resource_class_resolver = lambda do |resource_klass_name|
+  klass_name = resource_klass_name.gsub(/Resource$/, '')
+  klass = klass_name.constantize
+  Wings::ModelRegistry.reverse_lookup(klass) || klass
+end
+
 # some aliases for use by diners of varying sophistication
 BuffaloWings = Wings
 MightyWings = Wings

--- a/lib/wings.rb
+++ b/lib/wings.rb
@@ -113,14 +113,6 @@ rescue NameError, Hyrax::SimpleSchemaLoader::UndefinedSchemaError => err
   :noop
 end
 
-Valkyrie.config.resource_class_resolver = lambda do |resource_klass_name|
-  klass_name = resource_klass_name.gsub(/Resource$/, '')
-  # Second one should throw a name error because we do not know what you want if
-  # it isn't one of these two options
-  klass = klass_name.safe_constantize || resource_klass_name.constantize
-  Wings::ModelRegistry.reverse_lookup(klass) || klass
-end
-
 # some aliases for use by diners of varying sophistication
 BuffaloWings = Wings
 MightyWings = Wings

--- a/lib/wings/setup.rb
+++ b/lib/wings/setup.rb
@@ -127,6 +127,15 @@ custom_queries.each do |query_handler|
   Valkyrie.config.metadata_adapter.query_service.custom_queries.register_query_handler(query_handler)
 end
 
+Valkyrie.config.resource_class_resolver = lambda do |resource_klass_name|
+  return resource_klass_name.constantize unless defined?(Wings)
+  klass_name = resource_klass_name.gsub(/Resource$/, '')
+  # Second one should throw a name error because we do not know what you want if
+  # it isn't one of these two options
+  klass = klass_name.safe_constantize || resource_klass_name.constantize
+  Wings::ModelRegistry.reverse_lookup(klass) || klass
+end
+
 Wings::ModelRegistry.register(Hyrax::AccessControl, Hydra::AccessControl)
 Wings::ModelRegistry.register(Hyrax.config.admin_set_class_for_wings, AdminSet)
 Wings::ModelRegistry.register(Hyrax.config.collection_class_for_wings, ::Collection)

--- a/spec/jobs/migrate_files_to_valkyrie_job_spec.rb
+++ b/spec/jobs/migrate_files_to_valkyrie_job_spec.rb
@@ -3,37 +3,26 @@ require 'wings'
 
 RSpec.describe MigrateFilesToValkyrieJob, valkyrie_adapter: :freyja_adapter, perform_enqueued: [MigrateFilesToValkyrieJob] do
   let(:user)      { create(:user) }
-  let(:file) { File.open(fixture_path + '/' + label) }
+  let(:content) { File.open(fixture_path + '/' + label) }
   let(:uploaded_file1) { build(:uploaded_file, file:) }
-  let(:fedora_file_set) { create(:file_set, title: ['Some title'], label: label, content: file) }
+  let(:fedora_file_set) { create(:file_set, title: ['Some title'], label: label, content: content) }
+  let!(:pcdm_file) do pcdm_file = fedora_file_set.files.first
+    pcdm_file.content = 'foo'
+    pcdm_file.original_name = label
+    pcdm_file.height = '111'
+    pcdm_file.width = '222'
+    pcdm_file.file_size = '123456'
+    pcdm_file.format_label = ["Portable Network Graphics"]
+    pcdm_file.original_checksum = ['checksum123']
+    pcdm_file.save!
+    pcdm_file
+  end
   let(:label) { 'image.jpg' }
   let(:wings_file_set) { Hyrax.query_service.find_by(id: fedora_file_set.id) }
   let(:migrated_file_set) { Hyrax.persister.save(resource: wings_file_set) }
-  let(:file_with_characterization) do
-    Hydra::PCDM::File.new.tap do |f|
-      f.content = 'foo'
-      f.original_name = label
-      f.height = '111'
-      f.width = '222'
-      f.file_size = '123456'
-      f.format_label = ["Portable Network Graphics"]
-      f.original_checksum = ['checksum123']
-      f.save!
-    end
-  end
 
   before do
     allow(Hyrax.config).to receive(:valkyrie_transition?).and_return(true)
-    allow(fedora_file_set).to receive(:characterization_proxy).and_return(file_with_characterization)
-    Valkyrie.config.resource_class_resolver = lambda do |resource_klass_name|
-      klass_name = resource_klass_name.gsub(/Resource$/, '')
-      if 'FileSet' == klass_name
-        Hyrax::FileSet
-      else
-        klass_name.constantize
-      end
-    end
-
     # allow(ActiveFedora::Base).to receive(:find).and_call_original
     # allow(ActiveFedora::Base).to receive(:find).with(migrated_file_set.original_file.file_identifier.to_s).and_return(file_with_characterization)
     # allow(File_Set).to receive(:find).with(fedora_file_set.id).and_return(fedora_file_set)
@@ -43,11 +32,8 @@ RSpec.describe MigrateFilesToValkyrieJob, valkyrie_adapter: :freyja_adapter, per
     described_class.perform_now(migrated_file_set)
 
     valkyrized_file_set = Hyrax.query_service.find_by(id: migrated_file_set.id)
-    terms = File_Set.characterization_terms - [:alpha_channels, :original_checksum]
-    terms.each do |t|
-      expect(valkyrized_file_set.original_file.send(t)).to eq(fedora_file_set.characterization_proxy.send(t))
+    described_class.new.attribute_mapping.each do |k, v|
+      expect(valkyrized_file_set.original_file.send(k)).to match_array(pcdm_file.send(v))
     end
-    expect(valkyrized_file_set.original_file.checksum).to eq(fedora_file_set.characterization_proxy.original_checksum)
-    expect(valkyrized_file_set.original_file.channels).to eq(fedora_file_set.characterization_proxy.alpha_channels)
   end
 end

--- a/spec/jobs/migrate_files_to_valkyrie_job_spec.rb
+++ b/spec/jobs/migrate_files_to_valkyrie_job_spec.rb
@@ -7,8 +7,8 @@ RSpec.describe MigrateFilesToValkyrieJob, valkyrie_adapter: :freyja_adapter, per
   let(:uploaded_file1) { build(:uploaded_file, file:) }
   let(:fedora_file_set) { create(:file_set, title: ['Some title'], label: label, content: file) }
   let(:label) { 'image.jpg' }
-
-  let(:migrated_fileset) { Hyrax.persister.save(resource: fedora_file_set.valkyrie_resource) }
+  let(:wings_file_set) { Hyrax.query_service.find_by(id: fedora_file_set.id) }
+  let(:migrated_file_set) { Hyrax.persister.save(resource: wings_file_set) }
   let(:file_with_characterization) do
     Hydra::PCDM::File.new.tap do |f|
       f.content = 'foo'
@@ -25,16 +25,25 @@ RSpec.describe MigrateFilesToValkyrieJob, valkyrie_adapter: :freyja_adapter, per
   before do
     allow(Hyrax.config).to receive(:valkyrie_transition?).and_return(true)
     allow(fedora_file_set).to receive(:characterization_proxy).and_return(file_with_characterization)
+    Valkyrie.config.resource_class_resolver = lambda do |resource_klass_name|
+      klass_name = resource_klass_name.gsub(/Resource$/, '')
+      if 'FileSet' == klass_name
+        Hyrax::FileSet
+      else
+        klass_name.constantize
+      end
+    end
+
     # allow(ActiveFedora::Base).to receive(:find).and_call_original
-    # allow(ActiveFedora::Base).to receive(:find).with(migrated_fileset.original_file.file_identifier.to_s).and_return(file_with_characterization)
-    # allow(FileSet).to receive(:find).with(fedora_file_set.id).and_return(fedora_file_set)
+    # allow(ActiveFedora::Base).to receive(:find).with(migrated_file_set.original_file.file_identifier.to_s).and_return(file_with_characterization)
+    # allow(File_Set).to receive(:find).with(fedora_file_set.id).and_return(fedora_file_set)
   end
 
   it "it migrates all derivatives along with a file" do
-    described_class.perform_now(migrated_fileset)
+    described_class.perform_now(migrated_file_set)
 
-    valkyrized_file_set = Hyrax.query_service.find_by(id: migrated_fileset.id)
-    terms = FileSet.characterization_terms - [:alpha_channels, :original_checksum]
+    valkyrized_file_set = Hyrax.query_service.find_by(id: migrated_file_set.id)
+    terms = File_Set.characterization_terms - [:alpha_channels, :original_checksum]
     terms.each do |t|
       expect(valkyrized_file_set.original_file.send(t)).to eq(fedora_file_set.characterization_proxy.send(t))
     end
@@ -42,4 +51,3 @@ RSpec.describe MigrateFilesToValkyrieJob, valkyrie_adapter: :freyja_adapter, per
     expect(valkyrized_file_set.original_file.channels).to eq(fedora_file_set.characterization_proxy.alpha_channels)
   end
 end
-  

--- a/spec/jobs/migrate_files_to_valkyrie_job_spec.rb
+++ b/spec/jobs/migrate_files_to_valkyrie_job_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+require 'wings'
+
+RSpec.describe MigrateFilesToValkyrieJob, valkyrie_adapter: :freyja_adapter, perform_enqueued: [MigrateFilesToValkyrieJob] do
+  let(:user)      { create(:user) }
+  let(:file) { File.open(fixture_path + '/' + label) }
+  let(:uploaded_file1) { build(:uploaded_file, file:) }
+  let(:fedora_file_set) { create(:file_set, title: ['Some title'], label: label, content: file) }
+  let(:label) { 'image.jpg' }
+
+  let(:migrated_fileset) { Hyrax.persister.save(resource: fedora_file_set.valkyrie_resource) }
+  let(:file_with_characterization) do
+    Hydra::PCDM::File.new.tap do |f|
+      f.content = 'foo'
+      f.original_name = label
+      f.height = '111'
+      f.width = '222'
+      f.file_size = '123456'
+      f.format_label = ["Portable Network Graphics"]
+      f.original_checksum = ['checksum123']
+      f.save!
+    end
+  end
+
+  before do
+    allow(Hyrax.config).to receive(:valkyrie_transition?).and_return(true)
+    allow(fedora_file_set).to receive(:characterization_proxy).and_return(file_with_characterization)
+    # allow(ActiveFedora::Base).to receive(:find).and_call_original
+    # allow(ActiveFedora::Base).to receive(:find).with(migrated_fileset.original_file.file_identifier.to_s).and_return(file_with_characterization)
+    # allow(FileSet).to receive(:find).with(fedora_file_set.id).and_return(fedora_file_set)
+  end
+
+  it "it migrates all derivatives along with a file" do
+    described_class.perform_now(migrated_fileset)
+
+    valkyrized_file_set = Hyrax.query_service.find_by(id: migrated_fileset.id)
+    terms = FileSet.characterization_terms - [:alpha_channels, :original_checksum]
+    terms.each do |t|
+      expect(valkyrized_file_set.original_file.send(t)).to eq(fedora_file_set.characterization_proxy.send(t))
+    end
+    expect(valkyrized_file_set.original_file.checksum).to eq(fedora_file_set.characterization_proxy.original_checksum)
+    expect(valkyrized_file_set.original_file.channels).to eq(fedora_file_set.characterization_proxy.alpha_channels)
+  end
+end
+  

--- a/spec/lib/freyja/persister_spec.rb
+++ b/spec/lib/freyja/persister_spec.rb
@@ -7,7 +7,7 @@ require 'valkyrie/specs/shared_specs'
 require 'wings'
 require 'freyja/metadata_adapter'
 
-RSpec.describe Freyja::Persister, :active_fedora, :clean_repo do
+RSpec.describe Freyja::Persister, :active_fedora, :clean_repo, valkyrie_adapter: :freyja_adapter do
   subject(:persister) { described_class.new(adapter: adapter) }
   let(:adapter) { Freyja::MetadataAdapter.new }
   let(:query_service) { adapter.query_service }
@@ -36,6 +36,8 @@ RSpec.describe Freyja::Persister, :active_fedora, :clean_repo do
         accepts_nested_attributes_for :nested_resource
         include Hydra::Works::WorkBehavior
       end
+
+      Wings::ModelRegistry.register(CustomResource, Custom)
     end
     after do
       Object.send(:remove_const, :CustomResource)

--- a/spec/lib/freyja/persister_spec.rb
+++ b/spec/lib/freyja/persister_spec.rb
@@ -39,7 +39,10 @@ RSpec.describe Freyja::Persister, :active_fedora, :clean_repo, valkyrie_adapter:
 
       Wings::ModelRegistry.register(CustomResource, Custom)
     end
+
     after do
+      Wings::ModelRegistry.unregister(CustomResource)
+
       Object.send(:remove_const, :CustomResource)
       Object.send(:remove_const, :Custom)
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -357,10 +357,10 @@ RSpec.configure do |config|
       unless adapter_name == :wings_adapter
         Valkyrie::StorageAdapter.register(
           Valkyrie::Storage::Disk.new(base_path: Rails.root.join("tmp", "storage", "files"),
-            file_mover: FileUtils.method(:cp)),
+                                      file_mover: FileUtils.method(:cp)),
           :disk
         )
-        Valkyrie.config.storage_adapter  = :disk
+        Valkyrie.config.storage_adapter = :disk
       end
     else
       allow(Hyrax.config).to receive(:disable_wings).and_return(true)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -244,7 +244,7 @@ RSpec.configure do |config|
       # trust that clean_repo performed the clean if present
       example.metadata[:clean_repo] ||
       # don't run for adapters other than wings
-      (example.metadata[:valkyrie_adapter].present? && example.metadata[:valkyrie_adapter] != :wings_adapter)
+      (example.metadata[:valkyrie_adapter].present? && ![:wings_adapter, :freyja_adapter, :frigg_adapter].include?(adapter_name))
   end
 
   config.append_after(:each, type: :feature) do
@@ -352,7 +352,7 @@ RSpec.configure do |config|
   config.prepend_before(:example, :valkyrie_adapter) do |example|
     adapter_name = example.metadata[:valkyrie_adapter]
 
-    if adapter_name == :wings_adapter
+    if [:wings_adapter, :freyja_adapter, :frigg_adapter].include?(adapter_name)
       skip("Don't test Wings when it is dasabled") if Hyrax.config.disable_wings
     else
       allow(Hyrax.config).to receive(:disable_wings).and_return(true)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -354,6 +354,14 @@ RSpec.configure do |config|
 
     if [:wings_adapter, :freyja_adapter, :frigg_adapter].include?(adapter_name)
       skip("Don't test Wings when it is dasabled") if Hyrax.config.disable_wings
+      unless adapter_name == :wings_adapter
+        Valkyrie::StorageAdapter.register(
+          Valkyrie::Storage::Disk.new(base_path: Rails.root.join("tmp", "storage", "files"),
+            file_mover: FileUtils.method(:cp)),
+          :disk
+        )
+        Valkyrie.config.storage_adapter  = :disk
+      end
     else
       allow(Hyrax.config).to receive(:disable_wings).and_return(true)
       hide_const("Wings") # disable_wings=true removes the Wings constant

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -362,7 +362,9 @@ RSpec.configure do |config|
                                       file_mover: FileUtils.method(:cp)),
           :disk
         )
-        Valkyrie.config.storage_adapter = :disk
+        allow(Valkyrie.config)
+          .to receive(:storage_adapter)
+          .and_return(Valkyrie::StorageAdapter.find(:disk))
       end
     else
       allow(Hyrax.config).to receive(:disable_wings).and_return(true)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -240,11 +240,13 @@ RSpec.configure do |config|
   config.include Warden::Test::Helpers, type: :feature
 
   config.before(:each, type: :feature) do |example|
+    adapter_name = example.metadata[:valkyrie_adapter]
+
     clean_active_fedora_repository unless
       # trust that clean_repo performed the clean if present
       example.metadata[:clean_repo] ||
       # don't run for adapters other than wings
-      (example.metadata[:valkyrie_adapter].present? && ![:wings_adapter, :freyja_adapter, :frigg_adapter].include?(adapter_name))
+      (adapter_name.present? && ![:wings_adapter, :freyja_adapter, :frigg_adapter].include?(adapter_name))
   end
 
   config.append_after(:each, type: :feature) do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -60,6 +60,8 @@ Valkyrie::MetadataAdapter
   .register(Valkyrie::Persistence::Memory::MetadataAdapter.new, :test_adapter)
 Valkyrie::MetadataAdapter
   .register(Valkyrie::Persistence::Postgres::MetadataAdapter.new, :postgres_adapter)
+Valkyrie::MetadataAdapter
+  .register(Freyja::MetadataAdapter.new, :freyja_adapter)
 version_path = Rails.root / 'tmp' / 'test_adapter_uploads'
 Valkyrie::StorageAdapter.register(
   Valkyrie::Storage::VersionedDisk.new(base_path: version_path),


### PR DESCRIPTION
### Fixes

When migrating file_sets, the actual file is currently transfering, but file characterization data is getting lost. This fix prevents the file characterization data (such as height and width) from going missing after saving to Postgres or Fcrepo 6 from a perviously saved Fcrepo 4 object.

### Changes proposed in this pull request:
* Fix characterization fields going missing on transfer of FileSets from fcrepo 4 to postgres
* Make sure custom queries are loaded when ever the Goddess adapters are loaded [1]
* Default resource_class_resolver for Valkyrie objects should use the model registry [1]
* Improve the spec helpers to make testing freyja and frigg adapters easier

[1] - Both of these two points are things we have been putting in all the config/initializer/wings.rb files when we enable Freyja. In order to get specs working for this migration issue, we needed to pull them in to Hyrax. It seemed better to make the included instead of duplicating the logic in the spec helpers.


