### PR TITLE
Delete PermissionTemplate when destroying a Hyrax::AdministrativeSet or Hyrax collection

### DIFF
--- a/lib/hyrax/transactions/admin_set_destroy.rb
+++ b/lib/hyrax/transactions/admin_set_destroy.rb
@@ -11,7 +11,8 @@ module Hyrax
       DEFAULT_STEPS = ['admin_set_resource.check_default',
                        'admin_set_resource.check_empty',
                        'admin_set_resource.delete',
-                       'admin_set_resource.delete_acl'].freeze
+                       'admin_set_resource.delete_acl',
+                       'admin_set_resource.delete_permission_template'].freeze
 
       ##
       # @see Hyrax::Transactions::Transaction

--- a/lib/hyrax/transactions/collection_destroy.rb
+++ b/lib/hyrax/transactions/collection_destroy.rb
@@ -11,7 +11,8 @@ module Hyrax
       # TODO: Add step that checks if collection is empty for collections of types that require it
       DEFAULT_STEPS = ['collection_resource.delete_acl',
                        'collection_resource.remove_from_membership',
-                       'collection_resource.delete'].freeze
+                       'collection_resource.delete',
+                       'collection_resource.delete_permission_template'].freeze.freeze
 
       ##
       # @see Hyrax::Transactions::Transaction

--- a/lib/hyrax/transactions/container.rb
+++ b/lib/hyrax/transactions/container.rb
@@ -42,6 +42,7 @@ module Hyrax
       require 'hyrax/transactions/steps/delete_access_control'
       require 'hyrax/transactions/steps/delete_all_file_metadata'
       require 'hyrax/transactions/steps/delete_all_file_sets'
+      require 'hyrax/transactions/steps/delete_permission_template'
       require 'hyrax/transactions/steps/delete_resource'
       require 'hyrax/transactions/steps/ensure_admin_set'
       require 'hyrax/transactions/steps/file_metadata_delete'
@@ -202,6 +203,10 @@ module Hyrax
         ops.register 'save_acl' do
           Steps::SaveAccessControl.new
         end
+
+        ops.register 'delete_permission_template' do
+          Steps::DeletePermissionTemplate.new
+        end
       end
 
       namespace 'collection_resource' do |ops| # Hyrax::PcdmCollection resource
@@ -227,6 +232,10 @@ module Hyrax
 
         ops.register 'save_acl' do
           Steps::SaveAccessControl.new
+        end
+
+        ops.register 'delete_permission_template' do
+          Steps::DeletePermissionTemplate.new
         end
 
         ops.register 'save_collection_banner' do

--- a/lib/hyrax/transactions/steps/delete_permission_template.rb
+++ b/lib/hyrax/transactions/steps/delete_permission_template.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+require 'dry/monads'
+
+module Hyrax
+  module Transactions
+    module Steps
+      ##
+      # Deletes the Hyrax::PermissionTemplate for a resource.
+      # If no PermissionTemplate associated with that resource is found, succeeds.
+      #
+      # @see https://dry-rb.org/gems/dry-monads/1.0/result/
+      class DeletePermissionTemplate
+        include Dry::Monads[:result]
+
+        ##
+        # @param [Valkyrie::Resource] obj
+        #
+        # @return [Dry::Monads::Result]
+        def call(obj)
+          permission_template = Hyrax::PermissionTemplate.find_by(source_id: obj.id)
+          return Success(obj) if permission_template.nil?
+
+          permission_template.destroy || (return Failure[:failed_to_delete_permission_template, permission_template])
+
+          Success(obj)
+        end
+      end
+    end
+  end
+end

--- a/spec/hyrax/transactions/admin_set_destroy_spec.rb
+++ b/spec/hyrax/transactions/admin_set_destroy_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 require 'hyrax/transactions'
 
 RSpec.describe Hyrax::Transactions::AdminSetDestroy, valkyrie_adapter: :test_adapter do
-  subject(:tx)   { described_class.new }
+  subject(:tx) { described_class.new }
   let(:resource) { FactoryBot.valkyrie_create(:hyrax_admin_set) }
 
   describe '#call' do
@@ -25,6 +25,36 @@ RSpec.describe Hyrax::Transactions::AdminSetDestroy, valkyrie_adapter: :test_ada
       it 'gives useful error data' do
         expect(tx.call(resource).failure)
           .to include(contain_exactly(member_work))
+      end
+    end
+
+    context 'with the default admin set' do
+      it 'is a failure' do
+        default_admin_set = Hyrax.config.default_admin_set
+        expect(tx.call(default_admin_set)).to be_failure
+      end
+    end
+
+    context 'with a permission template' do
+      let(:resource_with_pt) { FactoryBot.valkyrie_create(:hyrax_admin_set, :with_permission_template) }
+
+      describe '#call' do
+        it 'is a success' do
+          expect(tx.call(resource_with_pt)).to be_success
+        end
+
+        it 'will destroy the associated permission template' do
+          # NOTE: We don't just check the PermissionTemplate count, because there are too many
+          # possible PermissionTemplate-creating side effects to depend the "before" value
+          tx.call(resource_with_pt)
+          expect(Hyrax::PermissionTemplate.where(source_id: resource_with_pt.id)).not_to exist
+        end
+
+        it 'succeeds if the associated permission template has already been destroyed' do
+          permission_template = Hyrax::PermissionTemplate.find_by!(source_id: resource_with_pt.id)
+          permission_template.destroy!
+          expect(tx.call(resource_with_pt)).to be_success
+        end
       end
     end
   end

--- a/spec/hyrax/transactions/collection_destroy_spec.rb
+++ b/spec/hyrax/transactions/collection_destroy_spec.rb
@@ -3,18 +3,43 @@ require 'spec_helper'
 require 'hyrax/transactions'
 
 RSpec.describe Hyrax::Transactions::CollectionDestroy, valkyrie_adapter: :test_adapter do
-  subject(:tx)   { described_class.new }
   let(:resource) { FactoryBot.valkyrie_create(:hyrax_collection) }
   let(:user)     { FactoryBot.create(:user) }
 
+  subject(:tx) do
+    described_class.new
+                   .with_step_args(
+                     'collection_resource.delete' => { user: user },
+                     'collection_resource.remove_from_membership' => { user: user }
+                   )
+  end
+
   describe '#call' do
     it 'is a success' do
-      expect(
-        tx
-          .with_step_args('collection_resource.delete' => { user: user },
-                          'collection_resource.remove_from_membership' => { user: user })
-          .call(resource)
-      ).to be_success
+      expect(tx.call(resource)).to be_success
+    end
+
+    context 'with a permission template' do
+      let(:resource_with_pt) { FactoryBot.valkyrie_create(:hyrax_collection, :with_permission_template) }
+
+      describe '#call' do
+        it 'is a success' do
+          expect(tx.call(resource_with_pt)).to be_success
+        end
+
+        it 'will destroy the associated permission template' do
+          # NOTE: We don't just check the PermissionTemplate count, because there are too many
+          # possible PermissionTemplate-creating side effects to depend the "before" value
+          tx.call(resource_with_pt)
+          expect(Hyrax::PermissionTemplate.where(source_id: resource_with_pt.id)).not_to exist
+        end
+
+        it 'succeeds if the associated permission template has already been destroyed' do
+          permission_template = Hyrax::PermissionTemplate.find_by!(source_id: resource_with_pt.id)
+          permission_template.destroy!
+          expect(tx.call(resource_with_pt)).to be_success
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
### Fixes

Fixes #6916 

### Summary

Adds a workflow step to destroy the associated `PermissionTemplate` when destroying a `Hyrax::AdministrativeSet` or Hyrax collection.

### Type of change (for release notes)

- `notes-bugfix` Bug Fixes

### Detailed Description

I couldn't find an exact analogue for this -- the closest was `DeleteAccessControl` transaction, so I modeled the behavior on that with a corresponding `DeletePermissionTemplate` step. Note that the tests are a little more involved than the [corresponding test for `AdminSet`](https://github.com/samvera/hyrax/blob/aeb5e3e57c113069e19fbd0c1102b3098c032fc0/spec/models/admin_set_spec.rb#L53), as I found there were `PermissionTemplate` records being created by side effect during the transaction call (e.g. creating the default `AdministrativeSet`, while checking to make sure the `AdministrativeSet` we're deleting wasn't it). I didn't want to mess with that behavior, but I'm open to suggestions about ways to make the tests cleaner.

### Changes proposed in this pull request:

`AdminSetDestroy` and `CollectionDestroy` now destroy the associated `PermissionTemplate` along with the `AdministrativeSet` or collection.

@samvera/hyrax-code-reviewers
