### PR TITLE
update to bitnami legacy docker images

### DIFF
--- a/.github/workflows/release-charts.yml
+++ b/.github/workflows/release-charts.yml
@@ -1,0 +1,47 @@
+name: Release Charts
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "charts/**"
+  workflow_dispatch:
+    inputs:
+      debug_enabled:
+        type: boolean
+        description: "Run the build with tmate debugging enabled (https://github.com/marketplace/actions/debugging-with-tmate)"
+        required: false
+        default: false
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      packages: write
+    steps:
+      - name: Setup tmate session
+        uses: mxschmitt/action-tmate@v3
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.debug_enabled }}
+        with:
+          detached: true
+
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Configure Git
+        run: |
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+
+      - name: Run chart-releaser
+        uses: samvera-labs/helm-oci-charts-releaser@main
+        with:
+          oci_registry: ghcr.io/samvera
+          oci_username: samvera
+          oci_password: ${{ secrets.GITHUB_TOKEN }}
+          oci_path: charts
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          tag_name_pattern: "{chartName}-chart"

--- a/chart/hyrax/Chart.yaml
+++ b/chart/hyrax/Chart.yaml
@@ -2,11 +2,11 @@ apiVersion: v2
 name: hyrax
 description: An open-source, Samvera-powered digital repository system
 type: application
-version: 3.7.0
+version: 3.7.1
 appVersion: 5.0.0
 dependencies:
   - name: fcrepo
-    version: 2.0.0
+    version: 2.0.2
     repository: oci://ghcr.io/samvera
     condition: fcrepo.enabled
   - name: memcached

--- a/chart/hyrax/values.yaml
+++ b/chart/hyrax/values.yaml
@@ -235,7 +235,7 @@ fcrepo:
   postgresql:
     enabled: false
     image:
-      repository: bitnami/postgresql
+      repository: bitnamilegacy/postgresql
       tag: 12.17.0-debian-11-r28
 
 # configuration for an external/existing fits service;
@@ -252,13 +252,13 @@ fits:
 memcached:
   enabled: false
   image:
-    repository: bitnami/memcached
+    repository: bitnamilegacy/memcached
     tag: 1.6.15-debian-11-r12
 
 minio:
   enabled: false
   image:
-    repository: bitnami/minio
+    repository: bitnamilegacy/minio
     tag: 2022.7.4-debian-11-r0
   auth:
     rootUser: hyrax-access-key
@@ -270,7 +270,7 @@ minio:
 postgresql:
   enabled: true
   image:
-    repository: bitnami/postgresql
+    repository: bitnamilegacy/postgresql
     tag: 12.11.0-debian-11-r12
   auth:
     database: hyrax
@@ -292,7 +292,7 @@ postgresql:
 nginx:
   enabled: false
   image:
-    repository: bitnami/nginx
+    repository: bitnamilegacy/nginx
     tag: 1.23.0-debian-11-r1
   # this needs to be set since templates/ingress.yaml tries to
   # evaluate .Values.nginx.service.port, and it needs to at least evaluate to
@@ -430,11 +430,10 @@ nginx:
   #       }
   #   }
 
-
 redis:
   enabled: true
   image:
-    repository: bitnami/redis
+    repository: bitnamilegacy/redis
     tag: 7.0.2-debian-11-r7
   auth:
     password: mysecret
@@ -442,7 +441,7 @@ redis:
 solr:
   enabled: true
   image:
-    repository: bitnami/solr
+    repository: bitnamilegacy/solr
     tag: 8.11.2-debian-11-r4
   containerPorts:
     http: 8983
@@ -458,6 +457,9 @@ solr:
     enabled: true
   zookeeper:
     enabled: true
+    image:
+      repository: bitnamilegacy/zookeeper
+      tag: 3.8.2-debian-11-r9
     persistence:
       enabled: true
 

--- a/docker-compose-dassie.yml
+++ b/docker-compose-dassie.yml
@@ -116,18 +116,18 @@ services:
       - hyrax
 
   memcached:
-    image: bitnami/memcached
+    image: bitnamilegacy/memcached
     ports:
       - "11211:11211"
     networks:
       - hyrax
 
   redis:
-    image: bitnami/redis:6.2
+    image: bitnamilegacy/redis:6.2
     env_file:
       - .dassie/.env
     volumes:
-      - redis:/bitnami/redis/data
+      - redis:/bitnamilegacy/redis/data
     networks:
       - hyrax
 

--- a/docker-compose-koppie.yml
+++ b/docker-compose-koppie.yml
@@ -71,14 +71,14 @@ services:
   chrome:
     image: selenium/standalone-chromium:4
     environment:
-#      - START_XVFB=false
+      #      - START_XVFB=false
       - SE_NODE_SESSION_TIMEOUT=800
       - SE_ENABLE_TRACING=false
       - SE_ENABLE_BROWSER_LEFTOVERS_CLEANUP=true
       - SE_BROWSER_ARGS_DISABLE_DSHM=--disable-dev-shm-usage
       - SE_BROWSER_ARGS_HEADLESS=--headless=new
-#    logging:
-#      driver: none
+    #    logging:
+    #      driver: none
     volumes:
       - /dev/shm:/dev/shm
     shm_size: 2g
@@ -108,18 +108,18 @@ services:
       - koppie
 
   memcached:
-    image: bitnami/memcached
+    image: bitnamilegacy/memcached
     ports:
-      - '11212:11211'
+      - "11212:11211"
     networks:
       - koppie
 
   redis:
-    image: bitnami/redis:6.2
+    image: bitnamilegacy/redis:6.2
     env_file:
       - .koppie/.env
     volumes:
-      - redis:/bitnami/redis/data
+      - redis:/bitnamilegacy/redis/data
     networks:
       - koppie
 

--- a/docker-compose-sirenia.yml
+++ b/docker-compose-sirenia.yml
@@ -79,14 +79,14 @@ services:
   chrome:
     image: selenium/standalone-chromium:4
     environment:
-#      - START_XVFB=false
+      #      - START_XVFB=false
       - SE_NODE_SESSION_TIMEOUT=800
       - SE_ENABLE_TRACING=false
       - SE_ENABLE_BROWSER_LEFTOVERS_CLEANUP=true
       - SE_BROWSER_ARGS_DISABLE_DSHM=--disable-dev-shm-usage
       - SE_BROWSER_ARGS_HEADLESS=--headless=new
-#    logging:
-#      driver: none
+    #    logging:
+    #      driver: none
     volumes:
       - /dev/shm:/dev/shm
     shm_size: 2g
@@ -134,18 +134,18 @@ services:
       - sirenia
 
   memcached:
-    image: bitnami/memcached
+    image: bitnamilegacy/memcached
     ports:
-      - '11213:11211'
+      - "11213:11211"
     networks:
       - sirenia
 
   redis:
-    image: bitnami/redis:6.2
+    image: bitnamilegacy/redis:6.2
     env_file:
       - .koppie/.env
     volumes:
-      - redis:/bitnami/redis/data
+      - redis:/bitnamilegacy/redis/data
     networks:
       - sirenia
 


### PR DESCRIPTION
### Fixes

Fixes #7170

### Summary

Bitnami is moving all their images from /bitnami to /bitnamilegacy. We're just moving our references to them at the moment. I also took the opportunity to add the helm chart releaser here.

@samvera/hyrax-code-reviewers
