### PR TITLE
Remove #id call

### DIFF
--- a/lib/freyja/persister.rb
+++ b/lib/freyja/persister.rb
@@ -43,7 +43,7 @@ module Freyja
       # if the resource was wings and is now a Valkyrie resource, we need to migrate sipity, files, and members
       if Hyrax.config.valkyrie_transition? && was_wings && !new_resource.wings?
         # Check if all file_ids match the '/files/' pattern
-        MigrateFilesToValkyrieJob.perform_later(new_resource) if new_resource.is_a?(Hyrax::FileSet) && new_resource.file_ids.all? { |id_holder| id_holder.id.to_s.match('/files/') }
+        MigrateFilesToValkyrieJob.perform_later(new_resource) if new_resource.is_a?(Hyrax::FileSet) && new_resource.file_ids.all? { |id_holder| id_holder.to_s.match('/files/') }
         # migrate any members if the resource is a Hyrax work
         if new_resource.is_a?(Hyrax::Work)
           member_ids = new_resource.member_ids.map(&:to_s)


### PR DESCRIPTION
### Summary

It seems that sometimes we may get a string for the id_holder instead of a Valkyrie::ID object.  Both a string and a Valkyrie::ID respond to to_s, so we can just call to_s on the id_holder directly.

### Type of change (for release notes)

- `notes-bugfix` Bug Fixes

@samvera/hyrax-code-reviewers
