### PR TITLE
Handle Blacklight::Base deprecation warnings

### DIFF
--- a/app/controllers/concerns/hyrax/collections_controller_behavior.rb
+++ b/app/controllers/concerns/hyrax/collections_controller_behavior.rb
@@ -3,7 +3,8 @@ module Hyrax
   module CollectionsControllerBehavior
     extend ActiveSupport::Concern
     include Blacklight::AccessControls::Catalog
-    include Blacklight::Base
+    include Blacklight::Configurable
+    include Blacklight::SearchContext
 
     included do
       # include the display_trophy_link view helper method

--- a/app/controllers/concerns/hyrax/works_controller_behavior.rb
+++ b/app/controllers/concerns/hyrax/works_controller_behavior.rb
@@ -4,7 +4,8 @@ require 'iiif_manifest'
 module Hyrax
   module WorksControllerBehavior
     extend ActiveSupport::Concern
-    include Blacklight::Base
+    include Blacklight::Configurable
+    include Blacklight::SearchContext
     include Blacklight::AccessControls::Catalog
     include Hyrax::FlexibleSchemaBehavior if Hyrax.config.flexible?
     include Hyrax::EnsureMigratedBehavior

--- a/app/controllers/hyrax/dashboard/collections_controller.rb
+++ b/app/controllers/hyrax/dashboard/collections_controller.rb
@@ -4,7 +4,8 @@ module Hyrax
     ## Shows a list of all collections to the admins
     class CollectionsController < Hyrax::My::CollectionsController
       include Blacklight::AccessControls::Catalog
-      include Blacklight::Base
+      include Blacklight::Configurable
+      include Blacklight::SearchContext
       include Hyrax::FlexibleSchemaBehavior if Hyrax.config.collection_flexible?
       include Hyrax::EnsureMigratedBehavior
 

--- a/app/controllers/hyrax/dashboard/nest_collections_controller.rb
+++ b/app/controllers/hyrax/dashboard/nest_collections_controller.rb
@@ -4,7 +4,8 @@ module Hyrax
     ##
     # @api public
     class NestCollectionsController < ApplicationController
-      include Blacklight::Base
+      include Blacklight::Configurable
+      include Blacklight::SearchContext
 
       class_attribute :form_class, :new_collection_form_class
       self.form_class = Hyrax::Forms::Dashboard::NestCollectionForm

--- a/app/controllers/hyrax/dashboard_controller.rb
+++ b/app/controllers/hyrax/dashboard_controller.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 module Hyrax
   class DashboardController < ApplicationController
-    include Blacklight::Base
+    include Blacklight::Configurable
+    include Blacklight::SearchContext
     include Hyrax::Breadcrumbs
     with_themed_layout 'dashboard'
     before_action :authenticate_user!

--- a/app/controllers/hyrax/file_sets_controller.rb
+++ b/app/controllers/hyrax/file_sets_controller.rb
@@ -3,7 +3,8 @@ module Hyrax
   class FileSetsController < ApplicationController
     rescue_from WorkflowAuthorizationException, with: :render_unavailable
 
-    include Blacklight::Base
+    include Blacklight::Configurable
+    include Blacklight::SearchContext
     include Blacklight::AccessControls::Catalog
     include Hyrax::Breadcrumbs
     include Hyrax::FlexibleSchemaBehavior if Hyrax.config.file_set_flexible?

--- a/app/controllers/hyrax/single_use_links_viewer_controller.rb
+++ b/app/controllers/hyrax/single_use_links_viewer_controller.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 module Hyrax
   class SingleUseLinksViewerController < DownloadsController
-    include Blacklight::Base
+    include Blacklight::Configurable
+    include Blacklight::SearchContext
     include Blacklight::AccessControls::Catalog
     include ActionDispatch::Routing::PolymorphicRoutes
 


### PR DESCRIPTION
### Summary
We're getting a number of Blacklight Deprecation Warnings for `Blacklight::Base`

### Fixes
```
DEPRECATION WARNING: Blacklight::Base is deprecated and will be removed in Blacklight 8.0.0.
	Include Blacklight::Configurable and Blacklight::SearchContext as needed
        (included in CatalogController).
        (called from include at /app/samvera/hyrax-webapp/app/controllers/catalog_controller.rb:3)
```

### Changes proposed in this pull request:
Replace the included modules as indicated in the deprecation warning.

@samvera/hyrax-code-reviewers
