### PR TITLE
Hyrax/update informational icon

### DIFF
--- a/app/views/hyrax/dashboard/profiles/_edit_primary.html.erb
+++ b/app/views/hyrax/dashboard/profiles/_edit_primary.html.erb
@@ -13,7 +13,7 @@
         <%= f.label :remove_avatar, class: 'form-check-label' do %>
           <%= f.check_box :remove_avatar, class: 'form-check-input' %>
           <%= t(".delete_picture") %>
-          <a href="#" id="delete_picture_help" data-toggle="popover" data-content="<%= t('.delete_picture_data_content') %>" data-original-title="<%= t('.delete_picture_data_original_title') %>"><i class="fa fa-question"></i></a>
+          <a href="#" id="delete_picture_help" data-toggle="popover" data-content="<%= t('.delete_picture_data_content') %>" data-original-title="<%= t('.delete_picture_data_original_title') %>"><i class="fa fa-info-circle"></i></a>
         <% end %>
       </div>
     </div>

--- a/app/views/hyrax/dashboard/profiles/_edit_primary.html.erb
+++ b/app/views/hyrax/dashboard/profiles/_edit_primary.html.erb
@@ -46,13 +46,6 @@
     </div>
   </div><!-- .form-group -->
 
-  <div class="form-group row">
-    <%= f.label :googleplus_handle, t(".google_handle").html_safe, class: 'col-4 col-form-label' %>
-    <div class="col-8">
-       <%= f.text_field :googleplus_handle, class: "form-control" %>
-    </div>
-  </div><!-- .form-group -->
-
   <%= render 'trophy_edit', trophies: @trophies %>
 
   <%= f.button t(".save_profile").html_safe, type: 'submit', class: "btn btn-primary" %>

--- a/app/views/hyrax/dashboard/profiles/_trophy_edit.html.erb
+++ b/app/views/hyrax/dashboard/profiles/_trophy_edit.html.erb
@@ -2,7 +2,7 @@
   <div class="form-group">
     <span>
       <i class="fa fa-star trophy-on"></i> Remove Highlight Designation
-      <a href="#" id="remove_trophy_help" data-toggle="popover" data-content="If you would like to remove a highlight designation, check the box and save your profile." data-original-title="Remove Highlight Designation"><i class="fa fa-question"></i></a>
+      <a href="#" id="remove_trophy_help" data-toggle="popover" data-content="If you would like to remove a highlight designation, check the box and save your profile." data-original-title="Remove Highlight Designation"><i class="fa fa-info-circle"></i></a>
     </span>
     <% trophies.each do |t| %>
       <div class="form-check">

--- a/app/views/hyrax/users/_user_info.html.erb
+++ b/app/views/hyrax/users/_user_info.html.erb
@@ -20,11 +20,6 @@
   <dd><%= link_to user.twitter_handle, "http://twitter.com/#{user.twitter_handle}", {target:'_blank'} %></dd>
 <% end %>
 
-<% if user.googleplus_handle.present? %>
-  <dt><span class="fa fa-google-plus" aria-hidden="true"></span> Google+ Handle</dt>
-  <dd><%= link_to user.googleplus_handle, "http://google.com/+#{user.googleplus_handle}", {target:'_blank'} %></dd>
-<% end %>
-
 <% if user.linkedin_handle.present? %>
   <dt><span class="fa fa-linkedin" aria-hidden="true"></span> LinkedIn</dt>
   <dd><%= link_to "#{@linkedInUrl}", "#{@linkedInUrl}", { target: '_blank' } %></dd>

--- a/spec/controllers/hyrax/dashboard/profiles_controller_spec.rb
+++ b/spec/controllers/hyrax/dashboard/profiles_controller_spec.rb
@@ -120,13 +120,12 @@ RSpec.describe Hyrax::Dashboard::ProfilesController do
     end
 
     it "sets an social handles" do
-      post :update, params: { id: user.user_key, user: { twitter_handle: 'twit', facebook_handle: 'face', googleplus_handle: 'goo', linkedin_handle: "link", orcid: '0000-0000-1111-2222' } }
+      post :update, params: { id: user.user_key, user: { twitter_handle: 'twit', facebook_handle: 'face', linkedin_handle: "link", orcid: '0000-0000-1111-2222' } }
       expect(response).to redirect_to(routes.url_helpers.dashboard_profile_path(user.to_param, locale: 'en'))
       expect(flash[:notice]).to include("Your profile has been updated")
       u = User.find_by_user_key(user.user_key)
       expect(u.twitter_handle).to eq 'twit'
       expect(u.facebook_handle).to eq 'face'
-      expect(u.googleplus_handle).to eq 'goo'
       expect(u.linkedin_handle).to eq 'link'
       expect(u.orcid).to eq 'https://orcid.org/0000-0000-1111-2222'
     end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -88,7 +88,6 @@ RSpec.describe User, type: :model do
   it "has social attributes" do
     expect(user).to respond_to(:twitter_handle)
     expect(user).to respond_to(:facebook_handle)
-    expect(user).to respond_to(:googleplus_handle)
     expect(user).to respond_to(:linkedin_handle)
     expect(user).to respond_to(:orcid)
   end


### PR DESCRIPTION
### Fixes

Fixes [#7069](https://github.com/samvera/hyrax/issues/7069)

### Summary

Updated informational icon from question mark to i icon when more information is needed. Only found two instances

### Guidance for testing, such as acceptance criteria or new user interface behaviors:
* trophy_edit
* edit_primary

### Type of change (for release notes)

Add an appropriate `notes-*` label to the PR (or indicate here) that classifies this change.

Choose from:
- `notes-minor` New Features that are backward compatible

@samvera/hyrax-code-reviewers
