### PR TITLE
Upgrade base image to debian trixie

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG DEBIAN_VERSION=bookworm
+ARG DEBIAN_VERSION=trixie
 ARG RUBY_VERSION=3.3
 
 FROM ruby:$RUBY_VERSION-$DEBIAN_VERSION AS hyrax-base
@@ -13,6 +13,7 @@ RUN apt-get update && \
     ffmpeg \
     ghostscript \
     git \
+    imagemagick \
     less \
     libgsf-1-dev \
     libimagequant-dev \
@@ -54,27 +55,6 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/* && \
     ln -s /usr/lib/*-linux-gnu/libjemalloc.so.2 /usr/lib/libjemalloc.so.2 && \
     echo "******** Packages Installed *********"
-
-RUN bash -x -c "\
-    if [ $(dpkg --print-architecture) = 'amd64' ]; then \
-      wget https://github.com/ImageMagick/ImageMagick/releases/download/7.1.1-47/ImageMagick-82572af-gcc-x86_64.AppImage -O magick \
-        && chmod a+x magick \
-        && ./magick --appimage-extract \
-        && mv squashfs-root/usr/etc/ImageMagick*  /etc \
-        && rm -rf squashfs-root/usr/share/doc \
-        && cp -rv squashfs-root/usr/*  /usr/local \
-        && rm -rf magick squashfs-root ; \
-    else \
-      wget https://github.com/ImageMagick/ImageMagick/archive/refs/tags/7.1.1-47.tar.gz \
-        && tar xf 7.1.1-47.tar.gz \
-        && cd ImageMagick* \
-        && ./configure \
-        && make install \
-        && ldconfig /usr/local/lib \
-        && cd $OLDPWD \
-        && rm -rf 7.1.1-47.tar.gz ImageMagick* ; \
-    fi \
-    && identify -version"
 
 RUN setfacl -d -m o::rwx /usr/local/bundle && \
     gem update --silent --system


### PR DESCRIPTION
trixie has ImageMagick 7 (finally!) so we should be able to use the official package now.

### Changes proposed in this pull request:
* Upgrade Docker base image to debian trixie
* Use debian's imagemagick package

