### PR TITLE
The valkyrie initializer from the install template needs to_prepare b…

### DIFF
--- a/lib/generators/hyrax/templates/config/initializers/1_valkyrie.rb
+++ b/lib/generators/hyrax/templates/config/initializers/1_valkyrie.rb
@@ -86,21 +86,23 @@ Valkyrie.config.storage_adapter  = ENV.fetch('VALKYRIE_STORAGE_ADAPTER') { :vers
 
 Valkyrie.config.indexing_adapter = :solr_index
 
-custom_queries = [Hyrax::CustomQueries::Navigators::CollectionMembers,
-                  Hyrax::CustomQueries::Navigators::ChildCollectionsNavigator,
-                  Hyrax::CustomQueries::Navigators::ParentCollectionsNavigator,
-                  Hyrax::CustomQueries::Navigators::ChildFileSetsNavigator,
-                  Hyrax::CustomQueries::Navigators::ChildWorksNavigator,
-                  Hyrax::CustomQueries::Navigators::ParentWorkNavigator,
-                  Hyrax::CustomQueries::Navigators::FindFiles,
-                  Hyrax::CustomQueries::FindAccessControl,
-                  Hyrax::CustomQueries::FindCollectionsByType,
-                  Hyrax::CustomQueries::FindFileMetadata,
-                  Hyrax::CustomQueries::FindIdsByModel,
-                  Hyrax::CustomQueries::FindManyByAlternateIds,
-                  Hyrax::CustomQueries::FindModelsByAccess,
-                  Hyrax::CustomQueries::FindCountBy,
-                  Hyrax::CustomQueries::FindByDateRange]
-custom_queries.each do |handler|
-  Hyrax.query_service.custom_queries.register_query_handler(handler)
+Rails.application.reloader.to_prepare do
+  custom_queries = [Hyrax::CustomQueries::Navigators::CollectionMembers,
+                    Hyrax::CustomQueries::Navigators::ChildCollectionsNavigator,
+                    Hyrax::CustomQueries::Navigators::ParentCollectionsNavigator,
+                    Hyrax::CustomQueries::Navigators::ChildFileSetsNavigator,
+                    Hyrax::CustomQueries::Navigators::ChildWorksNavigator,
+                    Hyrax::CustomQueries::Navigators::ParentWorkNavigator,
+                    Hyrax::CustomQueries::Navigators::FindFiles,
+                    Hyrax::CustomQueries::FindAccessControl,
+                    Hyrax::CustomQueries::FindCollectionsByType,
+                    Hyrax::CustomQueries::FindFileMetadata,
+                    Hyrax::CustomQueries::FindIdsByModel,
+                    Hyrax::CustomQueries::FindManyByAlternateIds,
+                    Hyrax::CustomQueries::FindModelsByAccess,
+                    Hyrax::CustomQueries::FindCountBy,
+                    Hyrax::CustomQueries::FindByDateRange]
+  custom_queries.each do |handler|
+    Hyrax.query_service.custom_queries.register_query_handler(handler)
+  end
 end


### PR DESCRIPTION
### Fixes

Fixes #7047

### Summary

The template install method creates a valkyrie initializer containing a block that defines `custom_queries`, but because of Rails 7.2 autoloading behavior, this will fail because it can't find `Hyrax::CustomQueries`.  It seems to be working properly when wrapped in a `reloader.to_prepare block`.