### PR TITLE
[5.0 forward port] Add depositor_ssim to core_metadata.yaml

### DIFF
--- a/config/metadata/core_metadata.yaml
+++ b/config/metadata/core_metadata.yaml
@@ -20,4 +20,5 @@ attributes:
     type: string
     predicate: http://id.loc.gov/vocabulary/relators/dpt
     index_keys:
+      - "depositor_ssim"
       - "depositor_tesim"


### PR DESCRIPTION
FileSets were not getting the depositor_ssim indexed while other resources were.  This then fails ::FileSet.search_in_batches search in the UserStatImporter because `depositor_field` is set to "depositor_ssim" in DepositSearchBuilder.

@samvera/hyrax-code-reviewers
