### PR TITLE
Update deprecation calls to use new call signature

### DIFF
--- a/app/controllers/hyrax/dashboard/collections_controller.rb
+++ b/app/controllers/hyrax/dashboard/collections_controller.rb
@@ -446,7 +446,7 @@ module Hyrax
         # TODO: REMOVE in 3.0 - part of deprecation of permission attributes
         permissions = attributes.delete("permissions_attributes")
         return [] unless permissions
-        Deprecation.warn(self, "Passing in permissions_attributes parameter with a new collection is deprecated and support will be removed from Hyrax 3.0. " \
+        Deprecation.warn("Passing in permissions_attributes parameter with a new collection is deprecated and support will be removed from Hyrax 3.0. " \
                                "Use Hyrax::PermissionTemplate instead to grant Manage, Deposit, or View access.")
         participants = []
         permissions.each do |p|

--- a/app/models/hyrax/virus_scanner.rb
+++ b/app/models/hyrax/virus_scanner.rb
@@ -56,7 +56,7 @@ module Hyrax
     end
 
     def clam_av_scanner
-      Deprecation.warn(self, "ClamAV support has been deprecated. Please use Clamby instead.")
+      Deprecation.warn("ClamAV support has been deprecated. Please use Clamby instead.")
       scan_result = ClamAV.instance.method(:scanfile).call(file)
       return false if scan_result.zero?
       warning "A virus was found in #{file}: #{scan_result}"

--- a/app/services/hyrax/callbacks.rb
+++ b/app/services/hyrax/callbacks.rb
@@ -48,7 +48,7 @@ module Hyrax
 
       # Defines a callback for a given hook.
       def set(hook, warn: true, &block)
-        Deprecation.warn(self, warning_for_set) if warn
+        Deprecation.warn(warning_for_set) if warn
         raise NoBlockGiven, "a block is required when setting a callback" unless block_given?
         @callbacks[hook] = proc(&block)
       end
@@ -60,7 +60,7 @@ module Hyrax
 
       # Runs the callback defined for a given hook, with the arguments provided
       def run(hook, *args, warn: true, **opts)
-        Deprecation.warn(self, warning_for_run) if warn
+        Deprecation.warn(warning_for_run) if warn
         raise NotEnabled unless enabled?(hook)
         return nil unless set?(hook)
         @callbacks[hook].call(*args, **opts)

--- a/app/services/hyrax/schema_loader.rb
+++ b/app/services/hyrax/schema_loader.rb
@@ -84,7 +84,7 @@ module Hyrax
       def view_options
         # prefer display_label over view:label for labels, make available in the view
         @view_options = config.fetch('view', {})&.with_indifferent_access || {}
-        Deprecation.warn(self, 'view: label is deprecated, use display_label instead') if @view_options[:label].present?
+        Deprecation.warn('view: label is deprecated, use display_label instead') if @view_options[:label].present?
         @view_options.delete(:label)
         @view_options[:display_label] = display_label
         @view_options[:admin_only] = admin_only?

--- a/app/services/hyrax/search_service.rb
+++ b/app/services/hyrax/search_service.rb
@@ -10,7 +10,7 @@ module Hyrax
 
     def method_missing(method_name, *arguments, &block)
       if scope&.respond_to?(method_name)
-        Deprecation.warn(self.class, "Calling `#{method_name}` on scope " \
+        Deprecation.warn("Calling `#{method_name}` on scope " \
           'is deprecated and will be removed in Blacklight 8. Call #to_h first if you ' \
           ' need to use hash methods (or, preferably, use your own SearchState implementation)')
         scope&.public_send(method_name, *arguments, &block)

--- a/app/services/hyrax/solr_service.rb
+++ b/app/services/hyrax/solr_service.rb
@@ -39,7 +39,7 @@ module Hyrax
 
     def instance
       # Deprecation warning for calling from outside of the Hyrax::SolrService class
-      Deprecation.warn(self, rsolr_call_warning) unless caller[1].include?("#{self.class.name.underscore}.rb")
+      Deprecation.warn(rsolr_call_warning) unless caller[1].include?("#{self.class.name.underscore}.rb")
 
       @old_service.instance
     end


### PR DESCRIPTION
### RELATED TO
* https://github.com/samvera/hyrax/issues/7303
* https://github.com/samvera/maintenance/issues/175

### DETAILS
* Old signature takes 3 positional arguments: https://github.com/cbeer/deprecation/blob/v1.1.0/lib/deprecation/reporting.rb#L12 ``` def warn(context, message = nil, callstack = nil) ```

* New signature only takes 2 arguments(so positions change): https://github.com/rails/rails/blob/v6.0.0/activesupport/lib/active_support/deprecation/reporting.rb#L18 ``` def warn(message = nil, callstack = nil) ```

@samvera/hyrax-code-reviewers
