### PR TITLE
Add :hide_social_buttons feature flipper

### DIFF
--- a/app/views/hyrax/base/_social_media.html.erb
+++ b/app/views/hyrax/base/_social_media.html.erb
@@ -1,3 +1,5 @@
+<% return '' if Flipflop.hide_social_buttons? %>
+
 <% page_title ||= content_for?(:page_title) ? content_for(:page_title) : default_page_title %>
 <% share_url ||= request.original_url %>
 <div class="social-media">

--- a/config/features.rb
+++ b/config/features.rb
@@ -15,6 +15,10 @@ Flipflop.configure do
             default: false,
             description: "Do not show the private items."
 
+    feature :hide_social_buttons,
+            default: false,
+            description: "Do not show social media share buttons."
+
     feature :hide_users_list,
             default: true,
             description: "Do not show users list unless user has authenticated."

--- a/config/features.rb
+++ b/config/features.rb
@@ -6,46 +6,52 @@ Flipflop.configure do
   strategy Hyrax::Strategies::YamlStrategy, config: Hyrax.config.feature_config_path
   strategy :default
 
-  feature :proxy_deposit,
-          default: true,
-          description: "Depositors may designate proxies to deposit works on their behalf"
+  group :site_configuration do
+    feature :cache_work_iiif_manifest,
+            default: false,
+            description: "Use Rails.cache to cache the JSON document for IIIF manifests"
 
-  feature :transfer_works,
-          default: true,
-          description: "Depositors may transfer their works to another user"
+    feature :hide_private_items,
+            default: false,
+            description: "Do not show the private items."
 
-  # Note, if this is deactivated, a default admin set will be created and all
-  # works will be assigned to it when they are created.
-  feature :assign_admin_set,
-          default: true,
-          description: "Ability to assign uploaded items to an admin set"
+    feature :hide_users_list,
+            default: true,
+            description: "Do not show users list unless user has authenticated."
 
-  feature :show_deposit_agreement,
-          default: true,
-          description: "Show a deposit agreement to users creating works"
+    feature :read_only,
+            default: false,
+            description: "Put the system into read-only mode. Deposits, edits, approvals and anything that makes a change to the data will be disabled."
+  end
 
-  feature :active_deposit_agreement_acceptance,
-          default: Hyrax.config.active_deposit_agreement_acceptance?,
-          description: "Require an active acceptance of the deposit agreement by checking a checkbox"
+  group :repository_management do
+    feature :active_deposit_agreement_acceptance,
+            default: Hyrax.config.active_deposit_agreement_acceptance?,
+            description: "Require an active acceptance of the deposit agreement by checking a checkbox"
 
-  feature :batch_upload,
-          default: false,
-          description: "Enable uploading batches of works"
+    # Note, if this is deactivated, a default admin set will be created and all
+    # works will be assigned to it when they are created.
+    feature :assign_admin_set,
+            default: true,
+            description: "Ability to assign uploaded items to an admin set"
 
-  feature :hide_private_items,
-          default: false,
-          description: "Do not show the private items."
+    feature :batch_upload,
+            default: false,
+            description: "Enable uploading batches of works"
 
-  feature :hide_users_list,
-          default: true,
-          description: "Do not show users list unless user has authenticated."
+    feature :proxy_deposit,
+            default: true,
+            description: "Depositors may designate proxies to deposit works on their behalf"
 
-  feature :cache_work_iiif_manifest,
-          default: false,
-          description: "Use Rails.cache to cache the JSON document for IIIF manifests"
-  feature :read_only,
-          default: false,
-          description: "Put the system into read-only mode. Deposits, edits, approvals and anything that makes a change to the data will be disabled."
+    feature :show_deposit_agreement,
+            default: true,
+            description: "Show a deposit agreement to users creating works"
+
+    feature :transfer_works,
+            default: true,
+            description: "Depositors may transfer their works to another user"
+  end
+
 rescue Flipflop::StrategyError, Flipflop::FeatureError => err
   Hyrax.logger.warn "Ignoring #{err}: #{err.message}"
 end

--- a/spec/views/hyrax/base/_social_media.html.erb_spec.rb
+++ b/spec/views/hyrax/base/_social_media.html.erb_spec.rb
@@ -13,4 +13,14 @@ RSpec.describe 'hyrax/base/_social_media.html.erb', type: :view do
     expect(page).to have_link '', href: 'https://twitter.com/intent/tweet/?text=Example&url=http%3A%2F%2Fexample.com%2F'
     expect(page).to have_link '', href: 'https://www.tumblr.com/widgets/share/tool?canonicalUrl=http%3A%2F%2Fexample.com%2F&posttype=link&shareSource=tumblr_share_button'
   end
+
+  context 'when hide_social_buttons feature is true' do
+    before do
+      allow(Flipflop).to receive(:hide_social_buttons?).and_return(true)
+    end
+
+    it 'does not render social links' do
+      expect(page).not_to have_selector '.resp-sharing-button__link'
+    end
+  end
 end


### PR DESCRIPTION
### Fixes

Fixes #7093

### Summary

The social share buttons can now be easily hidden via the features dashboard

### Guidance for testing, such as acceptance criteria or new user interface behaviors:
* Enabling the "Hide social buttons" feature prevents the display of social buttons on the work show page.
* The features dashboard is reorganized and easier to use.
*

### Changes proposed in this pull request:
* The _social_media partial will only render if Flipflop.hide_social_buttons? is false
* Features are sorted into groups.
*

@samvera/hyrax-code-reviewers
