### PR TITLE
Corrects the casting logic to account for the lack of :parent method for Valkyrie FileSets.

### DIFF
--- a/app/controllers/hyrax/file_sets_controller.rb
+++ b/app/controllers/hyrax/file_sets_controller.rb
@@ -167,7 +167,7 @@ module Hyrax
       return unless @file_set.class == ::FileSet
       # We can tell if a Hyrax::FileSet was improperly cast because this AF method will
       # return nil since its parent is not a ActiveFedora work.
-      @file_set = @file_set.valkyrie_resource if @file_set.parent&.id.nil?
+      @file_set = @file_set.valkyrie_resource if @file_set.respond_to?(:parent) && @file_set.parent&.id.nil?
     end
 
     def parent(file_set: curation_concern)


### PR DESCRIPTION
### Summary

Since Valkyrie-made FileSets lack a `:parent` method, this make sure the object responds to `:parent` before attempting that call.

### Type of change (for release notes)

- `notes-bugfix` Bug Fixes

@samvera/hyrax-code-reviewers
