### PR TITLE
Migration fix for filesets

### DIFF
--- a/app/forms/hyrax/forms/batch_edit_form.rb
+++ b/app/forms/hyrax/forms/batch_edit_form.rb
@@ -5,8 +5,7 @@ module Hyrax
       # Used for drawing the fields that appear on the page
       self.terms = [:creator, :contributor, :description,
                     :keyword, :resource_type, :license, :publisher, :date_created,
-                    :subject, :language, :identifier, :based_near,
-                    :related_url]
+                    :subject, :language, :identifier, :related_url]
       self.required_fields = []
       self.model_class = Hyrax.primary_work_type
 

--- a/lib/freyja/persister.rb
+++ b/lib/freyja/persister.rb
@@ -42,7 +42,8 @@ module Freyja
       new_resource = resource_factory.to_resource(object: orm_object)
       # if the resource was wings and is now a Valkyrie resource, we need to migrate sipity, files, and members
       if Hyrax.config.valkyrie_transition? && was_wings && !new_resource.wings?
-        MigrateFilesToValkyrieJob.perform_later(new_resource) if new_resource.is_a?(Hyrax::FileSet) && new_resource.file_ids.size == 1 && new_resource.file_ids.first.id.to_s.match('/files/')
+        # Check if all file_ids match the '/files/' pattern
+        MigrateFilesToValkyrieJob.perform_later(new_resource) if new_resource.is_a?(Hyrax::FileSet) && new_resource.file_ids.all? { |id_holder| id_holder.id.to_s.match('/files/') }
         # migrate any members if the resource is a Hyrax work
         if new_resource.is_a?(Hyrax::Work)
           member_ids = new_resource.member_ids.map(&:to_s)


### PR DESCRIPTION
### Fixes

Bring in necessary pieces of  https://github.com/samvera/hyrax/pull/7196

### Summary

- fixes lazy migration of filesets so migration doesn't skip when a fileset has >1 file
- removes based_near from the list of terms valid for batch edit, as this breaks the form when data is present
