### PR TITLE
Fix RSpec deprecation warning

### DIFF
--- a/spec/support/matchers/pcdm_matchers.rb
+++ b/spec/support/matchers/pcdm_matchers.rb
@@ -15,7 +15,7 @@ RSpec::Matchers.define :have_attached_files do |*expected_files|
       values_match?(expected_files, @actual_files)
   end
 
-  failure_message_for_should do |actual_file_set|
+  failure_message do |actual_file_set|
     if expected_files.empty?
       "Expected #{actual_file_set} to have at least one file.\n" \
       "Found #{@actual_files}."


### PR DESCRIPTION
### Summary
Running the test suite gives the following deprecation warning:
```
Deprecation Warnings:

`failure_message_for_should` is deprecated. Use `failure_message` instead.
Called from /app/samvera/hyrax-engine/spec/support/matchers/pcdm_matchers.rb:18:in `block in <top (required)>'.
```

### Changes proposed in this pull request:
Update the matcher code as indicated by the deprecation warning.

@samvera/hyrax-code-reviewers
