### PR TITLE
call to_rdf_representation in #collections?

### DIFF
--- a/app/models/hyrax/collection_type.rb
+++ b/app/models/hyrax/collection_type.rb
@@ -111,7 +111,7 @@ module Hyrax
     # @return [Boolean] True if there are any collections of this collection type in the repository
     def collections?
       return false unless id
-      Hyrax::SolrQueryService.new.with_field_pairs(field_pairs: { Hyrax.config.collection_type_index_field.to_sym => to_global_id.to_s }).with_model(model: Hyrax.config.collection_class).count > 0
+      Hyrax::SolrQueryService.new.with_field_pairs(field_pairs: { Hyrax.config.collection_type_index_field.to_sym => to_global_id.to_s }).with_model(model: Hyrax.config.collection_class.to_rdf_representation).count > 0
     end
 
     # @return [Boolean] True if this is the Admin Set type


### PR DESCRIPTION
When we upgraded Hyku's hyrax, two specs were failing for collection types.

Ultimately it's because our has_model_ssim for a CollectionResource is Collection. When Collections had collection types the search query still returned 0. Calling #to_rdf_representation resolves this issue, and is how the resource indexer indexes the has_model_ property.

## Failing Hyku Specs:

### BEFORE
- [x] rspec ./spec/features/collection_type_spec.rb:461 # collection_type delete collection type when collections exist of this type shows unable to delete dialog and forwards to All Collections with filter applied
- [x] rspec ./spec/features/collection_type_spec.rb:386 # collection_type edit collection type when collections exist of this type all settings are disabled

### AFTER

![image](https://github.com/user-attachments/assets/6f6b41d2-ece5-4fe1-9934-e0b138929013)


## Related PR:
- https://github.com/samvera/hyrax/commit/e11d5d0ace49a1cb8a55502d29c3f879387c741c#diff-72960bb29a2ce3ad9714ae0441c3a15def11b7ff2af54e47bc5d8b846bbc1d16



