### PR TITLE
Update navbar style for color contrast accessibility

### DIFF
--- a/app/views/_controls.html.erb
+++ b/app/views/_controls.html.erb
@@ -1,12 +1,12 @@
-<nav class="navbar navbar-light bg-light navbar-expand-sm justify-content-between align-items-center px-2 py-3 border-bottom" role="navigation" aria-label="Root Menu">
+<nav class="navbar bg-light navbar-expand-sm justify-content-between align-items-center px-2 py-3 border-bottom" role="navigation" aria-label="Root Menu">
     <ul class="nav navbar-nav col-sm-5">
-      <li class="nav-item <%= 'active' if current_page?(hyrax.root_path) %>">
+      <li class="nav-item <%= 'active font-weight-bold' if current_page?(hyrax.root_path) %>">
         <%= link_to t(:'hyrax.controls.home'), hyrax.root_path, class: "nav-link", aria: current_page?(hyrax.root_path) ? {current: 'page'} : nil %></li>
-      <li class="nav-item <%= 'active' if current_page?(hyrax.about_path) %>">
+      <li class="nav-item <%= 'active font-weight-bold' if current_page?(hyrax.about_path) %>">
         <%= link_to t(:'hyrax.controls.about'), hyrax.about_path, class: "nav-link", aria: current_page?(hyrax.about_path) ? {current: 'page'} : nil %></li>
-      <li class="nav-item <%= 'active' if current_page?(hyrax.help_path) %>">
+      <li class="nav-item <%= 'active font-weight-bold' if current_page?(hyrax.help_path) %>">
         <%= link_to t(:'hyrax.controls.help'), hyrax.help_path, class: "nav-link", aria: current_page?(hyrax.help_path) ? {current: 'page'} : nil %></li>
-      <li class="nav-item <%= 'active' if current_page?(hyrax.contact_path) %>">
+      <li class="nav-item <%= 'active font-weight-bold' if current_page?(hyrax.contact_path) %>">
         <%= link_to t(:'hyrax.controls.contact'), hyrax.contact_path, class: "nav-link", aria: current_page?(hyrax.contact_path) ? {current: 'page'} : nil %></li>
     </ul><!-- /.nav -->
     <div class="col-sm-7">


### PR DESCRIPTION
### Fixes

Fixes #6745 

### Summary

Removes `navbar-light` class from `<nav>` and adds `font-weight-bold` class when nav item is active for more accessible color contrast.

### Type of change (for release notes)

- `notes-minor` Adjusts color contrast on main navigation for accessibility

### Detailed Description

Removes `navbar-light` class from `<nav>` that doesn't have enough color contrast so that default link color is used that does have enough color contrast. Also adds `font-weight-bold` class on active menu item to bring back styling similar to `navbar-light` that helps visually identify location.

@samvera/hyrax-code-reviewers
