### PR TITLE
BatchCreateJob loses attributes

### DIFF
--- a/app/jobs/batch_create_job.rb
+++ b/app/jobs/batch_create_job.rb
@@ -25,18 +25,19 @@ class BatchCreateJob < Hyrax::ApplicationJob
   private
 
   def create(user, titles, resource_types, uploaded_files, attributes, operation)
-    model = attributes.delete(:model) || attributes.delete('model')
+    job_attributes = attributes
+    model = job_attributes.delete(:model) || job_attributes.delete('model')
     raise ArgumentError, 'attributes must include "model" => ClassName.to_s' unless model
     uploaded_files.each do |upload_id|
       title = [titles[upload_id]] if titles[upload_id]
       resource_type = Array.wrap(resource_types[upload_id]) if resource_types[upload_id]
-      attributes = attributes.merge(uploaded_files: [upload_id],
+      job_attributes = job_attributes.merge(uploaded_files: [upload_id],
                                     title: title,
                                     resource_type: resource_type)
       child_operation = Hyrax::Operation.create!(user: user,
                                                  operation_type: "Create Work",
                                                  parent: operation)
-      CreateWorkJob.perform_later(user, model, attributes, child_operation)
+      CreateWorkJob.perform_later(user, model, job_attributes, child_operation)
     end
   end
 end


### PR DESCRIPTION
### Fixes

When the job is rescheduled, the attributes are lost.

This commit removes the reassignment of attributes so a job autoretry has all of the attributes of the original job.
