### PR TITLE
Fixes lazy migration form bug (main)

### DIFF
--- a/app/services/migrate_resource_service.rb
+++ b/app/services/migrate_resource_service.rb
@@ -25,7 +25,13 @@ class MigrateResourceService
   end
 
   def resource_form
-    @resource_form ||= Hyrax::Forms::ResourceForm.for(resource: resource)
+    # needs to validate the form to prevent potential frozen errors in custom transaction steps
+    @resource_form ||= begin
+      form_params = resource.attributes.to_h.with_indifferent_access
+      form = Hyrax::Forms::ResourceForm.for(resource: resource)
+      form.validate(form_params)
+      form
+    end
   end
 
   def model_events(model)


### PR DESCRIPTION
### Fixes

The issue we found was that the resource form couldn't be modified for a custom worktype. This worked in the UI with lazy migration, but not in a submitted migration job, and the difference seemed to be that the form wasn't going through the same steps.

This fix mimics the steps taken through the UI when lazy migration happens.

### Summary

Sets the resource form for migrations the same as is done in the UI.

### Guidance for testing, such as acceptance criteria or new user interface behaviors:

Testing will be done in Hyku using work type OER which has a custom transaction that was erroring during migration due to the form limitations.

### Type of change (for release notes)

bugfix

### Detailed Description
