### PR TITLE
Catch errors that cause unnecessary retries

### DIFF
--- a/app/jobs/migrate_files_to_valkyrie_job.rb
+++ b/app/jobs/migrate_files_to_valkyrie_job.rb
@@ -4,7 +4,7 @@
 class MigrateFilesToValkyrieJob < Hyrax::ApplicationJob
   # Define a logger for this job
   def logger
-    @logger ||= Logger.new(Rails.root.join('log', 'migrate_files_to_valkyrie_job.log'))
+    @logger ||= Logger.new(Rails.root.join('tmp', 'imports', 'migrate_files_to_valkyrie_job.log'))
   end
   ##
   #

--- a/app/jobs/migrate_sipity_entity_job.rb
+++ b/app/jobs/migrate_sipity_entity_job.rb
@@ -10,6 +10,7 @@ class MigrateSipityEntityJob < ApplicationJob
     original_gid = Hyrax::GlobalID(work).to_s
     return if new_gid == original_gid
     original_entity = Sipity::Entity.find_by(proxy_for_global_id: original_gid)
+    return if original_entity.nil?
     original_entity.update(proxy_for_global_id: new_gid)
   rescue ActiveFedora::ObjectNotFoundError
     # this happens when the resource was never in Fedora so there is nothing to migrate.


### PR DESCRIPTION
### Fixes

In order to speed up migrations, we want to skip out of jobs which error that don't need 5 retries.
