### PR TITLE
darker link color for contrast

### DIFF
--- a/app/forms/hyrax/forms/admin/appearance.rb
+++ b/app/forms/hyrax/forms/admin/appearance.rb
@@ -47,7 +47,7 @@ module Hyrax
 
         # The color links
         def link_color
-          block_for('link_color', '#2e74b2')
+          block_for('link_color', '#104C75')
         end
 
         # The color for links in the footer


### PR DESCRIPTION
### Fixes

Fixes #6892

### Summary

This changes the link color where it is defined in app/forms/hyrax/forms/admin/appearance.rb to color slightly darker (and used on the Nurax site). Dashboard works page now passing Siteimprove

### Guidance for testing, such as acceptance criteria or new user interface behaviors:
* Retest for contrast
*
*

### Type of change (for release notes)
notes-minor  

@samvera/hyrax-code-reviewers
