### PR TITLE
Fixes accessibility issues with the member image partials in the File Manager

### DIFF
--- a/app/views/hyrax/base/_file_manager_member.html.erb
+++ b/app/views/hyrax/base/_file_manager_member.html.erb
@@ -3,7 +3,8 @@
       <%= simple_form_for [main_app, node], remote: true, html: {'data-type': 'json'} do |f| %>
         <div class="card-header">
           <div class="order-title">
-            <%= f.input :title, as: :string, input_html: { name: "#{f.object.model_name.singular}[title][]", class: "title" }, value: node.to_s, label: false, hint: false %>
+            <label class="sr-only" id='<%= "edit_#{f.object.model_name.singular}_title" %>'>Edit title</label>
+            <%= f.input :title, as: :string, input_html: { name: "#{f.object.model_name.singular}[title][]", class: "title", 'aria-labelledby': "edit_#{f.object.model_name.singular}_title" }, value: node.to_s, label: false, hint: false %>
           </div>
           <div class="file-set-link float-right">
             <%= link_to contextual_path(node, @presenter), title: "Edit file" do %>
@@ -11,9 +12,11 @@
             <% end %>
           </div>
           <% if node.respond_to?(:label) %>
-            <div class="order-filename">
-              <em title="<%= node.page_title %>">(<%= truncate(node.label, length: 29) %>)</em>
-            </div>
+            <% unless node.label.nil? %>
+              <div class="order-filename" >
+                <em title="<%= node.page_title %>">(<%= truncate(node.label, length: 29) %>)</em>
+              </div>
+            <% end %>
           <% end %>
         </div>
         <div class="card-body">

--- a/app/views/hyrax/base/_file_manager_thumbnail.html.erb
+++ b/app/views/hyrax/base/_file_manager_thumbnail.html.erb
@@ -1,1 +1,1 @@
-<%= document_presenter(node)&.thumbnail&.thumbnail_tag({ class: 'thumbnail-inner mw-100' }, {}) %>
+<%= document_presenter(node)&.thumbnail&.thumbnail_tag({ class: 'thumbnail-inner mw-100', 'alt': "Thumbnail image for #{node.title[0]}" }, {}) %>


### PR DESCRIPTION
### Fixes

Fixes #6812
Fixes #6813

### Summary

Adds minor accessibility fixes to the partials that render the member image panels.  It makes sure the thumbnails have text alternatives, and the edit title fields have labels.

- `notes-minor` 
