### PR TITLE
Adding alt attribute for collection thumbnail

### DIFF
--- a/app/views/catalog/_thumbnail_list_collection.html.erb
+++ b/app/views/catalog/_thumbnail_list_collection.html.erb
@@ -1,4 +1,4 @@
 <div class="col-md-3">
-  <%= document_presenter(document)&.thumbnail&.thumbnail_tag({}, { suppress_link: true }) %>
+  <%= document_presenter(document)&.thumbnail&.thumbnail_tag({ alt: document.title_or_label }, { suppress_link: true }) %>
 </div> 
 

--- a/app/views/catalog/_thumbnail_list_default.html.erb
+++ b/app/views/catalog/_thumbnail_list_default.html.erb
@@ -1,7 +1,7 @@
 <% model = document.hydra_model %>
 <div class="col-md-3">
   <% if model == Hyrax::PcdmCollection || model < Hyrax::PcdmCollection %>
-    <%= document_presenter(document)&.thumbnail&.thumbnail_tag({}, suppress_link: true, alt: document.title_or_label) %>
+    <%= document_presenter(document)&.thumbnail&.thumbnail_tag({ alt: document.title_or_label }, { suppress_link: true }) %>
   <% else %>
     <div class="list-thumbnail">
       <%= document_presenter(document)&.thumbnail&.thumbnail_tag(alt: document.title_or_label) %>


### PR DESCRIPTION
### Fixes 

Fixes #6891 - Adds alt attribute on collection thumbnails when shown in search results. Also adjusts default search result list to include alt attribute on collection results using same method (alt attributes added there for work thumbnails in fix for #6749)

### Summary

Calling up collection title and using that for alternative text attribute value

### Type of change (for release notes)

Choose from:
- `notes-minor` Addresses accessibility-concern of missing alternative text

@samvera/hyrax-code-reviewers
