### PR TITLE
Use released nulldb gem

### DIFF
--- a/.dassie/Gemfile
+++ b/.dassie/Gemfile
@@ -41,7 +41,7 @@ gem 'turbolinks', '~> 5'
 gem 'twitter-typeahead-rails', '0.11.1.pre.corejavascript'
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 gem 'uglifier', '>= 1.3.0'
-gem 'activerecord-nulldb-adapter', git: 'https://github.com/taylorthurlow/nulldb', branch: 'fix/activerecord72-register-adapter'
+gem 'activerecord-nulldb-adapter', '~> 1.1'
 gem 'hydra-editor', github: 'samvera/hydra-editor', branch: 'revert_and_modernize'
 
 group :development do

--- a/.koppie/Gemfile
+++ b/.koppie/Gemfile
@@ -41,7 +41,7 @@ gem 'turbolinks', '~> 5'
 gem 'twitter-typeahead-rails', '0.11.1.pre.corejavascript'
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 gem 'uglifier', '>= 1.3.0'
-gem 'activerecord-nulldb-adapter', git: 'https://github.com/taylorthurlow/nulldb', branch: 'fix/activerecord72-register-adapter'
+gem 'activerecord-nulldb-adapter', '~> 1.1'
 gem 'hydra-editor', github: 'samvera/hydra-editor', branch: 'revert_and_modernize'
 
 group :development do


### PR DESCRIPTION
Use the released version of activerecord-nulldb-adapter gem that includes the branch we were using via git.