### PR TITLE
Added presentation role to edit collection type list items

### DIFF
--- a/app/views/hyrax/admin/collection_types/_form.html.erb
+++ b/app/views/hyrax/admin/collection_types/_form.html.erb
@@ -1,17 +1,17 @@
 <%= render "shared/nav_safety_modal" %>
 <div class="card tabs" id="collection-types-controls">
   <ul class="nav nav-tabs" role="tablist">
-    <li class="nav-item">
+    <li class="nav-item" role="presentation">
       <a href="#metadata" role="tab" data-toggle="tab" class="nav-link active nav-safety-confirm"><%= t('hyrax.admin.collection_types.form.tab.metadata') %></a>
     </li>
     <% if @form.persisted? %>
-      <li class="nav-item">
+      <li class="nav-item" role="presentation">
         <a href="#settings" role="tab" data-toggle="tab" class="nav-link nav-safety-confirm"><%= t('hyrax.admin.collection_types.form.tab.settings') %></a>
       </li>
-      <li class="nav-item">
+      <li class="nav-item" role="presentation">
         <a href="#participants" role="tab" data-toggle="tab" class="nav-link nav-safety-confirm"><%= t('hyrax.admin.collection_types.form.tab.participants') %></a>
       </li>
-      <li class="nav-item">
+      <li class="nav-item" role="presentation">
         <a href="#appearance" role="tab" data-toggle="tab" class="nav-link nav-safety-confirm"><%= t('hyrax.admin.collection_types.form.tab.appearance') %></a>
       </li>
     <% end %>


### PR DESCRIPTION
### Fixes

Fixes #6799 

### Summary

Corrects accessibility issue with list items in edit collection type form.
Adds `role="presentation"` to `<li class="nav-item">` elements to prevent ARIA semantics from unnecessarily being exposed.

### Type of change (for release notes)

- `notes-minor` Adds presentation role to list items for accessibility

@samvera/hyrax-code-reviewers
