### PR TITLE
🐛 Metadata properties respond to view key

### DIFF
--- a/app/services/hyrax/m3_schema_loader.rb
+++ b/app/services/hyrax/m3_schema_loader.rb
@@ -11,7 +11,8 @@ module Hyrax
     def view_definitions_for(schema:, version: 1, contexts: nil)
       definitions(schema, version, contexts).each_with_object({}) do |definition, hash|
         view_options = definition.view_options
-        next if view_options.without(:display_label).empty?
+        # display_label and admin_only keys are always added to the view_options hash
+        next if view_options.without(:display_label).without(:admin_only).empty?
 
         hash[definition.name] = definition.view_options
       end


### PR DESCRIPTION
If a flexible metadata property does not have a `view` key, it should 
not be displayed on the index or the show page. If there is no `view` key, the
view_definitions_for method in the M3SchemaLoader will not include the 
name of the property in the returned hash.

Before:

<img width="1504" height="938" alt="Screenshot 2025-11-04 at 1 16 03 PM" src="https://github.com/user-attachments/assets/fd067025-ca12-4891-bfa3-72d90a4bfc37" />

After:

<img width="1529" height="903" alt="Screenshot 2025-11-04 at 1 18 12 PM" src="https://github.com/user-attachments/assets/00774e5f-3dda-4abd-b074-f47eed00b95a" />

Ref:
- https://github.com/samvera/hyku/issues/2774

@samvera/hyrax-code-reviewers
