### PR TITLE
🐛 Admin Set dropdown label when creating new work

### DIFF
--- a/app/controllers/hyrax/my/works_controller.rb
+++ b/app/controllers/hyrax/my/works_controller.rb
@@ -53,7 +53,7 @@ module Hyrax
         source_ids = Hyrax::Collections::PermissionsService.source_ids_for_deposit(ability: current_ability, source_type: 'admin_set')
 
         admin_sets_list = Hyrax.query_service.find_many_by_ids(ids: source_ids).map do |source|
-          [source.title.first, source.id]
+          [source.title, source.id]
         end
 
         # Sorts the default admin set to be first, then the rest by title.


### PR DESCRIPTION
### Fixes

This commit fixes a bug where only the first letter of the name of the Admin Set was being displayed in the dropdown when creating a new work.

Ref:
- https://github.com/notch8/wvu_knapsack/issues/22
- `notes-bugfix` Bug Fixes

@samvera/hyrax-code-reviewers
