### PR TITLE
Parameterized lock requests

### DIFF
--- a/app/services/hyrax/lockable.rb
+++ b/app/services/hyrax/lockable.rb
@@ -1,11 +1,12 @@
 # frozen_string_literal: true
+require 'forwardable'
+
 module Hyrax
   module Lockable
+    extend Forwardable
     extend ActiveSupport::Concern
 
-    def acquire_lock_for(lock_key, &block)
-      lock_manager.lock(lock_key, &block)
-    end
+    def_delegator :lock_manager, :lock, :acquire_lock_for
 
     def lock_manager
       @lock_manager ||= LockManager.new(

--- a/spec/services/hyrax/lock_manager_spec.rb
+++ b/spec/services/hyrax/lock_manager_spec.rb
@@ -13,24 +13,81 @@ RSpec.describe Hyrax::LockManager do
       expect { |probe| subject.lock('foobar', &probe) }.to yield_with_no_args
     end
 
-    it "uses the configured ttl" do
-      client = instance_double(Redlock::Client)
-      allow(Redlock::Client).to receive(:new).and_return(client)
+    describe 'ttl' do
+      it "uses the configured ttl" do
+        client = instance_double(Redlock::Client)
+        allow(Redlock::Client).to receive(:new).and_return(client)
 
-      key = 'the key'
-      expect(client).to receive(:lock).with(key, ttl).and_yield(true)
-      subject.lock(key) { |_| }
+        key = 'the key'
+        expect(client).to receive(:lock).with(key, ttl).and_yield(true)
+        subject.lock(key) { |_| }
+      end
+
+      it "accepts an optional ttl argument" do
+        new_ttl = 1000
+        expect(new_ttl).not_to eq(ttl) # just to be sure
+
+        client = instance_double(Redlock::Client)
+        allow(Redlock::Client).to receive(:new).and_return(client)
+
+        key = 'the key'
+        expect(client).to receive(:lock).with(key, new_ttl).and_yield(true)
+        subject.lock(key, ttl: new_ttl) { |_| }
+      end
     end
 
-    it "uses the configured retry_count and retry_delay" do
-      client = instance_double(Redlock::Client)
-      expect(Redlock::Client)
-        .to receive(:new)
-        .with(kind_of(Array), retry_count: retry_count, retry_delay: retry_delay)
-        .and_return(client)
+    describe 'retry_count' do
+      it "uses the configured retry_count" do
+        client = instance_double(Redlock::Client)
+        expect(Redlock::Client)
+          .to receive(:new)
+          .with(kind_of(Array), retry_count: retry_count, retry_delay: kind_of(Integer))
+          .and_return(client)
 
-      allow(client).to receive(:lock).and_yield(true)
-      subject.lock("a key") { |_| }
+        allow(client).to receive(:lock).and_yield(true)
+        subject.lock("a key") { |_| }
+      end
+
+      it "accepts an optional retry_count argument" do
+        new_retry_count = 11
+        expect(new_retry_count).not_to eq(retry_count) # just to be sure
+
+        client = instance_double(Redlock::Client)
+        expect(Redlock::Client)
+          .to receive(:new)
+          .with(kind_of(Array), retry_count: new_retry_count, retry_delay: retry_delay)
+          .and_return(client)
+
+        allow(client).to receive(:lock).and_yield(true)
+        subject.lock("a key", retry_count: new_retry_count) { |_| }
+      end
+    end
+
+    describe 'retry_delay' do
+      it "uses the configured retry_delay" do
+        client = instance_double(Redlock::Client)
+        expect(Redlock::Client)
+          .to receive(:new)
+          .with(kind_of(Array), retry_count: kind_of(Integer), retry_delay: retry_delay)
+          .and_return(client)
+
+        allow(client).to receive(:lock).and_yield(true)
+        subject.lock("a key") { |_| }
+      end
+
+      it "accepts an optional retry_delay argument" do
+        new_retry_delay = 11
+        expect(new_retry_delay).not_to eq(retry_delay) # just to be sure
+
+        client = instance_double(Redlock::Client)
+        expect(Redlock::Client)
+          .to receive(:new)
+          .with(kind_of(Array), retry_count: retry_count, retry_delay: new_retry_delay)
+          .and_return(client)
+
+        allow(client).to receive(:lock).and_yield(true)
+        subject.lock("a key", retry_delay: new_retry_delay) { |_| }
+      end
     end
   end
 end

--- a/spec/services/hyrax/lock_manager_spec.rb
+++ b/spec/services/hyrax/lock_manager_spec.rb
@@ -1,14 +1,36 @@
 # frozen_string_literal: true
 RSpec.describe Hyrax::LockManager do
+  let(:ttl) { Hyrax.config.lock_time_to_live }
+  let(:retry_count) { Hyrax.config.lock_retry_count }
+  let(:retry_delay) { Hyrax.config.lock_retry_delay }
+
   subject do
-    described_class.new(Hyrax.config.lock_time_to_live,
-                        Hyrax.config.lock_retry_count,
-                        Hyrax.config.lock_retry_delay)
+    described_class.new(ttl, retry_count, retry_delay)
   end
 
   describe "lock", unless: ENV['TRAVIS'] do
     it "calls the block" do
       expect { |probe| subject.lock('foobar', &probe) }.to yield_with_no_args
+    end
+
+    it "uses the configured ttl" do
+      client = instance_double(Redlock::Client)
+      allow(Redlock::Client).to receive(:new).and_return(client)
+
+      key = 'the key'
+      expect(client).to receive(:lock).with(key, ttl).and_yield(true)
+      subject.lock(key) { |_| }
+    end
+
+    it "uses the configured retry_count and retry_delay" do
+      client = instance_double(Redlock::Client)
+      expect(Redlock::Client)
+        .to receive(:new)
+        .with(kind_of(Array), retry_count: retry_count, retry_delay: retry_delay)
+        .and_return(client)
+
+      allow(client).to receive(:lock).and_yield(true)
+      subject.lock("a key") { |_| }
     end
   end
 end

--- a/spec/services/hyrax/lockable_spec.rb
+++ b/spec/services/hyrax/lockable_spec.rb
@@ -1,19 +1,57 @@
 # frozen_string_literal: true
 RSpec.describe Hyrax::Lockable do
+  let(:lockable_class) { Class.new.include(described_class) }
   let(:lock_manager) { instance_double(Hyrax::LockManager) }
 
-  subject do
-    Class.new.include(described_class).new.tap do |lockable|
-      lockable.instance_variable_set(:@lock_manager, lock_manager)
+  subject { lockable_class.new }
+
+  describe "lock_manager" do
+    it "lazily creates a new lock manager with the default configuration" do
+      expect(Hyrax::LockManager).to receive(:new).once.with(
+        Hyrax.config.lock_time_to_live,
+        Hyrax.config.lock_retry_count,
+        Hyrax.config.lock_retry_delay
+      ).and_return(lock_manager)
+
+      expect(subject.lock_manager).to be(lock_manager)
+      expect(subject.lock_manager).to be(lock_manager)
     end
   end
 
   describe "acquire_lock_for" do
+    before do
+      subject.instance_variable_set(:@lock_manager, lock_manager)
+    end
+
     it 'acquires the lock' do
       key = 'a key'
       block = proc {}
       expect(lock_manager).to receive(:lock).with(key, &block)
       subject.acquire_lock_for(key, &block)
+    end
+
+    it 'accepts an optional ttl argument' do
+      key = 'a key'
+      new_ttl = 1000
+      block = proc {}
+      expect(lock_manager).to receive(:lock).with(key, ttl: new_ttl, &block)
+      subject.acquire_lock_for(key, ttl: new_ttl, &block)
+    end
+
+    it 'accepts an optional retry_count argument' do
+      key = 'a key'
+      new_retry_count = 11
+      block = proc {}
+      expect(lock_manager).to receive(:lock).with(key, retry_count: new_retry_count, &block)
+      subject.acquire_lock_for(key, retry_count: new_retry_count, &block)
+    end
+
+    it 'accepts an optional retry_delay argument' do
+      key = 'a key'
+      new_retry_delay = 11
+      block = proc {}
+      expect(lock_manager).to receive(:lock).with(key, retry_delay: new_retry_delay, &block)
+      subject.acquire_lock_for(key, retry_delay: new_retry_delay, &block)
     end
   end
 end

--- a/spec/services/hyrax/lockable_spec.rb
+++ b/spec/services/hyrax/lockable_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+RSpec.describe Hyrax::Lockable do
+  let(:lock_manager) { instance_double(Hyrax::LockManager) }
+
+  subject do
+    Class.new.include(described_class).new.tap do |lockable|
+      lockable.instance_variable_set(:@lock_manager, lock_manager)
+    end
+  end
+
+  describe "acquire_lock_for" do
+    it 'acquires the lock' do
+      key = 'a key'
+      block = proc {}
+      expect(lock_manager).to receive(:lock).with(key, &block)
+      subject.acquire_lock_for(key, &block)
+    end
+  end
+end


### PR DESCRIPTION
### Fixes

Fixes #6947.

### Summary

Allows callers of `LockManager#lock` and `Lockable#acquire_lock_for` to optionally pass in `ttl`, `retry_count`, and/or `retry_delay` parameters that will override the lock manager configuration for that particular lock request.

### Type of change (for release notes)

- `notes-minor` New Features that are backward compatible

### Detailed Description

`LockManager#lock` now optionally takes `ttl`, `retry_count`, and `retry_delay` keyword arguments, which override the configured values for that lock request only, e.g.

```ruby
lock_manager.lock(some_key, ttl: 5000) do  # overrides default ttl of 60,000 ms
  some_operation
end
```

The same applies to `Lockable#acquire_lock_for`:

```ruby
class SomeTask
  include Hyrax::Lockable

  def perform
    acquire_lock_for(some_key, retry_delay: 30) do  # overrides default delay of 30 ms
      some_operation
    end
  end

  private

  def some_operation
    # ...
  end
end
```

The default behavior of `LockManager` and `Lockable` haven't changed.

### Notes

Currently, in this PR, `LockManager#lock` explicitly declares `ttl`, `retry_count`, and `retry_delay` keyword parameters. An alternative approach would be to just take `ttl` (which is passed to `Redlock::Client#lock`) and an arbitrary hash of Redlock client options (of which `retry_count` and `retry_delay` are just two possible values). I decided not to go that direction because:

1. these are the only parameters we thought were worth configuring
2. there's been some discussion of getting off Redlock (and Redis), and I didn't want to tie us too closely to that API

I did, however, redefine `Lockable#acquire_lock_for` to be a simple delegate to `lock_manager.lock` -- that's how it was behaving anyway, and it seemed cleaner than re-declaring the parameters there. I've implemented it with `Forwardable`, but if we think that's too cute, we could instead do something like:

```ruby
def acquire_lock_for(key, **kwargs, &block)
  lock_manager.lock(key, **kwargs, &block)
end
```

@samvera/hyrax-code-reviewers
