### PR TITLE
Add id and missing style on disabled checkbox

### DIFF
--- a/app/views/hyrax/dashboard/collections/_list_collections.html.erb
+++ b/app/views/hyrax/dashboard/collections/_list_collections.html.erb
@@ -12,7 +12,7 @@
     <input type="checkbox" name="batch_document_ids[]" id="batch_document_<%= id %>" value="<%= id %>" class="batch_document_selector"
       data-hasaccess="<%= (can?(:edit, collection_presenter.solr_document)) %>" />
     <% else %>
-    <input type="checkbox" class="disabled batch_document_selector" disabled=true />
+    <input type="checkbox" id="batch_document_<%= id %>" class="disabled batch_document_selector" disabled=true />
     <% end %>
   </td>
   <td>

--- a/app/views/hyrax/my/collections/_list_collections.html.erb
+++ b/app/views/hyrax/my/collections/_list_collections.html.erb
@@ -14,7 +14,7 @@
         <input type="checkbox" name="batch_document_ids[]" id="batch_document_<%= id %>" value="<%= id %>" class="batch_document_selector"
                data-hasaccess="<%= (can?(:edit, collection_presenter.solr_document)) %>" />
     <% else %>
-        <input type="checkbox" class="disabled" disabled=true />
+        <input type="checkbox" id="batch_document_<%= id %>" class="disabled batch_document_selector" disabled=true />
     <% end %>
   </td>
   <td>


### PR DESCRIPTION
### Fixes

Fixes #6778 

### Summary

Add id for disabled checkbox input

### Type of change (for release notes)

- `notes-minor` New Features that are backward compatible

### Detailed Description

Adds id attribute on disabled checkbox input used in My Collections and All/Managed Collections for admin sets that are either the default admin set or are not deletable after items have been added. Assistive tech still needs info about a disabled checkbox to know what it is and the label was there but the input didn't include the id to match up to the label. Also My Collections was missing a style to align the disabled checkbox correctly so that was added.

@samvera/hyrax-code-reviewers
