### PR TITLE
🎁(profile): replace multi_value w/ data_type, use cardinality

### DIFF
--- a/app/presenters/hyrax/work_show_presenter.rb
+++ b/app/presenters/hyrax/work_show_presenter.rb
@@ -37,7 +37,7 @@ module Hyrax
         index_keys = property_details["indexing"]
         next unless index_keys
 
-        multi_value = property_details.dig("multi_value")
+        multi_value = property_details['multiple']
 
         next if self.class.method_defined?(method_name) && solr_document.respond_to?(method_name)
         # Define the method on the SolrDocument class

--- a/app/services/hyrax/m3_schema_loader.rb
+++ b/app/services/hyrax/m3_schema_loader.rb
@@ -45,7 +45,7 @@ module Hyrax
     def fallback_schema_for(_schema_name)
       { "title" =>
         { "cardinality" => { "minimum" => 1 },
-          "multi_value" => true,
+          "data_type" => "array",
           "controlled_values" => { "format" => "http://www.w3.org/2001/XMLSchema#string", "sources" => ["null"] },
           "definition" =>
           { "default" =>
@@ -53,7 +53,7 @@ module Hyrax
           "display_label" => { "default" => "Title" },
           "index_documentation" => "displayable, searchable",
           "indexing" => ["title_sim", "title_tesim"],
-          "form" => { "required" => true, "primary" => true, "multiple" => true },
+          "form" => { "primary" => true, "multiple" => true },
           "mappings" =>
           { "metatags" => "twitter:title, og:title",
             "mods_oai_pmh" => "mods:titleInfo/mods:title",

--- a/app/services/hyrax/schema_loader.rb
+++ b/app/services/hyrax/schema_loader.rb
@@ -84,7 +84,20 @@ module Hyrax
       ##
       # @return [Dry::Types::Type]
       def type
-        collection_type = if config['multiple']
+        # Determine whether this attribute allows multiple values.
+        multiple_flag = if config.key?('multiple')
+                          config['multiple']
+                        elsif config.key?('data_type')
+                          config['data_type'] == 'array'
+                        elsif (card = config['cardinality'])
+                          # Treat as multiple when maximum is greater than 1 or not specified
+                          max = card['maximum']
+                          max.nil? || max.to_i > 1
+                        else
+                          false
+                        end
+
+        collection_type = if multiple_flag
                             Valkyrie::Types::Array.constructor { |v| Array(v).select(&:present?) }
                           else
                             Identity

--- a/config/metadata_profiles/m3_profile.yaml
+++ b/config/metadata_profiles/m3_profile.yaml
@@ -41,7 +41,7 @@ properties:
       - Hyrax::Work
     cardinality:
       minimum: 1
-    multi_value: true
+    data_type: array
     controlled_values:
       format: http://www.w3.org/2001/XMLSchema#string
       sources:
@@ -56,9 +56,8 @@ properties:
     - title_sim
     - title_tesim
     form:
-      required: true
       primary: true
-      multi_value: true
+      data_type: array
     mappings:
       metatags: twitter:title, og:title
       mods_oai_pmh: mods:titleInfo/mods:title
@@ -66,7 +65,6 @@ properties:
       simple_dc_pmh: dc:title
     property_uri: http://purl.org/dc/terms/title
     range: http://www.w3.org/2001/XMLSchema#string
-    requirement: required
     sample_values:
     - Pencil drawn portrait study of woman
   date_modified:
@@ -79,7 +77,7 @@ properties:
     cardinality:
       minimum: 0
       maximum: 1
-    multi_value: false
+    data_type: string
     display_label:
       default: Date Modified
     property_uri: http://purl.org/dc/terms/modified
@@ -106,7 +104,7 @@ properties:
     cardinality:
       minimum: 0
       maximum: 1
-    multi_value: false
+    data_type: string
     display_label:
       default: Date Uploaded
     property_uri: http://purl.org/dc/terms/dateSubmitted
@@ -123,7 +121,7 @@ properties:
     cardinality:
       minimum: 0
       maximum: 1
-    multi_value: false
+    data_type: string
     controlled_values:
       format: http://www.w3.org/2001/XMLSchema#string
       sources:
@@ -146,7 +144,7 @@ properties:
       - Hyrax::Work
     cardinality:
       minimum: 1
-    multi_value: true
+    data_type: array
     controlled_values:
       format: http://www.w3.org/2001/XMLSchema#string
       sources:
@@ -158,7 +156,6 @@ properties:
     - creator_sim
     - creator_tesim
     form:
-      required: true
       primary: true
     property_uri: http://purl.org/dc/elements/1.1/creator
     range: http://www.w3.org/2001/XMLSchema#string
@@ -176,7 +173,7 @@ properties:
       - Hyrax::Work
     cardinality:
       minimum: 0
-    multi_value: true
+    data_type: array
     controlled_values:
       format: http://www.w3.org/2001/XMLSchema#string
       sources:
@@ -188,7 +185,6 @@ properties:
     - license_sim
     - license_tesim
     form:
-      required: false
       primary: false
     property_uri: http://purl.org/dc/terms/license
     range: http://www.w3.org/2001/XMLSchema#string
@@ -206,7 +202,7 @@ properties:
       - Hyrax::Work
     cardinality:
       minimum: 0
-    multi_value: true
+    data_type: array
     controlled_values:
       format: http://www.w3.org/2001/XMLSchema#string
       sources:
@@ -233,7 +229,7 @@ properties:
       - Hyrax::Work
     cardinality:
       minimum: 0
-    multi_value: true
+    data_type: array
     controlled_values:
       format: http://www.w3.org/2001/XMLSchema#string
       sources:
@@ -260,7 +256,7 @@ properties:
       - Hyrax::Work
     cardinality:
       minimum: 0
-    multi_value: true
+    data_type: array
     controlled_values:
       format: http://www.w3.org/2001/XMLSchema#string
       sources:
@@ -287,11 +283,11 @@ properties:
       class:
       - Hyrax::AdministrativeSet
       - Hyrax::PcdmCollection
-      - Hyrax::Work
+      - Hyrax::Worc
     cardinality:
       minimum: 0
       maximum: 1
-    multi_value: false
+    data_type: string
     controlled_values:
       format: http://www.w3.org/2001/XMLSchema#string
       sources:
@@ -313,7 +309,7 @@ properties:
       - Hyrax::Work
     cardinality:
       minimum: 0
-    multi_value: true
+    data_type: array
     controlled_values:
       format: http://www.w3.org/2001/XMLSchema#string
       sources:
@@ -342,7 +338,7 @@ properties:
       - Hyrax::Work
     cardinality:
       minimum: 0
-    multi_value: true
+    data_type: array
     controlled_values:
       format: http://www.w3.org/2001/XMLSchema#string
       sources:
@@ -370,7 +366,7 @@ properties:
       - Hyrax::Work
     cardinality:
       minimum: 0
-    multi_value: true
+    data_type: array
     controlled_values:
       format: http://www.w3.org/2001/XMLSchema#string
       sources:
@@ -399,7 +395,7 @@ properties:
       - Hyrax::Work
     cardinality:
       minimum: 0
-    multi_value: true
+    data_type: array
     controlled_values:
       format: http://www.w3.org/2001/XMLSchema#dateTime
       sources:
@@ -429,7 +425,7 @@ properties:
       - Hyrax::Work
     cardinality:
       minimum: 0
-    multi_value: true
+    data_type: array
     controlled_values:
       format: http://www.w3.org/2001/XMLSchema#string
       sources:
@@ -455,7 +451,7 @@ properties:
       - Hyrax::Work
     cardinality:
       minimum: 0
-    multi_value: true
+    data_type: array
     controlled_values:
       format: http://www.w3.org/2001/XMLSchema#string
       sources:
@@ -485,7 +481,7 @@ properties:
     cardinality:
       minimum: 0
       maximum: 1
-    multi_value: false
+    data_type: string
     controlled_values:
       format: http://www.w3.org/2001/XMLSchema#string
       sources:
@@ -505,7 +501,7 @@ properties:
       - Hyrax::Work
     cardinality:
       minimum: 0
-    multi_value: true
+    data_type: array
     controlled_values:
       format: http://www.w3.org/2001/XMLSchema#string
       sources:
@@ -533,7 +529,7 @@ properties:
     cardinality:
       minimum: 0
       maximum: 1
-    multi_value: false
+    data_type: string
     controlled_values:
       format: http://www.w3.org/2001/XMLSchema#string
       sources:
@@ -559,7 +555,7 @@ properties:
       - Hyrax::Work
     cardinality:
       minimum: 0
-    multi_value: true
+    data_type: array
     controlled_values:
       format: http://www.w3.org/2001/XMLSchema#string
       sources:
@@ -589,7 +585,7 @@ properties:
       - Hyrax::Work
     cardinality:
       minimum: 0
-    multi_value: true
+    data_type: array
     controlled_values:
       format: http://www.w3.org/2001/XMLSchema#string
       sources:
@@ -618,7 +614,7 @@ properties:
       - Hyrax::Work
     cardinality:
       minimum: 0
-    multi_value: true
+    data_type: array
     controlled_values:
       format: http://www.w3.org/2001/XMLSchema#string
       sources:
@@ -648,7 +644,7 @@ properties:
     cardinality:
       minimum: 0
       maximum: 1
-    multi_value: false
+    data_type: string
     controlled_values:
       format: http://www.w3.org/2001/XMLSchema#string
       sources:
@@ -668,7 +664,7 @@ properties:
       - Hyrax::Work
     cardinality:
       minimum: 0
-    multi_value: true
+    data_type: array
     controlled_values:
       format: http://www.w3.org/2001/XMLSchema#string
       sources:
@@ -698,7 +694,7 @@ properties:
       - Hyrax::Work
     cardinality:
       minimum: 0
-    multi_value: true
+    data_type: array
     controlled_values:
       format: http://www.w3.org/2001/XMLSchema#string
       sources:
@@ -726,7 +722,7 @@ properties:
       - Hyrax::Work
     cardinality:
       minimum: 0
-    multi_value: true
+    data_type: array
     controlled_values:
       format: http://www.w3.org/2001/XMLSchema#string
       sources:
@@ -755,7 +751,7 @@ properties:
       - Hyrax::Work
     cardinality:
       minimum: 0
-    multi_value: true
+    data_type: array
     controlled_values:
       format: http://www.w3.org/2001/XMLSchema#string
       sources:
@@ -784,7 +780,7 @@ properties:
       - Hyrax::Work
     cardinality:
       minimum: 0
-    multi_value: true
+    data_type: array
     controlled_values:
       format: http://www.w3.org/2001/XMLSchema#string
       sources:
@@ -813,7 +809,7 @@ properties:
       - special_context
     cardinality:
       minimum: 0
-    multi_value: true
+    data_type: array
     controlled_values:
       format: http://www.w3.org/2001/XMLSchema#string
       sources:


### PR DESCRIPTION

Issue:
- https://github.com/notch8/hykuup_knapsack/issues/425

• Re-introduce `cardinality` and make it authoritative for multiplicity/requiredness • Rename `multi_value` → `data_type` (`array` | `string`) • Derive `form.multiple` + validations from `data_type` or `cardinality` • Remove obsolete `required`/`requirement` keys
• Update code (schema loader, flexible schema, presenter) and migrate `m3_profile.yaml`

