### PR TITLE
Pinning blacklight_gallery to 4.7.x due to JS locations altered in 4.8.x

### DIFF
--- a/hyrax.gemspec
+++ b/hyrax.gemspec
@@ -38,7 +38,7 @@ SUMMARY
   spec.add_dependency 'almond-rails', '~> 0.1'
   spec.add_dependency 'awesome_nested_set', '~> 3.1'
   spec.add_dependency 'blacklight', '~> 7.29'
-  spec.add_dependency 'blacklight-gallery', '~> 4.0'
+  spec.add_dependency 'blacklight-gallery', '~> 4.7.0'
   spec.add_dependency 'breadcrumbs_on_rails', '~> 3.0'
   spec.add_dependency 'browse-everything', '>= 0.16', '< 2.0'
   spec.add_dependency 'carrierwave', '~> 1.0'


### PR DESCRIPTION
The current gem spec for blacklight_gallery allows it to upgrade to 4.8.1, which has rearranged Javascript packaging through a [series of commits](https://github.com/projectblacklight/blacklight-gallery/commits/v4.8.1/) in the last couple of weeks.  The result in Hyrax is:
```
Sprockets::FileNotFound: couldn't find file 'blacklight_gallery/default'
```
This PR would fix the problem by pinning the gem to 4.7.x.

@samvera/hyrax-code-reviewers
