### PR TITLE
Google Plus Removed

### DIFF
--- a/app/views/hyrax/dashboard/profiles/_edit_primary.html.erb
+++ b/app/views/hyrax/dashboard/profiles/_edit_primary.html.erb
@@ -46,13 +46,6 @@
     </div>
   </div><!-- .form-group -->
 
-  <div class="form-group row">
-    <%= f.label :googleplus_handle, t(".google_handle").html_safe, class: 'col-4 col-form-label' %>
-    <div class="col-8">
-       <%= f.text_field :googleplus_handle, class: "form-control" %>
-    </div>
-  </div><!-- .form-group -->
-
   <%= render 'trophy_edit', trophies: @trophies %>
 
   <%= f.button t(".save_profile").html_safe, type: 'submit', class: "btn btn-primary" %>

--- a/app/views/hyrax/users/_user_info.html.erb
+++ b/app/views/hyrax/users/_user_info.html.erb
@@ -20,11 +20,6 @@
   <dd><%= link_to user.twitter_handle, "http://twitter.com/#{user.twitter_handle}", {target:'_blank'} %></dd>
 <% end %>
 
-<% if user.googleplus_handle.present? %>
-  <dt><span class="fa fa-google-plus" aria-hidden="true"></span> Google+ Handle</dt>
-  <dd><%= link_to user.googleplus_handle, "http://google.com/+#{user.googleplus_handle}", {target:'_blank'} %></dd>
-<% end %>
-
 <% if user.linkedin_handle.present? %>
   <dt><span class="fa fa-linkedin" aria-hidden="true"></span> LinkedIn</dt>
   <dd><%= link_to "#{@linkedInUrl}", "#{@linkedInUrl}", { target: '_blank' } %></dd>

--- a/spec/controllers/hyrax/dashboard/profiles_controller_spec.rb
+++ b/spec/controllers/hyrax/dashboard/profiles_controller_spec.rb
@@ -120,13 +120,12 @@ RSpec.describe Hyrax::Dashboard::ProfilesController do
     end
 
     it "sets an social handles" do
-      post :update, params: { id: user.user_key, user: { twitter_handle: 'twit', facebook_handle: 'face', googleplus_handle: 'goo', linkedin_handle: "link", orcid: '0000-0000-1111-2222' } }
+      post :update, params: { id: user.user_key, user: { twitter_handle: 'twit', facebook_handle: 'face', linkedin_handle: "link", orcid: '0000-0000-1111-2222' } }
       expect(response).to redirect_to(routes.url_helpers.dashboard_profile_path(user.to_param, locale: 'en'))
       expect(flash[:notice]).to include("Your profile has been updated")
       u = User.find_by_user_key(user.user_key)
       expect(u.twitter_handle).to eq 'twit'
       expect(u.facebook_handle).to eq 'face'
-      expect(u.googleplus_handle).to eq 'goo'
       expect(u.linkedin_handle).to eq 'link'
       expect(u.orcid).to eq 'https://orcid.org/0000-0000-1111-2222'
     end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -88,7 +88,6 @@ RSpec.describe User, type: :model do
   it "has social attributes" do
     expect(user).to respond_to(:twitter_handle)
     expect(user).to respond_to(:facebook_handle)
-    expect(user).to respond_to(:googleplus_handle)
     expect(user).to respond_to(:linkedin_handle)
     expect(user).to respond_to(:orcid)
   end


### PR DESCRIPTION
Google Plus removed from profile edit, view, and spec code

### Fixes

Fixes [#7067](https://github.com/samvera/hyrax/issues/7067)

### Summary

Google Plus removed from profile edit, view, and spec code

### Guidance for testing, such as acceptance criteria or new user interface behaviors:
* View profile 
* View profile edit
* Run specs

### Type of change (for release notes)

Add an appropriate `notes-*` label to the PR (or indicate here) that classifies this change.

Choose from:
- `notes-deprecation` Deprecations


@samvera/hyrax-code-reviewers
