### PR TITLE
Fixes depositing a work into a collection

### DIFF
--- a/app/assets/javascripts/hyrax/select_work_type.es6
+++ b/app/assets/javascripts/hyrax/select_work_type.es6
@@ -39,8 +39,13 @@ export default class SelectWorkType {
   // for a single work.  So, given the value of 'this.type', return the appropriate
   // path.
   destination() {
-      let admin_set_id = this.form.find('select').val()
       let url = this.form.find('input[type="radio"]:checked').data(this.type)
-      return url + "&admin_set_id=" + admin_set_id
+      const select = this.form.find('select')
+
+      // Only append admin_set_id if the select exists and has a value
+      if (select.length && select.val()) {
+          url = url + "&admin_set_id=" + select.val()
+      }
+      return url
   }
 }

--- a/app/controllers/hyrax/dashboard/collections_controller.rb
+++ b/app/controllers/hyrax/dashboard/collections_controller.rb
@@ -70,6 +70,7 @@ module Hyrax
       def show
         # @todo: remove this unused assignment in 4.0.0
         @banner_file = presenter.banner_file if collection_type.brandable?
+        @admin_sets_for_select = helpers.available_admin_sets_for_creating_works(ability: current_ability)
 
         presenter
         query_collection_members

--- a/app/controllers/hyrax/my/works_controller.rb
+++ b/app/controllers/hyrax/my/works_controller.rb
@@ -24,7 +24,7 @@ module Hyrax
         add_breadcrumb t(:'hyrax.admin.sidebar.works'), hyrax.my_works_path
         managed_works_count
         @create_work_presenter = create_work_presenter_class.new(current_user)
-        @admin_sets_for_select = admin_sets_for_select
+        @admin_sets_for_select = helpers.available_admin_sets_for_creating_works(ability: current_ability)
         super
       end
 
@@ -47,25 +47,6 @@ module Hyrax
 
       def managed_works_count
         @managed_works_count = Hyrax::Works::ManagedWorksService.managed_works_count(scope: self)
-      end
-
-      def admin_sets_for_select
-        source_ids = Hyrax::Collections::PermissionsService.source_ids_for_deposit(ability: current_ability, source_type: 'admin_set')
-
-        admin_sets_list = Hyrax.query_service.find_many_by_ids(ids: source_ids).map do |source|
-          [source.title.first, source.id]
-        end
-
-        # Sorts the default admin set to be first, then the rest by title.
-        admin_sets_list.sort do |a, b|
-          if Hyrax::AdminSetCreateService.default_admin_set?(id: a[1])
-            -1
-          elsif Hyrax::AdminSetCreateService.default_admin_set?(id: b[1])
-            1
-          else
-            a[0] <=> b[0]
-          end
-        end
       end
     end
   end


### PR DESCRIPTION
### Fixes

Addresses https://github.com/notch8/hykuup_knapsack/issues/434
Brings fixes from https://github.com/samvera/hyrax/pull/7147 into main

### Summary

Depositing a work into a collection from the collection show page is broken.

### Guidance for testing, such as acceptance criteria or new user interface behaviors:
* Display a collection from the dashboard list
* Click `Deposit new work through this collection`
* Select admin set appears on the modal popup, and work can be created normally.

### Type of change (for release notes)

notes-bugfix

### Detailed Description

Depositing a work into a collection from the collection show page has been broken because the admin sets for selection were not being loaded. This caused the javascript to return "undefined" when trying to find the admin set, and caused the Hyrax.query_service.find to fail trying to find the admin set.

The fix encompasses several pieces:
1. Adding the `available_admin_sets_for_creating_works` method to the hyrax helper so it can be used in multiple places.
2. Updating the `@admin_sets_for_select` method in the `Hyrax::My::WorksController` to use the new helper method.
3. Adding the `@admin_sets_for_select` instance variable to the `Hyrax::Dashboard::CollectionsController#show`
4. Updating the javascript to return nil rather than undefined when no admin sets are available.

<details>
<summary>Video></summary>

[recorded (16).webm](https://github.com/user-attachments/assets/8bffa142-eafd-4dc9-a2bc-fbf996925de5)

</details>
@samvera/hyrax-code-reviewers
