### PR TITLE
🐛 Keep chunks in sync

### DIFF
--- a/app/controllers/hyrax/uploads_controller.rb
+++ b/app/controllers/hyrax/uploads_controller.rb
@@ -34,11 +34,6 @@ module Hyrax
 
     def handle_chunk(content_range, chunk)
       file_path = @upload.file.path
-
-      # In a multi-pod environment with a shared filesystem (like NFS), attribute
-      # caching can cause `File.size` to return a stale value. Opening the file
-      # for reading forces a metadata refresh, ensuring we get the correct size
-      # without reading the entire file into memory.
       current_size = 0
       File.open(file_path, "r") { |f| current_size = f.size } if file_path && File.exist?(file_path)
 


### PR DESCRIPTION
### Fixes

- https://github.com/notch8/hykuup_knapsack/issues/388


### Summary

Chunks would get out of sync when multi processes were involved, which caused incomplete uploaded files if they were over 20MB.

## 🐛 Keep chunks in sync

c369a41c0b456f733841504cb740e526118c1d7a

Chunks would get out of sync when multi processes were involved, which caused incomplete uploaded files if they were over 20MB.

## ♻️ Refactor to avoid rubocop error

Resolves `app/controllers/hyrax/uploads_controller.rb:23:5: C: Metrics/AbcSize: Assignment Branch Condition size for upload_with_chunking is too high. `

a49fd952f10a9b457402aa17527554e618e0609c



### Guidance for testing, such as acceptance criteria or new user interface behaviors:
* In an environment with multi processing, when creating a work attach a file that's larger than 20MB
* The file should fully upload


### BEFORE

Fully upload should be 72.92MB (which is the size of the file), but it only partially uploaded. When saved the file is invalid.

![image](https://github.com/user-attachments/assets/1bd37798-bc44-4e1d-a7e9-e652e0574795)



### AFTER

![image](https://github.com/user-attachments/assets/12addb73-5815-4330-975a-8592bdeb7bcd)


@samvera/hyrax-code-reviewers
