### PR TITLE
Restore Type Facet for Valkyrie Resources

### DIFF
--- a/app/indexers/hyrax/indexers/resource_indexer.rb
+++ b/app/indexers/hyrax/indexers/resource_indexer.rb
@@ -47,6 +47,7 @@ module Hyrax
           "system_modified_dtsi": resource.updated_at,
           "has_model_ssim": resource.to_rdf_representation,
           "human_readable_type_tesim": resource.human_readable_type,
+          "human_readable_type_sim": resource.human_readable_type,
           "alternate_ids_sim": resource.alternate_ids.map(&:to_s)
         }.with_indifferent_access
       end


### PR DESCRIPTION
<img width="463" alt="Screenshot 2024-11-07 at 20 58 25" src="https://github.com/user-attachments/assets/0d29c9fc-c351-45ed-a8e9-aee451de732f">

the side bar type is missing once AF records are reindexed.