### PR TITLE
Remove navigation role from collection tabs

### DIFF
--- a/app/views/hyrax/my/collections/_tabs.html.erb
+++ b/app/views/hyrax/my/collections/_tabs.html.erb
@@ -1,5 +1,5 @@
 <% current_page_dashboard = current_page?(hyrax.dashboard_collections_path(locale: nil)) %>
-<ul class="nav nav-tabs" id="my_nav" role="navigation">
+<ul class="nav nav-tabs" id="my_nav">
   <li<%= ' class="nav-item"'.html_safe if current_page_dashboard %>>
     <%= link_to(
       t("hyrax.dashboard.#{current_ability.admin? ? 'all' : 'managed'}.collections"), 


### PR DESCRIPTION
### Fixes

Fixes #6776 

### Summary

`role="navigation"` was removed from `<ul class="nav nav-tabs" id="my_nav" role="navigation">` in the collection tabs for accessibility.

### Type of change (for release notes)

`notes-minor` Removes navigation role from unordered list for accessibility

@samvera/hyrax-code-reviewers
