### PR TITLE
Collection spec failure

### DIFF
--- a/spec/features/dashboard/collection_spec.rb
+++ b/spec/features/dashboard/collection_spec.rb
@@ -310,6 +310,7 @@ RSpec.describe 'collection', type: :feature, clean_repo: true do
         fill_in('Creator', with: 'Doe, Jane')
         fill_in('Related URL', with: 'http://example.com/')
 
+        find('button.btn.btn-link.add', text: /Add another Location/i).click
         click_link('Search for a location')
         expect(page).to have_content 'Please enter 2 or more characters'
         find('#s2id_autogen1_search').send_keys("minneapolis")


### PR DESCRIPTION
Spec failing in koppie and sirenia. This is failing because the UI requires the user to click "add another location" before "search for a location" is rendered. 

PS. it seems like a user shouldn't be required to click that link first



![image (1)](https://github.com/user-attachments/assets/03ef7a3c-4754-46c6-a2d7-2035b035ea2d)


![image (2)](https://github.com/user-attachments/assets/a309f47d-ee06-4ca0-8c14-f64f06fb12bf)

