### PR TITLE
Fix unsupported aria attributes in dashboard

### DIFF
--- a/app/assets/javascripts/hyrax/collapse.js
+++ b/app/assets/javascripts/hyrax/collapse.js
@@ -40,10 +40,10 @@ function getStatusActivity(){
     }
     else if(isCollapsed){
         resultDiv.classList.remove("in");
-        resultDiv.setAttribute("aria-expanded", "false");
+        // resultDiv.setAttribute("aria-expanded", "false");
     }else{
         resultDiv.classList.add("in");
-        resultDiv.setAttribute("aria-expanded", "true");
+        // resultDiv.setAttribute("aria-expanded", "true");
     }
 }
 

--- a/app/assets/javascripts/hyrax/collapse.js
+++ b/app/assets/javascripts/hyrax/collapse.js
@@ -55,10 +55,10 @@ function getStatusSettings(){
     }
     else if(isCollapsed){
         resultDiv.classList.remove("in");
-        resultDiv.setAttribute("aria-expanded", "false");
+        // resultDiv.setAttribute("aria-expanded", "false");
     }else{
         resultDiv.classList.add("in");
-        resultDiv.setAttribute("aria-expanded", "true");
+        // resultDiv.setAttribute("aria-expanded", "true");
     }
 }
 


### PR DESCRIPTION
Fix #6840 


The aria-expanded attribute no longer appears on the UL tag.