### PR TITLE
Additional flexible metadata fixes for Dassie

### DIFF
--- a/app/actors/hyrax/actors/file_actor.rb
+++ b/app/actors/hyrax/actors/file_actor.rb
@@ -23,6 +23,8 @@ module Hyrax
       # @see IngestJob
       # @todo create a job to monitor the temp directory (or in a multi-worker system, directories!) to prune old files that have made it into the repo
       def ingest_file(io)
+        io.use_valkyrie = false # we are in the actors, we need af objects
+
         Hydra::Works::AddFileToFileSet.call(file_set,
                                             io,
                                             relation,

--- a/app/actors/hyrax/actors/file_set_actor.rb
+++ b/app/actors/hyrax/actors/file_set_actor.rb
@@ -123,7 +123,7 @@ module Hyrax
 
       # uses create! because object must be persisted to serialize for jobs
       def wrapper!(file:, relation:)
-        JobIoWrapper.create_with_varied_file_handling!(user: user, file: file, relation: relation, file_set: file_set)
+        JobIoWrapper.create_with_varied_file_handling!(user: user, file: file, relation: relation, file_set: file_set, use_valkyrie: false)
       end
 
       # For the label, use the original_filename or original_name if it's there.

--- a/app/controllers/concerns/hyrax/ensure_migrated_behavior.rb
+++ b/app/controllers/concerns/hyrax/ensure_migrated_behavior.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+module Hyrax
+  ##
+  # A shared module for controllers to ensure that a resource has been fully
+  # migrated from a Wings-backed ActiveFedora object to a native Valkyrie resource
+  # before an action (like `edit`) is performed.
+  #
+  # This is a temporary solution to handle just-in-time migrations for legacy
+  # objects when `Hyrax.config.flexible?` is true.
+  #
+  # @example
+  #   class MyController < ApplicationController
+  #     include Hyrax::EnsureMigratedBehavior
+  #
+  #     before_action do
+  #       @resource = find_my_resource
+  #       @resource = ensure_migrated(resource: @resource, form: build_form, transaction_key: 'my.transaction')
+  #     end
+  #   end
+  module EnsureMigratedBehavior
+    extend ActiveSupport::Concern
+
+    private
+
+    ##
+    # @param resource [Valkyrie::Resource] the resource to check
+    # @param transaction_key [String] the key for the update transaction
+    #
+    # @return [Valkyrie::Resource] the migrated resource if migration was needed,
+    #   otherwise the original resource.
+    def ensure_migrated(resource:, transaction_key:)
+      return resource unless resource.flexible? && wings_backed?(resource)
+
+      # Create a minimal form object to run the transaction.
+      # We can't use the controller's form because it may fail to build
+      # for a Wings-backed object, creating a circular dependency.
+      form = Hyrax::Forms::ResourceForm.for(resource: resource)
+      result = transactions[transaction_key].call(form)
+
+      raise "Valkyrie lazy migration failed for #{resource.class} #{resource.id}: #{result.failure}" unless result.success?
+
+      result.value!
+    end
+
+    def wings_backed?(resource)
+      resource.respond_to?(:wings?) && resource.wings?
+    end
+  end
+end

--- a/app/controllers/hyrax/batch_uploads_controller.rb
+++ b/app/controllers/hyrax/batch_uploads_controller.rb
@@ -80,6 +80,8 @@ module Hyrax
     def create_update_job(klass)
       operation = BatchCreateOperation.create!(user: current_user,
                                                operation_type: "Batch Create")
+      # Make sure we have the correct model name for the resource
+      klass = Valkyrie.config.resource_class_resolver.call(klass).to_s
       # ActionController::Parameters are not serializable, so cast to a hash
       BatchCreateJob.perform_later(current_user,
                                    params[:title].permit!.to_h,

--- a/app/controllers/hyrax/dashboard/collections_controller.rb
+++ b/app/controllers/hyrax/dashboard/collections_controller.rb
@@ -17,7 +17,6 @@ module Hyrax
 
       before_action :filter_docs_with_read_access!, except: [:show, :edit]
       before_action :remove_select_something_first_flash, except: :show
-      before_action :ensure_migrated_collection, only: :edit
 
       include Hyrax::Collections::AcceptsBatches
 
@@ -46,6 +45,7 @@ module Hyrax
       load_and_authorize_resource except: [:index, :create],
                                   instance_name: :collection,
                                   class: Hyrax.config.collection_model
+      before_action :ensure_migrated_collection, only: :edit
 
       def deny_collection_access(exception)
         if exception.action == :edit
@@ -188,7 +188,6 @@ module Hyrax
         # We need to know if a migration is going to happen, because if it is,
         # we need to reset the memoized form.
         needs_migration = wings_backed?(@collection)
-
         @collection = ensure_migrated(
           resource: @collection,
           transaction_key: 'change_set.update_collection'

--- a/app/controllers/hyrax/file_sets_controller.rb
+++ b/app/controllers/hyrax/file_sets_controller.rb
@@ -7,6 +7,7 @@ module Hyrax
     include Blacklight::AccessControls::Catalog
     include Hyrax::Breadcrumbs
     include Hyrax::FlexibleSchemaBehavior if Hyrax.config.file_set_flexible?
+    include Hyrax::EnsureMigratedBehavior
 
     before_action :authenticate_user!, except: [:show, :citation, :stats]
     load_and_authorize_resource class: Hyrax.config.file_set_class
@@ -15,6 +16,7 @@ module Hyrax
     # prevent method errors and nil objects later
     before_action :cast_file_set
     before_action :build_breadcrumbs, only: [:show, :edit, :stats]
+    before_action :ensure_migrated_file_set, only: :edit
     before_action do
       blacklight_config.track_search_session = false
     end
@@ -94,6 +96,20 @@ module Hyrax
     def citation; end
 
     private
+
+    def ensure_migrated_file_set
+      # We need to know if a migration is going to happen, because if it is,
+      # we need to reset the memoized form.
+      needs_migration = wings_backed?(@file_set)
+
+      @file_set = ensure_migrated(
+        resource: @file_set,
+        transaction_key: 'change_set.update_file_set'
+      )
+
+      # If a migration happened, the memoized @form is now stale.
+      @form = nil if needs_migration
+    end
 
     ##
     # @api public

--- a/app/forms/hyrax/forms/batch_upload_form.rb
+++ b/app/forms/hyrax/forms/batch_upload_form.rb
@@ -1,4 +1,6 @@
 # frozen_string_literal: true
+
+# It isn't ideal but this form is used for both active fedora and valkyrie.
 module Hyrax
   module Forms
     class BatchUploadForm < Hyrax::Forms::WorkForm
@@ -22,6 +24,18 @@ module Hyrax
         super - [:title]
       end
 
+      def required_fields
+        return super unless Hyrax.config.use_valkyrie?
+        form_class.required_fields
+      end
+
+      def payload_class
+        @payload_class ||= Valkyrie.config.resource_class_resolver.call(payload_concern)
+      end
+
+      def form_class
+        @form_class ||= "#{payload_class}Form".safe_constantize
+      end
       # # On the batch upload, title is set per-file.
       # def secondary_terms
       #   super - [:title]

--- a/app/forms/hyrax/forms/resource_batch_edit_form.rb
+++ b/app/forms/hyrax/forms/resource_batch_edit_form.rb
@@ -2,18 +2,20 @@
 module Hyrax
   module Forms
     class ResourceBatchEditForm < Hyrax::Forms::ResourceForm
-      include Hyrax::FormFields(:basic_metadata)
+      # batch edit is unfortunately all or nothing when it comes to flexible metadata
+      # because the form could be a mix of AF records, Valkyrie records and Flexible Valkyrie records
+      # we have no real way of turning this on or off more precisely
+      include Hyrax::FormFields(:batch_edit_metadata) unless Hyrax.primary_work_type.flexible?
+
       include Hyrax::ContainedInWorksBehavior
       include Hyrax::DepositAgreementBehavior
       include Hyrax::LeaseabilityBehavior
       include Hyrax::PermissionBehavior
 
+      class_attribute :terms
       self.required_fields = []
-      self.model_class = Hyrax.primary_work_type
-
-      # Terms that need to exclude from batch edit
-      class_attribute :terms_excluded
-      self.terms_excluded = [:abstract, :label, :source]
+      self.model_class = Valkyrie.config.resource_class_resolver.call(Hyrax.primary_work_type.to_s)
+      self.terms = Hyrax::Forms::BatchEditForm.terms
 
       # Contains a list of titles of all the works in the batch
       attr_accessor :names
@@ -30,21 +32,6 @@ module Hyrax
         else
           super(resource: model)
         end
-      end
-
-      def terms
-        self.class.terms
-      end
-
-      def self.terms
-        return Hyrax::Forms::BatchEditForm.terms if model_class < ActiveFedora::Base
-
-        terms_primary = definitions.select { |_, definition| definition[:primary] }
-                                   .keys.map(&:to_sym)
-        terms_secondary = definitions.select { |_, definition| definition[:display] && !definition[:primary] }
-                                     .keys.map(&:to_sym)
-
-        (terms_primary + terms_secondary) - terms_excluded
       end
 
       attr_reader :batch_document_ids
@@ -100,7 +87,7 @@ module Hyrax
         # For each of the files in the batch, set the attributes to be the concatenation of all the attributes
         batch_document_ids.each_with_object({}) do |doc_id, combined_attributes|
           work = Hyrax.query_service.find_by(id: doc_id)
-          terms.each do |field|
+          self.class.terms.each do |field|
             combined_attributes[field] ||= []
             combined_attributes[field] = (combined_attributes[field] + Array.wrap(work[field])).uniq
           end

--- a/app/forms/hyrax/forms/resource_form.rb
+++ b/app/forms/hyrax/forms/resource_form.rb
@@ -55,7 +55,7 @@ module Hyrax
           self.class.deserializer_class = nil # need to reload this on first use after schema is loaded
           singleton_class.schema_definitions = self.class.definitions
           context = r.respond_to?(:context) ? r.context : nil
-          Hyrax::Schema.m3_schema_loader.form_definitions_for(schema: r.class.to_s, version: Hyrax::FlexibleSchema.current_schema_id, contexts: context).map do |field_name, options|
+          Hyrax::Schema.m3_schema_loader.form_definitions_for(schema: r.class.name, version: Hyrax::FlexibleSchema.current_schema_id, contexts: context).map do |field_name, options|
             singleton_class.property field_name.to_sym, options.merge(display: options.fetch(:display, true), default: [])
             singleton_class.validates field_name.to_sym, presence: true if options.fetch(:required, false)
           end

--- a/app/jobs/create_work_job.rb
+++ b/app/jobs/create_work_job.rb
@@ -2,6 +2,7 @@
 # This is a job spawned by the BatchCreateJob
 class CreateWorkJob < Hyrax::ApplicationJob
   queue_as Hyrax.config.ingest_queue_name
+  discard_on StandardError
 
   before_enqueue do |job|
     operation = job.arguments.last
@@ -28,6 +29,7 @@ class CreateWorkJob < Hyrax::ApplicationJob
 
     return operation.success! if status
     operation.fail!(errors.full_messages.join(' '))
+    raise StandardError, operation.message
   end
 
   private

--- a/app/models/concerns/hyrax/collection_behavior.rb
+++ b/app/models/concerns/hyrax/collection_behavior.rb
@@ -68,6 +68,10 @@ module Hyrax
       title.present? ? title.join(' | ') : 'No Title'
     end
 
+    def flexible?
+      false
+    end
+
     module ClassMethods
       # This governs which partial to draw when you render this type of object
       def _to_partial_path # :nodoc:

--- a/app/models/hyrax/change_set.rb
+++ b/app/models/hyrax/change_set.rb
@@ -13,7 +13,7 @@ module Hyrax
   # @example
   #   Hyrax::ChangeSet(Monograph)
   def self.ChangeSet(resource_class)
-    klass = (resource_class.to_s + "ChangeSet").safe_constantize || Hyrax::ChangeSet
+    klass = (resource_class.name + "ChangeSet").safe_constantize || Hyrax::ChangeSet
     Class.new(klass) do
       (resource_class.fields - resource_class.reserved_attributes).each do |field|
         property field, default: nil

--- a/app/models/hyrax/resource.rb
+++ b/app/models/hyrax/resource.rb
@@ -47,13 +47,13 @@ module Hyrax
     class << self
       def inherited(subclass)
         super
-        subclass.acts_as_flexible_resource if Hyrax.config.flexible_classes.include?(subclass.to_s)
+        subclass.acts_as_flexible_resource if Hyrax.config.flexible_classes.include?(subclass.name)
       end
 
       def acts_as_flexible_resource
         include Hyrax::Flexibility
-        include Hyrax::Schema(to_s, schema_loader: Hyrax::Schema.m3_schema_loader)
-        Hyrax.config.flexible_classes << to_s unless Hyrax.config.flexible_classes.include?(to_s)
+        include Hyrax::Schema(name, schema_loader: Hyrax::Schema.m3_schema_loader)
+        Hyrax.config.flexible_classes << name unless Hyrax.config.flexible_classes.include?(name)
       end
 
       def flexible?

--- a/app/services/hyrax/workflow/workflow_factory.rb
+++ b/app/services/hyrax/workflow/workflow_factory.rb
@@ -50,9 +50,10 @@ module Hyrax
       private
 
       def create_workflow_entity!
-        Sipity::Entity.find_or_create_by!(proxy_for_global_id: Hyrax::GlobalID(work).to_s,
-                                          workflow: workflow_for(work),
-                                          workflow_state: nil)
+        entity = Sipity::Entity.find_by(proxy_for_global_id: Hyrax::GlobalID(work).to_s)
+        entity || Sipity::Entity.create!(proxy_for_global_id: Hyrax::GlobalID(work).to_s,
+                                         workflow: workflow_for(work),
+                                         workflow_state: nil)
       end
 
       def assign_specific_roles_to(entity:)

--- a/app/uploaders/hyrax/uploaded_file_uploader.rb
+++ b/app/uploaders/hyrax/uploaded_file_uploader.rb
@@ -4,11 +4,11 @@ module Hyrax
     # Override the directory where uploaded files will be stored.
     # This is a sensible default for uploaders that are meant to be mounted:
     def store_dir
-      (configured_upload_path / model.class.to_s.underscore / mounted_as.to_s / model.id.to_s).to_s
+      (configured_upload_path / model.class.name.underscore / mounted_as.to_s / model.id.to_s).to_s
     end
 
     def cache_dir
-      (configured_cache_path / model.class.to_s.underscore / mounted_as.to_s / model.id.to_s).to_s
+      (configured_cache_path / model.class.name.underscore / mounted_as.to_s / model.id.to_s).to_s
     end
 
     private

--- a/app/utils/hyrax/data_destroyers/collection_branding_destroyer.rb
+++ b/app/utils/hyrax/data_destroyers/collection_branding_destroyer.rb
@@ -20,7 +20,7 @@ module Hyrax
 
           logger.info("Destroying collection branding...")
 
-          Hyrax::CollectionBrandingInfo.destroy_all
+          CollectionBrandingInfo.destroy_all
           logger.info("   collection branding -- DESTROYED")
         end
       end

--- a/config/metadata/batch_edit_metadata.yaml
+++ b/config/metadata/batch_edit_metadata.yaml
@@ -1,0 +1,119 @@
+---
+attributes:
+  creator:
+    type: string
+    multiple: true
+    form:
+      primary: true
+    index_keys:
+      - "creator_sim"
+      - "creator_tesim"
+    predicate: http://purl.org/dc/elements/1.1/creator
+  contributor:
+    type: string
+    multiple: true
+    form:
+      primary: false
+    index_keys:
+      - "contributor_tesim"
+      - "contributor_sim"
+    predicate: http://purl.org/dc/elements/1.1/contributor
+  description:
+    type: string
+    multiple: true
+    form:
+      primary: false
+    index_keys:
+      - "description_sim"
+      - "description_tesim"
+    predicate: http://purl.org/dc/elements/1.1/description
+  keyword:
+    type: string
+    multiple: true
+    index_keys:
+      - "keyword_sim"
+      - "keyword_tesim"
+    form:
+      primary: false
+    predicate: http://schema.org/keywords
+  resource_type:
+    type: string
+    multiple: true
+    form:
+      primary: false
+    index_keys:
+      - "resource_type_sim"
+      - "resource_type_tesim"
+    predicate: http://purl.org/dc/terms/type
+  license:
+    type: string
+    multiple: true
+    form:
+      primary: false
+    index_keys:
+      - "license_sim"
+      - "license_tesim"
+    predicate: http://purl.org/dc/terms/license
+  publisher:
+    type: string
+    multiple: true
+    form:
+      primary: false
+    index_keys:
+      - "publisher_sim"
+      - "publisher_tesim"
+    predicate: http://purl.org/dc/elements/1.1/publisher
+  date_created:
+    type: date_time
+    multiple: true
+    form:
+      primary: false
+    index_keys:
+      - "date_created_sim"
+      - "date_created_tesim"
+    predicate: http://purl.org/dc/terms/created
+  subject:
+    type: string
+    multiple: true
+    index_keys:
+      - "subject_sim"
+      - "subject_tesim"
+    form:
+      primary: false
+    predicate: http://purl.org/dc/elements/1.1/subject
+  language:
+    type: string
+    multiple: true
+    form:
+      primary: false
+    index_keys:
+      - "language_sim"
+      - "language_tesim"
+    predicate: http://purl.org/dc/elements/1.1/language
+  identifier:
+    type: string
+    multiple: true
+    form:
+      primary: false
+    index_keys:
+      - "identifier_sim"
+      - "identifier_tesim"
+    predicate: http://purl.org/dc/terms/identifier
+  based_near:
+    type: string
+    multiple: true
+    form:
+      primary: false
+    index_keys:
+      - "based_near_sim"
+      - "based_near_tesim"
+    predicate: http://xmlns.com/foaf/0.1/based_near
+  related_url:
+    type: string
+    multiple: true
+    form:
+      primary: false
+    index_keys:
+      - "related_url_sim"
+      - "related_url_tesim"
+    predicate: http://www.w3.org/2000/01/rdf-schema#seeAlso

--- a/lib/hyrax/indexer.rb
+++ b/lib/hyrax/indexer.rb
@@ -56,7 +56,7 @@ module Hyrax
           schema_args = if index_loader.is_a?(Hyrax::M3SchemaLoader)
                           document['schema_version_ssi'] = resource.schema_version
                           document['contexts_ssim'] = resource.contexts
-                          { schema: resource.class.to_s, version: resource.schema_version, contexts: resource.contexts }
+                          { schema: resource.class.name, version: resource.schema_version, contexts: resource.contexts }
                         else
                           { schema: schema_name }
                         end

--- a/spec/features/batch_create_spec.rb
+++ b/spec/features/batch_create_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe 'Batch creation of works', type: :feature do
     Hyrax::EnsureWellFormedAdminSetService.call
     sign_in user
     allow(Flipflop).to receive(:batch_upload?).and_return true
+    allow(Hyrax.config).to receive(:use_valkyrie?).and_return(false)
   end
 
   it "renders the batch create form" do

--- a/spec/forms/hyrax/forms/batch_upload_form_spec.rb
+++ b/spec/forms/hyrax/forms/batch_upload_form_spec.rb
@@ -10,6 +10,11 @@ RSpec.describe Hyrax::Forms::BatchUploadForm, :active_fedora do
   let(:ability) { Ability.new(user) }
   let(:user) { build(:user, display_name: 'Jill Z. User') }
 
+  before do
+    allow(Valkyrie.config).to receive(:resource_class_resolver).and_return(->(_name) { model.class })
+    allow(Hyrax.config).to receive(:use_valkyrie?).and_return(false)
+  end
+
   describe "#primary_terms" do
     subject { form.primary_terms }
 

--- a/spec/forms/hyrax/forms/permission_template_form_spec.rb
+++ b/spec/forms/hyrax/forms/permission_template_form_spec.rb
@@ -169,6 +169,8 @@ RSpec.describe Hyrax::Forms::PermissionTemplateForm do
                                                   workflow: workflow,
                                                   agents: user3)
         permission_template.update!(active_workflow: workflow)
+        @start_count_for_user = count_workflow_roles_for(user)
+        @start_count_for_user2 = count_workflow_roles_for(user2)
       end
 
       def count_workflow_roles_for(user)
@@ -179,8 +181,8 @@ RSpec.describe Hyrax::Forms::PermissionTemplateForm do
 
       it "adds edit_access to the AdminSet itself and grants workflow roles" do
         expect { subject }.to change { permission_template.access_grants.count }.by(1)
-        expect(count_workflow_roles_for(user)).to eq 1
-        expect(count_workflow_roles_for(user2)).to eq 1
+        expect(count_workflow_roles_for(user)).to eq @start_count_for_user + 1
+        expect(count_workflow_roles_for(user2)).to eq @start_count_for_user2 + 1
         expect(count_workflow_roles_for(user3)).to eq 0
         reload = Hyrax.query_service.find_by id: admin_set.id
         expect(reload.edit_users).to match_array [user2.user_key, user.user_key]

--- a/spec/views/hyrax/batch_uploads/_form.html.erb_spec.rb
+++ b/spec/views/hyrax/batch_uploads/_form.html.erb_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe 'hyrax/batch_uploads/_form.html.erb', :active_fedora, type: :view
   end
 
   before do
+    allow(Hyrax.config).to receive(:use_valkyrie?).and_return(false)
     # Tell rspec where to find form_* partials
     view.lookup_context.prefixes << 'hyrax/base'
     allow(controller).to receive(:current_user).and_return(stub_model(User))


### PR DESCRIPTION
### Fixes

This PR pulls in code from Hyku and the 5.0-flexible branch in order to fix a variety of small issues found during flexible metadata testing with Dassie. 

### Guidance for testing, such as acceptance criteria or new user interface behaviors:
* Load flexible up (see `documentation/flexible_metadata.md`) for dassie and test editing and creating works individually and in batches
* Do the same test with flexible off

### Changes proposed in this pull request:
* Make sure we stay in ActiveFedora when doing things in the actor stack (fixes AF workflows)
* Ensure records get migrated before editing if Wings -> Valkyrie transition is underway
* Get consistent class names to make flexible metadata schema look up work properly
* Fix the seeds
* Fix batch edit post flexible metadata as best we can
* Fix batch upload 

@samvera/hyrax-code-reviewers
