### PR TITLE
Sync from main before rails 72

### DIFF
--- a/app/controllers/hyrax/uploads_controller.rb
+++ b/app/controllers/hyrax/uploads_controller.rb
@@ -23,20 +23,25 @@ module Hyrax
     def upload_with_chunking
       @upload = Hyrax::UploadedFile.find(params[:id])
       unpersisted_upload = Hyrax::UploadedFile.new(file: params[:files].first, user: current_user)
-
-      # Check if CONTENT-RANGE header is present
       content_range = request.headers['CONTENT-RANGE']
-      return @upload.file = unpersisted_upload.file if content_range.nil?
 
-      # deal with chunks
-      current_size = @upload.file.size
-      begin_of_chunk = content_range[/\ (.*?)-/, 1].to_i # "bytes 100-999999/1973660678" will return '100'
-
-      # Add the following chunk to the incomplete upload
-      if @upload.file.present? && begin_of_chunk == current_size
-        File.open(@upload.file.path, "ab") { |f| f.write(params[:files].first.read) }
+      if content_range
+        handle_chunk(content_range, unpersisted_upload.file)
       else
         @upload.file = unpersisted_upload.file
+      end
+    end
+
+    def handle_chunk(content_range, chunk)
+      current_size = @upload.file.size
+      begin_of_chunk = content_range[/\ (.*?)-/, 1].to_i
+
+      if @upload.file.present? && begin_of_chunk == current_size
+        `sync #{@upload.file.path}`
+        File.open(@upload.file.path, "ab") { |f| f.write(chunk.read) }
+        `sync #{@upload.file.path}`
+      else
+        @upload.file = chunk
       end
     end
   end

--- a/app/controllers/hyrax/uploads_controller.rb
+++ b/app/controllers/hyrax/uploads_controller.rb
@@ -33,13 +33,17 @@ module Hyrax
     end
 
     def handle_chunk(content_range, chunk)
-      current_size = @upload.file.size
+      file_path = @upload.file.path
+      current_size = 0
+      File.open(file_path, "r") { |f| current_size = f.size } if file_path && File.exist?(file_path)
+
       begin_of_chunk = content_range[/\ (.*?)-/, 1].to_i
 
       if @upload.file.present? && begin_of_chunk == current_size
-        `sync #{@upload.file.path}`
-        File.open(@upload.file.path, "ab") { |f| f.write(chunk.read) }
-        `sync #{@upload.file.path}`
+        File.open(file_path, "ab") do |f|
+          f.write(chunk.read)
+          f.fsync
+        end
       else
         @upload.file = chunk
       end

--- a/lib/freyja/metadata_adapter.rb
+++ b/lib/freyja/metadata_adapter.rb
@@ -11,7 +11,7 @@ module Freyja
     ##
     # @return [Freyja::Persister]
     def persister
-      @persister ||= Freyja::Persister.new(adapter: self)
+      @persister ||= Freyja::Persister.new(adapter: self, wings_service: Wings::Valkyrie::Persister.new(adapter: self))
     end
 
     ##

--- a/lib/freyja/persister.rb
+++ b/lib/freyja/persister.rb
@@ -64,7 +64,7 @@ module Freyja
       fedora_record = Hyrax.query_service.find_by(id: resource.id)
       wings_service.delete(resource: fedora_record) if fedora_record
       resource
-    rescue Valkyrie::Persistence::ObjectNotFoundError
+    rescue
       # If the resource is not found, we return the original resource
       resource
     end

--- a/lib/freyja/persister.rb
+++ b/lib/freyja/persister.rb
@@ -57,7 +57,7 @@ module Freyja
     # @param [Valkyrie::Resource] resource
     # @return [Valkyrie::Resource] the deleted resource
     def delete(resource:)
-     # call super to delete from postgres
+      # call super to delete from postgres
       super(resource: resource)
       # After deletion, we need to ensure that the resource is no longer found
       # because it could still exist in fedora.

--- a/lib/freyja/persister.rb
+++ b/lib/freyja/persister.rb
@@ -3,6 +3,13 @@
 module Freyja
   # Persister for Postgres MetadataAdapter.
   class Persister < Valkyrie::Persistence::Postgres::Persister
+    attr_reader :wings_service
+
+    def initialize(adapter:, wings_service:)
+      @wings_service = wings_service
+      super(adapter: adapter)
+    end
+
     # Persists a resource within the database
     #
     # Modified from the upstream to skip previously persisted check
@@ -44,6 +51,22 @@ module Freyja
         end
       end
       new_resource
+    end
+
+    # Deletes a resource persisted within the database from both postgres and fedora
+    # @param [Valkyrie::Resource] resource
+    # @return [Valkyrie::Resource] the deleted resource
+    def delete(resource:)
+     # call super to delete from postgres
+      super(resource: resource)
+      # After deletion, we need to ensure that the resource is no longer found
+      # because it could still exist in fedora.
+      fedora_record = Hyrax.query_service.find_by(id: resource.id)
+      wings_service.delete(resource: fedora_record) if fedora_record
+      resource
+    rescue Valkyrie::Persistence::ObjectNotFoundError
+      # If the resource is not found, we return the original resource
+      resource
     end
   end
 end

--- a/lib/valkyrie/indexing/redis_queue/indexing_adapter.rb
+++ b/lib/valkyrie/indexing/redis_queue/indexing_adapter.rb
@@ -61,7 +61,7 @@ module Valkyrie
           raise
         end
 
-       # If a batch fails, try running them one at a time to get down to just records that really fail
+        # If a batch fails, try running them one at a time to get down to just records that really fail
         def index_error_queue(size: 200)
           size.times do
             set = connection.zpopmin(index_queue_name + "-error", 1)
@@ -125,6 +125,7 @@ module Valkyrie
         def list_delete_errors
           connection.zrange(delete_queue_name + "-error", 0, -1, with_scores: true)
         end
+
         private
 
         def persist(resources)


### PR DESCRIPTION
### Fixes

Ref:
- https://github.com/notch8/adventist_knapsack/issues/968

### Summary

Cherry picking changes from `main_before_72` into `5.0-stable` so we can get rid of `main_before_72` in favor of `5.0-stable`

### Type of change (for release notes)

Add an appropriate `notes-*` label to the PR (or indicate here) that classifies this change.

Choose from:
- `notes-major` Major Changes (Potentially breaking changes)
- `notes-minor` New Features that are backward compatible
- `notes-deprecation` Deprecations
- `notes-bugfix` Bug Fixes
- `notes-valkyrie` Valkyrie Progress
- `notes-docs` Documentation
- `notes-container` Containerization related (Docker, Helm, etc)

@samvera/hyrax-code-reviewers
