### PR TITLE
move span inside button

### DIFF
--- a/app/views/hyrax/file_sets/_permission_form.html.erb
+++ b/app/views/hyrax/file_sets/_permission_form.html.erb
@@ -33,7 +33,7 @@
         <%= select_tag 'new_user_permission_skel', options_for_select(configured_permission_options), class: 'form-control' %>
       </div>
       <div class="col-sm-3">
-        <button class="btn btn-secondary" id="add_new_user_skel" aria-label="add this user">
+        <button class="btn btn-secondary" id="add_new_user_skel">
           <span class="sr-only"><%= t('.add_new_user_skel', account_label: t('hyrax.account_label')) %></span>
           <span aria-hidden="true"><i class="fa fa-plus"></i></span>
         </button>
@@ -56,8 +56,10 @@
         <%= select_tag 'new_group_permission_skel', options_for_select(configured_permission_options), class: 'form-control' %>
       </div>
       <div class="col-sm-3">
-        <span class="sr-only"><%= t('.add_new_group_skel') %></span>
-        <button class="btn btn-secondary" id="add_new_group_skel" aria-label="add this group"><i class="fa fa-plus"></i></button>
+        <button class="btn btn-secondary" id="add_new_group_skel">
+          <span class="sr-only"><%= t('.add_new_group_skel') %></span>
+          <i class="fa fa-plus"></i>
+        </button>
         <br /><span id="directory_group_result"></span>
       </div>
     </div>

--- a/app/views/hyrax/file_sets/_permission_form.html.erb
+++ b/app/views/hyrax/file_sets/_permission_form.html.erb
@@ -33,7 +33,7 @@
         <%= select_tag 'new_user_permission_skel', options_for_select(configured_permission_options), class: 'form-control' %>
       </div>
       <div class="col-sm-3">
-        <button class="btn btn-secondary" id="add_new_user_skel">
+        <button class="btn btn-secondary" id="add_new_user_skel" aria-label="add this user">
           <span class="sr-only"><%= t('.add_new_user_skel', account_label: t('hyrax.account_label')) %></span>
           <span aria-hidden="true"><i class="fa fa-plus"></i></span>
         </button>
@@ -57,7 +57,7 @@
       </div>
       <div class="col-sm-3">
         <span class="sr-only"><%= t('.add_new_group_skel') %></span>
-        <button class="btn btn-secondary" id="add_new_group_skel"><i class="fa fa-plus"></i></button>
+        <button class="btn btn-secondary" id="add_new_group_skel" aria-label="add this group"><i class="fa fa-plus"></i></button>
         <br /><span id="directory_group_result"></span>
       </div>
     </div>


### PR DESCRIPTION
### Fixes

Fixes #6811

### Summary
In the fileset edit, permissions tab, button to add groups to permitted list were without text

### Guidance for testing, such as acceptance criteria or new user interface behaviors:
* Siteimprove checking a fileset edit page with the permissions tab showing should not return "Button missing a text alternative" error.
*
*

### Type of change (for release notes)

notes-minor

### Detailed Description

In views/hyrax/file_sets/_permission_form.html.erb, only the second "add" button was getting flagged; this seems to be because the span with help text is within the button tag for the add user, but outside the button tag for add group. Moving the span cleared the error.
(First solution, adding aria-label was the wrong move.)

### Changes proposed in this pull request:
*Modifies html in views/hyrax/file_sets/_permission_form.html.erb
*
*

@samvera/hyrax-code-reviewers
