### PR TITLE
[Forward] 🐛 Collections facet in catalog search

### DIFF
--- a/app/indexers/hyrax/indexers/pcdm_object_indexer.rb
+++ b/app/indexers/hyrax/indexers/pcdm_object_indexer.rb
@@ -20,6 +20,7 @@ module Hyrax
           solr_doc['admin_set_tesim'] = admin_set_label
           solr_doc["#{Hyrax.config.admin_set_predicate.qname.last}_ssim"] = [resource.admin_set_id.to_s]
           solr_doc['member_of_collection_ids_ssim'] = resource.member_of_collection_ids&.map(&:to_s)
+          solr_doc['member_of_collections_ssim'] = collection_titles_for(resource.member_of_collection_ids)
           solr_doc['member_ids_ssim'] = resource.member_ids&.map(&:to_s)
           solr_doc['depositor_ssim'] = [resource.depositor]
           solr_doc['depositor_tesim'] = [resource.depositor]
@@ -41,6 +42,16 @@ module Hyrax
         return if resource.admin_set_id.blank?
         admin_set = Hyrax.query_service.find_by(id: resource.admin_set_id)
         admin_set.title
+      end
+
+      def collection_titles_for(collection_ids)
+        return [] if collection_ids.blank?
+        collection_ids.map do |id|
+          collection = Hyrax.query_service.find_by(id: id)
+          collection.title&.first
+        rescue Valkyrie::Persistence::ObjectNotFoundError
+          nil
+        end.compact
       end
 
       def index_embargo(doc)

--- a/spec/indexers/hyrax/indexers/pcdm_object_indexer_spec.rb
+++ b/spec/indexers/hyrax/indexers/pcdm_object_indexer_spec.rb
@@ -4,11 +4,7 @@ require 'hyrax/specs/shared_specs'
 
 RSpec.describe Hyrax::Indexers::PcdmObjectIndexer do
   let(:resource) { FactoryBot.valkyrie_create(:hyrax_work) }
-  let(:indexer_class) do
-    Class.new(described_class) do
-      include Hyrax::Indexer(:core_metadata)
-    end
-  end
+  let(:indexer_class) { described_class }
 
   it_behaves_like 'a Work indexer'
 
@@ -78,6 +74,7 @@ RSpec.describe Hyrax::Indexers::PcdmObjectIndexer do
       expect(solr_document.fetch('isPartOf_ssim')).to match_array [admin_set.id]
       expect(solr_document.fetch('member_ids_ssim')).to match_array work.member_ids
       expect(solr_document.fetch('member_of_collection_ids_ssim')).to match_array [col1.id]
+      expect(solr_document.fetch('member_of_collections_ssim')).to match_array [collection_title]
       expect(solr_document.fetch('depositor_ssim')).to match_array [user.email]
       expect(solr_document.fetch('depositor_tesim')).to match_array [user.email]
     end


### PR DESCRIPTION
This commit adds `member_of_collections_ssim` to the SolrDocument ensuring collections with associated works are faceted in the catalog search results.

Prior to this change, collections were faceted for Active Fedora works but once the works were migrated or when new works are created the `member_of_collections_ssim` was not present in the Solr document.

Ref:
- https://github.com/notch8/adventist_knapsack/issues/952

Co-Author: Sarah Proctor <sproctor950@gmail.com>

@samvera/hyrax-code-reviewers
