### PR TITLE
Pulls form from config to avoid downstream users from overriding method.

### DIFF
--- a/app/services/hyrax/edit_permissions_service.rb
+++ b/app/services/hyrax/edit_permissions_service.rb
@@ -41,7 +41,7 @@ module Hyrax
         # (+Hyrax::Forms::FileSetForm+), +:in_works_ids+ is prepopulated onto
         # the form object itself. For +Hyrax::Forms::FileSetEditForm+, the
         # +:in_works+ method is present on the wrapped +:model+.
-        if form.object.is_a?(Hyrax::Forms::FileSetForm)
+        if form.object.is_a?(Hyrax.config.file_set_form)
           object_id = form.object.in_works_ids.first
           new(object: Hyrax.query_service.find_by(id: object_id), ability: ability)
         else


### PR DESCRIPTION
### Summary

This change (pointing to the Hyrax configuration element that defaults to `Hyrax::Forms::FileSetForm`) allows those that create a customized FileSet form to avoid overriding the altered method to implicitly stub that new class.

### Type of change (for release notes)

- `notes-minor` New Features that are backward compatible

@samvera/hyrax-code-reviewers
