### PR TITLE
Queueable index adapter

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,4 +21,5 @@ group :development, :test do
   gem 'ruby-prof', require: false
   gem 'semaphore_test_boosters'
   gem "simplecov", require: false
+  gem 'timecop'
 end

--- a/app/jobs/concerns/hyrax/queued_job_behavior.rb
+++ b/app/jobs/concerns/hyrax/queued_job_behavior.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+module Hyrax
+  # Grants the user's edit access on the provided FileSet
+  module QueuedJobBehavior
+    extend ActiveSupport::Concern
+
+    included do
+      queue_as Hyrax.config.ingest_queue_name
+    end
+
+    private
+
+    def redis_queue
+      Valkyrie::IndexingAdapter.find(:redis_queue)
+    end
+
+    def requeue(*args)
+      self.class.set(wait_until: 5.minutes.from_now).perform_later(*args)
+    end
+  end
+end

--- a/app/jobs/concerns/hyrax/queued_job_behavior.rb
+++ b/app/jobs/concerns/hyrax/queued_job_behavior.rb
@@ -6,6 +6,7 @@ module Hyrax
 
     included do
       queue_as Hyrax.config.ingest_queue_name
+      cattr_accessor :requeue_frequency
     end
 
     private
@@ -15,7 +16,7 @@ module Hyrax
     end
 
     def requeue(*args)
-      self.class.set(wait_until: 5.minutes.from_now).perform_later(*args)
+      self.class.set(wait_until: (self.class.requeue_frequency || 5.minutes).from_now).perform_later(*args)
     end
   end
 end

--- a/app/jobs/hyrax/queued_delete_job.rb
+++ b/app/jobs/hyrax/queued_delete_job.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+module Hyrax
+  class QueuedDeleteJob < ApplicationJob
+    include QueuedJobBehavior
+
+    def perform(size: 200)
+      redis_queue.delete_queue(size: size)
+      requeue(size: size)
+    end
+  end
+end

--- a/app/jobs/hyrax/queued_indexing_job.rb
+++ b/app/jobs/hyrax/queued_indexing_job.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+module Hyrax
+  class QueuedIndexingJob < ApplicationJob
+    include QueuedJobBehavior
+
+    def perform(size: 200)
+      redis_queue.index_queue(size: size)
+      requeue(size: size)
+    end
+  end
+end

--- a/config/initializers/indexing_adapter_initializer.rb
+++ b/config/initializers/indexing_adapter_initializer.rb
@@ -7,3 +7,7 @@ Valkyrie::IndexingAdapter.register(
 Valkyrie::IndexingAdapter.register(
   Valkyrie::Indexing::NullIndexingAdapter.new, :null_index
 )
+Valkyrie::IndexingAdapter.register(
+  Valkyrie::Indexing::RedisQueue::IndexingAdapter.new,
+  :redis_queue
+)

--- a/docker-compose-dassie.yml
+++ b/docker-compose-dassie.yml
@@ -7,7 +7,9 @@ services:
         - EXTRA_APK_PACKAGES=git less
         - BUNDLE_GEMFILE=Gemfile.dassie
     image: samvera/hyrax-dev
-    command: sh -c 'bundle exec puma -v -b tcp://0.0.0.0:3000'
+    # command: sh -c 'bundle exec puma -v -b tcp://0.0.0.0:3000'
+    command: sleep infinity
+    entrypoint: ["hyrax-entrypoint.sh"]
     stdin_open: true
     tty: true
     user: root
@@ -68,14 +70,14 @@ services:
   chrome:
     image: selenium/standalone-chromium:4
     environment:
-#      - START_XVFB=false
+      #      - START_XVFB=false
       - SE_NODE_SESSION_TIMEOUT=800
       - SE_ENABLE_TRACING=false
       - SE_ENABLE_BROWSER_LEFTOVERS_CLEANUP=true
       - SE_BROWSER_ARGS_DISABLE_DSHM=--disable-dev-shm-usage
       - SE_BROWSER_ARGS_HEADLESS=--headless=new
-#    logging:
-#      driver: none
+    #    logging:
+    #      driver: none
     volumes:
       - /dev/shm:/dev/shm
     shm_size: 2g
@@ -118,7 +120,7 @@ services:
   memcached:
     image: bitnami/memcached
     ports:
-      - '11211:11211'
+      - "11211:11211"
     networks:
       - hyrax
 

--- a/docker-compose-dassie.yml
+++ b/docker-compose-dassie.yml
@@ -7,9 +7,7 @@ services:
         - EXTRA_APK_PACKAGES=git less
         - BUNDLE_GEMFILE=Gemfile.dassie
     image: samvera/hyrax-dev
-    # command: sh -c 'bundle exec puma -v -b tcp://0.0.0.0:3000'
-    command: sleep infinity
-    entrypoint: ["hyrax-entrypoint.sh"]
+    command: sh -c 'bundle exec puma -v -b tcp://0.0.0.0:3000'
     stdin_open: true
     tty: true
     user: root

--- a/lib/hyrax.rb
+++ b/lib/hyrax.rb
@@ -23,6 +23,7 @@ require 'hyrax/valkyrie_can_can_adapter'
 require 'retriable'
 require 'valkyrie/indexing_adapter'
 require 'valkyrie/indexing/solr/indexing_adapter'
+require 'valkyrie/indexing/redis_queue/indexing_adapter'
 require 'valkyrie/indexing/null_indexing_adapter'
 
 ##

--- a/lib/valkyrie/indexing/redis_queue/indexing_adapter.rb
+++ b/lib/valkyrie/indexing/redis_queue/indexing_adapter.rb
@@ -65,7 +65,7 @@ module Valkyrie
         private
 
         def persist(resources)
-          connection.sadd(index_queue_name, resources.map {|r| r.id.to_s})
+          connection.sadd(index_queue_name, resources.map { |r| r.id.to_s })
         end
 
         def default_connection

--- a/lib/valkyrie/indexing/redis_queue/indexing_adapter.rb
+++ b/lib/valkyrie/indexing/redis_queue/indexing_adapter.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+module Valkyrie
+  module Indexing
+    module RedisQueue
+      class IndexingAdapter
+        ##
+        # @!attribute [r] connection
+        #   @return [RSolr::Client]
+        attr_accessor :connection, :index_queue_name, :delete_queue_name
+
+        ##
+        # @param connection [RSolr::Client] The RSolr connection to index to.
+        def initialize(connection: default_connection, index_queue_name: 'toindex', delete_queue_name: 'todelete')
+          @connection = connection
+          @index_queue_name = index_queue_name
+          @delete_queue_name = delete_queue_name
+        end
+
+        def save(resource:)
+          persist([resource])
+        end
+
+        def save_all(resources:)
+          persist(resources)
+        end
+
+        # Deletes a Solr Document using the ID
+        # @return [Array<Valkyrie::Resource>] resources which have been deleted from Solr
+        def delete(resource:)
+          connection.sadd(delete_queue_name, resource.id.to_s)
+        end
+
+        # Delete the Solr index of all Documents
+        def wipe!
+          connection.del(index_queue_name)
+          connection.del(delete_queue_name)
+        end
+
+        def reset!
+          self.connection = default_connection
+        end
+
+        def index_queue(size: 200)
+          set = connection.spop(index_queue_name, size)
+          return [] if set.blank?
+          resources = Hyrax.query_service.find_many_by_ids(ids: set)
+          Valkyrie::IndexingAdapter.find(:solr_index).save_all(resources: resources)
+        rescue
+          persist(set) # if anything goes wrong, try to requeue the items
+        end
+
+        # We reach in to solr directly here to prevent needing to load the objects unnecessarily
+        def delete_queue(size: 200)
+          set = connection.spop(index_queue_name, size)
+          return [] if set.blank?
+          indexer = Valkyrie::IndexingAdapter.find(:solr_index)
+          set.each do |id|
+            indexer.connection.delete_by_id id.to_s, { softCommit: true }
+          end
+          indexer.connection.commit
+        rescue
+          persist(set) # if anything goes wrong, try to requeue the items
+        end
+
+        private
+
+        def persist(resources)
+          connection.sadd(index_queue_name, resources.map {|r| r.id.to_s})
+        end
+
+        def default_connection
+          Hyrax.config.redis_connection
+        end
+      end
+    end
+  end
+end

--- a/spec/jobs/concerns/hyrax/queued_job_behavior_spec.rb
+++ b/spec/jobs/concerns/hyrax/queued_job_behavior_spec.rb
@@ -33,11 +33,38 @@ RSpec.describe Hyrax::QueuedJobBehavior do
   end
 
   describe '#requeue' do
+    before do
+      allow(including_class).to receive(:set).and_return(including_class)
+      allow(including_class).to receive(:perform_later)
+    end
+
     it 'schedules the job to run again in 5 minutes' do
-      expect(including_class).to receive(:set).and_return(including_class)
+      expect(including_class).to receive(:set).with(wait_until: kind_of(ActiveSupport::TimeWithZone))
       expect(including_class).to receive(:perform_later).with('arg1', 'arg2')
 
       instance.send(:requeue, 'arg1', 'arg2')
+    end
+
+    it 'uses the class requeue_frequency if set' do
+      including_class.requeue_frequency = 10.minutes
+
+      expect(including_class).to receive(:set) do |options|
+        expect(options[:wait_until]).to be_within(1.second).of(10.minutes.from_now)
+        including_class
+      end
+
+      instance.send(:requeue)
+    end
+
+    it 'defaults to 5 minutes if requeue_frequency is not set' do
+      including_class.requeue_frequency = nil
+
+      expect(including_class).to receive(:set) do |options|
+        expect(options[:wait_until]).to be_within(1.second).of(5.minutes.from_now)
+        including_class
+      end
+
+      instance.send(:requeue)
     end
   end
 end

--- a/spec/jobs/concerns/hyrax/queued_job_behavior_spec.rb
+++ b/spec/jobs/concerns/hyrax/queued_job_behavior_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+require 'spec_helper'
+
+RSpec.describe Hyrax::QueuedJobBehavior do
+  let(:including_class) do
+    Class.new(ApplicationJob) do
+      include Hyrax::QueuedJobBehavior
+
+      def perform(*_args)
+        redis_queue.index_queue(size: 200)
+      end
+    end
+  end
+
+  let(:instance) { including_class.new }
+  let(:redis_queue) { instance_double(Valkyrie::Indexing::RedisQueue::IndexingAdapter) }
+
+  before do
+    allow(Valkyrie::IndexingAdapter).to receive(:find).with(:redis_queue).and_return(redis_queue)
+  end
+
+  describe '#queue_as' do
+    it 'uses the ingest queue name' do
+      expect(including_class.queue_name.to_s).to eq(Hyrax.config.ingest_queue_name.to_s)
+    end
+  end
+
+  describe '#redis_queue' do
+    it 'finds the redis queue indexing adapter' do
+      expect(Valkyrie::IndexingAdapter).to receive(:find).with(:redis_queue)
+      instance.send(:redis_queue)
+    end
+  end
+
+  describe '#requeue' do
+    it 'schedules the job to run again in 5 minutes' do
+      expect(including_class).to receive(:set).and_return(including_class)
+      expect(including_class).to receive(:perform_later).with('arg1', 'arg2')
+
+      instance.send(:requeue, 'arg1', 'arg2')
+    end
+  end
+end

--- a/spec/jobs/hyrax/queued_delete_job_spec.rb
+++ b/spec/jobs/hyrax/queued_delete_job_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+require 'spec_helper'
+
+RSpec.describe Hyrax::QueuedDeleteJob do
+  let(:job) { described_class.new }
+  let(:redis_queue) { instance_double(Valkyrie::Indexing::RedisQueue::IndexingAdapter) }
+
+  before do
+    allow(Valkyrie::IndexingAdapter).to receive(:find).with(:redis_queue).and_return(redis_queue)
+  end
+
+  it 'includes QueuedJobBehavior' do
+    expect(described_class.ancestors).to include(Hyrax::QueuedJobBehavior)
+  end
+
+  describe '#perform' do
+    it 'processes items from the delete queue and requeues itself' do
+      expect(redis_queue).to receive(:delete_queue).with(size: 200)
+      expect(job).to receive(:requeue).with(size: 200)
+
+      job.perform(size: 200)
+    end
+
+    it 'uses a default size of 200 when not specified' do
+      expect(redis_queue).to receive(:delete_queue).with(size: 200)
+      expect(job).to receive(:requeue).with(size: 200)
+
+      job.perform
+    end
+
+    it 'allows a custom size parameter' do
+      expect(redis_queue).to receive(:delete_queue).with(size: 500)
+      expect(job).to receive(:requeue).with(size: 500)
+
+      job.perform(size: 500)
+    end
+  end
+end

--- a/spec/jobs/hyrax/queued_indexing_job_spec.rb
+++ b/spec/jobs/hyrax/queued_indexing_job_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+require 'spec_helper'
+
+RSpec.describe Hyrax::QueuedIndexingJob do
+  let(:job) { described_class.new }
+  let(:redis_queue) { instance_double(Valkyrie::Indexing::RedisQueue::IndexingAdapter) }
+
+  before do
+    allow(Valkyrie::IndexingAdapter).to receive(:find).with(:redis_queue).and_return(redis_queue)
+  end
+
+  it 'includes QueuedJobBehavior' do
+    expect(described_class.ancestors).to include(Hyrax::QueuedJobBehavior)
+  end
+
+  describe '#perform' do
+    it 'processes items from the index queue and requeues itself' do
+      expect(redis_queue).to receive(:index_queue).with(size: 200)
+      expect(job).to receive(:requeue).with(size: 200)
+
+      job.perform(size: 200)
+    end
+
+    it 'uses a default size of 200 when not specified' do
+      expect(redis_queue).to receive(:index_queue).with(size: 200)
+      expect(job).to receive(:requeue).with(size: 200)
+
+      job.perform
+    end
+
+    it 'allows a custom size parameter' do
+      expect(redis_queue).to receive(:index_queue).with(size: 500)
+      expect(job).to receive(:requeue).with(size: 500)
+
+      job.perform(size: 500)
+    end
+  end
+end

--- a/spec/valkyrie/indexing/redis_queue/indexing_adapter_spec.rb
+++ b/spec/valkyrie/indexing/redis_queue/indexing_adapter_spec.rb
@@ -1,0 +1,118 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe Valkyrie::Indexing::RedisQueue::IndexingAdapter do
+  let(:connection) { instance_double(Redis) }
+  let(:index_queue_name) { 'toindex' }
+  let(:delete_queue_name) { 'todelete' }
+  let(:adapter) { described_class.new(connection: connection, index_queue_name: index_queue_name, delete_queue_name: delete_queue_name) }
+  let(:resource) { FactoryBot.valkyrie_create(:hyrax_resource) }
+  let(:resources) { [resource] }
+
+  describe '#initialize' do
+    it 'sets the connection, index_queue_name, and delete_queue_name' do
+      expect(adapter.connection).to eq(connection)
+      expect(adapter.index_queue_name).to eq(index_queue_name)
+      expect(adapter.delete_queue_name).to eq(delete_queue_name)
+    end
+  end
+
+  describe '#save' do
+    it 'persists the resource to the index queue' do
+      expect(connection).to receive(:sadd).with(index_queue_name, [resource.id.to_s])
+      adapter.save(resource: resource)
+    end
+  end
+
+  describe '#save_all' do
+    it 'persists multiple resources to the index queue' do
+      expect(connection).to receive(:sadd).with(index_queue_name, resources.map { |r| r.id.to_s })
+      adapter.save_all(resources: resources)
+    end
+  end
+
+  describe '#delete' do
+    it 'adds the resource ID to the delete queue' do
+      expect(connection).to receive(:sadd).with(delete_queue_name, resource.id.to_s)
+      adapter.delete(resource: resource)
+    end
+  end
+
+  describe '#wipe!' do
+    it 'deletes the index and delete queues' do
+      expect(connection).to receive(:del).with(index_queue_name)
+      expect(connection).to receive(:del).with(delete_queue_name)
+      adapter.wipe!
+    end
+  end
+
+  describe '#reset!' do
+    it 'resets the connection to the default connection' do
+      default_connection = instance_double(Redis)
+      allow(Hyrax.config).to receive(:redis_connection).and_return(default_connection)
+      adapter.reset!
+      expect(adapter.connection).to eq(default_connection)
+    end
+  end
+
+  describe '#index_queue' do
+    let(:set) { [resource.id.to_s] }
+    let(:solr_indexing_adapter) { instance_double(Valkyrie::Indexing::Solr::IndexingAdapter) }
+
+    before do
+      allow(connection).to receive(:spop).with(index_queue_name, 200).and_return(set)
+      allow(Hyrax.query_service).to receive(:find_many_by_ids).with(ids: set).and_return(resources)
+      allow(Valkyrie::IndexingAdapter).to receive(:find).with(:solr_index).and_return(solr_indexing_adapter)
+      allow(solr_indexing_adapter).to receive(:save_all)
+    end
+
+    it 'indexes the resources' do
+      expect(solr_indexing_adapter).to receive(:save_all).with(resources: resources)
+      adapter.index_queue
+    end
+
+    context 'when an error occurs' do
+      before do
+        allow(solr_indexing_adapter).to receive(:save_all).and_raise(StandardError)
+      end
+
+      it 'requeues the items' do
+        expect(connection).to receive(:sadd).with(index_queue_name, set)
+        adapter.index_queue
+      end
+    end
+  end
+
+  describe '#delete_queue' do
+    let(:set) { [resource.id.to_s] }
+    let(:solr_indexing_adapter) { instance_double(Valkyrie::Indexing::Solr::IndexingAdapter) }
+    let(:solr_connection) { instance_double(RSolr::Client) }
+
+    before do
+      allow(connection).to receive(:spop).with(delete_queue_name, 200).and_return(set)
+      allow(Valkyrie::IndexingAdapter).to receive(:find).with(:solr_index).and_return(solr_indexing_adapter)
+      allow(solr_indexing_adapter).to receive(:connection).and_return(solr_connection)
+      allow(solr_connection).to receive(:delete_by_id)
+      allow(solr_connection).to receive(:commit)
+    end
+
+    it 'deletes the resources from Solr' do
+      set.each do |id|
+        expect(solr_connection).to receive(:delete_by_id).with(id.to_s, { softCommit: true })
+      end
+      expect(solr_connection).to receive(:commit)
+      adapter.delete_queue
+    end
+
+    context 'when an error occurs' do
+      before do
+        allow(solr_connection).to receive(:delete_by_id).and_raise(StandardError)
+      end
+
+      it 'requeues the items' do
+        expect(connection).to receive(:sadd).with(delete_queue_name, set)
+        adapter.delete_queue
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Summary

Ability to queue index / delete calls in to Redis to process them via Solr more effectively. This method accomplishes two things. 1) all ids are unique in the Redis set, so adding the same item multiple times will only index it once and 2) should give us Solr performance by committing more items to the index before a commit. 

### TODO
- [x] Add specs
- [x] Rubocop fixes 
- [x] Add a requeing job that runs the index_queue method every 5 minutes so things actually get indexed
- [x] Add a requeing job that runs the delete_queue method every 5 minutes so things actually get deleted

### Guidance for testing, such as acceptance criteria or new user interface behaviors:
* Set indexing queue in an initializer: `Hyrax.config.index_adapter = :redis_queue`
* Add or edit or delete items, checking the queue with `Hyrax.config.redis_connection.smembers('toindex')` and `Hyrax.config.redis_connection.smembers('todelete')` to see that items are added to the queue
* Verify that items do get indexed properly when the indexing job runs
* Verify that items do get deleted properly when the delete job runs


@samvera/hyrax-code-reviewers
