### PR TITLE
🐛 Metadata properties respond to view key

### DIFF
--- a/app/services/hyrax/schema_loader.rb
+++ b/app/services/hyrax/schema_loader.rb
@@ -83,7 +83,9 @@ module Hyrax
       # @return [Hash{Symbol => Object}]
       def view_options
         # prefer display_label over view:label for labels, make available in the view
-        @view_options = config.fetch('view', {})&.with_indifferent_access || {}
+        @view_options = config.fetch('view', {})&.with_indifferent_access
+        # if the metadata property does not have a `view` key, the property should not be displayed
+        return {} if @view_options.blank?
         Deprecation.warn(self, 'view: label is deprecated, use display_label instead') if @view_options[:label].present?
         @view_options.delete(:label)
         @view_options[:display_label] = display_label


### PR DESCRIPTION
If a flexible metadata property does not have a `view` key, it should not be displayed in the UI. If there is no `view` key, the view_options method should return an empty hash which will ensure the view_definitions_for method in the M3SchemaLoader does not include the name of the property in the returned hash.

Before:
<img width="1504" height="938" alt="Screenshot 2025-11-04 at 1 16 03 PM" src="https://github.com/user-attachments/assets/fd067025-ca12-4891-bfa3-72d90a4bfc37" />

After:

<img width="1529" height="903" alt="Screenshot 2025-11-04 at 1 18 12 PM" src="https://github.com/user-attachments/assets/00774e5f-3dda-4abd-b074-f47eed00b95a" />



@samvera/hyrax-code-reviewers
