### PR TITLE
Changing fcrepo image to 6.5.1 official release

### DIFF
--- a/docker-compose-sirenia.yml
+++ b/docker-compose-sirenia.yml
@@ -109,7 +109,7 @@ services:
       - sirenia
 
   fcrepo:
-    image: fcrepo/fcrepo:6.5.1-RC3-tomcat9
+    image: fcrepo/fcrepo:6.5.1-tomcat9
     environment:
       - >-
         CATALINA_OPTS=-Dfcrepo.home=/fcrepo-home -Djava.awt.headless=true -Dfile.encoding=UTF-8


### PR DESCRIPTION
Backport https://github.com/samvera/hyrax/commit/665f810412b44320590930e745b129579f2eae70

Uses released version of Fedora 6 for Sirenia test app.