### PR TITLE
Add presentation role to list items

### DIFF
--- a/app/views/hyrax/dashboard/collections/_form.html.erb
+++ b/app/views/hyrax/dashboard/collections/_form.html.erb
@@ -1,28 +1,28 @@
 <%= render "shared/nav_safety_modal" %>
 <div class="tabs mt-4" id="collection-edit-controls">
   <ul class="nav nav-tabs" id="dashboard-collection-tab" role="tablist">
-    <li class="nav-item">
+    <li class="nav-item" role="presentation">
       <a href="#description" role="tab" data-toggle="tab" class="nav-link active nav-safety-confirm">
         <%= t('.tabs.description') %>
       </a>
     </li>
     <% if @form.persisted? %>
       <% if collection_brandable?(collection: @collection) %>
-      <li class="nav-item">
+      <li class="nav-item" role="presentation">
         <a href="#branding" role="tab" data-toggle="tab" class="nav-link nav-safety-confirm">
           <%= t('.tabs.branding') %>
         </a>
       </li>
       <% end %>
       <% if collection_discoverable?(collection: @collection) %>
-      <li class="nav-item">
+      <li class="nav-item" role="presentation">
         <a href="#discovery" role="tab" data-toggle="tab" class="nav-link nav-safety-confirm">
           <%= t('.tabs.discovery') %>
         </a>
       </li>
       <% end %>
       <% if collection_sharable?(collection: @collection) %>
-      <li class="nav-item">
+      <li class="nav-item" role="presentation">
         <a href="#sharing" role="tab" data-toggle="tab" class="nav-link nav-safety-confirm">
           <%= t('.tabs.sharing') %>
         </a>


### PR DESCRIPTION
### Fixes

Fixes #6797 
Fixes #6809 

### Summary

Corrects accessibility issue with list items in new user form.
Adds `role="presentation"` to `<li class="nav-item">` elements to prevent ARIA semantics from unnecessarily being exposed.

### Type of change (for release notes)

`notes-minor` Adds presentation role to list items for accessibility

@samvera/hyrax-code-reviewers
