### PR TITLE
Reindex fileset after file lazy migration

### DIFF
--- a/app/jobs/migrate_files_to_valkyrie_job.rb
+++ b/app/jobs/migrate_files_to_valkyrie_job.rb
@@ -73,6 +73,8 @@ class MigrateFilesToValkyrieJob < Hyrax::ApplicationJob
         Hyrax.persister.save(resource: valkyrie_file)
       end
     end
+    # reindex the file set after migrating files to include characterization info
+    Hyrax.index_adapter.save(resource: resource)
   end
 
   def copy_attributes(valkyrie_file:, original_file:)

--- a/spec/jobs/migrate_files_to_valkyrie_job_spec.rb
+++ b/spec/jobs/migrate_files_to_valkyrie_job_spec.rb
@@ -35,6 +35,7 @@ RSpec.describe MigrateFilesToValkyrieJob, valkyrie_adapter: :freyja_adapter, per
     described_class.new.attribute_mapping.each do |k, v|
       expect(valkyrized_file_set.original_file.send(k)).to match_array(pcdm_file.send(v))
     end
-    expect(SolrDocument.find(valkyrized_file_set.id.to_s).width).to eq(222)
+    solr_doc = Hyrax.index_adapter.connection.get("select", params: { q: "id:#{valkyrized_file_set.id.to_s}" })["response"]["docs"].first
+    expect(solr_doc['width_is']).to eq(222)
   end
 end

--- a/spec/jobs/migrate_files_to_valkyrie_job_spec.rb
+++ b/spec/jobs/migrate_files_to_valkyrie_job_spec.rb
@@ -35,5 +35,6 @@ RSpec.describe MigrateFilesToValkyrieJob, valkyrie_adapter: :freyja_adapter, per
     described_class.new.attribute_mapping.each do |k, v|
       expect(valkyrized_file_set.original_file.send(k)).to match_array(pcdm_file.send(v))
     end
+    expect(SolrDocument.find(valkyrized_file_set.id.to_s).width).to eq(222)
   end
 end

--- a/spec/jobs/migrate_files_to_valkyrie_job_spec.rb
+++ b/spec/jobs/migrate_files_to_valkyrie_job_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require 'wings'
 
-RSpec.describe MigrateFilesToValkyrieJob, valkyrie_adapter: :freyja_adapter, perform_enqueued: [MigrateFilesToValkyrieJob] do
+RSpec.describe MigrateFilesToValkyrieJob, index_adapter: :solr_index, valkyrie_adapter: :freyja_adapter, perform_enqueued: [MigrateFilesToValkyrieJob] do
   let(:user)      { create(:user) }
   let(:content) { File.open(fixture_path + '/' + label) }
   let(:uploaded_file1) { build(:uploaded_file, file:) }
@@ -23,9 +23,6 @@ RSpec.describe MigrateFilesToValkyrieJob, valkyrie_adapter: :freyja_adapter, per
 
   before do
     allow(Hyrax.config).to receive(:valkyrie_transition?).and_return(true)
-    # allow(ActiveFedora::Base).to receive(:find).and_call_original
-    # allow(ActiveFedora::Base).to receive(:find).with(migrated_file_set.original_file.file_identifier.to_s).and_return(file_with_characterization)
-    # allow(File_Set).to receive(:find).with(fedora_file_set.id).and_return(fedora_file_set)
   end
 
   it "it migrates all derivatives along with a file" do


### PR DESCRIPTION
### Fixes

Lazy migration on fileset did not index characterization.

<details>
<summary>Failing spec before changes</summary>

![Screenshot 2024-11-01 at 11 47 34 AM](https://github.com/user-attachments/assets/566fb356-5c0a-47ef-907e-725ccf1b9738)

</details>

### Summary

Reindexes the fileset after the files are migrated.

### Type of change (for release notes)

Bug fix

@samvera/hyrax-code-reviewers
