### PR TITLE
⚙️ Temporarily disable batch_upload feature

### DIFF
--- a/app/assets/stylesheets/hyrax/_admin_features.scss
+++ b/app/assets/stylesheets/hyrax/_admin_features.scss
@@ -1,0 +1,18 @@
+// Modify the batch_upload feature flipper to be disabled
+tr[data-feature="batch-upload"] {
+  background-color: #f8f9fa;
+
+  td.name {
+    color: #6c757d !important;
+    opacity: 0.65 !important;
+  }
+
+  td.status .badge {
+    background-color: #dc3545 !important;
+  }
+
+  td.toggle .btn-group {
+    pointer-events: none;
+    opacity: 0.5;
+  }
+}

--- a/app/assets/stylesheets/hyrax/_hyrax.scss
+++ b/app/assets/stylesheets/hyrax/_hyrax.scss
@@ -1,16 +1,16 @@
 @import "hyrax/variables", "hyrax/file_sets", "hyrax/settings", "hyrax/html",
-  "hyrax/header", "hyrax/styles", "hyrax/file-listing",
-  "hyrax/browse_everything_overrides", "hyrax/nestable", "hyrax/collections",
-  "hyrax/collection_types", "hyrax/batch-edit", "hyrax/home-page",
-  "hyrax/featured", "hyrax/usage-stats", "hyrax/catalog", "hyrax/buttons",
-  "hyrax/tinymce", "hyrax/proxy-rights", "hyrax/file-show", "hyrax/work-show",
-  "hyrax/modal", "hyrax/forms", "hyrax/form", "hyrax/file_manager",
-  "hyrax/form-progress", "hyrax/positioning", "hyrax/fixedsticky",
-  "hyrax/file_upload", "hyrax/representative-media", "hyrax/footer",
-  "hyrax/select_work_type", "hyrax/users", "hyrax/dashboard", "hyrax/sidebar",
-  "hyrax/controlled_vocabulary", "hyrax/accessibility", "hyrax/recent",
-  "hyrax/viewer", "hyrax/breadcrumbs", "hyrax/facets", "hyrax/card",
-  "hyrax/badge";
+"hyrax/header", "hyrax/styles", "hyrax/file-listing",
+"hyrax/browse_everything_overrides", "hyrax/nestable", "hyrax/collections",
+"hyrax/collection_types", "hyrax/batch-edit", "hyrax/home-page",
+"hyrax/featured", "hyrax/usage-stats", "hyrax/catalog", "hyrax/buttons",
+"hyrax/tinymce", "hyrax/proxy-rights", "hyrax/file-show", "hyrax/work-show",
+"hyrax/modal", "hyrax/forms", "hyrax/form", "hyrax/file_manager",
+"hyrax/form-progress", "hyrax/positioning", "hyrax/fixedsticky",
+"hyrax/file_upload", "hyrax/representative-media", "hyrax/footer",
+"hyrax/select_work_type", "hyrax/users", "hyrax/dashboard", "hyrax/sidebar",
+"hyrax/controlled_vocabulary", "hyrax/accessibility", "hyrax/recent",
+"hyrax/viewer", "hyrax/breadcrumbs", "hyrax/facets", "hyrax/card",
+"hyrax/badge", "hyrax/admin_features";
 @import "hydra-editor/multi_value_fields";
 @import "typeahead";
 @import "sharing_buttons";

--- a/app/strategies/hyrax/strategies/disable_feature_strategy.rb
+++ b/app/strategies/hyrax/strategies/disable_feature_strategy.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+module Hyrax::Strategies
+  class DisableFeatureStrategy < Flipflop::Strategies::AbstractStrategy
+    def enabled?(feature)
+      # Set batch upload to disabled
+      return false if feature == :batch_upload
+      # Return nil to pass through to next strategy for other features
+      nil
+    end
+  end
+end

--- a/config/features.rb
+++ b/config/features.rb
@@ -30,9 +30,11 @@ Flipflop.configure do
           default: Hyrax.config.active_deposit_agreement_acceptance?,
           description: "Require an active acceptance of the deposit agreement by checking a checkbox"
 
+  # rubocop:disable Layout/LineLength
   feature :batch_upload,
           default: false,
-          description: "Enable uploading batches of works. <br /><strong>NOTICE:</strong> This feature has been temporarily disabled. To add or upload works in bulk, please use the <a href='https://github.com/samvera/bulkrax/wiki' target='_blank'>Bulkrax importer feature</a>.".html_safe
+          description: "<strong>NOTICE:</strong> This feature has been temporarily disabled. To add or upload works in bulk, please use the <a href='https://github.com/samvera/bulkrax/wiki' target='_blank'>Bulkrax importer</a>.".html_safe
+  # rubocop:enable Layout/LineLength
 
   feature :hide_private_items,
           default: false,

--- a/config/features.rb
+++ b/config/features.rb
@@ -2,6 +2,8 @@
 Flipflop.configure do
   # Strategies will be used in the order listed here.
   strategy :cookie
+  # Configuration to prevent features from being enabled
+  strategy Hyrax::Strategies::DisableFeatureStrategy
   strategy :active_record, class: Hyrax::Feature
   strategy Hyrax::Strategies::YamlStrategy, config: Hyrax.config.feature_config_path
   strategy :default
@@ -30,7 +32,7 @@ Flipflop.configure do
 
   feature :batch_upload,
           default: false,
-          description: "This functionality has been deprecated. Please use the bulk importer feature (Bulkrax) to perform this function moving forward."
+          description: "Enable uploading batches of works. <br /><strong>NOTICE:</strong> This feature has been temporarily disabled. To add or upload works in bulk, please use the <a href='https://github.com/samvera/bulkrax/wiki' target='_blank'>Bulkrax importer feature</a>.".html_safe
 
   feature :hide_private_items,
           default: false,
@@ -43,6 +45,7 @@ Flipflop.configure do
   feature :cache_work_iiif_manifest,
           default: false,
           description: "Use Rails.cache to cache the JSON document for IIIF manifests"
+
   feature :read_only,
           default: false,
           description: "Put the system into read-only mode. Deposits, edits, approvals and anything that makes a change to the data will be disabled."

--- a/spec/features/batch_edit_spec.rb
+++ b/spec/features/batch_edit_spec.rb
@@ -48,6 +48,8 @@ RSpec.describe 'batch', type: :feature, clean_repo: true, js: true do
 
   describe 'editing' do
     it 'changes the value of each field for all selected works' do
+      skip 'due to temporarily disabling the batch_upload feature'
+      # Ref: https://github.com/samvera/hyrax/issues/7185
       click_on 'batch-edit'
       fill_in_batch_edit_fields_and_verify!
       reloaded_work1 = wings_disabled ? Hyrax.query_service.find_by(id: work1.id) : work1.reload
@@ -97,6 +99,8 @@ RSpec.describe 'batch', type: :feature, clean_repo: true, js: true do
     end
 
     it 'updates visibility' do
+      skip 'due to temporarily disabling the batch_upload feature'
+      # Ref: https://github.com/samvera/hyrax/issues/7185
       click_on 'batch-edit'
       find('#edit_permissions_link').click
       batch_edit_expand('permissions_visibility')


### PR DESCRIPTION
This change prevents admin users from enabling batch_upload in settings. This addresses the issue that batch uploads and Valkyrized works are incompatible. The current Batch Add uses a fake Active Fedora form with fixed terms that ignore the selected work type, causing Valkyrie validations to fail (especially on 6.2).

It was determined that fixing this issue is low-priority compared to general Bulkrax improvements. To ensure users are not enabling broken features, batch_upload is disabled until further decisions are made.

Ref:
- https://github.com/notch8/palni_palci_knapsack/issues/479
- https://github.com/samvera/hyrax/issues/7185

<img width="1105" height="650" alt="Screenshot 2025-09-19 at 2 39 06 PM" src="https://github.com/user-attachments/assets/ad52392f-063d-4702-9aab-b17853a6ed60" />



@samvera/hyrax-code-reviewers
