### PR TITLE
Stop using twitter url use x instead

### DIFF
--- a/app/views/hyrax/base/_social_media.html.erb
+++ b/app/views/hyrax/base/_social_media.html.erb
@@ -17,7 +17,7 @@
   <% end %>
 
   <!-- Sharingbutton Twitter -->
-  <%= link_to "https://twitter.com/intent/tweet/?#{{text: page_title, url: share_url}.to_param}", 'aria-label': t(:'hyrax.base.social_media.twitter_share'), class: 'resp-sharing-button__link', target: '_blank', rel: 'noopener noreferrer', title: t('hyrax.base.social_media.twitter') do %>
+  <%= link_to "https://x.com/intent/tweet/?#{{text: page_title, url: share_url}.to_param}", 'aria-label': t(:'hyrax.base.social_media.twitter_share'), class: 'resp-sharing-button__link', target: '_blank', rel: 'noopener noreferrer', title: t('hyrax.base.social_media.twitter') do %>
     <div class="resp-sharing-button resp-sharing-button--twitter resp-sharing-button--small"><div aria-hidden="true" class="resp-sharing-button__icon resp-sharing-button__icon--solid">
       <svg version="1.1" x="0px" y="0px" width="24px" height="24px" viewBox="0 0 24 24" enable-background="new 0 0 24 24" xml:space="preserve">
           <title><%= t(:'hyrax.base.social_media.twitter_share') %></title>

--- a/app/views/hyrax/users/_user_info.html.erb
+++ b/app/views/hyrax/users/_user_info.html.erb
@@ -17,7 +17,7 @@
 
 <% if user.twitter_handle.present? %>
   <dt><span class="fa fa-twitter" aria-hidden="true"></span> Twitter Handle</dt>
-  <dd><%= link_to user.twitter_handle, "http://twitter.com/#{user.twitter_handle}", {target:'_blank'} %></dd>
+  <dd><%= link_to user.twitter_handle, "http://x.com/#{user.twitter_handle}", {target:'_blank'} %></dd>
 <% end %>
 
 <% if user.linkedin_handle.present? %>

--- a/spec/features/users_spec.rb
+++ b/spec/features/users_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe "User Profile", type: :feature do
       fill_in 'user_twitter_handle', with: 'curatorOfData'
       click_button 'Save Profile'
       expect(page).to have_content 'Your profile has been updated'
-      expect(page).to have_link('curatorOfData', href: 'http://twitter.com/curatorOfData')
+      expect(page).to have_link('curatorOfData', href: 'http://x.com/curatorOfData')
     end
   end
 

--- a/spec/features/work_show_spec.rb
+++ b/spec/features/work_show_spec.rb
@@ -171,7 +171,7 @@ RSpec.describe "work show view" do
         expect(page).not_to have_selector "form#fileupload"
 
         # has some social media buttons
-        expect(page).to have_link '', href: "https://twitter.com/intent/tweet/?#{page_title}&url=#{CGI.escape(app_host)}%2Fconcern%2Fgeneric_works%2F#{work.id}"
+        expect(page).to have_link '', href: "https://x.com/intent/tweet/?#{page_title}&url=#{CGI.escape(app_host)}%2Fconcern%2Fgeneric_works%2F#{work.id}"
 
         # exports EndNote
         expect(page).to have_link 'EndNote'

--- a/spec/views/hyrax/base/_social_media.html.erb_spec.rb
+++ b/spec/views/hyrax/base/_social_media.html.erb_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe 'hyrax/base/_social_media.html.erb', type: :view do
   it 'renders various social media share links' do
     expect(page).to have_selector '.resp-sharing-button__link'
     expect(page).to have_link '', href: 'https://facebook.com/sharer/sharer.php?u=http%3A%2F%2Fexample.com%2F'
-    expect(page).to have_link '', href: 'https://twitter.com/intent/tweet/?text=Example&url=http%3A%2F%2Fexample.com%2F'
+    expect(page).to have_link '', href: 'https://x.com/intent/tweet/?text=Example&url=http%3A%2F%2Fexample.com%2F'
     expect(page).to have_link '', href: 'https://www.tumblr.com/widgets/share/tool?canonicalUrl=http%3A%2F%2Fexample.com%2F&posttype=link&shareSource=tumblr_share_button'
   end
 


### PR DESCRIPTION
### Fixes

Related to [#7066](https://github.com/samvera/hyrax/issues/7066)

### Summary
Repalces urls twitter.com with x.com

### Guidance for testing, such as acceptance criteria or new user interface behaviors:
* new links still work

### Type of change (for release notes)
Is there something less than notes minor. This change seems less than minor.
I saw other small PRs don't have this like https://github.com/samvera/hyrax/pull/7224
I don't think this needs to be mentioned in release notes. 

### Detailed Description
This is a very small minor change, i am not even sure if it qualifies as a minor change.
Repalces urls twitter.com with x.com

### Changes proposed in this pull request:
* Repalces urls twitter.com with x.com

