### PR TITLE
Changing hydra-editor to 7.0 for Rails 7.2 compatibility

### DIFF
--- a/.dassie/Gemfile
+++ b/.dassie/Gemfile
@@ -42,7 +42,6 @@ gem 'twitter-typeahead-rails', '0.11.1.pre.corejavascript'
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 gem 'uglifier', '>= 1.3.0'
 gem 'activerecord-nulldb-adapter', git: 'https://github.com/taylorthurlow/nulldb', branch: 'fix/activerecord72-register-adapter'
-gem 'hydra-editor', github: 'samvera/hydra-editor', branch: 'revert_and_modernize'
 
 group :development do
   gem 'better_errors' # add command line in browser when errors

--- a/.koppie/Gemfile
+++ b/.koppie/Gemfile
@@ -42,7 +42,6 @@ gem 'twitter-typeahead-rails', '0.11.1.pre.corejavascript'
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 gem 'uglifier', '>= 1.3.0'
 gem 'activerecord-nulldb-adapter', git: 'https://github.com/taylorthurlow/nulldb', branch: 'fix/activerecord72-register-adapter'
-gem 'hydra-editor', github: 'samvera/hydra-editor', branch: 'revert_and_modernize'
 
 group :development do
   gem 'better_errors' # add command line in browser when errors

--- a/hyrax.gemspec
+++ b/hyrax.gemspec
@@ -57,7 +57,7 @@ SUMMARY
   spec.add_dependency 'font-awesome-rails', '~> 4.2'
   spec.add_dependency 'google-analytics-data', '~> 0.6'
   spec.add_dependency 'hydra-derivatives', '~> 4.0'
-  spec.add_dependency 'hydra-editor', '~> 6.0'
+  spec.add_dependency 'hydra-editor', '~> 7.0'
   spec.add_dependency 'hydra-file_characterization', '~> 1.1'
   spec.add_dependency 'hydra-head', '~> 13.0'
   spec.add_dependency 'hydra-works', '>= 0.16'


### PR DESCRIPTION
We had been testing the Ruby/Rails upgrade work by pinning to an unmerged branch of `hydra-editor`.  That got merged so now we can properly spec a version that is compatible with Rails 7.2.  