### PR TITLE
⚙️ Adds 5.* branches to auto run pipelines

### DIFF
--- a/.github/workflows/lint-build-test.yml
+++ b/.github/workflows/lint-build-test.yml
@@ -4,9 +4,13 @@ on:
   push:
     branches:
       - main
+      - 5.0-flexible
+      - 5.0-stable
   pull_request:
     branches:
       - main
+      - 5.0-flexible
+      - 5.0-stable
   workflow_dispatch:
     inputs:
       debug_enabled:


### PR DESCRIPTION
The commit adds the 5.0-flexible and 5.0-stable branches to the actions so lint-build-test workflows run automatically on push and pull_request

### Type of change (for release notes)

Add an appropriate `notes-*` label to the PR (or indicate here) that classifies this change.

Choose from:
- `notes-major` Major Changes (Potentially breaking changes)
- `notes-minor` New Features that are backward compatible
- `notes-deprecation` Deprecations
- `notes-bugfix` Bug Fixes
- `notes-valkyrie` Valkyrie Progress
- `notes-docs` Documentation
- `notes-container` Containerization related (Docker, Helm, etc)

@samvera/hyrax-code-reviewers
