### PR TITLE
Use batching for adding file sets

### DIFF
--- a/lib/hyrax/transactions/steps/add_file_sets.rb
+++ b/lib/hyrax/transactions/steps/add_file_sets.rb
@@ -25,22 +25,33 @@ module Hyrax
         # @return [Dry::Monads::Result]
         def call(obj, uploaded_files: [], file_set_params: [])
           return Success(obj) if uploaded_files.empty? && file_set_params.blank? # Skip if no files to attach
-          if @handler.new(work: obj).add(files: uploaded_files, file_set_params: file_set_params).attach
-            if obj.lease || obj.embargo
-              file_sets = obj.member_ids.map do |member|
-                found = Hyrax.query_service.find_by(id: member)
-                found if found.is_a? Hyrax::FileSet
-              end.compact
 
-              # TODO: improve queries - Non performant to perform single queries. Perhaps queries ids then reject.
-              Hyrax::LeaseManager.create_or_update_lease_on_members(file_sets, obj) if obj.lease
-              Hyrax::EmbargoManager.create_or_update_embargo_on_members(file_sets, obj) if obj.embargo
-            end
+          uploaded_files.in_groups_of(5, false) do |uploaded_file_group|
+            handler = Hyrax::WorkUploadsHandler.new(work: obj).add(files: uploaded_file_group, file_set_params: file_set_params)
+            handler.attach
+          end
 
+          obj = Hyrax.query_service.find_by(id: obj.id)
+
+          update_embargoes_and_leases(obj)
+          if uploaded_files.size == obj.member_ids.size
             Success(obj)
           else
             Failure[:failed_to_attach_file_sets, uploaded_files]
           end
+        end
+
+        def update_embargoes_and_leases(obj)
+          return unless obj.lease || obj.embargo
+
+          file_sets = obj.member_ids.map do |member|
+            found = Hyrax.query_service.find_by(id: member)
+            found if found.is_a? Hyrax::FileSet
+          end.compact
+
+          # TODO: improve queries - Non performant to perform single queries. Perhaps queries ids then reject.
+          Hyrax::LeaseManager.create_or_update_lease_on_members(file_sets, obj) if obj.lease
+          Hyrax::EmbargoManager.create_or_update_embargo_on_members(file_sets, obj) if obj.embargo
         end
       end
     end

--- a/spec/hyrax/transactions/steps/add_file_sets_spec.rb
+++ b/spec/hyrax/transactions/steps/add_file_sets_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 require 'spec_helper'
 require 'hyrax/transactions'
+require 'hyrax/specs/shared_specs/simple_work'
 
 RSpec.describe Hyrax::Transactions::Steps::AddFileSets, valkyrie_adapter: :test_adapter do
   subject(:step) { described_class.new }
@@ -11,12 +12,14 @@ RSpec.describe Hyrax::Transactions::Steps::AddFileSets, valkyrie_adapter: :test_
   end
 
   context 'with uploaded files' do
-    let(:uploaded_files) { FactoryBot.create_list(:uploaded_file, 4) }
+    let(:uploaded_files) { FactoryBot.create_list(:uploaded_file, 16) }
 
     it 'attaches file_sets for the files' do
       expect(step.call(work, uploaded_files: uploaded_files).value!)
-        .to have_file_set_members(be_persisted, be_persisted,
-                                  be_persisted, be_persisted)
+        .to have_file_set_members(be_persisted, be_persisted, be_persisted, be_persisted,
+                                  be_persisted, be_persisted, be_persisted, be_persisted,
+                                  be_persisted, be_persisted, be_persisted, be_persisted,
+                                  be_persisted, be_persisted, be_persisted, be_persisted)
     end
   end
 end


### PR DESCRIPTION
- We were running into memory issues, and doing it in groups seems wiser anyway.
- We should probably make the batch size configurable with a sane default

### Fixes

Fixes #issuenumber ; refs #issuenumber

### Summary

Present tense short summary (50 characters or less)

### Guidance for testing, such as acceptance criteria or new user interface behaviors:
*
*
*

### Type of change (for release notes)

Add an appropriate `notes-*` label to the PR (or indicate here) that classifies this change.

Choose from:
- `notes-major` Major Changes (Potentially breaking changes)
- `notes-minor` New Features that are backward compatible
- `notes-deprecation` Deprecations
- `notes-bugfix` Bug Fixes
- `notes-valkyrie` Valkyrie Progress
- `notes-docs` Documentation
- `notes-container` Containerization related (Docker, Helm, etc)

### Detailed Description

More detailed description, if necessary. Try to be as descriptive as you can: even if you think that the PR content is obvious, it may not be obvious to others. Include tracebacks if helpful, and be sure to call out any bits of the PR that may be work-in-progress.

Description can have multiple paragraphs and you can use code examples inside:

``` ruby
class PostsController
  def index
    respond_with Post.limit(10)
  end
end
```

### Changes proposed in this pull request:
*
*
*

@samvera/hyrax-code-reviewers
