### PR TITLE
Fixes the Single Use Link delete button.

### DIFF
--- a/app/views/hyrax/file_sets/_single_use_link_rows.html.erb
+++ b/app/views/hyrax/file_sets/_single_use_link_rows.html.erb
@@ -13,7 +13,10 @@
       </button>
       <%= link_to t('hyrax.single_use_links.delete'),
                   hyrax.delete_single_use_link_path(params[:id], presenter),
-                  class: 'btn btn-sm btn-danger delete-single-use-link' %>
+                  class: 'btn btn-sm btn-danger delete-single-use-link',
+                  method: :delete,
+                  remote: true,
+                  onclick: 'alert("delete request sent!")' %>
     </td>
   </tr>
 <% end %>


### PR DESCRIPTION
### Summary

Fixes the link by forcing the method to be `DELETE` (it was defaulting to `GET`, causing a routing error), allowing it to perform without expecting a redirect (the `#destroy` controller action has no directive for redirect, just a [`head :ok` response](https://github.com/samvera/hyrax/blob/2c73a9b01efc6be237ca66ae7f43dba6d3ca2c90/app/controllers/hyrax/single_use_links_controller.rb#L37)), and a `onclick` alert response because clicking `Delete` produces no affirmation to the user.

### Guidance for testing, such as acceptance criteria or new user interface behaviors:
* Create a Single-Use Link on a FileSet's show page.
* Refresh the page, and then click the pull-down of Single-Use Links.
* Click the Delete button of the Link instance.
* After clicking, an alert window should appear announcing that the request was sent.
* Refresh the page and the link shouldn't appear in the pull-down anymore.

### Type of change (for release notes)

- `notes-bugfix` Bug Fixes

### Changes proposed in this pull request:
* adds `remote=true` to link.
* adds `method="DELETE"` to link.
* affirms user that request was sent after clicking.

@samvera/hyrax-code-reviewers
