### PR TITLE
Pull relevant work from 5.0-flexible for OAI mappings

### DIFF
--- a/app/models/concerns/hyrax/solr_document_behavior.rb
+++ b/app/models/concerns/hyrax/solr_document_behavior.rb
@@ -82,7 +82,7 @@ module Hyrax
 
     # Method to return the model
     def hydra_model(classifier: nil)
-      valkyrie_model = "#{hydra_model_name}Resource".safe_constantize if Hyrax.config.valkyrie_transition
+      valkyrie_model = "#{hydra_model_name}Resource".safe_constantize if Hyrax.config.valkyrie_transition?
 
       valkyrie_model ||
         hydra_model_name&.safe_constantize ||

--- a/app/models/hyrax/flexible_schema.rb
+++ b/app/models/hyrax/flexible_schema.rb
@@ -37,6 +37,20 @@ class Hyrax::FlexibleSchema < ApplicationRecord
     []
   end
 
+  # Retrieve the required data to use for mappings
+  def self.mappings_data_for(mapping = 'simple_dc_pmh')
+    # for OAI-PMH we need the mappings and indexing info
+    # for properties with the specified mapping
+    return {} unless current_version
+    current_version['properties'].each_with_object({}) do |(key, values), obj|
+      next unless values['mappings'] && values['mappings'][mapping]
+      obj[key] = {
+        'indexing' => values['indexing'],
+        'mappings' => { mapping => values['mappings'][mapping] }
+      }
+    end
+  end
+
   def update_contexts
     self.contexts = profile['contexts']
   end

--- a/spec/models/hyrax/flexible_schema_spec.rb
+++ b/spec/models/hyrax/flexible_schema_spec.rb
@@ -33,4 +33,40 @@ RSpec.describe Hyrax::FlexibleSchema, type: :model do
       end
     end
   end
+
+  describe '#mappings_data_for' do
+    before do
+      allow(described_class).to receive(:current_version).and_return(subject.profile)
+    end
+
+    context 'when mapping exists' do
+      let(:mapping_data) { described_class.mappings_data_for('simple_dc_pmh') }
+      let(:result_data) do
+        { "title" => { "indexing" => ["title_sim", "title_tesim"],
+                       "mappings" => { "simple_dc_pmh" => "dc:title" } } }
+      end
+
+      it 'returns the correct mappings data' do
+        expect(mapping_data).to eq(result_data)
+      end
+    end
+
+    context 'when mapping does not exist' do
+      it 'returns an empty hash' do
+        mapping_data = described_class.mappings_data_for('non_existent_mapping')
+        expect(mapping_data).to eq({})
+      end
+    end
+
+    context 'when profile does not exist' do
+      before do
+        allow(described_class).to receive(:current_version).and_return(nil)
+      end
+
+      it 'returns an empty hash' do
+        mapping_data = described_class.mappings_data_for('simple_dc_pmh')
+        expect(mapping_data).to eq({})
+      end
+    end
+  end
 end


### PR DESCRIPTION
### Fixes

Refs https://github.com/samvera/hyrax/pull/7297

### Summary

Adds new mappings_data_for method to extract mappings from profile to be used for OAI-PMH. 

For OAI-PMH we need the mappings and indexing info for properties with the specified mapping. The result of this will be used to configure the OAI-PMH provider with the flexible metadata.

Includes a bugfix to correctly load hydra_model in the solr document when using valkyrie_transition.
