### PR TITLE
Embargo/Lease form fixes

### DIFF
--- a/app/forms/hyrax/forms/work_embargo_form.rb
+++ b/app/forms/hyrax/forms/work_embargo_form.rb
@@ -31,6 +31,12 @@ module Hyrax
       def model_name
         model.to_model.model_name
       end
+
+      ##
+      # @return [String]
+      def to_s
+        [*model.title].join(' ')
+      end
     end
   end
 end

--- a/app/forms/hyrax/forms/work_lease_form.rb
+++ b/app/forms/hyrax/forms/work_lease_form.rb
@@ -31,6 +31,12 @@ module Hyrax
       def model_name
         model.to_model.model_name
       end
+
+      ##
+      # @return [String]
+      def to_s
+        [*model.title].join(' ')
+      end
     end
   end
 end

--- a/app/views/hyrax/embargoes/_list_expired_active_embargoes.html.erb
+++ b/app/views/hyrax/embargoes/_list_expired_active_embargoes.html.erb
@@ -35,15 +35,15 @@
           <td class="current-visibility"><%= visibility_badge(curation_concern.visibility) %></td>
           <td class="embargo-release-date"><%= curation_concern.embargo_release_date %></td>
           <td class="visibility-after-embargo"><%= visibility_badge(curation_concern.visibility_after_embargo) %></td>
-          <td class="actions"><%= link_to t('.deactivate'), embargo_path(curation_concern), method: :delete, class: 'btn btn-primary' %></td>
         </tr>
         <tr data-behavior="extra" data-id="<%= curation_concern.id %>" class="extra-embargo-info">
           <td></td>
-          <td colspan=5>
+          <td colspan=4>
             <%= check_box_tag "embargoes[#{i}][copy_visibility]", curation_concern.id, true, 'aria-labelledby': "embargoes_#{i}_copy_visibility" %>
             <label for="embargoes_<%= i %>_copy_visibility"><%= t('.change_all', cc: curation_concern) %>
             <%= visibility_badge(curation_concern.visibility_after_embargo) %>?</label>
           </td>
+          <td class="actions"><%= link_to t('.deactivate'), embargo_path(curation_concern), method: :delete, class: 'btn btn-primary' %></td>
         </tr>
       <% end %>
       </tbody>

--- a/app/views/hyrax/leases/_list_expired_active_leases.html.erb
+++ b/app/views/hyrax/leases/_list_expired_active_leases.html.erb
@@ -36,15 +36,15 @@
           <td class="current-visibility"><%= visibility_badge(curation_concern.visibility) %></td>
           <td class="lease-release-date"><%= curation_concern.lease_expiration_date %></td>
           <td class="visibility-after-lease"><%= visibility_badge(curation_concern.visibility_after_lease) %></td>
-          <td class="actions"><%= link_to t('.deactivate'), lease_path(curation_concern), method: :delete, class: 'btn btn-primary' %></td>
         </tr>
         <tr data-behavior="extra" data-id="<%= curation_concern.id %>" class="extra-lease-info">
           <td></td>
-          <td colspan=5>
+          <td colspan=4>
             <%= check_box_tag "leases[#{i}][copy_visibility]", curation_concern.id, true %>
             <%= t('.change_all', cc: curation_concern) %>
             <%= visibility_badge(curation_concern.visibility_after_lease) %>?
           </td>
+          <td class="actions"><%= link_to t('.deactivate'), lease_path(curation_concern), method: :delete, class: 'btn btn-primary' %></td>
         </tr>
       <% end %>
       </tbody>


### PR DESCRIPTION
### Fixes

Fixes #6782
Fixes #6784 
Fixes display of resource title on embargo/lease edit form

### Changes proposed in this pull request:
* Move location of deactivate button to the existing second row of each resource entry. This avoids having a column without a header, and avoids adding an "Actions" header to the other embargo tables.
* Add a `to_s` method to WorkEmbargoForm that is displayed on the form instead of the generic ruby object `to_s`
* Do these same fixes for leases too

@samvera/hyrax-code-reviewers
