### PR TITLE
Warn batch upload is not compatible with flex

### DIFF
--- a/config/features.rb
+++ b/config/features.rb
@@ -30,7 +30,7 @@ Flipflop.configure do
 
   feature :batch_upload,
           default: false,
-          description: "Enable uploading batches of works. <br /><strong>WARNING:</strong> This feature is not compatible with flexible metadata.".html_safe
+          description: "Enable uploading batches of works. <br /><strong>WARNING:</strong> Do not enable. This feature is broken and will be addressed in https://github.com/samvera/hyrax/issues/7185.".html_safe
 
   feature :hide_private_items,
           default: false,


### PR DESCRIPTION
## Warn batch upload is not compatible with flex

0b372eea21e5243347a2b3938215ddb7062fee6d

Batch upload and valkyrized works are incompatible. We will add help text to warn the user of this case: https://github.com/samvera/hyrax/issues/7185

<img width="1889" height="623" alt="image" src="https://github.com/user-attachments/assets/b05f92de-0e65-4087-8a9d-dca03534b5a9" />

Related issues: 
- https://github.com/samvera/hyrax/issues/7185
- https://github.com/notch8/palni_palci_knapsack/issues/473
