### PR TITLE
Disable/enable Save button via aria-disabled attribute

### DIFF
--- a/app/assets/javascripts/hyrax/file_manager/save_manager.es6
+++ b/app/assets/javascripts/hyrax/file_manager/save_manager.es6
@@ -26,8 +26,10 @@ export default class SaveManager {
   check_button() {
     if (this.is_changed) {
       this.save_button.removeClass("disabled")
+      this.save_button.attr("aria-disabled", "false")
     } else {
       this.save_button.addClass("disabled")
+      this.save_button.attr("aria-disabled", "true")
     }
   }
 

--- a/app/views/hyrax/base/_file_manager_actions.html.erb
+++ b/app/views/hyrax/base/_file_manager_actions.html.erb
@@ -1,6 +1,6 @@
   <div class="actions card">
     <div class="d-flex">
-      <%= button_tag t('.save'), class: "btn btn-primary disabled mr-2", data: { action: "save-actions" } %>
+      <%= button_tag t('.save'), class: "btn btn-primary disabled mr-2", data: { action: "save-actions" }, 'aria-disabled': true %>
       <%= button_tag t('.sort_alphabetically'), class: "btn btn-primary ", data: { action: "alpha-sort-action" } %>
     </div>
   </div>


### PR DESCRIPTION
### Fixes

Fixes #6814 

### Summary

Present tense short summary (50 characters or less)
Disables/enables aria-disabled attribute on Save button in File manager

### Guidance for testing, such as acceptance criteria or new user interface behaviors:
* In File Manager, inspect Save button and see aria-disabled="true" and Save button does no action when clicked
* Change file order or radio button selection, inspect Save button and see aria-disabled="false"
* Change back to original order or radio button settings, inspect Save button and see aria-disabled="true" and Save button does no action when clicked
* Change file order or radio button selection, inspect Save button and see aria-disabled="false" and Save button saves changes

### Type of change (for release notes)

- `notes-minor` Adding aria attribute to enable or disable Save button for assistive tech in File Manager

### Detailed Description

Fixing an accessibility issue with the Save button in File Manager. When there are no File Manager changes to save, clicking the button doesn't do anything but assistive tech still registers the Save button as an active button (there is no aria attribute on the button at all). The button is styled as being disabled and thus comes across to assistive tech as not having enough color contrast (because it is still an active button). SiteImprove is flagging the lack of color contrast on this button as an issue.

Adding aria-disabled as an attribute on the button allows assistive tech to disregard the button unless it is not disabled (aka aria-disabled="false"). This allows the Save button to be "greyed out" and functionally disabled for clicking and assistive tech (aria-disabled="true" by default) and then if a change is made in File Manager, the button is then activated via darkened/more contrasting style and enabled for clicking and assistive tech to register (aria-disabled="false"). 

These changes also correct the SiteImprove error reporting for color contrast not meeting minimum requirement because aria-disabled="true" when the Save button is disabled and it is disregarded for color contrast review.

@samvera/hyrax-code-reviewers
