### PR TITLE
Admin Set Create Form For Valkyrie - main version

### DIFF
--- a/app/presenters/hyrax/google_scholar_presenter.rb
+++ b/app/presenters/hyrax/google_scholar_presenter.rb
@@ -82,5 +82,44 @@ module Hyrax
     def title
       Array(object.try(:title)).sort.first || ""
     end
+
+    ##
+    # @return [String] a string representing the degree granting institution(s)
+    #   as a semicolon delimited list
+    def degree_grantor
+      Array(object.try(:degree_grantor)).join('; ')
+    end
+
+    ##
+    # @return [String] a string representing the journal title
+    def journal_title
+      Array(object.try(:journal_title)).first || ''
+    end
+
+    ##
+    # @return [String] a string representing the journal volume
+    def volume
+      Array(object.try(:journal_volume)).first || ''
+    end
+
+    ##
+    # @return [String] a string representing the journal issue
+    def issue
+      Array(object.try(:journal_issue)).first || ''
+    end
+
+    ##
+    # @return [String] a string representing the first page
+    def first_page
+      Array(object.try(:page_start)).first || ''
+    end
+    alias firstpage first_page
+
+    ##
+    # @return [String] a string representing the last page
+    def last_page
+      Array(object.try(:page_end)).first || ''
+    end
+    alias lastpage last_page
   end
 end

--- a/app/views/shared/_citations.html.erb
+++ b/app/views/shared/_citations.html.erb
@@ -17,37 +17,52 @@
 <% gscholar = Hyrax::GoogleScholarPresenter.new(@presenter) %>
 
 <% if gscholar.scholarly? %>
-<% content_for(:gscholar_meta) do %>
-  <meta name="description" content="<%= gscholar.description %>" />
-  <meta name="citation_title" content="<%= gscholar.title %>" />
+  <% content_for(:gscholar_meta) do %>
+    <meta name="description" content="<%= gscholar.description %>" />
+    <meta name="citation_title" content="<%= gscholar.title %>" />
 
-  <% gscholar.authors.each do |author| %>
-  <meta name="citation_author" content="<%= author %>" />
+    <% gscholar.authors.each do |author| %>
+      <meta name="citation_author" content="<%= author %>" />
+    <% end %>
+
+    <% if gscholar.publication_date.present? %>
+      <meta name="citation_publication_date" content="<%= gscholar.publication_date %>" />
+    <% end %>
+
+    <% if gscholar.pdf_url.present? %>
+      <meta name="citation_pdf_url" content="<%= gscholar.pdf_url %>" />
+    <% end %>
+
+    <% if gscholar.keywords.present? %>
+      <meta name="citation_keywords" content="<%= gscholar.keywords %>" />
+    <% end %>
+
+    <% if gscholar.publisher.present? %>
+      <meta name="citation_publisher" content="<%= gscholar.publisher %>" />
+    <% end %>
+
+    <% if gscholar.degree_grantor.present?  %>
+      <meta name="citation_dissertation_institution" content="<%= gscholar.degree_grantor %>" />
+    <% end %>
+
+    <% if gscholar.journal_title.present? %>
+      <meta name="citation_journal_title" content="<%= gscholar.journal_title %>" />
+    <% end %>
+
+    <% if gscholar.volume.present? %>
+      <meta name="citation_volume" content="<%= gscholar.volume %>" />
+    <% end %>
+
+    <% if gscholar.issue.present? %>
+      <meta name="citation_issue" content="<%= gscholar.issue %>" />
+    <% end %>
+
+    <% if gscholar.first_page.present? %>
+      <meta name="citation_firstpage" content="<%= gscholar.first_page %>" />
+    <% end %>
+
+    <% if gscholar.last_page.present? %>
+      <meta name="citation_lastpage" content="<%= gscholar.last_page %>" />
+    <% end %>
   <% end %>
-
-  <% if gscholar.publication_date.present? %>
-  <meta name="citation_publication_date" content="<%= gscholar.publication_date %>" />
-  <% end %>
-
-  <% if gscholar.pdf_url.present? %>
-  <meta name="citation_pdf_url" content="<%= gscholar.pdf_url %>" />
-  <% end %>
-
-  <% if gscholar.keywords.present? %>
-  <meta name="citation_keywords" content="<%= gscholar.keywords %>" />
-  <% end %>
-
-  <% if gscholar.publisher.present? %>
-  <meta name="citation_publisher" content="<%= gscholar.publisher %>" />
-  <% end %>
-
-  <!-- Hyrax does not yet support these metadata -->
-  <!--
-    <meta name="citation_journal_title" content=""/>
-    <meta name="citation_volume" content=""/>
-    <meta name="citation_issue" content=""/>
-    <meta name="citation_firstpage" content=""/>
-    <meta name="citation_lastpage" content=""/>
-  -->
-<% end %>
 <% end %>

--- a/spec/presenters/hyrax/google_scholar_presenter_spec.rb
+++ b/spec/presenters/hyrax/google_scholar_presenter_spec.rb
@@ -82,4 +82,58 @@ RSpec.describe Hyrax::GoogleScholarPresenter do
       expect(presenter.title).to eq 'On Moomins'
     end
   end
+
+  describe '#degree_grantor' do
+    context 'with a work that responds to degree_grantor' do
+      let(:work) { double('GenericWork', degree_grantor: ["University of Strasbourg", "University of Heidelberg"]) }
+
+      it 'gives the degree grantors as a semicolon delimited list' do
+        expect(presenter.degree_grantor).to eq("University of Strasbourg; University of Heidelberg")
+      end
+    end
+    context 'with a work that does not respond to degree_grantor' do
+      let(:work) { double('GenericWork') }
+
+      it 'returns a non-present value' do
+        expect(presenter.degree_grantor.present?).to be false
+      end
+    end
+  end
+
+  describe '#journal_title' do
+    let(:work) { double('GenericWork', resource_type: 'Journal', journal_title: "My cool journal") }
+    it 'gives the journal title' do
+      expect(presenter.journal_title).to eq('My cool journal')
+    end
+  end
+
+  describe '#volume' do
+    let(:work) { double('GenericWork', resource_type: 'Journal', journal_volume: 'III') }
+    it 'gives the volume' do
+      expect(presenter.volume).to eq('III')
+    end
+  end
+
+  describe '#issue' do
+    let(:work) { double('GenericWork', resource_type: 'Journal', journal_issue: '23') }
+    it 'gives the issue' do
+      expect(presenter.issue).to eq('23')
+    end
+  end
+
+  describe '#first_page' do
+    let(:work) { double('GenericWork', resource_type: 'Journal', page_start: '112') }
+    it 'gives the first page' do
+      expect(presenter.first_page).to eq('112')
+      expect(presenter.firstpage).to eq('112')
+    end
+  end
+
+  describe '#last_page' do
+    let(:work) { double('GenericWork', resource_type: 'Journal', page_end: '135') }
+    it 'gives the last page' do
+      expect(presenter.last_page).to eq('135')
+      expect(presenter.lastpage).to eq('135')
+    end
+  end
 end

--- a/spec/views/hyrax/base/show.html.erb_spec.rb
+++ b/spec/views/hyrax/base/show.html.erb_spec.rb
@@ -106,121 +106,18 @@ RSpec.describe 'hyrax/base/show.html.erb', type: :view do
   end
 
   describe 'google scholar' do
+    # More tests for google scholar metadata in the view test for the partial - spec/views/shared/_citations.html.erb_spec.rb
     it 'appears in meta tags' do
       gscholar_meta_tags = Nokogiri::HTML(rendered).xpath("//meta[contains(@name, 'citation_')]")
       expect(gscholar_meta_tags.count).to eq(7)
     end
-
-    it 'displays the spectrum of meta data tags' do
-      tag = Nokogiri::HTML(rendered).xpath("//meta[@name='description']")
-      expect(tag.attribute('content').value).to eq('Lorem ipsum lorem ipsum.')
-
-      tag = Nokogiri::HTML(rendered).xpath("//meta[@name='citation_title']")
-      expect(tag.attribute('content').value).to eq('My Title')
-
-      tags = Nokogiri::HTML(rendered).xpath("//meta[@name='citation_author']")
-      expect(tags.first.attribute('content').value).to eq('Doe, John')
-      expect(tags.last.attribute('content').value).to eq('Doe, Jane')
-
-      tag = Nokogiri::HTML(rendered).xpath("//meta[@name='citation_publication_date']")
-      expect(tag.attribute('content').value).to eq('1984-01-02')
-
-      tag = Nokogiri::HTML(rendered).xpath("//meta[@name='citation_pdf_url']")
-      expect(tag.attribute('content').value).to eq('http://test.host/downloads/123')
-
-      tag = Nokogiri::HTML(rendered).xpath("//meta[@name='citation_keywords']")
-      expect(tag.attribute('content').value).to eq('bacon; sausage; eggs')
-
-      tag = Nokogiri::HTML(rendered).xpath("//meta[@name='citation_publisher']")
-      expect(tag.attribute('content').value).to eq('French Press')
-    end
-
-    context 'with minimal record' do
-      let(:work_solr_document) do
-        SolrDocument.new(id: '999',
-                         title_tesim: ['My Title'],
-                         date_modified_dtsi: '2011-04-01',
-                         has_model_ssim: ['GenericWork'],
-                         depositor_tesim: depositor.user_key)
-      end
-      let(:representative_presenter) { nil }
-
-      it 'appears in meta tags' do
-        gscholar_meta_tags = Nokogiri::HTML(rendered).xpath("//meta[contains(@name, 'citation_')]")
-        expect(gscholar_meta_tags.count).to eq(1)
-      end
-
-      it 'displays the spectrum of meta data tags' do
-        # it 'displays title as description'
-        tag = Nokogiri::HTML(rendered).xpath("//meta[@name='description']")
-        expect(tag.attribute('content').value).to eq('My Title')
-
-        tag = Nokogiri::HTML(rendered).xpath("//meta[@name='citation_title']")
-        expect(tag.attribute('content').value).to eq('My Title')
-
-        tags = Nokogiri::HTML(rendered).xpath("//meta[@name='citation_author']")
-        expect(tags).to be_blank
-
-        tag = Nokogiri::HTML(rendered).xpath("//meta[@name='citation_publication_date']")
-        expect(tag).to be_blank
-
-        tag = Nokogiri::HTML(rendered).xpath("//meta[@name='citation_pdf_url']")
-        expect(tag).to be_blank
-
-        tag = Nokogiri::HTML(rendered).xpath("//meta[@name='citation_keywords']")
-        expect(tag).to be_blank
-
-        tag = Nokogiri::HTML(rendered).xpath("//meta[@name='citation_publisher']")
-        expect(tag).to be_blank
-      end
-    end
   end
 
   describe 'twitter cards' do
+    # More tests for twitter metadata in the view test for the partial - spec/views/shared/_citations.html.erb_spec.rb
     it 'appears in meta tags' do
       twitter_meta_tags = Nokogiri::HTML(rendered).xpath("//meta[contains(@name, 'twitter:') or contains(@property, 'og:')]")
       expect(twitter_meta_tags.count).to eq(13)
-    end
-
-    it 'displays the spectrum of twitter meta attributes' do
-      tag = Nokogiri::HTML(rendered).xpath("//meta[@name='twitter:card']")
-      expect(tag.attribute('content').value).to eq('product')
-
-      tag = Nokogiri::HTML(rendered).xpath("//meta[@name='twitter:site']")
-      expect(tag.attribute('content').value).to eq('@SamveraRepo')
-
-      tag = Nokogiri::HTML(rendered).xpath("//meta[@name='twitter:creator']")
-      expect(tag.attribute('content').value).to eq('@bot4lib')
-
-      tag = Nokogiri::HTML(rendered).xpath("//meta[@property='og:site_name']")
-      expect(tag.attribute('content').value).to eq(I18n.t('hyrax.product_name'))
-
-      tag = Nokogiri::HTML(rendered).xpath("//meta[@property='og:type']")
-      expect(tag.attribute('content').value).to eq('object')
-
-      tag = Nokogiri::HTML(rendered).xpath("//meta[@property='og:title']")
-      expect(tag.attribute('content').value).to eq('My Title')
-
-      tag = Nokogiri::HTML(rendered).xpath("//meta[@property='og:description']")
-      expect(tag.attribute('content').value).to eq('Lorem ipsum lorem ipsum.')
-
-      tag = Nokogiri::HTML(rendered).xpath("//meta[@property='og:image']")
-      expect(tag.attribute('content').value).to eq('http://test.host/downloads/123')
-
-      tag = Nokogiri::HTML(rendered).xpath("//meta[@property='og:url']")
-      expect(tag.attribute('content').value).to eq('http://test.host/concern/generic_works/999')
-
-      tag = Nokogiri::HTML(rendered).xpath("//meta[@name='twitter:data1']")
-      expect(tag.attribute('content').value).to eq('bacon, sausage, eggs')
-
-      tag = Nokogiri::HTML(rendered).xpath("//meta[@name='twitter:label1']")
-      expect(tag.attribute('content').value).to eq('Keywords')
-
-      tag = Nokogiri::HTML(rendered).xpath("//meta[@name='twitter:data2']")
-      expect(tag.attribute('content').value).to eq('http://example.org/rs/1')
-
-      tag = Nokogiri::HTML(rendered).xpath("//meta[@name='twitter:label2']")
-      expect(tag.attribute('content').value).to eq('Rights Statement')
     end
   end
 end

--- a/spec/views/shared/_citations.html.erb_spec.rb
+++ b/spec/views/shared/_citations.html.erb_spec.rb
@@ -1,0 +1,203 @@
+# frozen_string_literal: true
+RSpec.describe 'shared/_citations.html.erb', type: :view do
+  let(:work_solr_document) do
+    SolrDocument.new(id: '999',
+                     title_tesim: ['My Title'],
+                     creator_tesim: ['Doe, John', 'Doe, Jane'],
+                     date_modified_dtsi: '2011-04-01',
+                     has_model_ssim: ['GenericWork'],
+                     depositor_tesim: depositor.user_key,
+                     description_tesim: ['Lorem ipsum lorem ipsum.'],
+                     keyword_tesim: ['bacon', 'sausage', 'eggs'],
+                     rights_statement_tesim: ['http://example.org/rs/1'],
+                     rights_notes_tesim: ['Notes on the rights'],
+                     date_created_tesim: ['1984-01-02'],
+                     publisher_tesim: ['French Press'])
+  end
+
+  let(:file_set_solr_document) do
+    SolrDocument.new(id: '123',
+                     title_tesim: ['My FileSet'],
+                     depositor_tesim: depositor.user_key)
+  end
+
+  let(:ability) { double }
+
+  let(:request) { double('request', host: 'test.host') }
+
+  let(:depositor) do
+    stub_model(User,
+               user_key: 'bob',
+               twitter_handle: 'bot4lib')
+  end
+
+  let(:presenter) do
+    Hyrax::WorkShowPresenter.new(work_solr_document, ability, request)
+  end
+
+  let(:representative_presenter) do
+    Hyrax::FileSetPresenter.new(file_set_solr_document, ability)
+  end
+
+  before do
+    assign(:presenter, presenter)
+    allow(presenter).to receive(:representative_presenter).and_return(representative_presenter)
+  end
+
+  describe 'content for google scholar' do
+    let(:content) { view.content_for(:gscholar_meta) }
+    context 'with a full record' do
+      let(:expected_meta_tags) do
+        {
+          'description' => 'Lorem ipsum lorem ipsum.',
+          'citation_title' => 'My Title',
+          'citation_publication_date' => '1984-01-02',
+          'citation_pdf_url' => 'http://test.host/downloads/123',
+          'citation_keywords' => 'bacon; sausage; eggs',
+          'citation_publisher' => 'French Press',
+          'citation_dissertation_institution' => 'University of Strasbourg; University of Heidelberg'
+        }
+      end
+
+      let(:expected_authors) { ['Doe, John', 'Doe, Jane'] }
+
+      before do
+        allow(presenter).to receive(:degree_grantor).and_return(["University of Strasbourg", "University of Heidelberg"])
+        render partial: 'shared/citations', locals: { presenter: presenter }
+      end
+
+      it 'appears in meta tags' do
+        gscholar_meta_tags = Nokogiri::HTML(content).xpath("//meta[contains(@name, 'citation_')]")
+        expect(gscholar_meta_tags.count).to eq(8)
+      end
+
+      it 'displays the spectrum of meta data tags' do
+        doc = Nokogiri::HTML(content)
+        expected_meta_tags.each do |name, expected_value|
+          tag = doc.xpath("//meta[@name='#{name}']")
+          expect(tag.attribute('content').value).to eq(expected_value),
+            "Expected meta tag '#{name}' to have content '#{expected_value}'"
+        end
+
+        author_tags = doc.xpath("//meta[@name='citation_author']")
+        expect(author_tags.map { |t| t.attribute('content').value }).to eq(expected_authors)
+      end
+    end
+
+    context 'with a journal article' do
+      let(:expected_meta_tags) do
+        {
+          'citation_journal_title' => 'My cool journal',
+          'citation_volume' => 'III',
+          'citation_issue' => '23',
+          'citation_firstpage' => '112',
+          'citation_lastpage' => '135'
+        }
+      end
+
+      before do
+        allow(presenter).to receive(:journal_title).and_return('My cool journal')
+        allow(presenter).to receive(:journal_volume).and_return('III')
+        allow(presenter).to receive(:journal_issue).and_return('23')
+        allow(presenter).to receive(:page_start).and_return('112')
+        allow(presenter).to receive(:page_end).and_return('135')
+        render partial: 'shared/citations', locals: { presenter: presenter }
+      end
+      it 'displays the spectrum of meta data tags' do
+        doc = Nokogiri::HTML(content)
+        expected_meta_tags.each do |name, expected_value|
+          tag = doc.xpath("//meta[@name='#{name}']")
+          expect(tag.attribute('content').value).to eq(expected_value),
+            "Expected meta tag '#{name}' to have content '#{expected_value}'"
+        end
+      end
+    end
+
+    context 'with minimal record' do
+      let(:work_solr_document) do
+        SolrDocument.new(id: '999',
+                         title_tesim: ['My Title'],
+                         date_modified_dtsi: '2011-04-01',
+                         has_model_ssim: ['GenericWork'],
+                         depositor_tesim: depositor.user_key)
+      end
+      let(:representative_presenter) { nil }
+
+      before do
+        render partial: 'shared/citations', locals: { presenter: presenter }
+      end
+
+      it 'appears in meta tags' do
+        gscholar_meta_tags = Nokogiri::HTML(content).xpath("//meta[contains(@name, 'citation_')]")
+        expect(gscholar_meta_tags.count).to eq(1)
+      end
+
+      it 'displays only title metadata' do
+        doc = Nokogiri::HTML(content)
+
+        tag = doc.xpath("//meta[@name='description']")
+        expect(tag.attribute('content').value).to eq('My Title')
+
+        tag = doc.xpath("//meta[@name='citation_title']")
+        expect(tag.attribute('content').value).to eq('My Title')
+
+        expect(doc.xpath("//meta[@name='citation_author']")).to be_blank
+        expect(doc.xpath("//meta[@name='citation_publication_date']")).to be_blank
+        expect(doc.xpath("//meta[@name='citation_pdf_url']")).to be_blank
+        expect(doc.xpath("//meta[@name='citation_dissertation_institution']")).to be_blank
+      end
+    end
+  end
+  describe 'content for twitter cards' do
+    let(:content) { view.content_for(:twitter_meta) }
+    let(:expected_twitter_meta_tags) do
+      {
+        'twitter:card' => 'product',
+        'twitter:site' => '@SamveraRepo',
+        'twitter:creator' => '@bot4lib',
+        'twitter:data1' => 'bacon, sausage, eggs',
+        'twitter:label1' => 'Keywords',
+        'twitter:data2' => 'http://example.org/rs/1',
+        'twitter:label2' => 'Rights Statement'
+      }
+    end
+
+    let(:expected_og_meta_tags) do
+      {
+        'og:site_name' => I18n.t('hyrax.product_name'),
+        'og:type' => 'object',
+        'og:title' => 'My Title',
+        'og:description' => 'Lorem ipsum lorem ipsum.',
+        'og:image' => 'http://test.host/downloads/123',
+        'og:url' => 'http://test.host/concern/generic_works/999'
+      }
+    end
+    before do
+      allow(presenter).to receive(:tweeter).and_return("@#{depositor.twitter_handle}")
+      allow(controller).to receive(:current_user).and_return(depositor)
+      allow(::User).to receive(:find_by_user_key).and_return(depositor.user_key)
+      render partial: 'shared/citations', locals: { presenter: presenter }
+    end
+
+    it 'appears in meta tags' do
+      twitter_meta_tags = Nokogiri::HTML(content).xpath("//meta[contains(@name, 'twitter:') or contains(@property, 'og:')]")
+      expect(twitter_meta_tags.count).to eq(13)
+    end
+
+    it 'displays the spectrum of twitter meta attributes' do
+      doc = Nokogiri::HTML(content)
+
+      expected_twitter_meta_tags.each do |name, expected_value|
+        tag = doc.xpath("//meta[@name='#{name}']")
+        expect(tag.attribute('content').value).to eq(expected_value),
+          "Expected meta tag '#{name}' to have content '#{expected_value}'"
+      end
+
+      expected_og_meta_tags.each do |property, expected_value|
+        tag = doc.xpath("//meta[@property='#{property}']")
+        expect(tag.attribute('content').value).to eq(expected_value),
+          "Expected meta tag '#{property}' to have content '#{expected_value}'"
+      end
+    end
+  end
+end


### PR DESCRIPTION
Same as #7311 but this version is for main

### Fixes

Fixes #7263

### Summary

For Valkyrie works, if a field is missing in the admin set create, the admin set gets created anyway. This code shows a user level error flash instead and reloads the form. If flexible is true, the creator is mandatory but never set. Also additional fields are never shown to the user, only title and description. This code expands the fields display to handle whatever properties the AdministrativeSetForm object knows about.

### Guidance for testing, such as acceptance criteria or new user interface behaviors:
* Set flexible on (see docs/flexible.md)
* Create an admin set via the UI
* See that creator is present and editable
* Save the admin set without creator and see that an error is returned
* Save the admin set with creator and see that the admin set saves correctly.

@samvera/hyrax-code-reviewers
