### PR TITLE
ForewardPort(?): Allow additional metadata to be set on FileSets via the WorkUploadsHandler

### DIFF
--- a/app/controllers/concerns/hyrax/works_controller_behavior.rb
+++ b/app/controllers/concerns/hyrax/works_controller_behavior.rb
@@ -220,9 +220,10 @@ module Hyrax
     def update_valkyrie_work
       form = build_form
       return after_update_error(form_err_msg(form)) unless form.validate(params[hash_key_for_curation_concern])
+
       result =
         transactions['change_set.update_work']
-        .with_step_args('work_resource.add_file_sets' => { uploaded_files: uploaded_files, file_set_params: params[hash_key_for_curation_concern][:file_set] },
+        .with_step_args('work_resource.add_file_sets' => { uploaded_files: uploaded_files, file_set_params: file_set_attributes },
                         'work_resource.update_work_members' => { work_members_attributes: work_members_attributes },
                         'work_resource.save_acl' => { permissions_params: form.input_params["permissions"] })
         .call(form)
@@ -232,6 +233,10 @@ module Hyrax
 
     def work_members_attributes
       params[hash_key_for_curation_concern][:work_members_attributes]&.permit!&.to_h
+    end
+
+    def file_set_attributes
+      params[hash_key_for_curation_concern][:file_set]&.map { |fs| fs.permit!&.to_h }
     end
 
     def form_err_msg(form)

--- a/app/services/hyrax/action/create_valkyrie_work.rb
+++ b/app/services/hyrax/action/create_valkyrie_work.rb
@@ -35,6 +35,7 @@ module Hyrax
         @params = params
         @work_attributes_key = work_attributes_key
         @work_attributes = @params.fetch(work_attributes_key, {})
+        @file_set_params = work_attributes[:file_set]&.map { |fs| fs.permit! } || []
       end
 
       attr_reader :form, :transactions, :user, :parent_id, :work_attributes, :uploaded_files, :params, :work_attributes_key
@@ -42,7 +43,7 @@ module Hyrax
       ##
       # @api public
       # @return [TrueClass] when the object is valid.
-      # @return [FalseClass] when the object is valid.
+      # @return [FalseClass] when the object is not valid.
       def validate
         form.validate(work_attributes)
       end
@@ -63,7 +64,7 @@ module Hyrax
       def step_args
         {
           'work_resource.add_to_parent' => { parent_id: params[:parent_id], user: user },
-          'work_resource.add_file_sets' => { uploaded_files: uploaded_files, file_set_params: work_attributes[:file_set] },
+          'work_resource.add_file_sets' => { uploaded_files: uploaded_files, file_set_params: @file_set_params },
           'change_set.set_user_as_depositor' => { user: user },
           'work_resource.change_depositor' => { user: ::User.find_by_user_key(form.on_behalf_of) },
           'work_resource.save_acl' => { permissions_params: form.input_params["permissions"] }

--- a/app/services/hyrax/work_uploads_handler.rb
+++ b/app/services/hyrax/work_uploads_handler.rb
@@ -68,7 +68,9 @@ module Hyrax
     #   (for job retries). this is for legacy/AttachFilesToWorkJob
     #   compatibility, but could stand for a robust reimplementation.
     #
-    # @param [Enumberable<Hyrax::UploadedFile>] files  files to add
+    # @param [Enumerable<Hyrax::UploadedFile>] files  files to add
+    #
+    # @param [Enumerable<Hash>] file_set_params additional parameters for each file_set
     #
     # @return [WorkFileSetManager] self
     # @raise [ArgumentError] if any of the uploaded files are not an
@@ -76,21 +78,24 @@ module Hyrax
     def add(files:, file_set_params: [])
       validate_files(files) &&
         @files = Array.wrap(files).reject { |f| f.file_set_uri.present? }
-      @file_set_params = file_set_params
+      @file_set_params = file_set_params || []
       self
     end
 
     ##
     # @api public
     #
-    # Create filesets for each added file
+    # Create filesets for each added file, and add some additional metadata passed in file_set_params
+    # Additional metadata will only be set if it is not overriden by the `file_set_args` hash, and if it is a valid part of the schema
     #
     # @return [Boolean] true if all requested files were attached
     def attach
       return true if Array.wrap(files).empty? # short circuit to avoid aquiring a lock we won't use
 
       acquire_lock_for(work.id) do
-        event_payloads = files.each_with_object([]) { |file, arry| arry << make_file_set_and_ingest(file) }
+        event_payloads = files.each_with_object([]).with_index do |(file, arry), index|
+          arry << make_file_set_and_ingest(file, @file_set_params[index] || {})
+        end
         @persister.save(resource: work)
         Hyrax.publisher.publish('object.metadata.updated', object: work, user: files.first.user)
         event_payloads.each do |payload|
@@ -104,8 +109,8 @@ module Hyrax
 
     ##
     # @api private
-    def make_file_set_and_ingest(file)
-      file_set = @persister.save(resource: Hyrax::FileSet.new(file_set_args(file)))
+    def make_file_set_and_ingest(file, file_set_params = {})
+      file_set = @persister.save(resource: Hyrax::FileSet.new(file_set_args(file, file_set_params)))
       Hyrax.publisher.publish('object.deposited', object: file_set, user: file.user)
       file.add_file_set!(file_set)
 
@@ -133,14 +138,17 @@ module Hyrax
     ##
     # @api private
     #
+    # @note the second hash overrides values in the first hash
+    #
+    #
     # @return [Hash{Symbol => Object}]
-    def file_set_args(file)
+    def file_set_args(file, file_set_params = {})
       { depositor: file.user.user_key,
         creator: file.user.user_key,
         date_uploaded: file.created_at,
         date_modified: Hyrax::TimeService.time_in_utc,
         label: file.uploader.filename,
-        title: file.uploader.filename }
+        title: file.uploader.filename }.merge(file_set_params)
     end
 
     ##

--- a/spec/models/sipity/role_spec.rb
+++ b/spec/models/sipity/role_spec.rb
@@ -29,7 +29,7 @@ module Sipity
 
     context '#destroy' do
       it 'will not allow registered role names to be destroyed' do
-        role = described_class.create!(name: Hyrax::RoleRegistry::MANAGING)
+        role = described_class.find_or_create_by!(name: Hyrax::RoleRegistry::MANAGING)
         expect { role.destroy! }.to raise_error(ActiveRecord::RecordNotDestroyed)
       end
       it 'will allow unregistered role names to be destroyed' do

--- a/spec/services/hyrax/work_uploads_handler_spec.rb
+++ b/spec/services/hyrax/work_uploads_handler_spec.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 require 'hyrax/specs/spy_listener'
+require 'hyrax/specs/shared_specs/simple_work'
 
 RSpec.describe Hyrax::WorkUploadsHandler, valkyrie_adapter: :test_adapter do
   subject(:service) { described_class.new(work: work) }
@@ -75,6 +76,46 @@ RSpec.describe Hyrax::WorkUploadsHandler, valkyrie_adapter: :test_adapter do
         expect { service.attach }
           .to change { listener.object_metadata_updated }
           .to contain_exactly(have_attributes(payload: include(object: be_work)))
+      end
+
+      context 'with file_set_params' do
+        context 'that are valid' do
+          let(:file_set_params) do
+            [
+              { alternate_ids: ['fs-1'] },
+              { alternate_ids: ['fs-2'] },
+              { alternate_ids: ['fs-3'] }
+            ]
+          end
+
+          it 'assigns the file_set_params to the FileSets' do
+            service.add(files: uploads, file_set_params: file_set_params)
+            service.attach
+            expect(work).to have_file_set_members(have_attributes(alternate_ids: ['fs-1']),
+                                                  have_attributes(alternate_ids: ['fs-2']),
+                                                  have_attributes(alternate_ids: ['fs-3']))
+          end
+        end
+
+        context 'that are not in the schema' do
+          let(:file_set_params) do
+            [
+              { liverwurst: ['not applied 1'] },
+              { liverwurst: ['not applied 2'] },
+              { liverwurst: ['not applied 3'] }
+            ]
+          end
+
+          it 'does not assign the invalid file_set_params to the FileSets' do
+            service.add(files: uploads, file_set_params: file_set_params)
+            service.attach
+            actual_file_sets = Hyrax.custom_queries.find_child_file_sets(resource: work)
+            expect(actual_file_sets.size).to eq(3)
+            actual_file_sets.each do |fs|
+              expect(fs).not_to have_attribute(:liverwurst)
+            end
+          end
+        end
       end
 
       # we can't use the memory based test_adapter to test asynch,


### PR DESCRIPTION
- This is needed so that Bulkrax can set metadata such as source_identifier / bulkrax_identifier to the FileSet and have it be persisted. This then allows Bulkrax to re-find the FileSet based on that metadata, and connect it to the original ingest.
- Ensure file_set_params match expectations
- Follow existing pattern for method
- Fix flakey test
### Fixes
Refs https://github.com/notch8/hykuup_knapsack/issues/454

### Summary
Non-UI uploaders, such as Bulkrax, cannot set metadata on FileSets that then allow them to re-find the uploaded object, such as :source_identifier.

### Guidance for testing, such as acceptance criteria or new user interface behaviors:
* Tested via the UI against 
  * [Hyku](https://github.com/samvera/hyku/tree/file_set_flexible_metadata)
  * [Bulkrax](https://github.com/samvera/bulkrax/pull/1067/commits/33f883b0e78af01539fc23b3b83897c21e42f3b3)
* Example testing CSV
```
file,model,source_identifier,parents,title,creator,rights_statement,visibility
,GenericWork,gw-123,,"Custom Generic Work Title",KKW,http://rightsstatements.org/vocab/NKC/1.0/,open
dummy.jpg,FileSet,fs-123,gw-123,Custom File Set Title,KKW,,restricted
```
  * My example directory looks like this - Archive.zip is the files directory and fs_test.csv zipped together, and that's what I uploaded to my Bulkrax importer:
```
├── file_sets
│   ├── Archive.zip
│   ├── files
│   │   └── dummy.jpg
│   └── fs_test.csv
```

### Type of change (for release notes)
I'm not sure I got the label right - feel free to change or suggest a change.

### Detailed Description
Previously, we were passing `file_set_params` to the `#add` method and setting them to an instance variable, but then we weren't doing anything with them. Instead, the only attributes that were set on the FileSet were in a pre-defined hash in `file_set_args`, not anything from the passed in parameters. 

This update passes the `file_set_params` through to the `file_set_args` method and merges them.

In order to pair up the files with the file sets we are using the index of the arrays to match them up.

@samvera/hyrax-code-reviewers
