### PR TITLE
Added text-dark for accessibility

### DIFF
--- a/app/views/hyrax/homepage/_recent_document.html.erb
+++ b/app/views/hyrax/homepage/_recent_document.html.erb
@@ -11,10 +11,10 @@
           <% end %>
         </h3>
         <p class="recent-field">
-          <span class="recent-label"><%= t('hyrax.homepage.recently_uploaded.document.depositor_label') %>:</span> <%= link_to_profile recent_document.depositor(t('hyrax.homepage.recently_uploaded.document.depositor_missing')) %>
+          <span class="recent-label text-dark"><%= t('hyrax.homepage.recently_uploaded.document.depositor_label') %>:</span> <%= link_to_profile recent_document.depositor(t('hyrax.homepage.recently_uploaded.document.depositor_missing')) %>
         </p>
         <p class="recent-field">
-          <span class="recent-label"><%= t('hyrax.homepage.recently_uploaded.document.keyword_label') %>:</span> <%= link_to_facet_list(recent_document.keyword, 'keyword', t('hyrax.homepage.recently_uploaded.document.keyword_missing')).html_safe %>
+          <span class="recent-label text-dark"><%= t('hyrax.homepage.recently_uploaded.document.keyword_label') %>:</span> <%= link_to_facet_list(recent_document.keyword, 'keyword', t('hyrax.homepage.recently_uploaded.document.keyword_missing')).html_safe %>
         </p>
       </div>
     </div>


### PR DESCRIPTION
### Fixes

Fixes #6746 

### Summary

Adds "text-dark" to "recent-label" to correct accessibility issue.

### Type of change (for release notes)

- `notes-minor` Adds text-dark recent-label for accessibility

@samvera/hyrax-code-reviewers
