### PR TITLE
Ensuring the template install method and hyrax installer work for v5.1 release

### DIFF
--- a/hyrax.gemspec
+++ b/hyrax.gemspec
@@ -38,7 +38,7 @@ SUMMARY
   spec.add_dependency 'almond-rails', '~> 0.1'
   spec.add_dependency 'awesome_nested_set', '~> 3.1'
   spec.add_dependency 'blacklight', '~> 7.29'
-  spec.add_dependency 'blacklight-gallery', '~> 4.7.0'
+  spec.add_dependency 'blacklight-gallery', '~> 4.6.4'
   spec.add_dependency 'breadcrumbs_on_rails', '~> 3.0'
   spec.add_dependency 'browse-everything', '>= 0.16', '< 2.0'
   spec.add_dependency 'carrierwave', '~> 1.0'

--- a/lib/generators/hyrax/install_generator.rb
+++ b/lib/generators/hyrax/install_generator.rb
@@ -209,10 +209,5 @@ module Hyrax
         gem 'dotenv-rails', '~> 2.8'
       end
     end
-
-    def support_analytics
-      gem 'google-protobuf', force_ruby_platform: true # required because google-protobuf is not compatible with Alpine linux
-      gem 'grpc', force_ruby_platform: true # required because grpc is not compatible with Alpine linux
-    end
   end
 end

--- a/lib/generators/hyrax/templates/db/migrate/20170131142607_add_permission_template_to_sipity_workflow.rb.erb
+++ b/lib/generators/hyrax/templates/db/migrate/20170131142607_add_permission_template_to_sipity_workflow.rb.erb
@@ -1,4 +1,4 @@
-class AddPermissionTemplateToSipityWorkflow < ActiveRecord::Migration<%= migration_version %>
+class AddPermissionTemplateToSipityWorkflow < ActiveRecord::Migration[6.1]
   def change
     add_column :sipity_workflows, :permission_template_id, :integer, index: true
     remove_index :sipity_workflows, :name

--- a/lib/generators/hyrax/templates/db/migrate/20170810190549_update_collection_type_column_options.rb.erb
+++ b/lib/generators/hyrax/templates/db/migrate/20170810190549_update_collection_type_column_options.rb.erb
@@ -1,4 +1,4 @@
-class UpdateCollectionTypeColumnOptions < ActiveRecord::Migration<%= migration_version %>
+class UpdateCollectionTypeColumnOptions < ActiveRecord::Migration[6.1]
   def up
     change_column :hyrax_collection_types, :title, :string, unique: true
     change_column :hyrax_collection_types, :machine_id, :string, unique: true

--- a/lib/generators/hyrax/templates/db/migrate/20230821153635_add_fields_to_counter_metric.rb.erb
+++ b/lib/generators/hyrax/templates/db/migrate/20230821153635_add_fields_to_counter_metric.rb.erb
@@ -1,4 +1,4 @@
-class AddFieldsToCounterMetric < ActiveRecord::Migration<%= migration_version %>
+class AddFieldsToCounterMetric < ActiveRecord::Migration[6.1]
   def change
     add_column :hyrax_counter_metrics, :title, :string
     add_column :hyrax_counter_metrics, :year_of_publication, :integer, index: true


### PR DESCRIPTION
Adding several fixes to ensure the template install method, via `hyrax:install`, works with all latest changes at v5.1.  