### PR TITLE
Check if db is active?

### DIFF
--- a/lib/hyrax/engine.rb
+++ b/lib/hyrax/engine.rb
@@ -63,11 +63,12 @@ module Hyrax
       #
       # (Some time later...) Simply accessing the connection obj is not raising PG::ConnectionBad,
       # so let's call active? too.
-      can_connect = begin
-        ActiveRecord::Base.connection.active?
-      rescue StandardError
-        false
-      end
+      can_connect =
+        begin
+          ActiveRecord::Base.connection.active?
+        rescue StandardError
+          false
+        end
 
       can_persist = can_connect && begin
         Hyrax.config.persist_registered_roles!

--- a/lib/hyrax/engine.rb
+++ b/lib/hyrax/engine.rb
@@ -60,11 +60,13 @@ module Hyrax
       # raises PG::ConnectionBad. There's no good common ancestor to assume. That's why this test
       # is in its own tiny chunk of code – so we know that whatever the StandardError is, it's coming
       # from the attempt to connect.
+      #
+      # (Some time later...) Simply accessing the connection obj is not raising PG::ConnectionBad,
+      # so let's call active? too.
       can_connect = begin
-        ActiveRecord::Base.connection
-        true
-                    rescue StandardError
-                      false
+        ActiveRecord::Base.connection.active?
+      rescue StandardError
+        false
       end
 
       can_persist = can_connect && begin


### PR DESCRIPTION
### Fixes

Failed attempts to access the database during initialization.

### Summary

This code is designed to prevent errors during initialization when the database connection is not ready. The postgres adapter does not raise an error as expected when accessed, causing errors in situations such as application generation. Calling `active?` should give us a better idea if the db is really ready.

### Guidance for testing, such as acceptance criteria or new user interface behaviors:
* Can generate a hyrax application without the database being up. Other commands such as rake tasks may also benefit.
*
*

### Changes proposed in this pull request:
* Rely on `active?` to determine db status.
*
*

@samvera/hyrax-code-reviewers
