### PR TITLE
Sirenia depends on fcrepo

### DIFF
--- a/docker-compose-sirenia.yml
+++ b/docker-compose-sirenia.yml
@@ -23,6 +23,7 @@ services:
     depends_on:
       - worker
       - chrome
+      - fcrepo
       - fits
       - memcached
       - postgres
@@ -59,6 +60,7 @@ services:
       - VALKYRIE_METADATA_ADAPTER=fedora_metadata
       - VALKYRIE_STORAGE_ADAPTER=fedora_storage
     depends_on:
+      - fcrepo
       - fits
       - memcached
       - postgres


### PR DESCRIPTION
- This allows you do run `docker compose up web` successfully - otherwise fcrepo does not come up and the web pod dies

@samvera/hyrax-code-reviewers
