### PR TITLE
Sign out via configured method

### DIFF
--- a/.dassie/config/initializers/devise.rb
+++ b/.dassie/config/initializers/devise.rb
@@ -10,4 +10,5 @@ Devise.setup do |config|
   config.password_length = 6..128
   config.email_regexp = /\A[^@\s]+@[^@\s]+\z/
   config.reset_password_within = 6.hours
+  config.sign_out_via = :delete
 end

--- a/.koppie/config/initializers/devise.rb
+++ b/.koppie/config/initializers/devise.rb
@@ -266,7 +266,7 @@ Devise.setup do |config|
   # config.navigational_formats = ['*/*', :html]
 
   # The default HTTP method used to sign out a resource. Default is :delete.
-  config.sign_out_via = :get
+  config.sign_out_via = :delete
 
   # ==> OmniAuth
   # Add a new OmniAuth provider. Check the wiki for more information on setting

--- a/app/views/_user_util_links.html.erb
+++ b/app/views/_user_util_links.html.erb
@@ -14,7 +14,8 @@
         <%= link_to "My Profile", hyrax.dashboard_profile_path(current_user), class: 'dropdown-item' %>
         <%= link_to t("hyrax.toolbar.dashboard.menu"), hyrax.dashboard_path, class: "dropdown-item" %>
         <div class="dropdown-divider"></div>
-        <%= link_to t("hyrax.toolbar.profile.logout"), main_app.destroy_user_session_path, class: "dropdown-item" %>
+        <%= button_to t("hyrax.toolbar.profile.logout"), main_app.destroy_user_session_path, class: "dropdown-item",
+                      method: ::Devise.sign_out_via %>
       </div>
     </li>
   <% else %>


### PR DESCRIPTION
### Fixes
Unable to sign out from dassie; use of GET to sign out.

### Changes proposed in this pull request:
* Change sign out link to a button to allow use of http delete (devise's default).
* Use the configured request type for that button.
* Alter dassie/koppie config to use delete.

@samvera/hyrax-code-reviewers
