### PR TITLE
Use TimeService when determining expired embargoes/leases

### DIFF
--- a/app/search_builders/hyrax/expired_embargo_search_builder.rb
+++ b/app/search_builders/hyrax/expired_embargo_search_builder.rb
@@ -12,7 +12,7 @@ module Hyrax
     private
 
     def now
-      Hyrax::TimeService.time_in_utc.xmlschema
+      Hyrax::TimeService.time_in_utc.utc.xmlschema
     end
   end
 end

--- a/app/search_builders/hyrax/expired_embargo_search_builder.rb
+++ b/app/search_builders/hyrax/expired_embargo_search_builder.rb
@@ -6,7 +6,13 @@ module Hyrax
 
     def only_expired_embargoes(solr_params)
       solr_params[:fq] ||= []
-      solr_params[:fq] = 'embargo_release_date_dtsi:[* TO NOW]'
+      solr_params[:fq] = "embargo_release_date_dtsi:[* TO #{now}]"
+    end
+
+    private
+
+    def now
+      Hyrax::TimeService.time_in_utc.xmlschema
     end
   end
 end

--- a/app/search_builders/hyrax/expired_lease_search_builder.rb
+++ b/app/search_builders/hyrax/expired_lease_search_builder.rb
@@ -6,7 +6,13 @@ module Hyrax
 
     def only_expired_leases(solr_params)
       solr_params[:fq] ||= []
-      solr_params[:fq] = 'lease_expiration_date_dtsi:[* TO NOW]'
+      solr_params[:fq] = "lease_expiration_date_dtsi:[* TO #{now}]"
+    end
+
+    private
+
+    def now
+      Hyrax::TimeService.time_in_utc.xmlschema
     end
   end
 end

--- a/app/search_builders/hyrax/expired_lease_search_builder.rb
+++ b/app/search_builders/hyrax/expired_lease_search_builder.rb
@@ -12,7 +12,7 @@ module Hyrax
     private
 
     def now
-      Hyrax::TimeService.time_in_utc.xmlschema
+      Hyrax::TimeService.time_in_utc.utc.xmlschema
     end
   end
 end


### PR DESCRIPTION
This allows timely local testing of embargoes/leases without waiting a day for the expiration, or resorting to other temporal shenanigans.

### Changes proposed in this pull request:
* Use a time generated from Hyrax::TimeService (which might be altered for testing purposes) instead of solr's internal time.

@samvera/hyrax-code-reviewers
