### PR TITLE
Persister changes for freyja - bring forward to main

### DIFF
--- a/lib/freyja/metadata_adapter.rb
+++ b/lib/freyja/metadata_adapter.rb
@@ -11,7 +11,7 @@ module Freyja
     ##
     # @return [Freyja::Persister]
     def persister
-      @persister ||= Freyja::Persister.new(adapter: self)
+      @persister ||= Freyja::Persister.new(adapter: self, wings_service: Wings::Valkyrie::Persister.new(adapter: self))
     end
 
     ##

--- a/lib/freyja/persister.rb
+++ b/lib/freyja/persister.rb
@@ -3,6 +3,13 @@
 module Freyja
   # Persister for Postgres MetadataAdapter.
   class Persister < Valkyrie::Persistence::Postgres::Persister
+    attr_reader :wings_service
+
+    def initialize(adapter:, wings_service:)
+      @wings_service = wings_service
+      super(adapter: adapter)
+    end
+
     # Persists a resource within the database
     #
     # Modified from the upstream to skip previously persisted check
@@ -35,7 +42,8 @@ module Freyja
       new_resource = resource_factory.to_resource(object: orm_object)
       # if the resource was wings and is now a Valkyrie resource, we need to migrate sipity, files, and members
       if Hyrax.config.valkyrie_transition? && was_wings && !new_resource.wings?
-        MigrateFilesToValkyrieJob.perform_later(new_resource) if new_resource.is_a?(Hyrax::FileSet) && new_resource.file_ids.size == 1 && new_resource.file_ids.first.id.to_s.match('/files/')
+        # Check if all file_ids match the '/files/' pattern
+        MigrateFilesToValkyrieJob.perform_later(new_resource) if new_resource.is_a?(Hyrax::FileSet) && new_resource.file_ids.all? { |id_holder| id_holder.id.to_s.match('/files/') }
         # migrate any members if the resource is a Hyrax work
         if new_resource.is_a?(Hyrax::Work)
           member_ids = new_resource.member_ids.map(&:to_s)
@@ -44,6 +52,22 @@ module Freyja
         end
       end
       new_resource
+    end
+
+    # Deletes a resource persisted within the database from both postgres and fedora
+    # @param [Valkyrie::Resource] resource
+    # @return [Valkyrie::Resource] the deleted resource
+    def delete(resource:)
+      # call super to delete from postgres
+      super(resource: resource)
+      # After deletion, we need to ensure that the resource is no longer found
+      # because it could still exist in fedora.
+      fedora_record = Hyrax.query_service.find_by(id: resource.id)
+      wings_service.delete(resource: fedora_record) if fedora_record
+      resource
+    rescue Valkyrie::Persistence::ObjectNotFoundError
+      # If the resource is not found, we return the original resource
+      resource
     end
   end
 end

--- a/spec/lib/freyja/persister_spec.rb
+++ b/spec/lib/freyja/persister_spec.rb
@@ -8,7 +8,8 @@ require 'wings'
 require 'freyja/metadata_adapter'
 
 RSpec.describe Freyja::Persister, :active_fedora, :clean_repo, valkyrie_adapter: :freyja_adapter do
-  subject(:persister) { described_class.new(adapter: adapter) }
+  subject(:persister) { described_class.new(adapter: adapter, wings_service: wings_service) }
+  let(:wings_service) { Wings::Valkyrie::Persister.new(adapter: adapter) }
   let(:adapter) { Freyja::MetadataAdapter.new }
   let(:query_service) { adapter.query_service }
 


### PR DESCRIPTION
### Fixes

- Handle deletion - ensure that fedora works are also deleted if work was migrated.
- Trigger file set migration appropriately... some fedora filesets have multiple files

Brings forward changes to persister from 5.0 branches
