### PR TITLE
Making WorkflowFactory idempotent

### DIFF
--- a/app/services/hyrax/workflow/workflow_factory.rb
+++ b/app/services/hyrax/workflow/workflow_factory.rb
@@ -50,9 +50,9 @@ module Hyrax
       private
 
       def create_workflow_entity!
-        Sipity::Entity.create!(proxy_for_global_id: Hyrax::GlobalID(work).to_s,
-                               workflow: workflow_for(work),
-                               workflow_state: nil)
+        Sipity::Entity.find_or_create_by!(proxy_for_global_id: Hyrax::GlobalID(work).to_s,
+                                          workflow: workflow_for(work),
+                                          workflow_state: nil)
       end
 
       def assign_specific_roles_to(entity:)

--- a/spec/services/hyrax/workflow/workflow_factory_spec.rb
+++ b/spec/services/hyrax/workflow/workflow_factory_spec.rb
@@ -24,6 +24,11 @@ RSpec.describe Hyrax::Workflow::WorkflowFactory do
         .by(1)
       expect(Sipity::WorkflowResponsibility.count).to eq initial_workflow_responsibility_count
     end
+    it 'is idempotent if called more than once' do
+      deposit_action
+      factory.create(work, attributes, user)
+      expect { factory.create(work, attributes, user) }.to_not raise_error ActiveRecord::RecordNotUnique
+    end
   end
 
   describe '.create' do


### PR DESCRIPTION
Making WorkflowFactory idempotent if `create` is called more than once for the same work and same workflow/state.

### Fixes

Fixes #7129 

Replaces `Sipity::Entity.create!` with `Sipity::Entity.find_or_create_by!` in case it gets called more than once during a save.  Also adds a spec to check for `ActiveRecord::RecordNotUnique` in that scenario.