### PR TITLE
Overriding Rails config defaults for compatibility

### DIFF
--- a/.dassie/config/application.rb
+++ b/.dassie/config/application.rb
@@ -11,6 +11,10 @@ module Dassie
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 7.2
     config.add_autoload_paths_to_load_path = true
+    config.action_view.apply_stylesheet_media_default = true
+    config.action_view.button_to_generates_button_tag = false
+    config.action_controller.raise_on_open_redirects = false
+    config.action_view.sanitizer_vendor = Rails::HTML4::Sanitizer
 
 
     # Settings in config/environments/* take precedence over those specified here.

--- a/.dassie/config/application.rb
+++ b/.dassie/config/application.rb
@@ -11,7 +11,6 @@ module Dassie
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 7.2
     config.add_autoload_paths_to_load_path = true
-    config.action_view.apply_stylesheet_media_default = true
     config.action_view.button_to_generates_button_tag = false
     config.action_controller.raise_on_open_redirects = false
     config.action_view.sanitizer_vendor = Rails::HTML4::Sanitizer

--- a/.dassie/config/application.rb
+++ b/.dassie/config/application.rb
@@ -9,7 +9,9 @@ Bundler.require(*Rails.groups)
 module Dassie
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
-    config.load_defaults 6.0
+    config.load_defaults 7.2
+    config.add_autoload_paths_to_load_path = true
+
 
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers

--- a/.dassie/config/application.rb
+++ b/.dassie/config/application.rb
@@ -12,7 +12,6 @@ module Dassie
     config.load_defaults 7.2
     config.add_autoload_paths_to_load_path = true
     config.action_view.button_to_generates_button_tag = false
-    config.action_controller.raise_on_open_redirects = false
     config.action_view.sanitizer_vendor = Rails::HTML4::Sanitizer
 
 

--- a/.dassie/config/application.rb
+++ b/.dassie/config/application.rb
@@ -11,9 +11,6 @@ module Dassie
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 7.2
     config.add_autoload_paths_to_load_path = true
-    config.action_view.button_to_generates_button_tag = false
-    config.action_view.sanitizer_vendor = Rails::HTML4::Sanitizer
-
 
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers

--- a/.koppie/config/application.rb
+++ b/.koppie/config/application.rb
@@ -11,7 +11,6 @@ module Koppie
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 7.2
     config.add_autoload_paths_to_load_path = true
-    config.action_view.apply_stylesheet_media_default = true
     config.action_view.button_to_generates_button_tag = false
     config.action_controller.raise_on_open_redirects = false
     config.action_view.sanitizer_vendor = Rails::HTML4::Sanitizer

--- a/.koppie/config/application.rb
+++ b/.koppie/config/application.rb
@@ -11,8 +11,9 @@ module Koppie
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 7.2
     config.add_autoload_paths_to_load_path = true
-    config.action_view.apply_stylesheet_media_default = true
+    # config.action_view.apply_stylesheet_media_default = true
     config.action_view.button_to_generates_button_tag = false
+    config.action_controller.raise_on_open_redirects = false
 
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers

--- a/.koppie/config/application.rb
+++ b/.koppie/config/application.rb
@@ -9,7 +9,8 @@ Bundler.require(*Rails.groups)
 module Koppie
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
-    config.load_defaults 6.0
+    config.load_defaults 7.2
+    config.add_autoload_paths_to_load_path = true
 
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers

--- a/.koppie/config/application.rb
+++ b/.koppie/config/application.rb
@@ -11,8 +11,6 @@ module Koppie
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 7.2
     config.add_autoload_paths_to_load_path = true
-    config.action_view.button_to_generates_button_tag = false
-    config.action_view.sanitizer_vendor = Rails::HTML4::Sanitizer
 
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers

--- a/.koppie/config/application.rb
+++ b/.koppie/config/application.rb
@@ -12,7 +12,6 @@ module Koppie
     config.load_defaults 7.2
     config.add_autoload_paths_to_load_path = true
     config.action_view.button_to_generates_button_tag = false
-    config.action_controller.raise_on_open_redirects = false
     config.action_view.sanitizer_vendor = Rails::HTML4::Sanitizer
 
     # Settings in config/environments/* take precedence over those specified here.

--- a/.koppie/config/application.rb
+++ b/.koppie/config/application.rb
@@ -11,9 +11,10 @@ module Koppie
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 7.2
     config.add_autoload_paths_to_load_path = true
-    # config.action_view.apply_stylesheet_media_default = true
+    config.action_view.apply_stylesheet_media_default = true
     config.action_view.button_to_generates_button_tag = false
     config.action_controller.raise_on_open_redirects = false
+    config.action_view.sanitizer_vendor = Rails::HTML4::Sanitizer
 
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers

--- a/.koppie/config/application.rb
+++ b/.koppie/config/application.rb
@@ -11,6 +11,8 @@ module Koppie
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 7.2
     config.add_autoload_paths_to_load_path = true
+    config.action_view.apply_stylesheet_media_default = true
+    config.action_view.button_to_generates_button_tag = false
 
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers

--- a/app/controllers/hyrax/api/zotero_controller.rb
+++ b/app/controllers/hyrax/api/zotero_controller.rb
@@ -14,7 +14,7 @@ module Hyrax
         session[:request_token] = request_token
         current_user.zotero_token = request_token
         current_user.save
-        redirect_to request_token.authorize_url(identity: '1', oauth_callback: callback_url)
+        redirect_to request_token.authorize_url(identity: '1', oauth_callback: callback_url), allow_other_host: true
       rescue OAuth::Unauthorized
         redirect_to root_url, alert: 'Invalid Zotero client key pair'
       end

--- a/config/initializers/new_framework_defaults_7_2.rb
+++ b/config/initializers/new_framework_defaults_7_2.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+# Any options set here are to override Rails 7.2 configuration defaults
+
+# These fix a couple of issues arising from Rails 7.2 enforcement of HTML5 semantics
+# by default when using certain Rails methods
+Rails.application.config.action_view.button_to_generates_button_tag = false
+Rails.application.config.action_view.sanitizer_vendor = Rails::HTML4::Sanitizer

--- a/lib/generators/hyrax/install_generator.rb
+++ b/lib/generators/hyrax/install_generator.rb
@@ -190,10 +190,7 @@ module Hyrax
 
     def insert_application_config
       insert_into_file 'config/application.rb', after: /config\.load_defaults [0-9.]+$/ do
-        "\n    config.action_view.button_to_generates_button_tag = false" \
-        "\n    config.action_controller.raise_on_open_redirects = false" \
-        "\n    config.action_view.sanitizer_vendor = Rails::HTML4::Sanitizer" \
-        "\n    config.active_job.queue_adapter = ENV.fetch('HYRAX_ACTIVE_JOB_QUEUE') { 'async' }.to_sym"
+        "\n    config.active_job.queue_adapter = ENV.fetch('HYRAX_ACTIVE_JOB_QUEUE') { 'async' }.to_sym\n"
       end
     end
 

--- a/lib/generators/hyrax/install_generator.rb
+++ b/lib/generators/hyrax/install_generator.rb
@@ -188,9 +188,12 @@ module Hyrax
       generate 'hyrax:riiif' unless options[:'skip-riiif']
     end
 
-    def insert_env_queue_adapter
+    def insert_application_config
       insert_into_file 'config/application.rb', after: /config\.load_defaults [0-9.]+$/ do
-        "\n    config.active_job.queue_adapter = ENV.fetch('HYRAX_ACTIVE_JOB_QUEUE') { 'async' }.to_sym\n"
+        "\n    config.action_view.button_to_generates_button_tag = false" \
+        "\n    config.action_controller.raise_on_open_redirects = false" \
+        "\n    config.action_view.sanitizer_vendor = Rails::HTML4::Sanitizer" \
+        "\n    config.active_job.queue_adapter = ENV.fetch('HYRAX_ACTIVE_JOB_QUEUE') { 'async' }.to_sym"
       end
     end
 

--- a/template.rb
+++ b/template.rb
@@ -1,4 +1,9 @@
 # frozen_string_literal: true
+
+insert_into_file 'config/application.rb', after: /config\.load_defaults [0-9.]+$/ do
+  "\n    config.add_autoload_paths_to_load_path = true"
+end
+
 gem 'hyrax', '5.0.3'
 run 'bundle install'
 generate 'hyrax:install', '-f'


### PR DESCRIPTION
Fixes #7011 

In #6913 to get running on Rails 7.2, I missed that the test apps were still set to load configuration defaults for 6.0.  When the target version gets bumped to 7.2 in any scenario, such as generating a new Rails app from the template, things start breaking.

This PR sets the test apps to load configuration defaults for 7.2, but adds several overrides to pre-7.x values for compatibility.  

Where possible, overrides were put in a Hyrax-managed initializer to keep from having to persist options in the actual application.   However, `add_autoload_paths_to_load_path` has to be in the `application.rb` of the application so that it takes effect before code starts to load.  That is accomplished by an insert in the install template.