### PR TITLE
Always save nonpersisted ACLs

### DIFF
--- a/app/services/hyrax/access_control_list.rb
+++ b/app/services/hyrax/access_control_list.rb
@@ -136,7 +136,7 @@ module Hyrax
     #
     # @return [Boolean]
     def pending_changes?
-      change_set.changed?
+      !change_set.resource.persisted? || change_set.changed?
     end
 
     ##

--- a/app/services/hyrax/custom_queries/find_access_control.rb
+++ b/app/services/hyrax/custom_queries/find_access_control.rb
@@ -20,7 +20,7 @@ module Hyrax
           .find_inverse_references_by(resource: resource, property: :access_to)
           .find { |r| r.is_a?(Hyrax::AccessControl) } ||
           raise(Valkyrie::Persistence::ObjectNotFoundError)
-      rescue ArgumentError # some adapters raise ArgumentError for missing resources
+      rescue ArgumentError, Ldp::Gone # some adapters raise ArgumentError for missing resources
         raise(Valkyrie::Persistence::ObjectNotFoundError)
       end
     end

--- a/spec/services/hyrax/access_control_list_spec.rb
+++ b/spec/services/hyrax/access_control_list_spec.rb
@@ -119,10 +119,21 @@ RSpec.describe Hyrax::AccessControlList do
         .from be_empty
     end
 
-    it 'does not publish when permissions are unchanged' do
-      expect { acl.save }
-        .not_to change { listener.object_acl_updated }
-        .from nil
+    context 'when not persisted' do
+      it 'publishes when permissions are unchanged' do
+        expect { acl.save }
+          .to change { listener.object_acl_updated }
+          .from nil
+      end
+    end
+
+    context 'when persisted' do
+      before { acl.save }
+
+      it 'does not publish when permissions are unchanged' do
+        expect { acl.save }
+          .not_to change { listener.object_acl_updated }
+      end
     end
 
     context 'with additions' do

--- a/spec/services/hyrax/custom_queries/find_access_control_spec.rb
+++ b/spec/services/hyrax/custom_queries/find_access_control_spec.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-RSpec.describe Hyrax::CustomQueries::FindAccessControl do
+RSpec.describe Hyrax::CustomQueries::FindAccessControl, skip: !Hyrax.config.disable_wings do
   subject(:query_handler) { described_class.new(query_service: query_service) }
   let(:adapter)           { Hyrax.metadata_adapter }
   let(:persister)         { adapter.persister }

--- a/spec/services/hyrax/custom_queries/find_access_control_spec.rb
+++ b/spec/services/hyrax/custom_queries/find_access_control_spec.rb
@@ -33,8 +33,8 @@ RSpec.describe Hyrax::CustomQueries::FindAccessControl, skip: !Hyrax.config.disa
       before { acl } # ensure the acl gets saved
 
       it 'returns the acl' do
-        expect(query_handler.find_access_control_for(resource: resource))
-          .to eq acl
+        expect(query_handler.find_access_control_for(resource: resource).id)
+          .to eq acl.id
       end
     end
 

--- a/spec/services/hyrax/custom_queries/find_access_control_spec.rb
+++ b/spec/services/hyrax/custom_queries/find_access_control_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 RSpec.describe Hyrax::CustomQueries::FindAccessControl do
   subject(:query_handler) { described_class.new(query_service: query_service) }
-  let(:adapter)           { Valkyrie::MetadataAdapter.find(:test_adapter) }
+  let(:adapter)           { Hyrax.metadata_adapter }
   let(:persister)         { adapter.persister }
   let(:query_service)     { adapter.query_service }
 

--- a/spec/services/hyrax/custom_queries/find_access_control_spec.rb
+++ b/spec/services/hyrax/custom_queries/find_access_control_spec.rb
@@ -15,6 +15,17 @@ RSpec.describe Hyrax::CustomQueries::FindAccessControl do
       end
     end
 
+    context 'for deleted object' do
+      let(:resource) { persister.save(resource: Hyrax::Resource.new) }
+
+      before { persister.delete(resource: resource) }
+
+      it 'raises ObjectNotFoundError' do
+        expect { query_handler.find_access_control_for(resource: resource) }
+          .to raise_error Valkyrie::Persistence::ObjectNotFoundError
+      end
+    end
+
     context 'when an acl exists' do
       let(:acl)      { persister.save(resource: Hyrax::AccessControl.new(access_to: resource.id)) }
       let(:resource) { persister.save(resource: Hyrax::Resource.new) }

--- a/spec/services/hyrax/custom_queries/find_access_control_spec.rb
+++ b/spec/services/hyrax/custom_queries/find_access_control_spec.rb
@@ -7,11 +7,11 @@ RSpec.describe Hyrax::CustomQueries::FindAccessControl do
 
   describe '#find_access_control' do
     context 'for missing object' do
-      let(:resource) { Valkyrie::Resource.new }
+      let(:resource) { Hyrax::Resource.new }
 
       it 'raises ObjectNotFoundError' do
         expect { query_handler.find_access_control_for(resource: resource) }
-          .to raise_error { Valkyrie::Persistence::ObjectNotFoundError }
+          .to raise_error Valkyrie::Persistence::ObjectNotFoundError
       end
     end
 
@@ -50,7 +50,7 @@ RSpec.describe Hyrax::CustomQueries::FindAccessControl do
 
       it 'raises ObjectNotFoundError' do
         expect { query_handler.find_access_control_for(resource: resource) }
-          .to raise_error { Valkyrie::Persistence::ObjectNotFoundError }
+          .to raise_error Valkyrie::Persistence::ObjectNotFoundError
       end
     end
   end

--- a/spec/services/hyrax/listeners/file_metadata_listener_spec.rb
+++ b/spec/services/hyrax/listeners/file_metadata_listener_spec.rb
@@ -20,8 +20,8 @@ RSpec.describe Hyrax::Listeners::FileMetadataListener, valkyrie_adapter: :test_a
     it 'indexes the file_set' do
       expect { listener.on_file_metadata_updated(event) }
         .to change { fake_adapter.saved_resources }
-        .from(be_empty)
-        .to contain_exactly(file_set)
+        .from(contain_exactly(file_set)) # Saving the ACL triggers an index
+        .to(contain_exactly(file_set, file_set))
     end
 
     context 'when the file is not in a file set' do
@@ -53,7 +53,7 @@ RSpec.describe Hyrax::Listeners::FileMetadataListener, valkyrie_adapter: :test_a
       it 'does not index the file_set' do
         expect { listener.on_file_metadata_updated(event) }
           .not_to change { fake_adapter.saved_resources }
-          .from(be_empty)
+          .from(contain_exactly(file_set)) # Saving the ACL triggers an index
       end
     end
   end

--- a/spec/wings/services/custom_queries/find_access_control_spec.rb
+++ b/spec/wings/services/custom_queries/find_access_control_spec.rb
@@ -13,11 +13,11 @@ RSpec.describe Wings::CustomQueries::FindAccessControl, :active_fedora do
 
   describe '#find_access_control' do
     context 'for missing object' do
-      let(:resource) { Valkyrie::Resource.new }
+      let(:resource) { Hyrax::Resource.new }
 
       it 'raises ObjectNotFoundError' do
         expect { query_handler.find_access_control_for(resource: resource) }
-          .to raise_error { Valkyrie::Persistence::ObjectNotFoundError }
+          .to raise_error Valkyrie::Persistence::ObjectNotFoundError
       end
     end
 


### PR DESCRIPTION
### Summary

Calling save on a new (unpersisted) ACL object should persist it even when there are no changes otherwise. 
