### PR TITLE
Fixing accessibility violations in user detail row

### DIFF
--- a/app/views/hyrax/users/_user_row.html.erb
+++ b/app/views/hyrax/users/_user_row.html.erb
@@ -1,8 +1,11 @@
 <tr>
-  <td><%= link_to hyrax.user_path(user) do %>
-        <%= image_tag(user.avatar.url(:thumb), width: 30) if user.avatar.file %>
+   <td>
+     <% if user.avatar.file %>
+      <%= link_to hyrax.user_path(user) do %>
+        <%= image_tag(user.avatar.url(:thumb), width: 30, alt: user.name) %>
       <% end %>
-  </td>
+     <% end %>
+   </td>
    <td><%= link_to user.name, hyrax.user_path(user) %></td>
    <td><%= link_to user.user_key, hyrax.user_path(user) %></td>
    <td><%= user.department %></td>


### PR DESCRIPTION
### Fixes

Fixes #6759 

### Summary

Suppresses user avatar link, when no avatar file specified, and adds an alt text for when one does.

### Type of change (for release notes)

- `notes-minor` Simple logic change around handling of avatar link in the user detail list

@samvera/hyrax-code-reviewers
