### PR TITLE
🔄 Revert changes to select type of work label

### DIFF
--- a/app/controllers/hyrax/my/works_controller.rb
+++ b/app/controllers/hyrax/my/works_controller.rb
@@ -53,7 +53,7 @@ module Hyrax
         source_ids = Hyrax::Collections::PermissionsService.source_ids_for_deposit(ability: current_ability, source_type: 'admin_set')
 
         admin_sets_list = Hyrax.query_service.find_many_by_ids(ids: source_ids).map do |source|
-          [source.title, source.id]
+          [source.title.first, source.id]
         end
 
         # Sorts the default admin set to be first, then the rest by title.


### PR DESCRIPTION
### Fixes

Ref:
- https://github.com/notch8/hykuup_knapsack/issues/383

### Summary

This commit reverts the changes made to the label for selecting the type a work type.

### Detailed Description

This bug stemmed from an incorrect fix of an issue that arose from adding flexible metadata profiles that had `multi_value: false` on the title property.

Flexible metadata profiles must have `multi_value: true` on the title.

@samvera/hyrax-code-reviewers
