### PR TITLE
More batch fixes

### DIFF
--- a/app/forms/hyrax/forms/batch_upload_form.rb
+++ b/app/forms/hyrax/forms/batch_upload_form.rb
@@ -1,4 +1,6 @@
 # frozen_string_literal: true
+
+# It isn't ideal but this form is used for both active fedora and valkyrie.
 module Hyrax
   module Forms
     class BatchUploadForm < Hyrax::Forms::WorkForm
@@ -22,6 +24,18 @@ module Hyrax
         super - [:title]
       end
 
+      def required_fields
+        return [] unless Hyrax.config.use_valkyrie?
+        form_class.required_fields
+      end
+
+      def payload_class
+        @payload_class ||= Valkyrie.config.resource_class_resolver.call(payload_concern)
+      end
+
+      def form_class
+        @form_class ||= "#{payload_class}Form".safe_constantize
+      end
       # # On the batch upload, title is set per-file.
       # def secondary_terms
       #   super - [:title]

--- a/app/forms/hyrax/forms/batch_upload_form.rb
+++ b/app/forms/hyrax/forms/batch_upload_form.rb
@@ -25,7 +25,7 @@ module Hyrax
       end
 
       def required_fields
-        return [] unless Hyrax.config.use_valkyrie?
+        return super unless Hyrax.config.use_valkyrie?
         form_class.required_fields
       end
 

--- a/app/jobs/create_work_job.rb
+++ b/app/jobs/create_work_job.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 # This is a job spawned by the BatchCreateJob
 class CreateWorkJob < Hyrax::ApplicationJob
+  sidekiq_options retry: false
+  discard_on StandardError
   queue_as Hyrax.config.ingest_queue_name
 
   before_enqueue do |job|
@@ -28,6 +30,7 @@ class CreateWorkJob < Hyrax::ApplicationJob
 
     return operation.success! if status
     operation.fail!(errors.full_messages.join(' '))
+    raise StandardError, operation.message
   end
 
   private

--- a/config/metadata/batch_edit_metadata.yaml
+++ b/config/metadata/batch_edit_metadata.yaml
@@ -4,7 +4,6 @@ attributes:
     type: string
     multiple: true
     form:
-      required: true
       primary: true
     index_keys:
       - "creator_sim"

--- a/spec/features/batch_create_spec.rb
+++ b/spec/features/batch_create_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe 'Batch creation of works', type: :feature do
     Hyrax::EnsureWellFormedAdminSetService.call
     sign_in user
     allow(Flipflop).to receive(:batch_upload?).and_return true
+    allow(Hyrax.config).to receive(:use_valkyrie?).and_return(false)
   end
 
   it "renders the batch create form" do

--- a/spec/forms/hyrax/forms/batch_upload_form_spec.rb
+++ b/spec/forms/hyrax/forms/batch_upload_form_spec.rb
@@ -10,6 +10,11 @@ RSpec.describe Hyrax::Forms::BatchUploadForm, :active_fedora do
   let(:ability) { Ability.new(user) }
   let(:user) { build(:user, display_name: 'Jill Z. User') }
 
+  before do
+    allow(Valkyrie.config).to receive(:resource_class_resolver).and_return(->(_name) { model.class })
+    allow(Hyrax.config).to receive(:use_valkyrie?).and_return(false)
+  end
+
   describe "#primary_terms" do
     subject { form.primary_terms }
 

--- a/spec/views/hyrax/batch_uploads/_form.html.erb_spec.rb
+++ b/spec/views/hyrax/batch_uploads/_form.html.erb_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe 'hyrax/batch_uploads/_form.html.erb', :active_fedora, type: :view
   end
 
   before do
+    allow(Hyrax.config).to receive(:use_valkyrie?).and_return(false)
     # Tell rspec where to find form_* partials
     view.lookup_context.prefixes << 'hyrax/base'
     allow(controller).to receive(:current_user).and_return(stub_model(User))


### PR DESCRIPTION
## Summary

Fixes required terms for batch upload

The required terms were being pulled from the batch create form
rather than the actual selected work type. This has been fixed to ensure
that the correct required terms are used based on the selected work type.

Additionally, updates the CreateWorkJob to end with an error if the jobs
is not successful. Along with this, the job is modified to only run once.
Subsequent runs are not possible because uploaded_file is removed after
the first run, and any subsequent attempts will fail but override the
original cause for failure.