### PR TITLE
Fix notification bell aria issues.

### DIFF
--- a/app/helpers/hyrax/hyrax_helper_behavior.rb
+++ b/app/helpers/hyrax/hyrax_helper_behavior.rb
@@ -68,10 +68,10 @@ module Hyrax
       mailbox = UserMailbox.new(user)
       unread_notifications = mailbox.unread_count
       link_to(hyrax.notifications_path,
-              'aria-label' => mailbox.label(params[:locale]),
+              'aria-description' => mailbox.label(params[:locale]),
               class: 'notify-number nav-link') do
         capture do
-          concat tag.span('', class: 'fa fa-bell')
+          concat tag.span('', class: 'fa fa-bell', 'aria-label': t('hyrax.admin.sidebar.notifications'))
           concat "\n"
           concat tag.span(unread_notifications,
                              class: count_classes_for(unread_notifications))

--- a/spec/abilities/ability_spec.rb
+++ b/spec/abilities/ability_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe Hyrax::Ability do
   describe "can?(:review, :submissions)", :clean_repo do
     subject { ability.can?(:review, :submissions) }
 
-    let(:role) { Sipity::Role.create(name: role_name) }
+    let(:role) { Sipity::Role.find_or_create_by(name: role_name) } # Using only create has flaky uniqueness in CI
     let(:user) { create(:user) }
     let(:permission_template) { create(:permission_template, with_active_workflow: true) }
     let(:workflow) { permission_template.active_workflow }

--- a/spec/forms/hyrax/forms/permission_template_form_spec.rb
+++ b/spec/forms/hyrax/forms/permission_template_form_spec.rb
@@ -162,7 +162,7 @@ RSpec.describe Hyrax::Forms::PermissionTemplateForm do
       end
 
       before do
-        role = Sipity::Role.create(name: 'approving')
+        role = Sipity::Role.find_or_create_by(name: 'approving')
         workflow.workflow_roles.create(role: role)
         # We are testing that this workflow role is removed
         Hyrax::Workflow::PermissionGenerator.call(roles: role,

--- a/spec/helpers/hyrax_helper_spec.rb
+++ b/spec/helpers/hyrax_helper_spec.rb
@@ -35,7 +35,8 @@ RSpec.describe HyraxHelper, type: :helper do
       let(:unread_count) { 10 }
 
       it 'renders with badge-danger and is visible' do
-        expect(subject).to eq '<a aria-label="Foobar" class="notify-number nav-link" href="/notifications"><span class="fa fa-bell"></span>' \
+        expect(subject).to eq '<a aria-description="Foobar" class="notify-number nav-link" href="/notifications">' \
+                              '<span class="fa fa-bell" aria-label="Notifications"></span>' \
                               "\n" \
                               '<span class="count badge badge-danger">10</span></a>'
       end
@@ -45,7 +46,8 @@ RSpec.describe HyraxHelper, type: :helper do
       let(:unread_count) { 0 }
 
       it 'renders with badge-secondary and is invisible' do
-        expect(subject).to eq '<a aria-label="Foobar" class="notify-number nav-link" href="/notifications"><span class="fa fa-bell"></span>' \
+        expect(subject).to eq '<a aria-description="Foobar" class="notify-number nav-link" href="/notifications">' \
+                              '<span class="fa fa-bell" aria-label="Notifications"></span>' \
                               "\n" \
                               '<span class="count badge invisible badge-secondary">0</span></a>'
       end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -266,6 +266,9 @@ RSpec.configure do |config|
 
   config.append_after do
     DatabaseCleaner.clean
+    ActiveRecord::Base.connection_handler.clear_active_connections!(:all)
+    ActiveRecord::Base.connection_handler.flush_idle_connections!(:all)
+
     # Ensuring we have a clear queue between each spec.
     ActiveJob::Base.queue_adapter.enqueued_jobs  = []
     ActiveJob::Base.queue_adapter.performed_jobs = []

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -236,14 +236,6 @@ RSpec.configure do |config|
     visit "/assets/application.js"
   end
 
-  config.after do
-    DatabaseCleaner.clean
-    # Ensuring we have a clear queue between each spec.
-    ActiveJob::Base.queue_adapter.enqueued_jobs  = []
-    ActiveJob::Base.queue_adapter.performed_jobs = []
-    User.group_service.clear
-  end
-
   # If true, the base class of anonymous controllers will be inferred
   # automatically. This will be the default behavior in future versions of
   # rspec-rails.
@@ -270,6 +262,14 @@ RSpec.configure do |config|
     Warden.test_reset!
     Capybara.reset_sessions!
     page.driver.reset!
+  end
+
+  config.append_after do
+    DatabaseCleaner.clean
+    # Ensuring we have a clear queue between each spec.
+    ActiveJob::Base.queue_adapter.enqueued_jobs  = []
+    ActiveJob::Base.queue_adapter.performed_jobs = []
+    User.group_service.clear
   end
 
   config.include Capybara::RSpecMatchers, type: :input

--- a/spec/views/_user_util_links.html.erb_spec.rb
+++ b/spec/views/_user_util_links.html.erb_spec.rb
@@ -2,44 +2,74 @@
 RSpec.describe '/_user_util_links.html.erb', type: :view do
   let(:join_date) { 5.days.ago }
   let(:can_create_file) { true }
+  let(:user) { FactoryBot.create(:user) }
+  let(:other_user) { FactoryBot.create(:user) }
 
-  before do
-    allow(view).to receive(:user_signed_in?).and_return(true)
-    allow(view).to receive(:current_user).and_return(stub_model(User, user_key: 'userX'))
-    allow(view).to receive(:can?).with(:create, GenericWork).and_return(can_create_file)
+  context 'signed in' do
+    before do
+      allow(view).to receive(:user_signed_in?).and_return(true)
+      allow(view).to receive(:current_user).and_return(user)
+      allow(view).to receive(:can?).with(:create, GenericWork).and_return(can_create_file)
+    end
+
+    context 'partial elements' do
+      it 'has dropdown list of links' do
+        render
+        expect(rendered).to have_link user.user_key, href: '#', id: 'navbarDropdown'
+        expect(rendered).to have_link 'My Profile', href: hyrax.dashboard_profile_path(user)
+        expect(rendered).to have_link 'Dashboard', href: hyrax.dashboard_path
+        # expect(rendered).to have_button 'Logout'
+        # expect(rendered).to have_field '_method', type: :hidden, with: Devise.sign_out_via
+      end
+
+      it 'shows zero outstanding messages' do
+        render
+        expect(rendered).to have_selector "a[aria-description='You have no unread notifications'][href='#{hyrax.notifications_path}']"
+        expect(rendered).to have_selector 'a.notify-number.nav-link span.count.badge.invisible.badge-secondary', text: '0'
+      end
+
+      context 'with pending notifications' do
+        it 'shows the number of outstanding messages' do
+          2.times { other_user.send_message(user, 'Test', 'Test message') }
+          render
+          expect(rendered).to have_selector "a[aria-description='You have 2 unread notifications'][href='#{hyrax.notifications_path}']"
+          expect(rendered).to have_selector 'a.notify-number.nav-link span.count.badge.badge-danger', text: '2'
+        end
+      end
+    end
+
+    describe 'translations' do
+      context 'with two languages' do
+        before do
+          allow(view).to receive(:available_translations) { { 'en' => 'English', 'es' => 'Español' } }
+          render
+        end
+        it 'displays the current language' do
+          expect(rendered).to have_link('English')
+        end
+      end
+      context 'with one language' do
+        before do
+          allow(view).to receive(:available_translations) { { 'en' => 'English' } }
+          render
+        end
+        it 'does not display the language picker' do
+          expect(rendered).not_to have_link('English')
+        end
+      end
+    end
   end
 
-  context 'partial elements' do
-    before { render }
-
-    it 'has dropdown list of links' do
-      expect(rendered).to have_link 'userX', href: '#', id: 'navbarDropdown'
-      expect(rendered).to have_link 'Dashboard', href: hyrax.dashboard_path
+  context 'not signed in' do
+    before do
+      allow(view).to receive(:user_signed_in?).and_return(false)
     end
 
-    it 'shows the number of outstanding messages' do
-      expect(rendered).to have_selector "a[aria-label='You have no unread notifications'][href='#{hyrax.notifications_path}']"
-      expect(rendered).to have_selector 'a.notify-number.nav-link span.count.badge.invisible.badge-secondary', text: '0'
-    end
-  end
+    describe 'authentication links' do
+      before { render }
 
-  describe 'translations' do
-    context 'with two languages' do
-      before do
-        allow(view).to receive(:available_translations) { { 'en' => 'English', 'es' => 'Español' } }
-        render
-      end
-      it 'displays the current language' do
-        expect(rendered).to have_link('English')
-      end
-    end
-    context 'with one language' do
-      before do
-        allow(view).to receive(:available_translations) { { 'en' => 'English' } }
-        render
-      end
-      it 'does not display the language picker' do
-        expect(rendered).not_to have_link('English')
+      it 'displays a login link' do
+        expect(rendered).to have_link('Login')
       end
     end
   end


### PR DESCRIPTION
### Fixes

Fixes #7122 

### Summary

aria-label did not match the displayed values. Moving that verbose string to aria-description and adding a label to the bell icon should resolve the issue and be more succinct.

The view spec is refactored to allow test messages to render, and some additional auth related specs are added. The commented lines depend on PR #7127 

@samvera/hyrax-code-reviewers
