### PR TITLE
:gift: Enable dynamic loading of flexible schema for forms

### DIFF
--- a/app/forms/concerns/hyrax/flexible_form_behavior.rb
+++ b/app/forms/concerns/hyrax/flexible_form_behavior.rb
@@ -10,18 +10,21 @@ module Hyrax
 
     # OVERRIDE disposable 0.6.3 to make schema dynamic
     def schema
-      Hyrax::Forms::ResourceForm::Definition::Each.new(singleton_class.schema_definitions)
+      Hyrax::Forms::ResourceForm::Definition::Each.new(_form_field_definitions)
     end
 
     private
 
     # OVERRIDE valkyrie 3.0.1 to make schema dynamic
     def field(field_name)
-      singleton_class.schema_definitions.fetch(field_name.to_s)
+      _form_field_definitions.fetch(field_name.to_s)
+    rescue KeyError
+      Rails.logger.warn("Field '#{field_name}' not found in dynamic schema for #{model.class.name}")
+      nil
     end
 
     def _form_field_definitions
-      singleton_class.schema_definitions
+      @_dynamic_form_field_definitions ||= Hyrax::FlexibleSchema.definitions_for(class_name: model.class.name)
     end
   end
 end

--- a/app/forms/concerns/hyrax/flexible_form_behavior.rb
+++ b/app/forms/concerns/hyrax/flexible_form_behavior.rb
@@ -18,9 +18,6 @@ module Hyrax
     # OVERRIDE valkyrie 3.0.1 to make schema dynamic
     def field(field_name)
       _form_field_definitions.fetch(field_name.to_s)
-    rescue KeyError
-      Rails.logger.warn("Field '#{field_name}' not found in dynamic schema for #{model.class.name}")
-      nil
     end
 
     def _form_field_definitions


### PR DESCRIPTION
Issue:
- https://github.com/notch8/wvu_knapsack/issues/43


https://github.com/user-attachments/assets/e33e9a98-3dab-4f0a-8388-f53384e7b9b8


Problem:
- Forms including `Hyrax::FlexibleFormBehavior` relied on schema definitions potentially cached at class load time.
- Runtime updates to `Hyrax::FlexibleSchema` (e.g., adding new fields) were not reflected in these forms until the application server or background workers were restarted.
- This caused issues in downstream consumers like Bulkrax, where new fields were not recognized or processed correctly during imports/updates.

Solution:
- Added a new class method `Hyrax::FlexibleSchema.definitions_for` that fetches the latest schema profile from the database and processes it to return the up-to-date definitions for a given model class name.
- Modified `Hyrax::FlexibleFormBehavior` (methods `schema`, `field`, and `_form_field_definitions`) to use this new dynamic `Hyrax::FlexibleSchema.definitions_for` method as the source for form field definitions, replacing the previous reliance on potentially stale `singleton_class.schema_definitions`.

Impact:
- Forms utilizing `FlexibleFormBehavior` now dynamically retrieve their field definitions based on the most current `Hyrax::FlexibleSchema` record at runtime.
- Enables components like Bulkrax ObjectFactories to correctly interact with forms that reflect the latest schema changes without requiring restarts.

Related to changes in:
- [bulkrax/app/factories/bulkrax/valkyrie_object_factory.rb](https://github.com/samvera/bulkrax/pull/1032)

