### PR TITLE
fix  #6655

### DIFF
--- a/app/assets/stylesheets/hyrax/_styles.scss
+++ b/app/assets/stylesheets/hyrax/_styles.scss
@@ -72,3 +72,7 @@ label.disabled {
     margin-bottom: 1rem;
   }
 }
+
+#content_block_page {
+  display: block;
+}


### PR DESCRIPTION
Fix #6655 


Text on about, help, etc. now show correctly.

![Captura desde 2024-12-10 16-43-17](https://github.com/user-attachments/assets/f1f9a400-f302-4896-aad8-542e11ce1d66)
