### PR TITLE
Override hydra-editor screen reader text to 'this field' for accessib…

### DIFF
--- a/app/assets/javascripts/hyrax.js
+++ b/app/assets/javascripts/hyrax.js
@@ -94,3 +94,4 @@
 
 // this needs to be after batch_select so that the form ids get setup correctly
 //= require hyrax/batch_edit
+//= require hyrax/hydra_editor_override

--- a/app/assets/javascripts/hyrax/hydra_editor_override.js
+++ b/app/assets/javascripts/hyrax/hydra_editor_override.js
@@ -1,0 +1,6 @@
+// app/assets/javascripts/hyrax/hydra_editor_override.js
+$(document).on('ready page:load turbolinks:load', function() {
+  $('.remove .sr-only').each(function() {
+    $(this).html('this <span class="controls-field-name-text">field</span>');
+  });
+});


### PR DESCRIPTION
Accessibility fix for screen reader text in hydra-editor (#7238)

### Fixes

Fixes #7238 ; refs #7238

### Summary

Override hydra-editor screen reader text to "this" for accessibility

### Guidance for testing, such as acceptance criteria or new user interface behaviors:
* The screen reader text for the remove button should now say "this" instead of "previous".
* Test with a screen reader to confirm the updated text is announced.
* Ensure the change appears on all relevant forms where hydra-editor is used.

### Type of change (for release notes)

`notes-bugfix` Bug Fixes

### Detailed Description

This PR adds a JavaScript override to update the screen reader text for the remove button in hydra-editor fields. Previously, the text read "previous", which was confusing for users relying on assistive technology. The override changes the text to "this" for clarity and improved accessibility.

The change is implemented in `app/assets/javascripts/hyrax/hydra_editor_override.js` and loaded via the asset pipeline. No changes were made to the hydra-editor gem itself.

### Changes proposed in this pull request:
* Add `hyrax/hydra_editor_override.js` to override screen reader text
* Update asset manifest to load the override after hydra-editor

@samvera/hyrax-code-reviewers
