### PR TITLE
Warn batch upload is not compatible with 6.2

### DIFF
--- a/config/features.rb
+++ b/config/features.rb
@@ -41,7 +41,7 @@ Flipflop.configure do
 
     feature :batch_upload,
             default: false,
-            description: "Enable uploading batches of works"
+            description: "Enable uploading batches of works. <br /><strong>WARNING:</strong> This feature is not compatible with flexible metadata.".html_safe
 
     feature :proxy_deposit,
             default: true,


### PR DESCRIPTION
## Warn batch upload is not compatible with flex

0b372eea21e5243347a2b3938215ddb7062fee6d

Batch upload and valkyrized works are incompatible. We will add help text to warn the user of this case: https://github.com/samvera/hyrax/issues/7185

<img width="1889" height="623" alt="image" src="https://github.com/user-attachments/assets/57dd8363-5d5e-46ce-b147-e52c955b2a11" />

Related issues: 
- https://github.com/samvera/hyrax/issues/7185
- https://github.com/notch8/palni_palci_knapsack/issues/473
