### PR TITLE
Fix location indexing

### DIFF
--- a/app/indexers/concerns/hyrax/location_indexer.rb
+++ b/app/indexers/concerns/hyrax/location_indexer.rb
@@ -6,7 +6,7 @@ module Hyrax
   module LocationIndexer
     def to_solr
       super.tap do |index_document|
-        index_document[:based_near_label_tesim] = based_near_label_lookup(resource.based_near) if resource.respond_to? :based_near
+        index_document[:based_near_label_tesim] = index_document[:based_near_label_tesim] = based_near_label_lookup(resource.based_near) if resource.respond_to? :based_near
       end
     end
 
@@ -14,7 +14,7 @@ module Hyrax
 
     def based_near_label_lookup(locations)
       locations.map do |loc|
-        location_service.full_label(loc)
+        location_service.full_label(loc) if loc.present?
       end
     end
 


### PR DESCRIPTION
### Fixes

Location indexer now includes the term needed for location faceting.

### Summary

Valkyrie resources were not indexing term `based_near_label_sim` which is needed for the location facet, so they were not appearing in the facet.

### Guidance for testing, such as acceptance criteria or new user interface behaviors:

A new work using based_near location will now appear in the facet on the catalog page.

### Type of change (for release notes)

- `notes-bugfix` Bug Fixes

### Changes proposed in this pull request:
* Fix location facet indexing by indexing the needed term
* Add a safeguard that we don't attempt to call the location service on a blank term, as this crashes the service.

@samvera/hyrax-code-reviewers
