### PR TITLE
Fix flakey spec - ensures it cleans up after itself

### DIFF
--- a/spec/features/dashboard/collection_spec.rb
+++ b/spec/features/dashboard/collection_spec.rb
@@ -691,10 +691,11 @@ RSpec.describe 'collection', type: :feature, clean_repo: true do
         sign_in user
         # stub out characterization. Travis doesn't have fits installed, and it's not relevant to the test.
         allow(CharacterizeJob).to receive(:perform_later)
-        Wings::ModelRegistry.register(GenericWorkResource, GenericWork) if defined?(Wings::ModelRegistry)
       end
 
-      after do
+      around do |example|
+        Wings::ModelRegistry.register(GenericWorkResource, GenericWork) if defined?(Wings::ModelRegistry)
+        example.run
         Wings::ModelRegistry.unregister(GenericWorkResource) if defined?(Wings::ModelRegistry)
       end
 


### PR DESCRIPTION
### Fixes

Fixes #7229;

### Summary
More consistent setup and breakdown of test context using `around` block rather than separate before and after blocks.

### Guidance for testing, such as acceptance criteria or new user interface behaviors:
* On 5.0-flexible branch, bring up the Sirenia app for testing
```bash
docker compose build -f docker-compose-sirenia.yml
docker compose -f docker-compose-sirenia.yml up -d
```
* Bash into the web container
```bash
docker compose -f docker-compose-sirenia.yml exec -w /app/samvera/hyrax-engine web bash
```
* Run reproduction command - even with this command, for me it was failing every other time. (Pass, Fail, Pass, Fail), so run a few times
```bash
bundle exec rspec './spec/features/dashboard/collection_spec.rb[1:7:4:1]' --seed 1341
```
* Checkout branch and run the same reproduction command several times - it should pass consistently

### Type of change (for release notes)

Add an appropriate `notes-*` label to the PR (or indicate here) that classifies this change.

Choose from:
- `notes-bugfix` Bug Fixes

@samvera/hyrax-code-reviewers
