### PR TITLE
[i32]- process based_near params for flexible metadata

### DIFF
--- a/app/forms/hyrax/forms/resource_form.rb
+++ b/app/forms/hyrax/forms/resource_form.rb
@@ -187,7 +187,33 @@ module Hyrax
         secondary_terms.any?
       end
 
+
+      def validate(params)
+        if Hyrax.config.flexible? && params.key?(:based_near_attributes)
+          process_based_near_params(params)
+        end
+
+        super(params)
+      end
+
       private
+
+      def process_based_near_params(params)
+        based_near_attributes = params.delete(:based_near_attributes)
+        return unless based_near_attributes.respond_to?(:each_pair)
+
+        uris_from_form = []
+        based_near_attributes.each do |_, h|
+          next unless h.respond_to?(:[])
+          next if h["_destroy"] == "true" || h["id"].blank?
+          begin
+            uris_from_form << RDF::URI.parse(h["id"]).to_s
+          rescue ArgumentError, TypeError, RDF::ReaderError
+             Rails.logger.warn("Invalid URI ignored during form processing: #{h['id']}")
+          end
+        end
+        params[:based_near] = uris_from_form.uniq
+      end
 
       def _form_field_definitions
         self.class.definitions

--- a/app/forms/hyrax/forms/resource_form.rb
+++ b/app/forms/hyrax/forms/resource_form.rb
@@ -187,11 +187,8 @@ module Hyrax
         secondary_terms.any?
       end
 
-
       def validate(params)
-        if Hyrax.config.flexible? && params.key?(:based_near_attributes)
-          process_based_near_params(params)
-        end
+        process_based_near_params(params) if Hyrax.config.flexible? && params.key?(:based_near_attributes)
 
         super(params)
       end
@@ -209,7 +206,7 @@ module Hyrax
           begin
             uris_from_form << RDF::URI.parse(h["id"]).to_s
           rescue ArgumentError, TypeError, RDF::ReaderError
-             Rails.logger.warn("Invalid URI ignored during form processing: #{h['id']}")
+            Rails.logger.warn("Invalid URI ignored during form processing: #{h['id']}")
           end
         end
         params[:based_near] = uris_from_form.uniq

--- a/app/helpers/hyrax/attributes_helper.rb
+++ b/app/helpers/hyrax/attributes_helper.rb
@@ -60,7 +60,8 @@ module Hyrax
 
     # @param [String] field name
     # @param [Hash<Hash>] a nested hash of view options...
-    #        {:render_term=>:based_near_label, :label=>{"en"=>"Title", "es"=>"Título"}, :html_dl=>true}
+    #        {:label=>{"en"=>"Title", "es"=>"Título"}, :html_dl=>true}
+    # @return [Hash] the transformed options for the field
     def conform_options(field_name, options_hash)
       options = HashWithIndifferentAccess.new(options_hash)
       options_hash = HashWithIndifferentAccess.new(options)


### PR DESCRIPTION
BEFORE based_near would save as a hash and insert a "0". this would cause errors "invalid type "0"' when editing the form, only when flexible == true

AFTER

![image](https://github.com/user-attachments/assets/3830a066-9c14-41ba-baea-1dcea053aea9)

![image](https://github.com/user-attachments/assets/eba07943-4a07-4f9c-85c1-9328c2e1e3b7)

metadata profile: 
[metadata-profile-render-term.yml.zip](https://github.com/user-attachments/files/19654832/metadata-profile-render-term.yml.zip)

