### PR TITLE
Speed up the IIIF Manifest feature test

### DIFF
--- a/spec/features/iiif_manifest_spec.rb
+++ b/spec/features/iiif_manifest_spec.rb
@@ -1,76 +1,44 @@
 # frozen_string_literal: true
 require 'rails_helper'
 
-RSpec.describe 'building a IIIF Manifest', :clean_repo do
-  let(:work) { valkyrie_create(:comet_in_moominland, :public, description: ['a novel about moomins']) }
+RSpec.describe 'building a IIIF Manifest', :aggregate_failures do
+  let(:work) { valkyrie_create(:comet_in_moominland, :public, description: ['a novel about moomins'], members: children) }
+  let(:children) { valkyrie_create_list(:monograph, 1, members: file_sets) + file_sets }
   let(:user) { create(:admin) }
-  let(:file_path) { fixture_path + '/world.png' }
-  let(:original_file) { File.open(file_path) }
-  let(:uploaded_file) { FactoryBot.create(:uploaded_file, file: original_file) }
-  let(:persister) { Hyrax.persister }
-
-  before do
-    2.times { build_a_child_work }
-    12.times { build_a_file_set_with_an_image }
-    persister.save(resource: work)
-    Hyrax.index_adapter.save(resource: work)
-
-    sign_in user
+  let(:uploaded_file) { FactoryBot.create(:uploaded_file, file: file_fixture('world.png').open) }
+  let(:file_sets) do
+    valkyrie_create_list(:hyrax_file_set, 1) .map do |file_set|
+      valkyrie_create(:hyrax_file_metadata, :original_file, :image, :with_file, original_filename: 'world.png', file_set: file_set, file: uploaded_file)
+      Hyrax.persister.save(resource: file_set)
+    end
   end
 
   it 'gets a full manifest for the work' do
-    manifest_json = load_manifest_check_standards
-    expect(manifest_json['sequences']).not_to be_empty
-
-    sequence = manifest_json['sequences'].first
-
-    # 12 file sets, plus 2 child works with 2 file sets each
-    expect(sequence['canvases'].count).to eq 16
-  end
-
-  context 'with a user missing read permissions on children' do
-    let(:user) { create(:user) }
-
-    before do
-      work.permission_manager.read_users = [user]
-      persister.save(resource: work)
-    end
-
-    it 'generates a bare manifest' do
-      manifest_json = load_manifest_check_standards
-      expect(manifest_json).not_to have_key 'sequences'
-    end
-  end
-
-  def build_a_child_work
-    first_file_set = valkyrie_create(:hyrax_file_set)
-    second_file_set = valkyrie_create(:hyrax_file_set)
-    valkyrie_create(:hyrax_file_metadata, :original_file, :image, :with_file, original_filename: 'world.png', file_set: first_file_set, file: uploaded_file)
-    valkyrie_create(:hyrax_file_metadata, :original_file, :image, :with_file, original_filename: 'world.png', file_set: second_file_set, file: uploaded_file)
-    [first_file_set, second_file_set].each { |fs| persister.save(resource: fs) }
-    child_work = valkyrie_create(:monograph,
-                                 members: [first_file_set, second_file_set],
-                                 title: ['supplemental object'],
-                                 creator: ['Author, Samantha'],
-                                 description: ['supplemental materials'])
-    work.member_ids += [child_work.id]
-  end
-
-  def build_a_file_set_with_an_image
-    file_set = valkyrie_create(:hyrax_file_set, title: ['page n'], creator: ['Jansson, Tove'], description: ['the nth page'])
-    valkyrie_create(:hyrax_file_metadata, :original_file, :image, :with_file, original_filename: 'world.png', file_set: file_set, file: uploaded_file)
-    persister.save(resource: file_set)
-    work.member_ids += [file_set.id]
-  end
-
-  def load_manifest_check_standards
+    sign_in user # admins have access to public and private resources
     visit "/concern/generic_works/#{work.id}/manifest"
-
-    # maybe validate this with https://github.com/IIIF/presentation-validator/blob/master/schema/iiif_3_0.json ?
     manifest_json = JSON.parse(page.body)
 
     expect(manifest_json['label']).to eq 'Comet in Moominland'
     expect(manifest_json['description']).to contain_exactly('a novel about moomins')
-    manifest_json
+
+    expect(manifest_json['sequences'].size).to eq 1
+
+    sequence = manifest_json['sequences'].first
+
+    # 1 file set, plus child work with 1 file set = 2 canvases (i.e. images)
+    expect(sequence['canvases'].count).to eq 2
+  end
+
+  context 'with a user missing read permissions on children' do
+    let(:children) { file_sets }
+
+    it 'generates a bare manifest' do
+      logout # unauthenticated users do not have access to private resources
+      visit "/concern/generic_works/#{work.id}/manifest"
+      manifest_json = JSON.parse(page.body)
+
+      expect(manifest_json['label']).to eq 'Comet in Moominland'
+      expect(manifest_json).not_to have_key 'sequences'
+    end
   end
 end


### PR DESCRIPTION
### Fixes

The IIIF manifest feature tests are extremely slow.

### Summary
The IIIF test setup created 3 works, and 12 additional file sets, all persisted to disk for the test. Only a single resource of each type is needed for the primary test. We need to persist an even smaller set of items for the access restriction test.

### Changes proposed in this pull request
Refactor the test to avoid creating unnecessary test objects. Also use factories where possible rather than manually constructing resources. We also do not need to clear the repository for this test.

#### TEST SPEED BEFORE *(over 5 minutes!!!)*
```
Slowest examples
  building a IIIF Manifest with a user missing read permissions on children generates a bare manifest
    ./spec/features/iiif_manifest_spec.rb:39
    162.382843552 seconds
  building a IIIF Manifest gets a full manifest for the work
    ./spec/features/iiif_manifest_spec.rb:21
    153.629054135 seconds

Finished in 5 minutes 18 seconds (files took 13.1 seconds to load)
2 examples, 0 failures
```

#### TEST SPEED AFTER *(more than 5 times faster)*
```
Slowest examples
  building a IIIF Manifest gets a full manifest for the work
    ./spec/features/iiif_manifest_spec.rb:23
    32.677574705 seconds
  building a IIIF Manifest with a user missing read permissions on children generates a bare manifest
    ./spec/features/iiif_manifest_spec.rb:42
    14.026897021 seconds

Finished in 48.9 seconds (files took 13.47 seconds to load)
2 examples, 0 failures
```

@samvera/hyrax-code-reviewers
