### PR TITLE
Remove based_near from batch edit form - bring forward to main

### DIFF
--- a/app/forms/hyrax/forms/batch_edit_form.rb
+++ b/app/forms/hyrax/forms/batch_edit_form.rb
@@ -38,7 +38,6 @@ module Hyrax
          { subject: [] },
          { language: [] },
          { identifier: [] },
-         { based_near: [] },
          { related_url: [] },
          { permissions_attributes: [:type, :name, :access, :id, :_destroy] },
          :on_behalf_of,

--- a/app/forms/hyrax/forms/batch_edit_form.rb
+++ b/app/forms/hyrax/forms/batch_edit_form.rb
@@ -5,8 +5,7 @@ module Hyrax
       # Used for drawing the fields that appear on the page
       self.terms = [:creator, :contributor, :description,
                     :keyword, :resource_type, :license, :publisher, :date_created,
-                    :subject, :language, :identifier, :based_near,
-                    :related_url]
+                    :subject, :language, :identifier, :related_url]
       self.required_fields = []
       self.model_class = Hyrax.primary_work_type
 

--- a/spec/forms/hyrax/forms/batch_edit_form_spec.rb
+++ b/spec/forms/hyrax/forms/batch_edit_form_spec.rb
@@ -15,7 +15,6 @@ RSpec.describe Hyrax::Forms::BatchEditForm, :active_fedora do
            license: ['license1'],
            subject: ['subject1'],
            identifier: ['id1'],
-           based_near: ['based_near1'],
            related_url: ['related_url1']
   end
 
@@ -34,7 +33,6 @@ RSpec.describe Hyrax::Forms::BatchEditForm, :active_fedora do
       license: ['license2'],
       subject: ['subject2'],
       identifier: ['id2'],
-      based_near: ['based_near2'],
       related_url: ['related_url2']
     )
   end
@@ -59,7 +57,6 @@ RSpec.describe Hyrax::Forms::BatchEditForm, :active_fedora do
                          :subject,
                          :language,
                          :identifier,
-                         :based_near,
                          :related_url]
     end
   end
@@ -76,7 +73,6 @@ RSpec.describe Hyrax::Forms::BatchEditForm, :active_fedora do
       expect(form.model.subject).to match_array ["subject1", "subject2"]
       expect(form.model.language).to match_array ["en"]
       expect(form.model.identifier).to match_array ["id1", "id2"]
-      expect(form.model.based_near).to match_array ["based_near1", "based_near2"]
       expect(form.model.related_url).to match_array ["related_url1", "related_url2"]
     end
   end
@@ -96,7 +92,6 @@ RSpec.describe Hyrax::Forms::BatchEditForm, :active_fedora do
                          { subject: [] },
                          { language: [] },
                          { identifier: [] },
-                         { based_near: [] },
                          { related_url: [] },
                          { permissions_attributes: [:type, :name, :access, :id, :_destroy] },
                          :on_behalf_of,

--- a/spec/forms/hyrax/forms/resource_batch_edit_form_spec.rb
+++ b/spec/forms/hyrax/forms/resource_batch_edit_form_spec.rb
@@ -12,7 +12,6 @@ RSpec.describe Hyrax::Forms::ResourceBatchEditForm do
            license: ['license1'],
            subject: ['subject1'],
            identifier: ['id1'],
-           based_near: ['based_near1'],
            related_url: ['related_url1'])
   end
 
@@ -29,7 +28,6 @@ RSpec.describe Hyrax::Forms::ResourceBatchEditForm do
       license: ['license2'],
       subject: ['subject2'],
       identifier: ['id2'],
-      based_near: ['based_near2'],
       related_url: ['related_url2'])
   end
 
@@ -57,7 +55,6 @@ RSpec.describe Hyrax::Forms::ResourceBatchEditForm do
         :subject,
         :language,
         :identifier,
-        :based_near,
         :related_url)
     end
   end
@@ -74,7 +71,6 @@ RSpec.describe Hyrax::Forms::ResourceBatchEditForm do
       expect(form.model.subject).to match_array ["subject1", "subject2"]
       expect(form.model.language).to match_array ["en"]
       expect(form.model.identifier).to match_array ["id1", "id2"]
-      expect(form.model.based_near).to match_array ["based_near1", "based_near2"]
       expect(form.model.related_url).to match_array ["related_url1", "related_url2"]
     end
   end
@@ -93,8 +89,6 @@ RSpec.describe Hyrax::Forms::ResourceBatchEditForm do
         { date_created: [] },
         { subject: [] },
         { language: [] },
-        { identifier: [] },
-        { based_near: [] },
         { related_url: [] },
         { permissions_attributes: [:type, :name, :access, :id, :_destroy] },
         :on_behalf_of,


### PR DESCRIPTION
### Summary

A location value on a work causes the batch edit form to break.

### Rationale

Batch edit is a very limited use functionality, so removing the based_near attribute to keep it from breaking the form  is the most time-efficient fix at this point.