### PR TITLE
Issue 6783

### DIFF
--- a/app/views/hyrax/batch_select/_add_button.html.erb
+++ b/app/views/hyrax/batch_select/_add_button.html.erb
@@ -1,3 +1,3 @@
 <div data-behavior="batch-add-button">
-  <%= check_box_tag "batch_document_ids[]", document.id, false, class:"batch_document_selector", id: "batch_document_#{document.id}", checks: "active" %>
+  <label><%= check_box_tag "batch_document_ids[]", document.id, false, class:"batch_document_selector", id: "batch_document_#{document.id}", checks: "active", 'aria-labelledby': "batch_document_#{document.id}" %></label>
 </div>

--- a/app/views/hyrax/batch_select/_add_button.html.erb
+++ b/app/views/hyrax/batch_select/_add_button.html.erb
@@ -1,3 +1,3 @@
 <div data-behavior="batch-add-button">
-  <label><%= check_box_tag "batch_document_ids[]", document.id, false, class:"batch_document_selector", id: "batch_document_#{document.id}", checks: "active", 'aria-labelledby': "batch_document_#{document.id}" %></label>
+  <%= check_box_tag "batch_document_ids[]", document.id, false, class:"batch_document_selector", id: "batch_document_#{document.id}", checks: "active", 'aria-labelledby': "batch_document_#{document.id}" %>
 </div>

--- a/app/views/hyrax/embargoes/_list_expired_active_embargoes.html.erb
+++ b/app/views/hyrax/embargoes/_list_expired_active_embargoes.html.erb
@@ -22,7 +22,7 @@
     <table class="embargoes table">
       <thead>
         <tr>
-          <th><label><input type="checkbox" id="checkAllBox" class="batch_document_selector" aria-labelledby="checkAllBox"/></label> <label for="checkAllBox"><%= t('.select_all') %></label></th>
+          <th><input type="checkbox" id="checkAllBox" class="batch_document_selector" aria-labelledby="checkAllBox"/> <label for="checkAllBox"><%= t('.select_all') %></label></th>
           <%= render partial: 'table_headers' %>
         </tr>
       </thead>
@@ -40,7 +40,7 @@
         <tr data-behavior="extra" data-id="<%= curation_concern.id %>" class="extra-embargo-info">
           <td></td>
           <td colspan=5>
-            <label><%= check_box_tag "embargoes[#{i}][copy_visibility]", curation_concern.id, true, 'aria-labelledby': "embargoes_#{i}_copy_visibility" %></label>
+            <%= check_box_tag "embargoes[#{i}][copy_visibility]", curation_concern.id, true, 'aria-labelledby': "embargoes_#{i}_copy_visibility" %>
             <label for="embargoes_<%= i %>_copy_visibility"><%= t('.change_all', cc: curation_concern) %>
             <%= visibility_badge(curation_concern.visibility_after_embargo) %>?</label>
           </td>

--- a/app/views/hyrax/embargoes/_list_expired_active_embargoes.html.erb
+++ b/app/views/hyrax/embargoes/_list_expired_active_embargoes.html.erb
@@ -22,7 +22,7 @@
     <table class="embargoes table">
       <thead>
         <tr>
-          <th><input type="checkbox" id="checkAllBox" class="batch_document_selector"/> <%= t('.select_all') %></th>
+          <th><label><input type="checkbox" id="checkAllBox" class="batch_document_selector" aria-labelledby="checkAllBox"/></label> <label for="checkAllBox"><%= t('.select_all') %></label></th>
           <%= render partial: 'table_headers' %>
         </tr>
       </thead>
@@ -31,7 +31,7 @@
         <tr>
           <td><%= render 'hyrax/batch_select/add_button', document: curation_concern %></td>
           <td class="human-readable-type"><%= curation_concern.human_readable_type %></td>
-          <td class="title"><%= link_to curation_concern, edit_embargo_path(curation_concern) %></td>
+          <td class="title"><label for="batch_document_<%= curation_concern.id %>"><%= link_to curation_concern, edit_embargo_path(curation_concern) %></label></td>
           <td class="current-visibility"><%= visibility_badge(curation_concern.visibility) %></td>
           <td class="embargo-release-date"><%= curation_concern.embargo_release_date %></td>
           <td class="visibility-after-embargo"><%= visibility_badge(curation_concern.visibility_after_embargo) %></td>
@@ -40,9 +40,9 @@
         <tr data-behavior="extra" data-id="<%= curation_concern.id %>" class="extra-embargo-info">
           <td></td>
           <td colspan=5>
-            <%= check_box_tag "embargoes[#{i}][copy_visibility]", curation_concern.id, true %>
-            <%= t('.change_all', cc: curation_concern) %>
-            <%= visibility_badge(curation_concern.visibility_after_embargo) %>?
+            <label><%= check_box_tag "embargoes[#{i}][copy_visibility]", curation_concern.id, true, 'aria-labelledby': "embargoes_#{i}_copy_visibility" %></label>
+            <label for="embargoes_<%= i %>_copy_visibility"><%= t('.change_all', cc: curation_concern) %>
+            <%= visibility_badge(curation_concern.visibility_after_embargo) %>?</label>
           </td>
         </tr>
       <% end %>


### PR DESCRIPTION
### Fixes

Fixes #6783 

### Summary

Adds labels and aria-labelledby attribute to checkbox lists on Expired Active Embargoes

### Type of change (for release notes)

- `notes-minor` New Features that are backward compatible

### Detailed Description

Adds label around titles in checkbox list (or around question text or "Select All" text) and adds aria-labelledby attribute on checkbox inputs using checkbox input id. The batch_select/_add_button seems to be a reusable bit of code but from what I can tell the change there should work in other checkbox lists that might use it.

@samvera/hyrax-code-reviewers
