### PR TITLE
changed the color of the badge_color to a more compliant color for ac…

### DIFF
--- a/app/utils/hyrax/required_data_seeders/collection_type_seeder.rb
+++ b/app/utils/hyrax/required_data_seeders/collection_type_seeder.rb
@@ -20,7 +20,7 @@ module Hyrax
           logger.info("   #{as_ct.title} -- FOUND OR CREATED")
 
           user_ct = Hyrax::CollectionType.find_or_create_default_collection_type
-          set_badge_color(user_ct, '#0099cc')
+          set_badge_color(user_ct, '#007EA8')
           logger.info("   #{user_ct.title} -- FOUND OR CREATED")
         end
 


### PR DESCRIPTION
### Fixes

Fixes #7108 ; refs #7108

### Summary

Improve accessibility of the "User Collection" badge color to meet WCAG 2.2 AA contrast requirements.

### Guidance for testing, such as acceptance criteria or new user interface behaviors:
* The "User Collection" badge now uses color #007EA8 for improved contrast and accessibility.
* The badge color passes automated accessibility checkers (e.g., Siteimprove).

### Type of change (for release notes)

`notes-bugfix` Bug Fixes

### Detailed Description

This PR updates the badge color for the default "User Collection" type to ensure it meets accessibility standards:
- Changes the badge color from #0099cc to #007EA8 based on accessibility checker feedback.
- Aligns with recommendations in the issue report and UI review.

### Changes proposed in this pull request:
* Update badge color for "User Collection" type in the collection type seeder.

@samvera/hyrax-code-reviewers
