### PR TITLE
Makes change sets flexible

### DIFF
--- a/app/models/hyrax/change_set.rb
+++ b/app/models/hyrax/change_set.rb
@@ -29,6 +29,11 @@ module Hyrax
   end
 
   class ChangeSet < Valkyrie::ChangeSet
+    # These do not get auto loaded when using a flexible schema and should instead
+    # be added to the individual Form classes for a work type or smart enough
+    # to be selective as to when they trigger
+    include FlexibleFormBehavior if Hyrax.config.flexible?
+
     ##
     # @api public
     #
@@ -45,5 +50,34 @@ module Hyrax
     def self.for(resource)
       Hyrax::ChangeSet(resource.class).new(resource)
     end
+
+    ##
+    # @api public
+    #
+    # Forms should be initialized with an explicit +resource:+ parameter to
+    # match indexers.
+    # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
+    def initialize(resource = nil)
+      if Hyrax.config.flexible?
+        self.class.deserializer_class = nil # need to reload this on first use after schema is loaded
+        singleton_class.schema_definitions = self.class.definitions
+
+        Hyrax::Schema.default_schema_loader.form_definitions_for(schema: resource.class.to_s, version: Hyrax::FlexibleSchema.current_schema_id, contexts: resource.contexts).map do |field_name, options|
+          singleton_class.property field_name.to_sym, options.merge(display: options.fetch(:display, true), default: [])
+        end
+
+        hash = resource.attributes.dup
+        hash[:schema_version] = Hyrax::FlexibleSchema.current_schema_id
+        resource = resource.class.new(hash)
+        # find any fields removed by the new schema
+        to_remove = singleton_class.definitions.select { |k, v| !resource.respond_to?(k) && v.instance_variable_get("@options")[:display] }
+        to_remove.keys.each do |removed_field|
+          singleton_class.definitions.delete(removed_field)
+        end
+      end
+
+      super(resource)
+    end # rubocop:enable Metrics/MethodLength, Metrics/AbcSize
+
   end
 end


### PR DESCRIPTION
### Fixes

Moves flexible schema loading behavior into the ChangeSet class from the ResourceForm class, so that it applies to all change sets, not just forms.

This fixes an issue where properties defined in a flexible schema were not being set on the change set when not using a form from the workflow's action taken service, and allows works created using mediated deposit to complete the workflow's transaction steps.

Fixes https://github.com/samvera/hyku/issues/2769

