### PR TITLE
Auto include AdminSet for Active Fedora -> Valkyrie migration

### DIFF
--- a/.github/workflows/lint-build-test.yml
+++ b/.github/workflows/lint-build-test.yml
@@ -4,9 +4,13 @@ on:
   push:
     branches:
       - main
+      - 5.0-flexible
+      - 5.0-stable
   pull_request:
     branches:
       - main
+      - 5.0-flexible
+      - 5.0-stable
   workflow_dispatch:
     inputs:
       debug_enabled:

--- a/app/models/hyrax/flexible_schema.rb
+++ b/app/models/hyrax/flexible_schema.rb
@@ -94,8 +94,21 @@ class Hyrax::FlexibleSchema < ApplicationRecord
     profile['classes'].keys.each do |class_name|
       @class_names[class_name] = {}
     end
+    
+    @class_names['AdminSet'] = {} unless @class_names.key?('AdminSet')
+    
     profile['properties'].each do |key, values|
-      values['available_on']['class'].each do |property_class|
+      available_classes = values.dig('available_on', 'class')
+      
+      next unless available_classes
+      
+      if available_classes.include?('AdminSetResource') && !available_classes.include?('AdminSet')
+        available_classes << 'AdminSet'
+      end
+      
+      available_classes.each do |property_class|
+        @class_names[property_class] ||= {}
+        
         # map some m3 items to what Hyrax expects
         values = values_map(values)
         @class_names[property_class][key] = values

--- a/app/models/hyrax/flexible_schema.rb
+++ b/app/models/hyrax/flexible_schema.rb
@@ -88,34 +88,32 @@ class Hyrax::FlexibleSchema < ApplicationRecord
     end
   end
 
+  # rubocop:disable Metrics/MethodLength
   def class_names
     return @class_names if @class_names
     @class_names = {}
     profile['classes'].keys.each do |class_name|
       @class_names[class_name] = {}
     end
-    
+
     # Pre-initialize AdminSet to prevent NoMethodError when auto-including it below
     # This ensures the hash key exists before we try to assign properties to it
     @class_names['AdminSet'] = {} unless @class_names.key?('AdminSet')
-    
+
     profile['properties'].each do |key, values|
       available_classes = values.dig('available_on', 'class')
-      
-      # Skip properties that don't define available_on classes
+
       next unless available_classes
-      
+
       # Auto-include AdminSet when AdminSetResource is present for Active Fedora -> Valkyrie migration compatibility
       # This handles cases where AF AdminSet objects are converted to AdminSetResource but the schema lookup
       # uses class.to_s ("AdminSet") instead of class.name ("AdminSetResource")
-      if available_classes.include?('AdminSetResource') && !available_classes.include?('AdminSet')
-        available_classes << 'AdminSet'
-      end
-      
+      available_classes << 'AdminSet' if available_classes.include?('AdminSetResource') && !available_classes.include?('AdminSet')
+
       available_classes.each do |property_class|
         # Ensure dynamically added classes are properly initialized in the hash
         @class_names[property_class] ||= {}
-        
+
         # map some m3 items to what Hyrax expects
         values = values_map(values)
         @class_names[property_class][key] = values
@@ -123,6 +121,7 @@ class Hyrax::FlexibleSchema < ApplicationRecord
     end
     @class_names
   end
+  # rubocop:enable Metrics/MethodLength
 
   def values_map(values)
     values['type'] = lookup_type(values['range'])


### PR DESCRIPTION
1. Pre-initialize AdminSet in the @class_names hash
2. Add a safety check @class_names[property_class] ||= {} to ensure any dynamically added class is properly initialized
3. This solution will not require users to add the AdminSet class to their m3 profiles

Solves the issue of AdminSet -> Valkyrie Resource edit failure

Issue:
- https://github.com/notch8/hykuup_knapsack/issues/460

## BEFORE (on edit AF AdminSet -> save)

<img width="2704" height="1462" alt="image" src="https://github.com/user-attachments/assets/3ca49fc2-dd12-454f-a924-80e4b1870bd3" />




## AFTER


<img width="2704" height="1460" alt="image" src="https://github.com/user-attachments/assets/76faf2a5-3d17-459d-afef-658047a19b0f" />
