### PR TITLE
Filter non-displayable file sets from v3 manifests

### DIFF
--- a/app/presenters/hyrax/iiif_manifest_presenter.rb
+++ b/app/presenters/hyrax/iiif_manifest_presenter.rb
@@ -63,7 +63,7 @@ module Hyrax
     ##
     # @return [Array<DisplayImagePresenter>]
     def file_set_presenters
-      member_presenters.select(&:file_set?)
+      member_presenters.select { |p| p.file_set? && (p.display_image || p.display_content) }
     end
 
     ##
@@ -119,14 +119,14 @@ module Hyrax
     ##
     # @return [Array<Hash{String => String}>]
     def sequence_rendering
-      Array(try(:rendering_ids)).map do |file_set_id|
-        rendering = file_set_presenters.find { |p| p.id == file_set_id }
+      Array(try(:rendering_ids)).filter_map do |file_set_id|
+        rendering = member_presenters.find { |p| p.file_set? && p.id == file_set_id }
         next unless rendering
 
         { '@id' => Hyrax::Engine.routes.url_helpers.download_url(rendering.id, host: hostname),
           'format' => rendering.mime_type.presence || I18n.t("hyrax.manifest.unknown_mime_text"),
           'label' => I18n.t("hyrax.manifest.download_text") + (rendering.label || '') }
-      end.flatten
+      end
     end
 
     ##


### PR DESCRIPTION
### Screenshots

#### Before
<img width="3456" height="3932" alt="image" src="https://github.com/user-attachments/assets/af7ecb29-78b2-403f-bfac-3c053d7e7c2e" />

#### After
<img width="3456" height="3932" alt="image" src="https://github.com/user-attachments/assets/fd7ffe67-c02d-4683-9805-ece324eec4e0" />

### Summary

Fix IIIF V3 Manifest with mix media (IIIF-displayable and non-IIIF-displayable).

### Guidance for testing, such as acceptance criteria or new user interface behaviors:
Since V3 Manifests is not configured on nurax we can trigger a V3 manifest with a video work
1. Create a work with a video file set
2. Add a text file set (or whatever non-IIIF displayable resource)
3. Confirm that only the video should display in the viewer

### Type of change (for release notes)

- `notes-bugfix` Bug Fixes

### Detailed Description

#### Filter non-displayable file sets from v3 manifests

722e8b83fed905a824010be5518057050339a1fe

This commit will adjust `IiifManifestPresenter#file_set_presenters` to
only send IIIF resources to the IIIF Manifest gem.  So now, for example,
if there's a work with an image file set and a text file set, the IIIF
Manifest gem won't try and make a canvas for the text file.  The other
option was to make a commit to the IIIF Manifest gem to check if the
resource responds to #display_image or #display_content but I figure
catching it early is not a bad idea.

Additionally, `IiifManifestPresenter#sequence_rendering` now looks up
file sets from `member_presenters` instead of `file_set_presenters`,
since rendering/downloads should be available for all file sets, not
just IIIF-displayable ones.

### Changes proposed in this pull request:
* adjust `IiifManifestPresenter#file_set_presenters` to only send IIIF resources to the IIIF Manifest gem

@samvera/hyrax-code-reviewers
