### PR TITLE
Deterministic jobs

### DIFF
--- a/config/features.rb
+++ b/config/features.rb
@@ -8,6 +8,10 @@ Flipflop.configure do
   strategy Hyrax::Strategies::YamlStrategy, config: Hyrax.config.feature_config_path
   strategy :default
 
+  feature :deterministic_jobs,
+          default: false,
+          description: "Run child jobs inline when called from a parent job"
+
   feature :proxy_deposit,
           default: true,
           description: "Depositors may designate proxies to deposit works on their behalf"


### PR DESCRIPTION
## DO NOT MERGE!

### Summary

Preliminary WIP to explore potential speed improvements from not running background jobs within background jobs.

Adds a feature flipper `deterministic_jobs`:
**off**: run jobs without modification (no change)
**on**: avoid queuing jobs when caller is already running in a backgorund worker
