### PR TITLE
fix cancel link for content blocks and pages

### DIFF
--- a/app/views/hyrax/content_blocks/_form.html.erb
+++ b/app/views/hyrax/content_blocks/_form.html.erb
@@ -29,7 +29,7 @@
           </div>
           <div class="card-footer d-flex justify-content-end">
             <%= f.button :submit, class: 'btn btn-primary text-white mr-2' %>
-            <%= link_to t(:'hyrax.content_blocks.cancel'), hyrax.admin_admin_sets_path, class: 'btn btn-light' %>
+            <%= link_to t(:'hyrax.content_blocks.cancel'), hyrax.edit_content_blocks_path, class: 'btn btn-light' %>
           </div>
         <% end %>
       </div>
@@ -45,7 +45,7 @@
           </div>
           <div class="card-footer d-flex justify-content-end">
             <%= f.button :submit, class: 'btn btn-primary text-white mr-2' %>
-            <%= link_to t(:'hyrax.content_blocks.cancel'), hyrax.admin_admin_sets_path, class: 'btn btn-light' %>
+            <%= link_to t(:'hyrax.content_blocks.cancel'), hyrax.edit_content_blocks_path, class: 'btn btn-light' %>
           </div>
         <% end %>
       </div>
@@ -61,7 +61,7 @@
           </div>
           <div class="card-footer d-flex justify-content-end">
             <%= f.button :submit, class: 'btn btn-primary text-white mr-2' %>
-            <%= link_to t(:'hyrax.content_blocks.cancel'), hyrax.admin_admin_sets_path, class: 'btn btn-light' %>
+            <%= link_to t(:'hyrax.content_blocks.cancel'), hyrax.edit_content_blocks_path, class: 'btn btn-light' %>
           </div>
         <% end %>
       </div>

--- a/app/views/hyrax/pages/_form.html.erb
+++ b/app/views/hyrax/pages/_form.html.erb
@@ -36,7 +36,7 @@
           </div>
           <div class="card-footer d-flex justify-content-end">
             <%= f.button :submit, class: 'btn btn-primary text-white mr-2' %>
-            <%= link_to t(:'hyrax.pages.cancel'), hyrax.admin_admin_sets_path, class: 'btn btn-light' %>
+            <%= link_to t(:'hyrax.pages.cancel'), hyrax.edit_pages_path, class: 'btn btn-light' %>
           </div>
         <% end %>
       </div>
@@ -52,7 +52,7 @@
           </div>
           <div class="card-footer d-flex justify-content-end">
             <%= f.button :submit, class: 'btn btn-primary text-white mr-2' %>
-            <%= link_to t(:'hyrax.pages.cancel'), hyrax.admin_admin_sets_path, class: 'btn btn-light' %>
+            <%= link_to t(:'hyrax.pages.cancel'), hyrax.edit_pages_path, class: 'btn btn-light' %>
           </div>
         <% end %>
       </div>
@@ -68,7 +68,7 @@
           </div>
           <div class="card-footer d-flex justify-content-end">
             <%= f.button :submit, class: 'btn btn-primary text-white mr-2' %>
-            <%= link_to t(:'hyrax.pages.cancel'), hyrax.admin_admin_sets_path, class: 'btn btn-light' %>
+            <%= link_to t(:'hyrax.pages.cancel'), hyrax.edit_pages_path, class: 'btn btn-light' %>
           </div>
         <% end %>
       </div>
@@ -84,7 +84,7 @@
           </div>
           <div class="card-footer d-flex justify-content-end">
             <%= f.button :submit, class: 'btn btn-primary text-white mr-2' %>
-            <%= link_to t(:'hyrax.pages.cancel'), hyrax.admin_admin_sets_path, class: 'btn btn-light' %>
+            <%= link_to t(:'hyrax.pages.cancel'), hyrax.edit_pages_path, class: 'btn btn-light' %>
           </div>
         <% end %>
       </div>


### PR DESCRIPTION
Just a simple fix for a link going to the wrong place. Comes from the DOT NTL project