### PR TITLE
rspec mocks 3.13.3 breaks nested mocks. lock to a lower version until a fix can be released

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,7 +18,8 @@ group :development, :test do
   gem 'pry' unless ENV['CI']
   gem 'pry-byebug' unless ENV['CI']
   gem 'rspec'
+  gem 'rspec-mocks', '< 3.13.3' # remove after https://github.com/rspec/rspec/pull/214 is released
   gem 'ruby-prof', require: false
   gem 'semaphore_test_boosters'
-  gem "simplecov", require: false
+  gem 'simplecov', require: false
 end


### PR DESCRIPTION
### Fixes

Specs in main are broken

### Summary

See https://github.com/rspec/rspec/pull/214 and the issues that are pointed to it for context.

@samvera/hyrax-code-reviewers
