### PR TITLE
Adding required data cells to collection membership rows in batch create

### DIFF
--- a/app/views/hyrax/base/_form_member_of_collections.html.erb
+++ b/app/views/hyrax/base/_form_member_of_collections.html.erb
@@ -33,6 +33,10 @@ HTML Properties:
     </tr>
     </thead>
     <tbody>
+      <tr class="sr-only">
+        <td>This table will only display data if works are assigned to collections</td>
+        <td><span></span></td>
+      </tr>
     </tbody>
   </table>
 </div>


### PR DESCRIPTION
### Fixes

#6808

### Summary

In the relationship tab for create work by batch, a table is opened to layout the assignment of works to collections.  When/if works are assigned using the drop-down list, a Javascript action will insert the required cell data rows into the table.  Since this is optional, the table inherently has header rows that have no cell rows assigned.

This adds a data row as `sr-only` that has placeholder text, explaining that the table only contains data when works are assigned to collections.

### Type of change (for release notes)

- `notes-minor` 
