### PR TITLE
Add overflow to scss

### DIFF
--- a/app/assets/stylesheets/hyrax/_forms.scss
+++ b/app/assets/stylesheets/hyrax/_forms.scss
@@ -40,6 +40,7 @@ legend small {
 
 .select2-container .select2-choice > .select2-chosen {
   max-width: 26em;
+  overflow: auto;
 }
 
 form {


### PR DESCRIPTION
### Fixes

Fixes #6771 

### Summary

Added `overflow: auto` to accept text size variations

### Type of change (for release notes)

- `notes-minor` Added `overflow: auto` for accessibility


@samvera/hyrax-code-reviewers
