### PR TITLE
lets stop forcing shoulda matchers from 8 years ago

### DIFF
--- a/hyrax.gemspec
+++ b/hyrax.gemspec
@@ -108,7 +108,7 @@ SUMMARY
   spec.add_development_dependency 'rails-controller-testing', '~> 1'
   # the hyrax style guide is based on `bixby`. see `.rubocop.yml`
   spec.add_development_dependency 'bixby', '~> 5.0', '>= 5.0.2' # bixby 5 briefly dropped Ruby 2.5
-  spec.add_development_dependency 'shoulda-callback-matchers', '~> 1.1.1'
-  spec.add_development_dependency 'shoulda-matchers', '~> 3.1'
+  spec.add_development_dependency 'shoulda-callback-matchers'
+  spec.add_development_dependency 'shoulda-matchers'
   spec.add_development_dependency 'webmock'
 end


### PR DESCRIPTION
### Fixes

Ran in to an issue in hryax-doi where hyrax dependency was forcing a very old version of shoulda_matchers

@samvera/hyrax-code-reviewers
