### PR TITLE
Combining ACL and visibility to prevent duplicative reads from Fedora

### DIFF
--- a/app/controllers/hyrax/permissions_controller.rb
+++ b/app/controllers/hyrax/permissions_controller.rb
@@ -24,11 +24,13 @@ module Hyrax
 
     def copy_access
       authorize! :edit, curation_concern
+
+      #CopyAccessJob.perform_later(curation_concern)
       # copy visibility
       VisibilityCopyJob.perform_later(curation_concern)
 
       # copy permissions
-      InheritPermissionsJob.perform_later(curation_concern)
+      #InheritPermissionsJob.perform_later(curation_concern)
       redirect_to [main_app, curation_concern], notice: I18n.t("hyrax.upload.change_access_flash_message")
     end
   end

--- a/app/services/hyrax/resource_visibility_propagator.rb
+++ b/app/services/hyrax/resource_visibility_propagator.rb
@@ -44,6 +44,8 @@ module Hyrax
         embargo_manager.copy_embargo_to(target: file_set)
         lease_manager.copy_lease_to(target: file_set)
 
+        Hyrax::AccessControlList
+          .copy_permissions(source: source, target: file_set)
         file_set.permission_manager.acl.save
         persister.save(resource: file_set)
       end


### PR DESCRIPTION
### Fixes

Fixes #7137 

### Summary

Changing the visibility of a work usually involves copying the new setting onto all of the member FileSets.  In the F6 storage scenario, this requires copying both permissions and visibility, which are two distinct jobs that get called in succession.  The problem is, both jobs start from scratch to load the work and then iterate over its members, and this can take up to 20 minutes for a work containing 150 pages, as identified in the perfomance testing matrix.

This PR would cut the time in half by having one job copy both visibility and permissions while it already has a work/members loaded.

Some other areas that have been identified as the biggest contributors to the problem are a lack of cache for the LDP requests, lack of caching on the graph, redundant predicate mapping etc.  