### PR TITLE
adds sr span to button

### DIFF
--- a/app/views/hyrax/transfers/_received.html.erb
+++ b/app/views/hyrax/transfers/_received.html.erb
@@ -23,7 +23,7 @@
         <% if req.pending? %>
             <div class="btn-group">
               <button class="btn btn-sm btn-primary" href="#"><%= t(".accept") %></button>
-              <button class="btn btn-sm dropdown-toggle accept" data-toggle="dropdown" href="#"></button>
+              <button class="btn btn-sm dropdown-toggle accept" data-toggle="dropdown" href="#"><span class="sr-only">accept options</span></button>
               <ul class="dropdown-menu">
                 <li class="dropdown-item">
                   <%= link_to t(".allow_depositor_to_retain_edit_access"), hyrax.accept_transfer_path(req), method: :put, class: 'accept-retain', title: t(".accept_the_file_and_allow_the_original_depositor_to_retain_access_to_edit_the_file_and_metadata") %>


### PR DESCRIPTION
### Fixes

Fixes #6770

### Summary

Button does not have text associated with it; adding an sr-only span.

### Guidance for testing, such as acceptance criteria or new user interface behaviors:
* Checker should not flag "Button missing a text alternative" Rule A 4.1.2
*
*

### Type of change (for release notes)

notes-minor

### Detailed Description

This button is on the transfer page in the form where the user clicks on a button to expose the options for accepting. The proposed solution is to add ```<span class="sr-only">accept options</span>``` within the button tags.

### Changes proposed in this pull request:
*Insert html into views/hyrax/transfers/_received.html.erb
*
*

@samvera/hyrax-code-reviewers
