### PR TITLE
Use solr for Ability admin set check

### DIFF
--- a/app/models/concerns/hyrax/ability.rb
+++ b/app/models/concerns/hyrax/ability.rb
@@ -404,11 +404,9 @@ module Hyrax
                                     .select(:source_id)
                                     .distinct
                                     .pluck(:source_id)
-
-      Hyrax.query_service.find_many_by_ids(ids: ids).any? do |resource|
-        Hyrax::ModelRegistry.admin_set_classes.any? do |c|
-          resource.is_a? c
-        end
+      return false if ids.empty?
+      Hyrax::SolrQueryService.new.with_ids(ids: ids).query_result(rows: 1000)['response']['docs'].any? do |doc|
+        (Hyrax::ModelRegistry.admin_set_rdf_representations & doc['has_model_ssim']).present?
       end
     end
 

--- a/spec/features/create_work_spec.rb
+++ b/spec/features/create_work_spec.rb
@@ -138,7 +138,7 @@ RSpec.describe 'Creating a new Work', :js, :workflow, :clean_repo do
     end
   end
 
-  context "with valkyrie resources", valkyrie_adapter: :postgres_adapter do
+  context "with valkyrie resources", index_adapter: :solr_index, valkyrie_adapter: :postgres_adapter do
     before do
       sign_in user
       click_link 'Works'


### PR DESCRIPTION
### Fixes

Slow checking if the user can deposit when there are many admin sets/collections.

### Summary

This ability meetings is called when determining to render the Add A Work button on the homepage and in the dashboard. It was instantiating all admin sets (and collections?) returned by the permission template, and with fedora this is very slow. Switching to a solr query speeds things up nicely.

### Guidance for testing, such as acceptance criteria or new user interface behaviors:
* Regarding homepage and works dashboard is faster on f6 nurax.
* 
*

