### PR TITLE
Added more overflow style overrides

### DIFF
--- a/app/assets/stylesheets/hyrax/_tinymce.scss
+++ b/app/assets/stylesheets/hyrax/_tinymce.scss
@@ -13,5 +13,8 @@
   color: black;
 }
 
-// Prevents text from being clipped in Tiny MCE bottom status bar (Issue #6789)
+// Prevents text from being clipped in Tiny MCE bottom status bar and drop-down style menu (Issue #6789)
 .tox .tox-statusbar { overflow: visible !important; }
+.tox .tox-tbtn--bespoke .tox-tbtn__select-label { overflow: visible !important; }
+.tox .tox-tbtn { overflow: visible !important; }
+.tox-tinymce { overflow: visible !important; }


### PR DESCRIPTION
### Fixes

Fixes #6789 

### Summary

Additional overflow style overrides for browser-specific SiteImprove errors

### Guidance for testing, such as acceptance criteria or new user interface behaviors:
* View Dashboard > Settings > Pages to see TinyMCE editor
* Run SiteImprove plug-in and should not see any errors about "Text is clipped when resized"

### Type of change (for release notes)

- `notes-minor` New Features that are backward compatible

### Detailed Description

SiteImprove is registering an accessibility error within the TinyMCE editor regarding text being clipped when the screen is resized. This was showing on Chrome on Mac for only the bottom status bar but it also is an issue in Chrome on Windows for the drop-down style menu. Adding overrides for (hopefully) all of the `overflow: hidden` styles to make them visible seems to not be disrupting things for the editor in Chrome on Mac. This change will need to be checked in Chrome on Windows (testing on pg.nurax, most likely) to know for sure that is fixes the accessibility issue and doesn't cause any other problems.

@samvera/hyrax-code-reviewers
