### PR TITLE
Lazy migrate sipity entity with work

### DIFF
--- a/app/jobs/migrate_sipity_entity_job.rb
+++ b/app/jobs/migrate_sipity_entity_job.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+# migrates a resource's sipity entity so it can be found
+class MigrateSipityEntityJob < ApplicationJob
+  # input [String] id of a migrated resource
+  def perform(id:)
+    resource = Hyrax.query_service.find_by(id: id)
+    new_gid = Hyrax::GlobalID(resource).to_s
+    work = resource.internal_resource.constantize.find(id)
+    original_gid = Hyrax::GlobalID(work).to_s
+    return if new_gid == original_gid
+    original_entity = Sipity::Entity.find_by(proxy_for_global_id: original_gid)
+    original_entity.update(proxy_for_global_id: new_gid)
+  end
+end

--- a/lib/freyja/persister.rb
+++ b/lib/freyja/persister.rb
@@ -38,6 +38,7 @@ module Freyja
         if new_resource.is_a?(Hyrax::Work)
           member_ids = new_resource.member_ids.map(&:to_s)
           MigrateResourcesJob.perform_later(ids: member_ids) unless member_ids.empty?
+          MigrateSipityEntityJob.perform_later(id: new_resource.id)
         end
       end
       new_resource


### PR DESCRIPTION
## Summary
When lazy migration is used, the sipity entity cannot be found for works
which are not yet migrated. Valkyrie resources have a `proxy_for_global_id`
with the format:
`gid://hyku/Hyrax::ValkyrieGlobalIdProxy/2f6da5dd-9314-421f-b0dd-fda84fec9ee3`
while prior works used the model name such as:
`gid://hyku/GenericWork/2f6da5dd-9314-421f-b0dd-fda84fec9ee3`.

## Description of changes

Fixes https://github.com/notch8/palni_palci_knapsack/issues/247

This commit introduces a lazy migration of the sipity entity via a job
which is submitted after a work is migrated to valkyrie via the Freyja
persister.

Prior work in pull request https://github.com/samvera/hyku/pull/2471
added some overrides in Hyku to resolve the sipity entity issues. These
changes still needs to be backported.

The prior work includes these changes:
The MigrateResourceService introduced a migration of the entity along
with the work's migration. This service is needed for direct migration
calls, but is not adequate for lazy migration, as the Freyja persister
does not call it for the work itself that was just migrated.

Hyku overrides to sipity.rb support cases where the entity is not yet migrated
and lazy migration is in use. This is necessary because the solr_document
is used to find the Sipity::Entity. Due to the model mapping found in the
solr document, the Entity method searches for the entity with the model
name. This is problematic when the entity is not yet migrated and the
entity is searched with a GenericWorkResource model rather than the
model.