### PR TITLE
Underline link text

### DIFF
--- a/app/assets/stylesheets/_bootstrap-default-overrides.scss
+++ b/app/assets/stylesheets/_bootstrap-default-overrides.scss
@@ -19,6 +19,9 @@ $warning: #565653 !default;
 $breadcrumb-active-color: #4c4c4c;
 $pagination-disabled-color: #4c4c4c;
 $blue: #0056B3 !default;
+// Adjusts link text to show as underlined and then not underlined on hover
+$link-decoration: underline !default;
+$link-hover-decoration: none !default;
 
 // Date picker on safari placeholder text was misaligned
 @media screen {


### PR DESCRIPTION
### Fixes

Fixes #6805 

### Summary

Changes link text to show as underlined and then not underlined on hover

### Type of change (for release notes)

Add an appropriate `notes-*` label to the PR (or indicate here) that classifies this change.

- `notes-minor` Change text links to show as underlined

### Detailed Description

Using Bootstrap variables to underline link text and not underline on hover. Does not appear to take over text links on entire site but will underline text links that don't have any other styling applied (main menu links remain not underlined, for example).

@samvera/hyrax-code-reviewers
