### PR TITLE
Use HTTP POST for Matomo 5 API

### DIFF
--- a/app/services/hyrax/analytics/matomo.rb
+++ b/app/services/hyrax/analytics/matomo.rb
@@ -179,14 +179,6 @@ module Hyrax
           response.is_a?(Hash) && response["result"] == "error"
         end
 
-        def get(params)
-          response = Faraday.get(config.base_url, params)
-          return [] if response.status != 200
-          api_response = JSON.parse(response.body)
-          return [] if contains_matomo_error?(api_response)
-          api_response
-        end
-
         def post(params)
           response = Faraday.post(config.base_url, params)
           return [] if response.status != 200


### PR DESCRIPTION
### Fixes

Fixes #6769

### Summary

> Matomo 5 (released Dec 2023) changes how auth tokens work when using the reporting API: https://developer.matomo.org/changelog#usage-of-authentication-tokens
>
> Anyone setting up a new auth token in Matomo 5 (e.g., to support Matomo analytics in a Hyrax app) will by default have it restricted to POST, which would make it not work with Hyrax.

### Guidance for testing, such as acceptance criteria or new user interface behaviors:

* Fresh Matomo 5 API tokens with POST restriction should now work

### Type of change (for release notes)

- `notes-bugfix` HTTP POST now used for Matomo API calls

### Changes proposed in this pull request:

* switch from GET to POST for all Matomo API calls

@samvera/hyrax-code-reviewers
