### PR TITLE
Fix #6798

### DIFF
--- a/app/views/hyrax/dashboard/collections/_show_document_list_row.html.erb
+++ b/app/views/hyrax/dashboard/collections/_show_document_list_row.html.erb
@@ -7,7 +7,7 @@
   </td>
   <td>
     <div class="media">
-      <%= link_to [main_app, document], "class" => "media-left mr-3", "aria-hidden" => "true" do %>
+      <%= link_to [main_app, document], "class" => "media-left mr-3" do %>
         <%= document_presenter(document)&.thumbnail&.thumbnail_tag(
           { class: "d-none d-md-block file_listing_thumbnail", alt: document.title_or_label }, { suppress_link: true }
         ) %>


### PR DESCRIPTION
Fix #6798

aria-hidden attribute is removed from tag A in thumbnails.