### PR TITLE
Fix fileset migration - to 5.0-stable

### DIFF
--- a/app/actors/hyrax/actors/file_actor.rb
+++ b/app/actors/hyrax/actors/file_actor.rb
@@ -23,6 +23,7 @@ module Hyrax
       # @see IngestJob
       # @todo create a job to monitor the temp directory (or in a multi-worker system, directories!) to prune old files that have made it into the repo
       def ingest_file(io)
+        io.use_valkyrie = false # we are in the actors, we need af objects
         Hydra::Works::AddFileToFileSet.call(file_set,
                                             io,
                                             relation,

--- a/app/actors/hyrax/actors/file_set_actor.rb
+++ b/app/actors/hyrax/actors/file_set_actor.rb
@@ -123,7 +123,7 @@ module Hyrax
 
       # uses create! because object must be persisted to serialize for jobs
       def wrapper!(file:, relation:)
-        JobIoWrapper.create_with_varied_file_handling!(user: user, file: file, relation: relation, file_set: file_set)
+        JobIoWrapper.create_with_varied_file_handling!(user: user, file: file, relation: relation, file_set: file_set, use_valkyrie: false)
       end
 
       # For the label, use the original_filename or original_name if it's there.

--- a/app/forms/hyrax/forms/batch_edit_form.rb
+++ b/app/forms/hyrax/forms/batch_edit_form.rb
@@ -5,8 +5,7 @@ module Hyrax
       # Used for drawing the fields that appear on the page
       self.terms = [:creator, :contributor, :description,
                     :keyword, :resource_type, :license, :publisher, :date_created,
-                    :subject, :language, :identifier, :based_near,
-                    :related_url]
+                    :subject, :language, :identifier, :related_url]
       self.required_fields = []
       self.model_class = Hyrax.primary_work_type
 

--- a/app/models/job_io_wrapper.rb
+++ b/app/models/job_io_wrapper.rb
@@ -51,7 +51,7 @@ class JobIoWrapper < ApplicationRecord
     create!(args)
   end
 
-   def initialize(attributes = {})
+  def initialize(attributes = {})
     @use_valkyrie = attributes&.delete(:use_valkyrie)
     @use_valkyrie = Hyrax.config.use_valkyrie? if @use_valkyrie.nil?
     super(attributes)

--- a/app/models/job_io_wrapper.rb
+++ b/app/models/job_io_wrapper.rb
@@ -25,6 +25,8 @@ class JobIoWrapper < ApplicationRecord
   after_initialize :static_defaults
   delegate :read, to: :file
 
+  attr_accessor :use_valkyrie
+
   # Responsible for creating a JobIoWrapper from the given parameters, with a
   # focus on sniffing out attributes from the given :file.
   #
@@ -34,8 +36,8 @@ class JobIoWrapper < ApplicationRecord
   # @param [FileSet] file_set - The associated file set
   # @return [JobIoWrapper]
   # @raise ActiveRecord::RecordInvalid - if the instance is not valid
-  def self.create_with_varied_file_handling!(user:, file:, relation:, file_set:)
-    args = { user: user, relation: relation.to_s, file_set_id: file_set.id }
+  def self.create_with_varied_file_handling!(user:, file:, relation:, file_set:, use_valkyrie: nil)
+    args = { user: user, relation: relation.to_s, file_set_id: file_set.id, use_valkyrie: use_valkyrie }
     if file.is_a?(Hyrax::UploadedFile)
       args[:uploaded_file] = file
       args[:path] = file.uploader.path
@@ -47,6 +49,12 @@ class JobIoWrapper < ApplicationRecord
       raise "Require Hyrax::UploadedFile or File-like object, received #{file.class} object: #{file}"
     end
     create!(args)
+  end
+
+   def initialize(attributes = {})
+    @use_valkyrie = attributes&.delete(:use_valkyrie)
+    @use_valkyrie = Hyrax.config.use_valkyrie? if @use_valkyrie.nil?
+    super(attributes)
   end
 
   def original_name
@@ -63,7 +71,8 @@ class JobIoWrapper < ApplicationRecord
     nil # unable to determine
   end
 
-  def file_set(use_valkyrie: Hyrax.config.query_index_from_valkyrie)
+  def file_set(use_valkyrie: nil)
+    use_valkyrie ||= @use_valkyrie
     return FileSet.find(file_set_id) unless use_valkyrie
     Hyrax.query_service.find_by(id: Valkyrie::ID.new(file_set_id))
   end

--- a/lib/freyja/persister.rb
+++ b/lib/freyja/persister.rb
@@ -42,7 +42,7 @@ module Freyja
       new_resource = resource_factory.to_resource(object: orm_object)
       # if the resource was wings and is now a Valkyrie resource, we need to migrate sipity, files, and members
       if Hyrax.config.valkyrie_transition? && was_wings && !new_resource.wings?
-        MigrateFilesToValkyrieJob.perform_later(new_resource) if new_resource.is_a?(Hyrax::FileSet) && new_resource.file_ids.detect {|id_holder| !id_holder.id.to_s.match('/files/')}
+        MigrateFilesToValkyrieJob.perform_later(new_resource) if new_resource.is_a?(Hyrax::FileSet) && new_resource.file_ids.detect { |id_holder| !id_holder.id.to_s.match('/files/')}
         # migrate any members if the resource is a Hyrax work
         if new_resource.is_a?(Hyrax::Work)
           member_ids = new_resource.member_ids.map(&:to_s)

--- a/lib/freyja/persister.rb
+++ b/lib/freyja/persister.rb
@@ -42,7 +42,7 @@ module Freyja
       new_resource = resource_factory.to_resource(object: orm_object)
       # if the resource was wings and is now a Valkyrie resource, we need to migrate sipity, files, and members
       if Hyrax.config.valkyrie_transition? && was_wings && !new_resource.wings?
-        MigrateFilesToValkyrieJob.perform_later(new_resource) if new_resource.is_a?(Hyrax::FileSet) && new_resource.file_ids.size == 1 && new_resource.file_ids.first.id.to_s.match('/files/')
+        MigrateFilesToValkyrieJob.perform_later(new_resource) if new_resource.is_a?(Hyrax::FileSet) && new_resource.file_ids.detect {|id_holder| !id_holder.id.to_s.match('/files/')}
         # migrate any members if the resource is a Hyrax work
         if new_resource.is_a?(Hyrax::Work)
           member_ids = new_resource.member_ids.map(&:to_s)

--- a/lib/freyja/persister.rb
+++ b/lib/freyja/persister.rb
@@ -42,7 +42,7 @@ module Freyja
       new_resource = resource_factory.to_resource(object: orm_object)
       # if the resource was wings and is now a Valkyrie resource, we need to migrate sipity, files, and members
       if Hyrax.config.valkyrie_transition? && was_wings && !new_resource.wings?
-        MigrateFilesToValkyrieJob.perform_later(new_resource) if new_resource.is_a?(Hyrax::FileSet) && new_resource.file_ids.detect { |id_holder| !id_holder.id.to_s.match('/files/')}
+        MigrateFilesToValkyrieJob.perform_later(new_resource) if new_resource.is_a?(Hyrax::FileSet) && new_resource.file_ids.detect { |id_holder| !id_holder.id.to_s.match('/files/') }
         # migrate any members if the resource is a Hyrax work
         if new_resource.is_a?(Hyrax::Work)
           member_ids = new_resource.member_ids.map(&:to_s)

--- a/spec/forms/hyrax/forms/batch_edit_form_spec.rb
+++ b/spec/forms/hyrax/forms/batch_edit_form_spec.rb
@@ -15,7 +15,6 @@ RSpec.describe Hyrax::Forms::BatchEditForm, :active_fedora do
            license: ['license1'],
            subject: ['subject1'],
            identifier: ['id1'],
-           based_near: ['based_near1'],
            related_url: ['related_url1']
   end
 
@@ -59,7 +58,6 @@ RSpec.describe Hyrax::Forms::BatchEditForm, :active_fedora do
                          :subject,
                          :language,
                          :identifier,
-                         :based_near,
                          :related_url]
     end
   end
@@ -76,7 +74,6 @@ RSpec.describe Hyrax::Forms::BatchEditForm, :active_fedora do
       expect(form.model.subject).to match_array ["subject1", "subject2"]
       expect(form.model.language).to match_array ["en"]
       expect(form.model.identifier).to match_array ["id1", "id2"]
-      expect(form.model.based_near).to match_array ["based_near1", "based_near2"]
       expect(form.model.related_url).to match_array ["related_url1", "related_url2"]
     end
   end
@@ -96,7 +93,6 @@ RSpec.describe Hyrax::Forms::BatchEditForm, :active_fedora do
                          { subject: [] },
                          { language: [] },
                          { identifier: [] },
-                         { based_near: [] },
                          { related_url: [] },
                          { permissions_attributes: [:type, :name, :access, :id, :_destroy] },
                          :on_behalf_of,

--- a/spec/forms/hyrax/forms/resource_batch_edit_form_spec.rb
+++ b/spec/forms/hyrax/forms/resource_batch_edit_form_spec.rb
@@ -12,7 +12,6 @@ RSpec.describe Hyrax::Forms::ResourceBatchEditForm do
            license: ['license1'],
            subject: ['subject1'],
            identifier: ['id1'],
-           based_near: ['based_near1'],
            related_url: ['related_url1'])
   end
 
@@ -29,7 +28,6 @@ RSpec.describe Hyrax::Forms::ResourceBatchEditForm do
       license: ['license2'],
       subject: ['subject2'],
       identifier: ['id2'],
-      based_near: ['based_near2'],
       related_url: ['related_url2'])
   end
 
@@ -57,7 +55,6 @@ RSpec.describe Hyrax::Forms::ResourceBatchEditForm do
         :subject,
         :language,
         :identifier,
-        :based_near,
         :related_url)
     end
   end
@@ -74,7 +71,6 @@ RSpec.describe Hyrax::Forms::ResourceBatchEditForm do
       expect(form.model.subject).to match_array ["subject1", "subject2"]
       expect(form.model.language).to match_array ["en"]
       expect(form.model.identifier).to match_array ["id1", "id2"]
-      expect(form.model.based_near).to match_array ["based_near1", "based_near2"]
       expect(form.model.related_url).to match_array ["related_url1", "related_url2"]
     end
   end
@@ -94,7 +90,6 @@ RSpec.describe Hyrax::Forms::ResourceBatchEditForm do
         { subject: [] },
         { language: [] },
         { identifier: [] },
-        { based_near: [] },
         { related_url: [] },
         { permissions_attributes: [:type, :name, :access, :id, :_destroy] },
         :on_behalf_of,


### PR DESCRIPTION
### Summary

PDF and some other types of files had a text derivative file attached to the same fileset as the original file. When migrating these situations, the fileset never was submitted for migration due to the incorrect assumption that filesets would only have 1 file in Fedora. 

### Changes included

- Modifies the logic for triggering file migration on a fileset.
- Brings in some changes from 5.0-flexible branch that were missed here, to facilitate Hyku's rake task for making fedora sample works
- removes based_near from the terms list used for batch changes, as it fails trying to load existing location information.