### PR TITLE
Use solr by default in Hyrax::CustomQueries::FindIdsByModel

### DIFF
--- a/app/models/concerns/hyrax/ability.rb
+++ b/app/models/concerns/hyrax/ability.rb
@@ -405,7 +405,11 @@ module Hyrax
                                     .distinct
                                     .pluck(:source_id)
 
-      Hyrax.custom_queries.find_ids_by_model(model: Hyrax::AdministrativeSet, ids: ids).any?
+      Hyrax.query_service.find_many_by_ids(ids: ids).any? do |resource|
+        Hyrax::ModelRegistry.admin_set_classes.any? do |c|
+          resource.is_a? c
+        end
+      end
     end
 
     def registered_user?

--- a/app/services/hyrax/custom_queries/find_ids_by_model.rb
+++ b/app/services/hyrax/custom_queries/find_ids_by_model.rb
@@ -8,8 +8,9 @@ module Hyrax
         [:find_ids_by_model]
       end
 
-      def initialize(query_service:)
+      def initialize(query_service:, query_rows: 1_000)
         @query_service = query_service
+        @query_rows = query_rows
       end
 
       attr_reader :query_service
@@ -23,14 +24,38 @@ module Hyrax
       #
       # @param model [Class]
       # @param ids [Enumerable<#to_s>, Symbol]
+      # @param use_solr [Boolean]
       #
       # @return [Enumerable<Valkyrie::ID>]
-      def find_ids_by_model(model:, ids: :all)
-        return query_service.find_all_of_model(model: model).map(&:id) if ids == :all
+      def find_ids_by_model(model:, ids: :all, use_solr: true)
+        if use_solr
+          query_solr(model, ids)
+        else
+          return query_service.find_all_of_model(model: model).map(&:id) if ids == :all
+          query_service.find_many_by_ids(ids: ids).select do |resource|
+            resource.is_a?(model)
+          end.map(&:id)
+        end
+      end
 
-        query_service.find_many_by_ids(ids: ids).select do |resource|
-          resource.is_a?(model)
-        end.map(&:id)
+      private
+
+      def query_solr(model, ids)
+        return enum_for(:query_solr, model, ids) unless block_given?
+        model_name = Hyrax::ModelRegistry.rdf_representations_from(Array(model)).first
+
+        solr_query = "_query_:\"{!raw f=has_model_ssim}#{model_name}\""
+        solr_response = Hyrax::SolrService.get(solr_query, fl: 'id', rows: @query_rows)['response']
+
+        loop do
+          response_docs = solr_response['docs']
+          response_docs.select! { |doc| ids.include?(doc['id']) } unless ids == :all
+
+          response_docs.each { |doc| yield doc['id'] }
+
+          break if (solr_response['start'] + solr_response['docs'].count) >= solr_response['numFound']
+          solr_response = Hyrax::SolrService.get(solr_query, fl: 'id', rows: @query_rows, start: solr_response['start'] + @query_rows)['response']
+        end
       end
     end
   end

--- a/lib/wings/valkyrie/query_service.rb
+++ b/lib/wings/valkyrie/query_service.rb
@@ -63,11 +63,10 @@ module Wings
       #
       # @param model [Class]
       # @return [Array<Valkyrie::Resource>]
-      #
-      # @note Due to implementation details, .find_all_of_model and .count_all_of_model may not
-      #       return the same number of results.  Is that a bug?  Probably.
       def find_all_of_model(model:)
-        model_class_for(model).all.map do |obj|
+        ActiveFedora::Base
+          .where(has_model_ssim: [model_class_for(model).to_rdf_representation,
+                                  model.to_rdf_representation]).map do |obj|
           resource_factory.to_resource(object: obj)
         end
       end

--- a/spec/jobs/create_work_job_spec.rb
+++ b/spec/jobs/create_work_job_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe CreateWorkJob do
         end
       end
 
-      it "it creates a work and a file_set" do
+      it "it creates a work and a file_set", :clean_repo do
         described_class.perform_later(user, 'GenericWork', metadata, log)
         work_id = Hyrax.custom_queries.find_ids_by_model(model: GenericWork).first
         work = Hyrax.query_service.find_by(id: work_id)

--- a/spec/services/hyrax/custom_queries/find_ids_by_model_spec.rb
+++ b/spec/services/hyrax/custom_queries/find_ids_by_model_spec.rb
@@ -1,37 +1,38 @@
 # frozen_string_literal: true
-RSpec.describe Hyrax::CustomQueries::FindIdsByModel, valkyrie_adapter: :test_adapter do
+RSpec.describe Hyrax::CustomQueries::FindIdsByModel, :clean_repo do
   subject(:query_handler) { described_class.new(query_service: Hyrax.query_service) }
 
-  after { Hyrax.persister.wipe! }
-  before { Hyrax.persister.wipe! }
+  shared_examples 'find_ids_by_model' do |use_solr|
+    it 'finds ids matching the model' do
+      expect(query_handler.find_ids_by_model(model: Monograph, use_solr: use_solr).count).to be_zero
+      monographs # create
+      expect(query_handler.find_ids_by_model(model: Monograph, use_solr: use_solr)).to contain_exactly(*monographs.map(&:id))
+    end
+
+    context 'with ids to filter' do
+      let(:ids) { ['first_id', 'second_id'] }
+
+      it 'finds ids matching the model' do
+        expect(query_handler.find_ids_by_model(model: Monograph, ids: ids, use_solr: use_solr).count).to be_zero
+        monograph_ids = monographs.map(&:id) # create
+        query_ids = monograph_ids.take(2) + ['fake_id']
+
+        expect(query_handler.find_ids_by_model(model: Monograph, ids: query_ids, use_solr: use_solr)).to contain_exactly(*monograph_ids.take(2))
+      end
+    end
+  end
 
   describe '#find_ids_by_model' do
     let(:monographs) { [FactoryBot.valkyrie_create(:monograph), FactoryBot.valkyrie_create(:monograph), FactoryBot.valkyrie_create(:monograph)] }
 
     before { [FactoryBot.valkyrie_create(:hyrax_work), FactoryBot.valkyrie_create(:hyrax_work)] }
 
-    it 'for a model without resources is empty' do
-      expect(query_handler.find_ids_by_model(model: Monograph)).to be_empty
+    context 'using solr' do
+      it_should_behave_like('find_ids_by_model', true)
     end
 
-    it 'finds ids matching the model' do
-      monographs # create
-      expect(query_handler.find_ids_by_model(model: Monograph)).to contain_exactly(*monographs.map(&:id))
-    end
-
-    context 'with ids to filter' do
-      let(:ids) { ['first_id', 'second_id'] }
-
-      it 'for a model without resources is empty' do
-        expect(query_handler.find_ids_by_model(model: Monograph, ids: ids)).to be_empty
-      end
-
-      it 'finds ids matching the model' do
-        monograph_ids = monographs.map(&:id)
-        query_ids = monograph_ids.take(2) + ['fake_id']
-
-        expect(query_handler.find_ids_by_model(model: Monograph, ids: query_ids)).to contain_exactly(*monograph_ids.take(2))
-      end
+    context 'not using solr' do
+      it_should_behave_like('find_ids_by_model', false)
     end
   end
 end


### PR DESCRIPTION
### Fixes

Fixes #7073 

### Summary

Use solr by default in Hyrax::CustomQueries::FindIdsByModel

### Guidance for testing, such as acceptance criteria or new user interface behaviors:
* Collections dashboard loads more quickly when using Fedora 6

### Detailed Description

This change copies and adapts the Wings version of this custom query while retaining the ability to still query the metadata adapter directly if desired. This should result in significant speedups when using Fedora 6 where the metadata adapter was making many requests to build the result.

@samvera/hyrax-code-reviewers
