### PR TITLE
Fix collection creation with flexible metadata (#7283)

### DIFF
--- a/app/controllers/hyrax/dashboard/collections_controller.rb
+++ b/app/controllers/hyrax/dashboard/collections_controller.rb
@@ -623,7 +623,10 @@ module Hyrax
       end
 
       def after_create_errors(errors) # for valkyrie
+        collection_type_id = params[:collection_type_id].presence || default_collection_type.id
+        @collection.collection_type_gid = CollectionType.find(collection_type_id).to_global_id
         return after_create_errors_for_active_fedora(errors) if @collection.is_a? ActiveFedora::Base
+
         respond_to do |wants|
           wants.html do
             flash[:error] = errors.to_s

--- a/app/forms/hyrax/forms/pcdm_collection_form.rb
+++ b/app/forms/hyrax/forms/pcdm_collection_form.rb
@@ -33,7 +33,7 @@ module Hyrax
         end
       end
 
-      property :depositor, required: true
+      property :depositor
       property :collection_type_gid, required: true
       property :visibility, default: VisibilityIntention::PRIVATE
 

--- a/spec/forms/hyrax/forms/pcdm_collection_form_spec.rb
+++ b/spec/forms/hyrax/forms/pcdm_collection_form_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Hyrax::Forms::PcdmCollectionForm do
   describe '.required_fields' do
     it 'lists required fields' do
       expect(described_class.required_fields)
-        .to contain_exactly(:title, :collection_type_gid, :depositor)
+        .to contain_exactly(:title, :collection_type_gid)
     end
   end
 


### PR DESCRIPTION
### Fixes

Fixes #7262 

### Summary

Fix collection creation with flexible metadata

### Guidance for testing, such as acceptance criteria or new user interface behaviors:
* In a flexible metadata environment, create a collection
* Collection should create

### Detailed Description

This commit will address the bug where collection creation with flexible metadata throws a `URI::InvalidURIError`.  This error is actually misleading because what's happening is that when the form fails to validate, it rerenders the new page but doesn't set the necessary `collection_type_gid` that a normal new action would do.  The real problem is that when using flexible metadata, validation fails because depositor is not set in the form.

`Hyrax::FlexibleFormBehavior#validate_flexible_required_fields` (which only runs when using flexible metadata) dynamically adds depositor as a required field to the form instance.  Since depositor is not set in the form params, validation fails.

This commit removes depositor from the flexible required fields since `Hyrax::Transactions::Steps::SetUserAsDepositor` already handles setting the depositor automatically.

### Changes proposed in this pull request:
* Remove `depositor` from required_fields that `Hyrax::FlexibleFormBehavior#validate_flexible_required_fields` sniffs out and instead let it be automatically set in `Hyrax::Transactions::Steps::SetUserAsDepositor` 
