### PR TITLE
Pin concurrent-ruby

### DIFF
--- a/hyrax.gemspec
+++ b/hyrax.gemspec
@@ -43,7 +43,7 @@ SUMMARY
   spec.add_dependency 'browse-everything', '>= 0.16', '< 2.0'
   spec.add_dependency 'carrierwave', '~> 1.0'
   spec.add_dependency 'clipboard-rails', '~> 1.5'
-  spec.add_dependency 'concurrent-ruby', '~> 1.0'
+  spec.add_dependency 'concurrent-ruby', '1.3.4' # Pinned until Rails 7 update
   spec.add_dependency 'connection_pool', '~> 2.4'
   spec.add_dependency 'draper', '~> 4.0'
   spec.add_dependency 'dry-logic', '~> 1.5'


### PR DESCRIPTION
1.3.5 exposes rails bug that is fixed in rails 7

### Fixes

Fixes hyrax not starting due to `uninitialized constant ActiveSupport::LoggerThreadSafeLevel::Logger`
