### PR TITLE
Issue loading workflow factory seems to be fixed if prefixed with nam…

### DIFF
--- a/app/services/hyrax/workflow/workflow_factory.rb
+++ b/app/services/hyrax/workflow/workflow_factory.rb
@@ -63,7 +63,7 @@ module Hyrax
       end
 
       def run_workflow_action!(action:)
-        subject = WorkflowActionInfo.new(work, user)
+        subject = Hyrax::WorkflowActionInfo.new(work, user)
         Workflow::WorkflowActionService.run(subject: subject,
                                             action: action)
       end


### PR DESCRIPTION
### Fixes
Issue loading workflow factory seems to be fixed if prefixed with namespace

Fixes #7166 against 5.0-flexible branch

### Summary
In development mode, frequently hitting the error `ArgumentError - A copy of Hyrax::Workflow::WorkflowFactory has been removed from the module tree but is still active!`, this has fixed that issue for others.

### Type of change (for release notes)
- `notes-bugfix` Bug Fixes

@samvera/hyrax-code-reviewers
