### PR TITLE
🐛 Creates a fallback for m3 flexible schema

### DIFF
--- a/app/services/hyrax/m3_schema_loader.rb
+++ b/app/services/hyrax/m3_schema_loader.rb
@@ -23,7 +23,9 @@ module Hyrax
     # @return [Enumerable<AttributeDefinition]
     def definitions(schema_name, version, contexts = nil)
       schema = Hyrax::FlexibleSchema.find_by(id: version) || Hyrax::FlexibleSchema.create_default_schema
-      schema.attributes_for(schema_name).map do |name, config|
+      attributes = schema.attributes_for(schema_name)
+      attributes ||= fallback_schema_for(schema_name)
+      attributes.map do |name, config|
         # We might be able to consolidate these conditions, but they have been kept separate to make it easier to reason about
         # If there is a context filter on the metadata field and no context is set, skip it
         next if contexts.blank? && config['context'].present?
@@ -37,8 +39,37 @@ module Hyrax
     rescue ActiveRecord::StatementInvalid
       Rails.logger.error "Skipping definition load for migrations to run"
       []
-    rescue NoMethodError
-      raise UndefinedSchemaError, "Flexible schema not found in version #{version} for #{schema_name}"
     end
+
+    # rubocop:disable Metrics/MethodLength
+    def fallback_schema_for(_schema_name)
+      { "title" =>
+        { "cardinality" => { "minimum" => 1 },
+          "multi_value" => true,
+          "controlled_values" => { "format" => "http://www.w3.org/2001/XMLSchema#string", "sources" => ["null"] },
+          "definition" =>
+          { "default" =>
+            "Enter a standardized title for display. If only one title is needed, transcribe the title from the source itself." },
+          "display_label" => { "default" => "Title" },
+          "index_documentation" => "displayable, searchable",
+          "indexing" => ["title_sim", "title_tesim"],
+          "form" => { "required" => true, "primary" => true, "multiple" => true },
+          "mappings" =>
+          { "metatags" => "twitter:title, og:title",
+            "mods_oai_pmh" => "mods:titleInfo/mods:title",
+            "qualified_dc_pmh" => "dcterms:title",
+            "simple_dc_pmh" => "dc:title" },
+          "property_uri" => "http://purl.org/dc/terms/title",
+          "range" => "http://www.w3.org/2001/XMLSchema#string",
+          "requirement" => "required",
+          "sample_values" => ["Pencil drawn portrait study of woman"],
+          "view" => { "label" => { "en" => "Title", "es" => "Título" }, "html_dl" => true },
+          "type" => "string",
+          "predicate" => "http://purl.org/dc/terms/title",
+          "index_keys" => ["title_sim", "title_tesim"],
+          "multiple" => true,
+          "context" => nil } }
+    end
+    # rubocop:enable Metrics/MethodLength
   end
 end

--- a/spec/services/hyrax/m3_schema_loader_spec.rb
+++ b/spec/services/hyrax/m3_schema_loader_spec.rb
@@ -68,9 +68,9 @@ RSpec.describe Hyrax::M3SchemaLoader do
       end
     end
 
-    it 'raises an error for an undefined schema' do
-      expect { schema_loader.attributes_for(schema: :NOT_A_SCHEMA) }
-        .to raise_error described_class::UndefinedSchemaError
+    it 'provides a default schema for an undefined schema' do
+      expect(schema_loader.attributes_for(schema: :NOT_A_SCHEMA))
+        .to include(title: Valkyrie::Types::Array.of(Valkyrie::Types::String))
     end
   end
 


### PR DESCRIPTION
### Fixes

Ref:
- https://github.com/notch8/wvu_knapsack/issues/22

### Summary

Allows for introduction of m3 flexible metadata profiles by creating a default resource. 

### Type of change (for release notes)

- `notes-bugfix` Bug Fixes

### Detailed Description

Prior to this PR, adding a m3 flexible metadata profile resource types that not include all default resource types produced a no method error. This change removes the error message in favor of a default resource that allows loading of a custom schema.

@samvera/hyrax-code-reviewers
