### PR TITLE
Fix intermittent I18n locale bug

### DIFF
--- a/app/models/user_mailbox.rb
+++ b/app/models/user_mailbox.rb
@@ -49,7 +49,9 @@ class UserMailbox
   end
 
   def preferred_locale
-    user.preferred_locale || I18n.default_locale
+    return I18n.default_locale unless I18n.locale_available?(user.preferred_locale)
+
+    user.preferred_locale
   end
 
   def empty_trash(user)

--- a/spec/models/user_mailbox_spec.rb
+++ b/spec/models/user_mailbox_spec.rb
@@ -87,6 +87,15 @@ RSpec.describe UserMailbox do
             expect(subject.label).to eq 'Sie haben 3 ungelesene Benachrichtigungen'
           end
         end
+
+        context 'when user has an undefined preferred locale' do
+          let(:preferred_locale) { 'invalid-locale-identifier' }
+
+          it 'returns the system default locale' do
+            expect(I18n).to receive(:default_locale).once.and_return('de')
+            expect(subject.label).to eq 'Sie haben 3 ungelesene Benachrichtigungen'
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
### Summary
We sometimes get unexpected locale exceptions like `I18n::InvalidLocale in Hyrax::Homepage#index`

The error can occur on any page that includes the user util links in the header.

### Detailed Description
We see a locale error after calling calling `UserMailbox#label`  from the the **app/views/_user_util_links.html.erb** partial.
```
I18n::InvalidLocale in Hyrax::Homepage#index
Showing /app/samvera/hyrax-webapp/app/views/_user_util_links.html.erb where line #7 raised:

"" is not a valid locale
Extracted source (around line #382):
380    def enforce_available_locales!(locale)
381      if locale != false && config.enforce_available_locales
382        raise I18n::InvalidLocale.new(locale) if !locale_available?(locale)
383      end
384    end
385

Trace of template inclusion: #<ActionView::Template app/views/_masthead.html.erb locals=["placement_class"]>, #<ActionView::Template app/views/layouts/hyrax.html.erb locals=[]>, #<ActionView::Template app/views/layouts/homepage.html.erb locals=[]>

Rails.root: /app/samvera/hyrax-webapp

Application Trace | Framework Trace | Full Trace
i18n (1.14.7) lib/i18n.rb:382:in `enforce_available_locales!'
i18n (1.14.7) lib/i18n.rb:214:in `translate'
hyrax (608076630306) app/models/user_mailbox.rb:21:in `label'
hyrax (608076630306) app/helpers/hyrax/hyrax_helper_behavior.rb:96:in `render_notifications'
app/views/_user_util_links.html.erb:7
. . .
```

### Diagnosis
When no locale is specified in the query parameters, the code to render mailbox notifications attempts to use the current user's preferred_locale. Most users' preferred_locale defaults to the empty string, i.e. "", which is not a vaild locale for tranlations.

## Resolution
Check that the user's preferred locale is set to an available locale; otherwise, use the default locale.

### Guidance for testing, such as acceptance criteria or new user interface behaviors:
* Create a user with a preferred locale set to the empty string ""
* Log in to the application as that user
* Enter the URL for the homepage, delete any locale parameter in the query string


### Changes proposed in this pull request:
* Add a guard clause to ensure we pass a valid locale for tranlations
* Add a test case replicating the bug - neither "" nor "invalid-locale-identifier" are valid locales

@samvera/hyrax-code-reviewers
