### PR TITLE
Handle old and new style Deprecation#warn calls

### DIFF
--- a/config/initializers/deprecation_patch.rb
+++ b/config/initializers/deprecation_patch.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+#
+# OVERRIDE deprecation v1.1.0  – handle calls using either the deprecation gem method signature
+#                                or newer Rails method signatues.
+#                                see: https://github.com/samvera/hyrax/issues/7303
+# Remove when: dependencies no longer pull in the deprecation gem
+
+module Deprecation
+  module DeprecationWarningPatch
+    def warn(*args)
+      # if the first argument being passed is a string,
+      # the caller is using the Rails-style siganture,
+      # so we need to pass a dummy first argument to
+      # the older gem method
+      if args.first.is_a?(String)
+        super(nil, *args)
+      else
+        super(*args)
+      end
+    end
+  end
+end
+
+using_deprecation_gem = Object.const_source_location('Deprecation').first.match?('gems/deprecation')
+
+# Only patch if we're using the separate deprecation gem
+Deprecation.singleton_class.prepend(Deprecation::DeprecationWarningPatch) if using_deprecation_gem


### PR DESCRIPTION
### Summary
The code (and dependencies) use a mix of signatures to call the Deprecation#warn method. In some cases, this swallows the text of the warning.

### Changes proposed in this pull reques
Patch the method to inspect arguments and ensure they get passed in the correct positions to the older method provided by the gem.

#### BEFORE
```
DEPRECATION WARNING: You are using deprecated behavior which will be removed from the next major or minor release.
          (called from <class:Work> at /app/samvera/hyrax-engine/app/models/hyrax/work.rb:98)
```

#### AFTER
```
DEPRECATION WARNING:  globally including `Hyrax::Schema(:core_metadata)` at the work level is deprecated.
          Add `include Hyrax::Schema(:core_metadata)` to your individual work classes or set
          up flexible metadata, then set `work_default_metadata = false` in config/hyrax.rb to remove this warning.
          (called from <class:Work> at /app/samvera/hyrax-engine/app/models/hyrax/work.rb:98)
```
### References
* https://github.com/samvera/hyrax/issues/7303
* https://github.com/samvera/maintenance/issues/175

@samvera/hyrax-code-reviewers
