### PR TITLE
h1 hidden but make contrasty anyway

### DIFF
--- a/app/views/_masthead.html.erb
+++ b/app/views/_masthead.html.erb
@@ -1,6 +1,6 @@
 <header aria-label="header" class="top-header">
   <nav id="masthead" class="navbar navbar-expand-lg navbar-dark bg-dark justify-content-between <%= placement_class %>" role="navigation" aria-label="masthead">
-    <h1 class="sr-only"><%= application_name %></h1>
+    <h1 class="sr-only navbar-text"><%= application_name %></h1>
     <%= render '/logo' %>
     <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#top-navbar-collapse" aria-expanded="false" aria-label="Toggle navigation">
       <span class="navbar-toggler-icon"></span>


### PR DESCRIPTION
### Fixes

Fixes #6892

### Summary

Second try: fixing h1 elt that is sr-only but still being flagged for contrast.

### Guidance for testing, such as acceptance criteria or new user interface behaviors:
*Running wave on the dashboard should not flag the navbar for contrast.
*
*

### Type of change (for release notes)

notes-minor

### Detailed Description

In the dashboard masthead, the visible span is compliant regarding contrast; the hidden h1 elt is not. Proposed solution is to add navbar-text class to the h1; .navbar-text is defined in views/shared/_appeearance_styles.html.erb and appears to just set color to appearance.header_text_color (.navbar-brand is set to the same color, and is used on the masthead/logo).

### Changes proposed in this pull request:
* Modifies html in views/_masthead.html
*
*

@samvera/hyrax-code-reviewers
