### PR TITLE
🐛 [i461] - Ensure AF works are Valkyrized before edit renders

### DIFF
--- a/app/controllers/concerns/hyrax/works_controller_behavior.rb
+++ b/app/controllers/concerns/hyrax/works_controller_behavior.rb
@@ -149,7 +149,7 @@ module Hyrax
     private
 
     def ensure_migrated_object
-      return unless wings_backed?
+      return unless wings_backed? && Hyrax.config.flexible?
       form = work_form_service.build(curation_concern, current_ability, self)
       result = transactions['change_set.update_work'].call(form)
 

--- a/app/controllers/concerns/hyrax/works_controller_behavior.rb
+++ b/app/controllers/concerns/hyrax/works_controller_behavior.rb
@@ -35,7 +35,7 @@ module Hyrax
     class_methods do
       def curation_concern_type=(curation_concern_type)
         load_and_authorize_resource class: curation_concern_type, instance_name: :curation_concern, except: [:show, :file_manager, :inspect_work, :manifest]
-        before_action :ensure_valkyrie_object, only: :edit
+        before_action :ensure_migrated_object, only: :edit
 
         # Load the fedora resource to get the etag.
         # No need to authorize for the file manager, because it does authorization via the presenter.
@@ -148,7 +148,7 @@ module Hyrax
 
     private
 
-    def ensure_valkyrie_object
+    def ensure_migrated_object
       return unless wings_backed?
 
       form = work_form_service.build(curation_concern, current_ability, self)
@@ -157,8 +157,7 @@ module Hyrax
       if result.success?
         @curation_concern = result.value!
       else
-        Rails.logger.error "Valkyrie lazy migration failed for work #{curation_concern.id}."
-        Rails.logger.error "Valkyrie lazy migration failed for work #{curation_concern.id}: #{result.failure}"
+        raise "Valkyrie lazy migration failed for work #{curation_concern.id}: #{result.failure}"
       end
     end
 

--- a/app/controllers/concerns/hyrax/works_controller_behavior.rb
+++ b/app/controllers/concerns/hyrax/works_controller_behavior.rb
@@ -150,15 +150,12 @@ module Hyrax
 
     def ensure_migrated_object
       return unless wings_backed?
-
       form = work_form_service.build(curation_concern, current_ability, self)
       result = transactions['change_set.update_work'].call(form)
 
-      if result.success?
-        @curation_concern = result.value!
-      else
-        raise "Valkyrie lazy migration failed for work #{curation_concern.id}: #{result.failure}"
-      end
+      raise "Valkyrie lazy migration failed for work #{curation_concern.id}: #{result.failure}" unless result.success?
+
+      @curation_concern = result.value!
     end
 
     def wings_backed?

--- a/app/controllers/concerns/hyrax/works_controller_behavior.rb
+++ b/app/controllers/concerns/hyrax/works_controller_behavior.rb
@@ -149,7 +149,7 @@ module Hyrax
     private
 
     def ensure_valkyrie_object
-      return unless curation_concern.respond_to?(:wings?) && curation_concern.wings?
+      return unless wings_backed?
 
       form = work_form_service.build(curation_concern, current_ability, self)
       result = transactions['change_set.update_work'].call(form)
@@ -160,6 +160,10 @@ module Hyrax
         Rails.logger.error "Valkyrie lazy migration failed for work #{curation_concern.id}."
         Rails.logger.error result.failure
       end
+    end
+
+    def wings_backed?
+      curation_concern.respond_to?(:wings?) && curation_concern.wings?
     end
 
     def load_curation_concern


### PR DESCRIPTION
Persists Wings-backed works via transaction on the edit action. This triggers a just-in-time migration to a native Valkyrie resource, ensuring the edit form renders all metadata correctly when `HYRAX_FLEXIBLE=true`.

Issue:
- https://github.com/notch8/hykuup_knapsack/issues/461

## BEFORE

<img width="2704" height="1620" alt="Screenshot 2025-08-19 at 14-02-56 Image 4 Video Documentation of Art Installation __ Image 91cc9bbc-3c23-4474-b2a0-52912a1a318d __ Hyku" src="https://github.com/user-attachments/assets/7a3f5b20-7ec7-4ffd-88a1-9997a767c076" />



## AFTER

<img width="2704" height="1460" alt="Screenshot 2025-08-19 at 14-05-15 Image 4 Video Documentation of Art Installation __ Image 91cc9bbc-3c23-4474-b2a0-52912a1a318d __ Hyku" src="https://github.com/user-attachments/assets/f2aac157-b623-4fa3-99b8-7324b7d295b7" />
