### PR TITLE
Do not show Versions tab when it is not supported

### DIFF
--- a/app/views/hyrax/file_sets/edit.html.erb
+++ b/app/views/hyrax/file_sets/edit.html.erb
@@ -1,5 +1,5 @@
 <%= render "shared/nav_safety_modal" %>
-<% provide :page_title, title_presenter(curation_concern).page_title %>
+<% provide :page_title, title_presenter(@presenter).page_title %>
 <% provide :page_header do %>
   <h1><span class="fa fa-edit" aria-hidden="true"></span><%= t('.header', file_set: curation_concern) %></h1>
 <% end %>
@@ -16,11 +16,13 @@
             <i class="fa fa-tags" aria-hidden="true"></i> <%= t('.descriptions') %>
           </a>
         </li>
-        <li id="edit_versioning_link" class="nav-item">
-          <a href="#versioning_display" data-toggle="tab" class="nav-link nav-safety-confirm">
-            <i class="fa fa-sitemap" aria-hidden="true"></i> <%= t('.versions') %>
-          </a>
-        </li>
+        <% if @version_list.supports_multiple_versions? %>
+          <li id="edit_versioning_link" class="nav-item">
+            <a href="#versioning_display" data-toggle="tab" class="nav-link nav-safety-confirm">
+              <i class="fa fa-sitemap" aria-hidden="true"></i> <%= t('.versions') %>
+            </a>
+          </li>
+        <% end %>
         <li id="edit_permissions_link" class="nav-item">
           <a href="#permissions_display" data-toggle="tab" class="nav-link nav-safety-confirm">
             <i class="fa fa-key" aria-hidden="true"></i> <%= t('.permissions') %>

--- a/spec/views/hyrax/file_sets/edit.html.erb_spec.rb
+++ b/spec/views/hyrax/file_sets/edit.html.erb_spec.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+RSpec.describe 'hyrax/file_sets/edit.html.erb', type: :view do
+  let(:ability) { double }
+  let(:doc) do
+    {
+      "has_model_ssim" => ["FileSet"],
+      :id => "123",
+      "title_tesim" => ["My Title"]
+    }
+  end
+  let(:solr_doc) { SolrDocument.new(doc) }
+  let(:presenter) { Hyrax::FileSetPresenter.new(solr_doc, ability) }
+  let(:work_solr_document) do
+    SolrDocument.new(id: '900', title_tesim: ['My Title'])
+  end
+  let(:parent_presenter) { Hyrax::WorkShowPresenter.new(work_solr_document, ability) }
+  let(:file_set) { double('Hyrax::FileSet') }
+
+  before do
+    allow(controller).to receive(:current_ability).and_return(ability)
+    allow(ability).to receive(:can?).with(:download, solr_doc).and_return(true)
+    assign(:presenter, presenter)
+    assign(:parent_presenter, parent_presenter)
+    allow(presenter).to receive(:parent).and_return(parent_presenter)
+    allow(presenter).to receive(:parent_presenter).and_return(parent_presenter)
+    assign(:document, solr_doc)
+    stub_template 'hyrax/file_sets/_form.html.erb' => 'Some form'
+    stub_template 'hyrax/file_sets/_permission.html.erb' => 'Permission form'
+    stub_template 'hyrax/file_sets/_versioning.html.erb' => 'Versioning form'
+    allow_any_instance_of(ActionView::Base).to receive(:curation_concern).and_return(file_set)
+  end
+
+  context 'with an adapter that allows for file versioning' do
+    before do
+      assign(:version_list, double('Hyrax::VersionListPresenter', supports_multiple_versions?: true))
+      render
+    end
+
+    it 'displays a versioning tab' do
+      expect(rendered).to have_selector('#edit_versioning_link', text: 'Versions')
+    end
+  end
+  context 'with an adapter that does not allow for file versioning' do
+    before do
+      assign(:version_list, double('Hyrax::VersionListPresenter', supports_multiple_versions?: false))
+      render
+    end
+
+    it 'does not display a versioning tab' do
+      expect(rendered).not_to have_selector('#edit_versioning_link', text: 'Versions')
+    end
+  end
+end


### PR DESCRIPTION
### Fixes

Fixes #7226

### Summary

Do not show a versions tab when versions are not supported by the persistence adapter

### Guidance for testing, such as acceptance criteria or new user interface behaviors:
After deploying this branch:
1. Go to [pg.nurax](https://pg.nurax.samvera.org/)
2. sign in as an admin user
3. go to a FileSet (e.g. [telegraph file set](https://pg.nurax.samvera.org/concern/parent/751c4fb2-6fbe-4e35-872d-deac59313b8c/file_sets/d5f1edf7-82b2-4b2d-8c78-252d1805f421)
4. Click on 'Edit this File Set'
5. Note the lack of a 'Versions' tab, and presence of 'Descriptions' and 'Permissions'

Go to [dev.nurax](https://dev.nurax.samvera.org/) and follow the same steps as above, replacing the FileSet with [Generic Work Copy 2 File Set](https://dev.nurax.samvera.org/concern/parent/df65v8113/file_sets/1544bp32g)

### Type of change (for release notes)
- `notes-bugfix` Bug Fixes

### Detailed Description
It is confusing to users to have an empty tab when a feature is not enabled. We should hide the tab, so users don't go down dead ends.

@samvera/hyrax-code-reviewers
