### PR TITLE
Fix Flexible Form required field validations

### DIFF
--- a/app/forms/concerns/hyrax/flexible_form_behavior.rb
+++ b/app/forms/concerns/hyrax/flexible_form_behavior.rb
@@ -6,6 +6,17 @@ module Hyrax
     included do
       include Hyrax::BasedNearFieldBehavior
       property :contexts
+
+      validate :validate_flexible_required_fields
+    end
+
+    def validate_flexible_required_fields
+      required_fields = singleton_class.schema_definitions.select { |_, opts| opts[:required] }.keys
+
+      required_fields.each do |field|
+        value = send(field)
+        errors.add(field, :blank) if value.blank?
+      end
     end
 
     # OVERRIDE disposable 0.6.3 to make schema dynamic

--- a/app/forms/hyrax/forms/resource_form.rb
+++ b/app/forms/hyrax/forms/resource_form.rb
@@ -60,7 +60,6 @@ module Hyrax
           r = resource || deprecated_resource
           Hyrax::Schema.default_schema_loader.form_definitions_for(schema: r.class.to_s, version: Hyrax::FlexibleSchema.current_schema_id, contexts: r.contexts).map do |field_name, options|
             singleton_class.property field_name.to_sym, options.merge(display: options.fetch(:display, true), default: [])
-            singleton_class.validates field_name.to_sym, presence: true if options.fetch(:required, false)
           end
         end
 


### PR DESCRIPTION
### Fixes

Refs https://github.com/notch8/hyku-community-issues/issues/1

### Summary

When HYRAX_FLEXIBLE=true, ActiveModel::Validations::PresenceValidator is never added to the Active Model validations.

- When Flexible is false, validations are added to the form in Hyrax::FormFields during boot-up.
- When Flexible is true, validations are attempted to be added to the form when it is instantiated in Hyrax::Forms::ResourceForm

It appears that this is too late in the process, as the PresenceValidator is not included in the validation steps. This change moves the validations into a custom validator, allowing the form validations to occur.
