### PR TITLE
Use Hyrax logger in hyrax:workflow:load Rake task

### DIFF
--- a/lib/tasks/workflow.rake
+++ b/lib/tasks/workflow.rake
@@ -3,8 +3,7 @@ namespace :hyrax do
   namespace :workflow do
     desc "Load workflow configuration into the database"
     task load: :environment do
-      logger = Logger.new(STDOUT)
-      logger.level = Logger::DEBUG
+      logger = Hyrax.logger || Logger.new(STDOUT, level: Logger::DEBUG)
       Hyrax::Workflow::WorkflowImporter.load_workflows(logger: logger)
       errors = Hyrax::Workflow::WorkflowImporter.load_errors
       abort("Failed to process all workflows:\n  #{errors.join('\n  ')}") unless errors.empty?


### PR DESCRIPTION
### Fixes

Fixes #7042 

### Summary

Modifies the `hyrax:workflow:load` Rake task to use `Hyrax.logger` (if available), rather
than always spin up its own logger.

### Type of change (for release notes)

`notes-minor`

@samvera/hyrax-code-reviewers
