### PR TITLE
Update issue template to new format

### DIFF
--- a/.github/ISSUE_TEMPLATE/issue_template.md
+++ b/.github/ISSUE_TEMPLATE/issue_template.md
@@ -1,3 +1,8 @@
+---
+name: Hyrax Issue
+about: Use this template for Hyrax issues
+---
+
 ### Descriptive summary
 
 Present tense short summary (30 words or less)


### PR DESCRIPTION
…/issue_template.md

Added required frontmatter to issue template, moved within new subdirectory and renamed file to avoid confusion.

### Fixes

Fixes #7154  

### Summary

Updates existing issue template with required frontmatter and subdirectory to be recognized by Github as an issue template.

### Guidance for testing
*When creating new issues in Github, users see template text rather than a blank submission box.
*Likely not testable locally

### Detailed description

According to [GitHub Documentation](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/manually-creating-a-single-issue-template-for-your-repository), I believe this is what the new format requires.

### Type of change (for release notes)

- `notes-docs` Documentation

### Changes proposed in this pull request:
*ISSUE_TEMPLATE.md changed to ISSUE_TEMPLATE/issue_template.md
*`name` and `about` added to YAML frontmatter 

@samvera/hyrax-code-reviewers
