### PR TITLE
Add install generator for Ramp

### DIFF
--- a/app/views/hyrax/base/iiif_viewers/_ramp.html.erb
+++ b/app/views/hyrax/base/iiif_viewers/_ramp.html.erb
@@ -1,29 +1,5 @@
 <%# run `bundle exec rails g hyrax:ramp:install` to install Ramp IIIF A/V player %>
-<% content_for(:head) do %>
-  <%= javascript_pack_tag 'application' %>
-  <%= stylesheet_pack_tag 'application' %>
-<% end %>
-<div id="ramp-player" class="ramp-player">
-  <%= react_component("RampPlayer", { manifestUrl: main_app.polymorphic_url([main_app, :manifest, presenter], { locale: I18n.locale }) }) %>
-</div>
-<script>
-  function loadRampPlayer() {
-    // RAMP player caches the previous manifest URL, so we must unmount/remount
-    // the React component to ensure it loads the correct manifest for this work.
-    // We also need to wait for the Webpacker pack to load asynchronously before
-    // ReactRailsUJS is available, using requestAnimationFrame to retry until ready.
-    if (typeof ReactRailsUJS === 'undefined') {
-      requestAnimationFrame(loadRampPlayer);
-      return;
-    }
-
-    ReactRailsUJS.unmountComponents();
-    ReactRailsUJS.mountComponents();
-  }
-
-  if (document.readyState === 'complete') {
-    loadRampPlayer();
-  } else {
-    window.addEventListener('load', loadRampPlayer);
-  }
-</script>
+<%= javascript_include_tag 'ramp', type: 'module' %>
+<%= react_component('RampPlayer', props: {
+  manifestUrl: main_app.polymorphic_url([main_app, :manifest, presenter], { locale: I18n.locale })
+}) %>

--- a/app/views/hyrax/base/iiif_viewers/_ramp.html.erb
+++ b/app/views/hyrax/base/iiif_viewers/_ramp.html.erb
@@ -1,0 +1,29 @@
+<%# run `bundle exec rails g hyrax:ramp:install` to install Ramp IIIF A/V player %>
+<% content_for(:head) do %>
+  <%= javascript_pack_tag 'application' %>
+  <%= stylesheet_pack_tag 'application' %>
+<% end %>
+<div id="ramp-player" class="ramp-player">
+  <%= react_component("RampPlayer", { manifestUrl: main_app.polymorphic_url([main_app, :manifest, presenter], { locale: I18n.locale }) }) %>
+</div>
+<script>
+  function loadRampPlayer() {
+    // RAMP player caches the previous manifest URL, so we must unmount/remount
+    // the React component to ensure it loads the correct manifest for this work.
+    // We also need to wait for the Webpacker pack to load asynchronously before
+    // ReactRailsUJS is available, using requestAnimationFrame to retry until ready.
+    if (typeof ReactRailsUJS === 'undefined') {
+      requestAnimationFrame(loadRampPlayer);
+      return;
+    }
+
+    ReactRailsUJS.unmountComponents();
+    ReactRailsUJS.mountComponents();
+  }
+
+  if (document.readyState === 'complete') {
+    loadRampPlayer();
+  } else {
+    window.addEventListener('load', loadRampPlayer);
+  }
+</script>

--- a/lib/generators/hyrax/ramp/install_generator.rb
+++ b/lib/generators/hyrax/ramp/install_generator.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+require 'rails/generators'
+
+module Hyrax
+  module Ramp
+    class InstallGenerator < Rails::Generators::Base
+      source_root File.expand_path('templates', __dir__)
+
+      desc "Install Ramp IIIF A/V player with React and Shakapacker"
+
+      def install_dependencies
+        gem 'shakapacker', '~> 8.0' unless gem_exists?('shakapacker')
+        gem 'react-rails' unless gem_exists?('react-rails')
+
+        Bundler.with_unbundled_env do
+          run "bundle install"
+        end
+      end
+
+      def add_package_manager_to_package_json
+        package_json_path = 'package.json'
+        return unless File.exist?(package_json_path)
+
+        package_json = JSON.parse(File.read(package_json_path))
+        return if package_json['packageManager']
+
+        package_json['packageManager'] = 'yarn@1.22.22'
+        File.write(package_json_path, JSON.pretty_generate(package_json))
+        say "Added packageManager to package.json", :green
+      end
+
+      def shakapacker_install
+        return if File.exist?('config/shakapacker.yml')
+        rake "shakapacker:install"
+      end
+
+      def react_install
+        return if File.exist?('app/javascript/packs/application.js')
+        generate "react:install"
+      end
+
+      def setup_babel_config
+        return if File.exist?('babel.config.js')
+        copy_file 'babel.config.js', 'babel.config.js'
+      end
+
+      def add_ramp_yarn_dependency
+        run "yarn add @samvera/ramp@4.0.2 react@^18.2.0 react-dom@^18.2.0 video.js@^8.10.0 react_ujs mini-css-extract-plugin css-loader style-loader"
+      end
+
+      def copy_ramp_react_component
+        copy_file 'RampPlayer.jsx', 'app/javascript/components/RampPlayer.jsx'
+      end
+
+      def configure_iiif_av_viewer
+        inject_into_file 'config/initializers/hyrax.rb',
+                        "\n  # IIIF AV viewer configuration\n  # Use :ramp for audio/video content\n  config.iiif_av_viewer = :ramp\n",
+                        after: "config.iiif_image_server = true\n"
+      end
+
+      def display_readme
+        readme "README" if behavior == :invoke
+      end
+
+      private
+
+      def gem_exists?(gem_name)
+        Gem::Specification.find_by_name(gem_name)
+      rescue Gem::MissingSpecError
+        false
+      end
+    end
+  end
+end

--- a/lib/generators/hyrax/ramp/install_generator.rb
+++ b/lib/generators/hyrax/ramp/install_generator.rb
@@ -5,61 +5,107 @@ module Hyrax
   module Ramp
     class InstallGenerator < Rails::Generators::Base
       source_root File.expand_path('templates', __dir__)
-
-      desc "Install Ramp IIIF A/V player with React and Shakapacker"
+      desc 'Install Ramp IIIF A/V player with React and jsbundling-rails'
 
       def install_dependencies
-        gem 'shakapacker', '~> 8.0' unless gem_exists?('shakapacker')
-        gem 'react-rails' unless gem_exists?('react-rails')
+        gem 'jsbundling-rails' unless gem_exists?('jsbundling-rails')
+        gem 'react_on_rails', '~> 14.0' unless gem_exists?('react_on_rails')
 
         Bundler.with_unbundled_env do
-          run "bundle install"
+          run 'bundle install'
         end
       end
 
-      def add_package_manager_to_package_json
-        package_json_path = 'package.json'
-        return unless File.exist?(package_json_path)
+      def javascript_install
+        # Check if webpack packages are installed
+        package_json = JSON.parse(File.read('package.json'))
+        return if package_json.dig('devDependencies', 'webpack')
 
-        package_json = JSON.parse(File.read(package_json_path))
-        return if package_json['packageManager']
-
-        package_json['packageManager'] = 'yarn@1.22.22'
-        File.write(package_json_path, JSON.pretty_generate(package_json))
-        say "Added packageManager to package.json", :green
+        rails_command 'javascript:install:webpack'
       end
 
-      def shakapacker_install
-        return if File.exist?('config/shakapacker.yml')
-        rake "shakapacker:install"
+      def copy_webpack_config
+        copy_file 'webpack.config.js', 'webpack.config.js', force: true
       end
 
-      def react_install
-        return if File.exist?('app/javascript/packs/application.js')
-        generate "react:install"
-      end
-
-      def setup_babel_config
+      def setup_babel
         return if File.exist?('babel.config.js')
+
         copy_file 'babel.config.js', 'babel.config.js'
       end
 
-      def add_ramp_yarn_dependency
-        run "yarn add @samvera/ramp@4.0.2 react@^18.2.0 react-dom@^18.2.0 video.js@^8.10.0 react_ujs mini-css-extract-plugin css-loader style-loader"
+      def add_react_dependencies
+        run 'yarn add react@^18.2.0 react-dom@^18.2.0 react-on-rails @babel/core @babel/preset-env @babel/preset-react babel-loader'
       end
 
-      def copy_ramp_react_component
+      def add_ramp_dependencies
+        run 'yarn add @samvera/ramp@4.0.2 video.js@^8.10.0 style-loader css-loader'
+      end
+
+      def copy_ramp_component
+        empty_directory 'app/javascript/components' unless File.directory?('app/javascript/components')
         copy_file 'RampPlayer.jsx', 'app/javascript/components/RampPlayer.jsx'
       end
 
+      def create_ramp_bundle
+        copy_file 'ramp.js', 'app/javascript/ramp.js'
+      end
+
+      def add_to_assets_precompile
+        append_to_file 'config/initializers/assets.rb' do
+          "\n# Precompile Ramp IIIF A/V player bundle\nRails.application.config.assets.precompile += %w[ramp.js]\n"
+        end
+      end
+
+      # rubocop:disable Metrics/MethodLength
       def configure_iiif_av_viewer
-        inject_into_file 'config/initializers/hyrax.rb',
-                        "\n  # IIIF AV viewer configuration\n  # Use :ramp for audio/video content\n  config.iiif_av_viewer = :ramp\n",
-                        after: "config.iiif_image_server = true\n"
+        hyrax_config = 'config/initializers/hyrax.rb'
+
+        unless File.exist?(hyrax_config)
+          say 'config/initializers/hyrax.rb not found', :yellow
+          say 'Please manually add: config.iiif_av_viewer = :ramp', :yellow
+          return
+        end
+
+        content = File.read(hyrax_config)
+
+        if content.match?(/config\.iiif_av_viewer\s*=/)
+          # Already configured - update it
+          gsub_file hyrax_config,
+                    /config\.iiif_av_viewer\s*=\s*.+/,
+                    'config.iiif_av_viewer = :ramp'
+          say 'Updated config.iiif_av_viewer to :ramp', :green
+        elsif content.include?('Hyrax.config do |config|')
+          # Not configured yet - add it
+          inject_into_file hyrax_config, after: "Hyrax.config do |config|\n" do
+            <<~RUBY
+              # IIIF AV viewer configuration
+              # Use :ramp for audio/video content
+              config.iiif_av_viewer = :ramp
+
+            RUBY
+          end
+          say 'Added config.iiif_av_viewer = :ramp to Hyrax config', :green
+        else
+          say 'Could not configure iiif_av_viewer automatically', :yellow
+          say 'Please manually add: config.iiif_av_viewer = :ramp', :yellow
+        end
+      end
+      # rubocop:enable Metrics/MethodLength
+
+      def build_ramp_bundle
+        say 'Building Ramp bundle...', :green
+        run 'yarn build'
+
+        # Remove application.js if it was built (we use Sprockets for that)
+        return unless File.exist?('app/assets/builds/application.js')
+
+        remove_file 'app/assets/builds/application.js'
+        say 'Removed webpack-built application.js (using Sprockets instead)', :yellow
       end
 
       def display_readme
-        readme "README" if behavior == :invoke
+        readme 'README' if behavior == :invoke
       end
 
       private

--- a/lib/generators/hyrax/ramp/templates/README
+++ b/lib/generators/hyrax/ramp/templates/README
@@ -1,0 +1,23 @@
+===============================================================================
+                  Ramp IIIF A/V Player Installation Complete!
+===============================================================================
+
+     Next steps:
+       1. Start your Rails server
+       2. Upload an audio or video file to a work
+       3. The Ramp player will render automatically on the work show page
+
+     Customization:
+       Edit the React component:
+         app/javascript/components/RampPlayer.jsx
+
+       Override the view partial:
+         app/views/hyrax/base/iiif_viewers/_ramp.html.erb
+
+       Change viewer configuration in config/initializers/hyrax.rb:
+         config.iiif_av_viewer = :ramp  # or :universal_viewer
+
+     For more information:
+       Ramp documentation: https://github.com/samvera-labs/ramp
+
+===============================================================================

--- a/lib/generators/hyrax/ramp/templates/RampPlayer.jsx
+++ b/lib/generators/hyrax/ramp/templates/RampPlayer.jsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { IIIFPlayer, MediaPlayer } from '@samvera/ramp';
+import 'video.js/dist/video-js.css';
+import '@samvera/ramp/dist/ramp.css';
+
+const RampPlayer = ({ manifestUrl }) => {
+  return (
+    <IIIFPlayer manifestUrl={manifestUrl}>
+      <MediaPlayer enableFileDownload={false} />
+    </IIIFPlayer>
+  );
+};
+
+export default RampPlayer;

--- a/lib/generators/hyrax/ramp/templates/babel.config.js
+++ b/lib/generators/hyrax/ramp/templates/babel.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  presets: ['@babel/preset-env', '@babel/preset-react']
+};

--- a/lib/generators/hyrax/ramp/templates/ramp.js
+++ b/lib/generators/hyrax/ramp/templates/ramp.js
@@ -1,0 +1,7 @@
+// Ramp IIIF A/V player bundle
+import ReactOnRails from 'react-on-rails';
+import RampPlayer from './components/RampPlayer';
+
+ReactOnRails.register({
+  RampPlayer,
+});

--- a/lib/generators/hyrax/ramp/templates/webpack.config.js
+++ b/lib/generators/hyrax/ramp/templates/webpack.config.js
@@ -1,0 +1,39 @@
+const path = require("path")
+const webpack = require("webpack")
+
+module.exports = {
+  mode: "production",
+  devtool: "source-map",
+  entry: {
+    ramp: "./app/javascript/ramp.js",
+  },
+  module: {
+    rules: [{
+        test: /\.css$/,
+        use: ['style-loader', 'css-loader']
+      },
+      {
+        test: /\.(js|jsx)$/,
+        exclude: /node_modules/,
+        use: {
+          loader: 'babel-loader'
+        }
+      }
+    ]
+  },
+  output: {
+    filename: "[name].js",
+    sourceMapFilename: "[file].map",
+    chunkFormat: "module",
+    path: path.resolve(__dirname, "app/assets/builds"),
+  },
+  resolve: {
+    extensions: ['.js', '.jsx'],
+    modules: [path.resolve(__dirname, 'app/javascript'), 'node_modules'],
+  },
+  plugins: [
+    new webpack.optimize.LimitChunkCountPlugin({
+      maxChunks: 1
+    })
+  ]
+}


### PR DESCRIPTION
### Screenshot

#### Video Example
<img width="1187" height="824" alt="image" src="https://github.com/user-attachments/assets/d4e4c93a-6990-42a3-a2b0-81d7b887602f" />

#### Audio Example
<img width="1184" height="357" alt="image" src="https://github.com/user-attachments/assets/cbf524fe-b930-4fcc-b2d0-9bf6a681b7ff" />

### Summary

Add an install generator for Ramp IIIF player for A/V resources.

### Guidance for testing, such as acceptance criteria or new user interface behaviors:
* ideally someone will run the generator in a deployed environment like Nurax
  - `rails g hyrax:ramp:install`
* they would also need to restart the server
* add a audio or video resource and check the show page
* the viewer should be the Ramp player instead of Universal Viewer

### Type of change (for release notes)

- `notes-minor` New Features that are backward compatible

### Detailed Description

#### Add install generator for Ramp

8a55f2dd422e0f8ea3bf4f7f3cea991704e00ecf

This commit will add an install generator for Ramp and also set the A/V
IIIF Viewer to use Ramp.

Usage:
```
rails generate hyrax:ramp:install
```

#### Switch from `shakapacker` to `jsbundling-rails`

3dd6861a7613a4f66bd4e14f5402af0623f090c9

This commit switches from using `shakapacker` to `jsbundling-rails` with
aligns better with Avalon's approach.

### Changes proposed in this pull request:
* add an install generator so Hyrax has another option for viewing A/V IIIF resources

@samvera/hyrax-code-reviewers
