### PR TITLE
adding CircleCI config so pipeline check passes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,12 @@
+version: 2.1
+
+# Run a no-op workflow so CircleCI reports as a green check in pull requests.
+# This file is needed until all active hyrax branches have moved off CircleCI
+# and the integration can be deactivated.
+jobs:
+  build:
+    docker:
+      - image: cimg/base:current
+    resource_class: small
+    steps:
+      - run: echo "Hyrax tests have moved to Github Actions."


### PR DESCRIPTION
### Summary

CircleCI pipeline check on `gh-pages` branch fails because config file not present

### Guidance for testing, such as acceptance criteria or new user interface behaviors:
* next PR into `gh-pages` branch for change to hyrax.samvera.org should not show the CircleCI pipeline check fail

### Detailed Description

Adds .circleci/config.yml based on same file in `main` branch. Last PR shows circleci pipeline check error because this config file was not present. `gh-pages` branch manages updates to hyrax.samvera.org so this should not impact anything with Hyrax software or release.
