### PR TITLE
Update overflow style in Tiny MCE editor

### DIFF
--- a/app/assets/stylesheets/hyrax/_tinymce.scss
+++ b/app/assets/stylesheets/hyrax/_tinymce.scss
@@ -12,3 +12,6 @@
 .home_marketing_text #content_block_external_key {
   color: black;
 }
+
+// Prevents text from being clipped in Tiny MCE bottom status bar (Issue #6789)
+.tox .tox-statusbar { overflow: visible !important; }


### PR DESCRIPTION
### Fixes

Fixes #6789 

### Summary

Changes overflow style from hidden to visible for bottom status bar in Tiny MCE editor

### Guidance for testing, such as acceptance criteria or new user interface behaviors:
* View any Tiny MCE WYSIWYG editor under Settings > Pages in the Dashboard (About Page, Help Page, Deposit Agreement, Terms of Use)
* Run SiteImprove browser plugin and make sure AA error "Text is clipped when resized" is not a resulting error

### Type of change (for release notes)

- `notes-minor` New Features that are backward compatible

### Detailed Description

The skin used for Tiny MCE has a WCAG 2.0 AA level accessibility issue with the bottom status bar that shows the chain of current HTML elements being used and the "POWERED BY TINY" tag line text. SiteImprove says that text is being clipped when the screen is resized. This style change to `overflow: visible` on this text is in an included `.scss` file and requires a `!important` to be applied but it seems to work. Maybe another Tiny MCE skin is rated better for accessibility but I am not coming up with any options so it seems better to work at reducing the accessibility issues with this skin.

@samvera/hyrax-code-reviewers
