### PR TITLE
Backport - Squash flaky test bug - `.create` leads to non-unique index failures

### DIFF
--- a/spec/abilities/ability_spec.rb
+++ b/spec/abilities/ability_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe Hyrax::Ability do
   describe "can?(:review, :submissions)", :clean_repo do
     subject { ability.can?(:review, :submissions) }
 
-    let(:role) { Sipity::Role.create(name: role_name) }
+    let(:role) { Sipity::Role.find_or_create_by(name: role_name) }
     let(:user) { create(:user) }
     let(:permission_template) { create(:permission_template, with_active_workflow: true) }
     let(:workflow) { permission_template.active_workflow }
@@ -67,7 +67,7 @@ RSpec.describe Hyrax::Ability do
       let(:role_name) { 'depositing' }
 
       before do
-        Sipity::Role.create(name: 'approving')
+        Sipity::Role.find_or_create_by(name: 'approving')
         # Admin-ify the user
         allow(user).to receive_messages(groups: ['admin', 'registered'])
       end
@@ -79,7 +79,7 @@ RSpec.describe Hyrax::Ability do
       let(:role_name) { 'depositing' }
 
       before do
-        Sipity::Role.create(name: 'approving')
+        Sipity::Role.find_or_create_by(name: 'approving')
       end
 
       it { is_expected.to be false }

--- a/spec/forms/hyrax/forms/permission_template_form_spec.rb
+++ b/spec/forms/hyrax/forms/permission_template_form_spec.rb
@@ -162,7 +162,8 @@ RSpec.describe Hyrax::Forms::PermissionTemplateForm do
       end
 
       before do
-        role = Sipity::Role.create(name: 'approving')
+        # This should be a find or create or something similar
+        role = Sipity::Role.find_or_create_by(name: 'approving')
         workflow.workflow_roles.create(role: role)
         # We are testing that this workflow role is removed
         Hyrax::Workflow::PermissionGenerator.call(roles: role,
@@ -354,8 +355,8 @@ RSpec.describe Hyrax::Forms::PermissionTemplateForm do
     let(:attributes) { { workflow_id: workflow.id } }
     let(:workflow) { create(:workflow, permission_template: permission_template, active: true) }
     let(:user) { create(:user) }
-    let(:role1) { Sipity::Role.create!(name: 'hello') }
-    let(:role2) { Sipity::Role.create!(name: 'goodbye') }
+    let(:role1) { Sipity::Role.find_or_create_by!(name: 'hello') }
+    let(:role2) { Sipity::Role.find_or_create_by!(name: 'goodbye') }
 
     let(:permission_template) do
       create(:permission_template,

--- a/spec/models/sipity_spec.rb
+++ b/spec/models/sipity_spec.rb
@@ -114,7 +114,7 @@ RSpec.describe Sipity do
     end
 
     it "converts a string to a Sipity::Role if there exists a Sipity::Role with a name equal to the string" do
-      Sipity::Role.create!(name: 'hello')
+      Sipity::Role.find_or_create_by!(name: 'hello')
       expect(described_class.Role('hello')).to be_a(Sipity::Role)
     end
 

--- a/spec/services/hyrax/workflow/permission_generator_spec.rb
+++ b/spec/services/hyrax/workflow/permission_generator_spec.rb
@@ -3,7 +3,7 @@ module Hyrax
   module Workflow
     RSpec.describe PermissionGenerator do
       let(:user) { create(:user) }
-      let(:role) { Sipity::Role.create!(name: 'creating_user') }
+      let(:role) { Sipity::Role.find_or_create_by!(name: 'creating_user') }
       let(:workflow) { create(:workflow, name: 'workflow') }
       let(:workflow_state) { workflow.initial_workflow_state }
       let(:entity) do


### PR DESCRIPTION
Backport https://github.com/samvera/hyrax/pull/7242

Fix flaky test (some instances already fixed on main in https://github.com/samvera/hyrax/commit/728dafa6ce04df422ba50ca0b557bb29798610c8#diff-62b0bd08300a8ab94f2e3e2be02af06fbcb59193eb883b88efc96a01a981c262)

Creating the Sipity::Role in the spec leads to order-dependent test failure - `duplicate key value violates unique constraint "index_sipity_roles_on_name"`. `find_or_create_by` makes it idempotent and not order dependent.
