### PR TITLE
[Forward] Add to collection UI improvement

### DIFF
--- a/app/assets/javascripts/hyrax.js
+++ b/app/assets/javascripts/hyrax.js
@@ -1,6 +1,5 @@
 //= require jquery-ui
 
-
 //= require select2
 //= require fixedsticky
 
@@ -71,6 +70,7 @@
 //= require hyrax/select_work_type
 //= require hyrax/collections
 //= require hyrax/collections_v2
+//= require hyrax/collection_select2
 //= require hyrax/collection_types
 //= require hyrax/collections_utils
 //= require hyrax/select_collection_type

--- a/app/assets/javascripts/hyrax/collection_select2.js
+++ b/app/assets/javascripts/hyrax/collection_select2.js
@@ -1,0 +1,45 @@
+(function($) {
+  $.fn.collectionSearch = function() {
+    return this.each(function() {
+      var $select = $(this);
+
+      // Skip if already initialized
+      if ($select.hasClass('select2-hidden-accessible') && $select.data('select2')) {
+        return;
+      }
+
+      $select.select2({
+        placeholder: $select.data('placeholder') || 'Select',
+        allowClear: true,
+        dropdownParent: $select.closest('.modal-body')
+      });
+    });
+  };
+})(jQuery);
+
+Blacklight.onLoad(function() {
+  $('select.collection-select2').collectionSearch();
+});
+
+// Fix for if select2 breaks because of clicking the back button on the browser
+// Essentially we delete the leftover elements and reinitialize it
+window.addEventListener('popstate', function(event) {
+  Blacklight.onLoad(function() {
+    $('.select2-drop-mask').remove();
+    $('.select2-drop').remove();
+
+    $('select.collection-select2').each(function() {
+      var $select = $(this);
+
+      // Find and remove the broken Select2 container
+      $select.siblings('.select2-container').remove();
+      $select.next('.select2-container').remove();
+      $select.parent().find('.select2-container').remove();
+
+      // Make sure the select is visible and ready
+      $select.show().removeClass('select2-hidden-accessible');
+
+      $select.collectionSearch();
+    });
+  });
+});

--- a/app/assets/javascripts/hyrax/relationships/control.es6
+++ b/app/assets/javascripts/hyrax/relationships/control.es6
@@ -18,7 +18,7 @@ export default class RelationshipsControl {
     this.element = $(element)
     this.members = this.element.data('members')
     this.registry = new Registry(this.element.find('tbody'), paramKey, property, templateId)
-    this.input = this.element.find(`[data-autocomplete]`)
+    this.input = this.element.find(`[data-autocomplete], .collection-select2`)
     this.warning = this.element.find(".message.has-warning")
     this.addButton = this.element.find("[data-behavior='add-relationship']")
     this.errors = null

--- a/app/helpers/hyrax/hyrax_helper_behavior.rb
+++ b/app/helpers/hyrax/hyrax_helper_behavior.rb
@@ -20,7 +20,7 @@ module Hyrax
     include Hyrax::WorkflowsHelper
     include Hyrax::FacetsHelper
     include Hyrax::AttributesHelper
-
+    include Hyrax::WorksHelper
 
     ##
     # @return [Array<String>] the list of admin sets available for creating works for this user

--- a/app/helpers/hyrax/works_helper.rb
+++ b/app/helpers/hyrax/works_helper.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module Hyrax
+  module WorksHelper
+    def available_collections(work:)
+      return [] if @current_ability.blank?
+
+      all_collections = Hyrax::CollectionsService.new(self).search_results(:deposit)
+      return all_collections if work.blank?
+
+      all_collections.reject { |col| work.member_of_collection_ids.include?(col.id) }
+    end
+  end
+end

--- a/app/views/hyrax/base/_form_member_of_collections.html.erb
+++ b/app/views/hyrax/base/_form_member_of_collections.html.erb
@@ -15,12 +15,12 @@ HTML Properties:
 
   <div class="form-inline mb-3">
       <%= f.label :member_of_collection_ids %>
-      <%= f.input_field :member_of_collection_ids,
-                  prompt: :translate,
-                  data: {
-                    autocomplete: 'collection',
-                    'autocomplete-url' => Rails.application.routes.url_helpers.qa_path + '/search/collections?access=deposit'
-                  } %>
+      <select name="member_of_collection_ids" class="ml-2 form-control collection-select2" style="width: 12rem;" data-placeholder="<%= t('hyrax.dashboard.my.action.select') %>">
+        <option value=""></option>
+        <% available_collections(work: @curation_concern).each do |coll| %>
+          <option value="<%= coll.id %>"><%= coll.title.first %></option>
+        <% end %>
+      </select>
       <a href="#" onclick="return false;" class="btn btn-secondary ml-2" data-behavior="add-relationship"><%= t('.add') %></a>
   </div>
 

--- a/app/views/hyrax/dashboard/collections/_button_for_update_collection.html.erb
+++ b/app/views/hyrax/dashboard/collections/_button_for_update_collection.html.erb
@@ -3,5 +3,6 @@
 <%# label -- button label %>
 <%= button_to label, hyrax.dashboard_collection_path(collection_id),
               method: :post,
-              class: "btn btn-primary submits-batches",
+              class: "btn btn-primary submits-batches modal-submit-button",
+              disabled: @add_works_to_collection.blank?,
               data: { behavior: 'updates-collection' } %>

--- a/app/views/hyrax/dashboard/collections/_form_for_select_collection.html.erb
+++ b/app/views/hyrax/dashboard/collections/_form_for_select_collection.html.erb
@@ -1,4 +1,4 @@
-<div role="dialog" class="modal collection-list-modal fade" id="collection-list-container" tabindex="-1" aria-labelledby="col_add_title">
+<div role="dialog" class="modal collection-list-modal fade disable-unless-selected" id="collection-list-container" tabindex="-1" aria-labelledby="col_add_title">
   <div class="modal-dialog text-left">
       <div class="modal-content">
         <div class="modal-header">
@@ -12,20 +12,17 @@
             <div class="collection-list">
               <div class="form-group">
                 <p><%= t("hyrax.collection.select_form.select_heading") %></p>
-              
                 <% if @add_works_to_collection.present? %>
                   <%= text_field_tag 'member_of_collection_label', @add_works_to_collection_label, disabled: true %>
                   <%= hidden_field_tag 'member_of_collection_ids', @add_works_to_collection %>
                 <% else %>
-                  <%= text_field_tag 'member_of_collection_ids', nil,
-                              prompt: :translate,
-                              data: {
-                                placeholder: t('simple_form.placeholders.defaults.member_of_collection_ids'),
-                                autocomplete: 'collection',
-                                'autocomplete-url' => Rails.application.routes.url_helpers.qa_path + '/search/collections?access=deposit'
-                              } %>
+                  <select name="member_of_collection_ids" id="member_of_collection_ids" class="form-control collection-select2" data-placeholder="<%= t('hyrax.dashboard.my.action.select') %>">
+                    <option value=""></option>
+                    <% available_collections(work: @presenter&.solr_document).each do |coll| %>
+                      <option value="<%= coll.id %>"><%= coll.title.first %></option>
+                    <% end %>
+                  </select>
                 <% end %>
-            
               </div>
             </div><!-- collection-list -->
           <% end %> <!-- else -->

--- a/app/views/hyrax/my/collections/_modal_add_subcollection.html.erb
+++ b/app/views/hyrax/my/collections/_modal_add_subcollection.html.erb
@@ -11,8 +11,8 @@
         <div class="modal-ajax-alert"></div>
         <label><%= t('hyrax.collection.actions.nest_collections.select_label') %></label>
         <input type="hidden" name="source" value="<%= source %>" />
-        <select name="child_id">
-          <option value="none"><%= t("hyrax.dashboard.my.action.select") %></option>
+        <select name="child_id" class="form-control collection-select2" data-placeholder="<%= t('hyrax.dashboard.my.action.select') %>">
+          <option value=""></option>
           <% available_child_collections(collection: presenter).each do |coll| %>
             <option value="<%= coll.id %>"><%= coll.title.first %></option>
           <% end %>

--- a/app/views/hyrax/my/collections/_modal_add_to_collection.html.erb
+++ b/app/views/hyrax/my/collections/_modal_add_to_collection.html.erb
@@ -13,8 +13,8 @@
 
         <label><%= t('hyrax.collection.actions.nested_subcollection.select_label') %></label>
         <input type="hidden" name="source" value="<%= source %>" />
-        <select name="parent_id">
-          <option value="none"><%= t("hyrax.dashboard.my.action.select") %></option>
+        <select name="parent_id" class="form-control collection-select2" data-placeholder="<%= t('hyrax.dashboard.my.action.select') %>">
+          <option value=""></option>
         </select>
       </div>
 


### PR DESCRIPTION
This commit will favor using the select2 with the drop down with a pre- populated list of collections over the current implementation where it makes a query to find the collections.  Prior, the user would need to know what the collection's name is before using this interface.  Now the user has the option of scrolling through and also using the type function to find the collection for deposit.

@samvera/hyrax-code-reviewers
