### PR TITLE
Fixing concurrent-ruby incompatibility with version bump

### DIFF
--- a/documentation/developing-your-hyrax-based-app.md
+++ b/documentation/developing-your-hyrax-based-app.md
@@ -32,7 +32,7 @@ You can also try [Running Hyrax-based application in local VM](https://github.co
 During development, running only the dependent services in a container environment may be beneficial. This avoids potential headaches concerning file permissions and eases the use of debugging tools. The application generation instructions below use [Lando](https://lando.dev) to achieve this setup.
 
 This document contains instructions specific to setting up an app with __Hyrax
-v5.0.2__. If you are looking for instructions on installing a different
+v5.0.3__. If you are looking for instructions on installing a different
 version, be sure to select the appropriate branch or tag from the drop-down
 menu above.
 
@@ -148,7 +148,7 @@ Generate a new Rails application using the template.
 **NOTE:** `HYRAX_SKIP_WINGS` is needed here to avoid loading the Wings compatibility layer during the application generation process.
 
 ```shell
-HYRAX_SKIP_WINGS=true rails _6.1.7.7_ new my_app --database=postgresql -m https://raw.githubusercontent.com/samvera/hyrax/hyrax-v5.0.2/template.rb
+HYRAX_SKIP_WINGS=true rails _6.1.7.7_ new my_app --database=postgresql -m https://raw.githubusercontent.com/samvera/hyrax/hyrax-v5.0.3/template.rb
 ```
 
 Generating a new Rails application using Hyrax's template above takes cares of a number of steps for you, including:

--- a/hyrax.gemspec
+++ b/hyrax.gemspec
@@ -43,7 +43,7 @@ SUMMARY
   spec.add_dependency 'browse-everything', '>= 0.16', '< 2.0'
   spec.add_dependency 'carrierwave', '~> 1.0'
   spec.add_dependency 'clipboard-rails', '~> 1.5'
-  spec.add_dependency 'concurrent-ruby', '~> 1.0'
+  spec.add_dependency 'concurrent-ruby', '1.3.4' # Pinned until Rails 7 update
   spec.add_dependency 'connection_pool', '~> 2.4'
   spec.add_dependency 'draper', '~> 4.0'
   spec.add_dependency 'dry-logic', '~> 1.5'

--- a/lib/hyrax/version.rb
+++ b/lib/hyrax/version.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 module Hyrax
-  VERSION = '5.0.2'
+  VERSION = '5.0.3'
 end

--- a/template.rb
+++ b/template.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
-gem 'hyrax', '5.0.2'
+gem 'hyrax', '5.0.3'
 run 'bundle install'
 generate 'hyrax:install', '-f'


### PR DESCRIPTION
While trying to release v5.0.2 containing all changes up to the Ruby/Rails upgrade, it was discovered that Hyrax would potentially not build because of an issue with `concurrent-ruby`.  This was addressed during that upgrade, so we're just cherry-picking and adding ec36aca504f8 so we can release v5.0.3.