### PR TITLE
💄 Metadata flash message text update

### DIFF
--- a/app/controllers/hyrax/metadata_profiles_controller.rb
+++ b/app/controllers/hyrax/metadata_profiles_controller.rb
@@ -25,7 +25,7 @@ module Hyrax
         @flexible_schema = Hyrax::FlexibleSchema.create(profile: YAML.safe_load_file(uploaded_io.path))
 
         if @flexible_schema.persisted?
-          redirect_to metadata_profiles_path, notice: 'AllinsonFlexProfile was successfully created.'
+          redirect_to metadata_profiles_path, notice: 'Flexible Metadata Profile was successfully created.'
         else
           redirect_to metadata_profiles_path, alert: @flexible_schema.errors.messages.to_s
         end


### PR DESCRIPTION
### Fixes

This commit changes the success flash message text when uploading a new metadata profile from `AllinsonFlexProfile was successfully created.` to `Flexible Metadata Profile was successfully created.`

Ref
- https://github.com/notch8/wvu_knapsack/issues/22

### Type of change (for release notes)

Add an appropriate `notes-*` label to the PR (or indicate here) that classifies this change.

This commit can be ignored for release.

@samvera/hyrax-code-reviewers
