### PR TITLE
:bug: [i2925] - Fix flexible form to use resource contexts for schema field inclusion copy

### DIFF
--- a/app/forms/hyrax/forms/resource_form.rb
+++ b/app/forms/hyrax/forms/resource_form.rb
@@ -54,8 +54,8 @@ module Hyrax
         if r.flexible?
           self.class.deserializer_class = nil # need to reload this on first use after schema is loaded
           singleton_class.schema_definitions = self.class.definitions
-          context = r.respond_to?(:context) ? r.context : nil
-          Hyrax::Schema.m3_schema_loader.form_definitions_for(schema: r.class.name, version: Hyrax::FlexibleSchema.current_schema_id, contexts: context).map do |field_name, options|
+          contexts = r.respond_to?(:contexts) ? r.contexts : nil
+          Hyrax::Schema.m3_schema_loader.form_definitions_for(schema: r.class.name, version: Hyrax::FlexibleSchema.current_schema_id, contexts: contexts).map do |field_name, options|
             singleton_class.property field_name.to_sym, options.merge(display: options.fetch(:display, true), default: [])
           end
         end


### PR DESCRIPTION
### Fixes

- https://github.com/samvera/hyku/issues/2925

### Summary

Bug: With HYRAX_FLEXIBLE=true, context-specific properties from the metadata profile (e.g. “dimensions” for special_context) do not appear on the work form even when the work’s admin set has that context assigned.

Cause: In Hyrax::Forms::ResourceForm#initialize, the form uses r.context (singular) to pass to form_definitions_for; the resource only has r.contexts (plural), so contexts is always nil and M3SchemaLoader omits all context-restricted properties.

PS. [5.0-flexible](https://github.com/samvera/hyrax/blob/5.0-flexible/app/forms/hyrax/forms/resource_form.rb#L61) has it as a plural reference as well 


### Changes proposed in this pull request:
Fix: In resource_form.rb, use the resource’s contexts (plural) when calling form_definitions_for (e.g. context = r.respond_to?(:contexts) ? r.contexts : nil and pass it as contexts: context), so the form includes properties for the work’s context(s), e.g. “dimensions” for admin sets with “special context.”

@samvera/hyrax-code-reviewers

<img width="1920" height="929" alt="image" src="https://github.com/user-attachments/assets/d32b1b11-347a-45e6-b776-5f001780f655" />

<img width="497" height="570" alt="image" src="https://github.com/user-attachments/assets/23e69184-2b92-4387-b1fe-dc24201d1fee" />

[metadata-profile-v.7 (1).yml](https://github.com/user-attachments/files/25270843/metadata-profile-v.7.1.yml)



# BEFORE

<details><summary>dimensions was missing from an ImageResource work created from the 'special context' admin set
</summary> 

<img width="1920" height="4981" alt="image" src="https://github.com/user-attachments/assets/32d405fa-88b8-4d2e-8fa4-c206c804bf72" />

</details> 



# AFTER

<img width="1125" height="801" alt="image" src="https://github.com/user-attachments/assets/353cdd22-177e-450b-866c-1069a8c3d14f" />

