### PR TITLE
Add presentation role to pages form

### DIFF
--- a/app/views/hyrax/pages/_form.html.erb
+++ b/app/views/hyrax/pages/_form.html.erb
@@ -2,22 +2,22 @@
 <div class="card tabs">
 
   <ul class="nav nav-tabs" role="tablist">
-    <li class="nav-item">
+    <li class="nav-item" role="presentation">
       <a href="#about" role="tab" data-toggle="tab" class="nav-link active nav-safety-confirm">
         <%= t(:'hyrax.pages.tabs.about_page') %>
       </a>
     </li>
-    <li class="nav-item">
+    <li class="nav-item" role="presentation">
       <a href="#help" role="tab" data-toggle="tab" class="nav-link nav-safety-confirm">
         <%= t(:'hyrax.pages.tabs.help_page') %>
       </a>
     </li>
-    <li class="nav-item">
+    <li class="nav-item" role="presentation">
       <a href="#agreement" role="tab" data-toggle="tab" class="nav-link nav-safety-confirm">
         <%= t(:'hyrax.pages.tabs.agreement_page') %>
       </a>
     </li>
-    <li class="nav-item">
+    <li class="nav-item" role="presentation">
       <a href="#terms" role="tab" data-toggle="tab" class="nav-link nav-safety-confirm">
         <%= t(:'hyrax.pages.tabs.terms_page') %>
       </a>


### PR DESCRIPTION
### Fixes

Fixes #6788  
Fixes #6787 

### Summary

Corrects accessibility issue with list items in pages form.
Adds `role="presentation"` to `<li class="nav-item">` elements to prevent ARIA semantics from unnecessarily being exposed.

### Type of change (for release notes)

- `notes-minor` Adds presentation role to list items for accessibility


@samvera/hyrax-code-reviewers
