### PR TITLE
should fix accessibility issue

### DIFF
--- a/app/views/hyrax/base/iiif_viewers/_universal_viewer.html.erb
+++ b/app/views/hyrax/base/iiif_viewers/_universal_viewer.html.erb
@@ -1,5 +1,5 @@
 <div class="viewer-wrapper">
-  <iframe aria-label="image view" 
+  <iframe title="image view" 
     src="<%= universal_viewer_base_url %>#?manifest=<%= main_app.polymorphic_url [main_app, :manifest, presenter], { locale: nil } %>&config=<%= universal_viewer_config_url %>" 
     allowfullscreen="true" 
     frameborder="0" 


### PR DESCRIPTION
### Fixes

Fixes #7055

### Summary

Swaps aria-label to title to fix accessibility error.

### Guidance for testing, such as acceptance criteria or new user interface behaviors:
Should only affect screen viewers.

### Type of change (for release notes)

- `notes-minor` New Features that are backward compatible

### Detailed Description

More detailed description, if necessary. Try to be as descriptive as you can: even if you think that the PR content is obvious, it may not be obvious to others. Include tracebacks if helpful, and be sure to call out any bits of the PR that may be work-in-progress.

Description can have multiple paragraphs and you can use code examples inside:

``` ruby
<iframe aria-label="image view" 
    src="[https://dev.nurax.samvera.org/uv/uv.html#?manifest=https://dev.nurax.samvera.org/concern/generic_works/6108vb674/manifest&config=https://dev.nurax.samvera.org/uv/uv-config.json](view-source:https://dev.nurax.samvera.org/uv/uv.html#?manifest=https://dev.nurax.samvera.org/concern/generic_works/6108vb674/manifest&config=https://dev.nurax.samvera.org/uv/uv-config.json)" 
    allowfullscreen="true" 
    frameborder="0" 
  ></iframe>
```
should become:
``` ruby
<iframe title="image view" 
    src="[https://dev.nurax.samvera.org/uv/uv.html#?manifest=https://dev.nurax.samvera.org/concern/generic_works/6108vb674/manifest&config=https://dev.nurax.samvera.org/uv/uv-config.json](view-source:https://dev.nurax.samvera.org/uv/uv.html#?manifest=https://dev.nurax.samvera.org/concern/generic_works/6108vb674/manifest&config=https://dev.nurax.samvera.org/uv/uv-config.json)" 
    allowfullscreen="true" 
    frameborder="0" 
  ></iframe>
```
### Changes proposed in this pull request:
* Just changes the iframe attribute to title.

@samvera/hyrax-code-reviewers
