### PR TITLE
Fix view specs to use full stub_template paths

### DIFF
--- a/spec/views/hyrax/admin/admin_sets/show.html.erb_spec.rb
+++ b/spec/views/hyrax/admin/admin_sets/show.html.erb_spec.rb
@@ -5,12 +5,12 @@ RSpec.describe "hyrax/admin/admin_sets/show.html.erb", type: :view do
   let(:presenter) { Hyrax::AdminSetPresenter.new(solr_document, ability) }
 
   before do
-    stub_template '_collection_description.html.erb' => ''
-    stub_template '_show_actions.erb' => ''
-    stub_template '_show_descriptions.erb' => ''
-    stub_template '_sort_and_per_page.html.erb' => 'sort and per page'
-    stub_template '_document_list.html.erb' => 'document list'
-    stub_template '_paginate.html.erb' => 'paginate'
+    stub_template 'hyrax/admin/admin_sets/_collection_description.html.erb' => ''
+    stub_template 'hyrax/admin/admin_sets/_show_actions.html.erb' => ''
+    stub_template 'hyrax/admin/admin_sets/_show_descriptions.html.erb' => ''
+    stub_template 'hyrax/admin/admin_sets/_sort_and_per_page.html.erb' => 'sort and per page'
+    stub_template 'hyrax/admin/admin_sets/_document_list.html.erb' => 'document list'
+    stub_template 'hyrax/admin/admin_sets/_paginate.html.erb' => 'paginate'
 
     assign(:member_docs, [])
     assign(:presenter, presenter)

--- a/spec/views/hyrax/dashboard/collections/edit.html.erb_spec.rb
+++ b/spec/views/hyrax/dashboard/collections/edit.html.erb_spec.rb
@@ -8,7 +8,8 @@ RSpec.describe 'hyrax/dashboard/collections/edit.html.erb', type: :view do
     assign(:collection, collection)
     assign(:form, form)
     allow(Hyrax::CollectionType).to receive(:for).with(collection: collection).and_return(collection_type)
-    stub_template '_form.html.erb' => 'my-edit-form partial'
+    stub_template 'hyrax/dashboard/collections/_form.html.erb' => 'my-edit-form partial'
+    stub_template 'hyrax/dashboard/collections/_flash_msg.html.erb' => 'flash_msg partial'
     stub_template '_flash_msg.html.erb' => 'flash_msg partial'
 
     render

--- a/spec/views/hyrax/dashboard/collections/show.html.erb_spec.rb
+++ b/spec/views/hyrax/dashboard/collections/show.html.erb_spec.rb
@@ -38,18 +38,18 @@ RSpec.describe 'hyrax/dashboard/collections/show.html.erb', type: :view do
     allow(view).to receive(:dashboard_collection_path).and_return("/dashboard/collection/123")
     allow(view).to receive(:collection_path).and_return("/collection/123")
 
-    stub_template '_search_form.html.erb' => 'search form'
+    stub_template 'hyrax/dashboard/collections/_search_form.html.erb' => 'search form'
     stub_template 'hyrax/dashboard/collections/_sort_and_per_page.html.erb' => 'sort and per page'
-    stub_template '_document_list.html.erb' => 'document list'
+    stub_template 'hyrax/dashboard/collections/_document_list.html.erb' => 'document list'
     # This is tested ./spec/views/hyrax/dashboard/collections/_show_actions.html.erb_spec.rb
-    stub_template '_show_actions.html.erb' => '<div class="stubbed-actions">THE COLLECTION ACTIONS</div>'
-    stub_template '_show_subcollection_actions.html.erb' => '<div class="stubbed-actions">THE SUBCOLLECTION ACTIONS</div>'
-    stub_template '_show_add_items_actions.html.erb' => '<div class="stubbed-actions">THE ADD ITEMS ACTIONS</div>'
-    stub_template '_show_parent_collections.html.erb' => '<div class="stubbed-actions">THE PARENT COLLECTIONS LIST</div>'
-    stub_template '_subcollection_list.html.erb' => '<div class="stubbed-actions">THE SUB-COLLECTIONS LIST</div>'
+    stub_template 'hyrax/dashboard/collections/_show_actions.html.erb' => '<div class="stubbed-actions">THE COLLECTION ACTIONS</div>'
+    stub_template 'hyrax/dashboard/collections/_show_subcollection_actions.html.erb' => '<div class="stubbed-actions">THE SUBCOLLECTION ACTIONS</div>'
+    stub_template 'hyrax/dashboard/collections/_show_add_items_actions.html.erb' => '<div class="stubbed-actions">THE ADD ITEMS ACTIONS</div>'
+    stub_template 'hyrax/dashboard/collections/_show_parent_collections.html.erb' => '<div class="stubbed-actions">THE PARENT COLLECTIONS LIST</div>'
+    stub_template 'hyrax/dashboard/collections/_subcollection_list.html.erb' => '<div class="stubbed-actions">THE SUB-COLLECTIONS LIST</div>'
     stub_template 'hyrax/collections/_paginate.html.erb' => 'paginate'
-    stub_template 'hyrax/collections/_media_display.html.erb' => '<span class="fa fa-cubes collection-icon-search"></span>'
-    stub_template 'hyrax/my/collections/_modal_add_to_collection.html.erb' => 'modal add as subcollection'
+    stub_template 'hyrax/dashboard/collections/_media_display.html.erb' => '<span class="fa fa-cubes collection-icon-search"></span>'
+    stub_template 'hyrax/dashboard/collections/_modal_add_to_collection.html.erb' => 'modal add as subcollection'
     stub_template 'hyrax/my/collections/_modal_add_subcollection.html.erb' => 'modal add as parent'
   end
 
@@ -59,7 +59,7 @@ RSpec.describe 'hyrax/dashboard/collections/show.html.erb', type: :view do
     expect(rendered).to have_css('.stubbed-actions', text: 'THE COLLECTION ACTIONS')
     expect(rendered).to have_css('.stubbed-actions', text: 'THE SUBCOLLECTION ACTIONS')
     expect(rendered).to have_css('.stubbed-actions', text: 'THE ADD ITEMS ACTIONS')
-    expect(rendered).to match '<span class="fa fa-cubes collection-icon-search"></span>'
+    expect(rendered).to have_css('span.fa.fa-cubes.collection-icon-search')
     expect(rendered).not_to have_text('Search Results within this Collection')
   end
 
@@ -74,7 +74,7 @@ RSpec.describe 'hyrax/dashboard/collections/show.html.erb', type: :view do
       expect(rendered).to have_css('.stubbed-actions', text: 'THE COLLECTION ACTIONS')
       expect(rendered).to have_css('.stubbed-actions', text: 'THE SUBCOLLECTION ACTIONS')
       expect(rendered).to have_css('.stubbed-actions', text: 'THE ADD ITEMS ACTIONS')
-      expect(rendered).to match '<span class="fa fa-cubes collection-icon-search"></span>'
+      expect(rendered).to have_css('span.fa.fa-cubes.collection-icon-search')
       expect(rendered).not_to have_text('Search Results within this Collection')
     end
   end


### PR DESCRIPTION
`rspec-rails` v8.0.3 prepends the controller path to lookup_context.prefixes, causing Rails to search for partials using their full namespaced path:

`hyrax/dashboard/collections/_show_actions.html.erb`

instead of the filename.  Short-form stub_template paths no longer match, so stubs must use the full path.

Ref:
  - https://github.com/rspec/rspec-rails/pull/2749/changes#diff-104fd0e14717644c4d9887ea03b002a615a7f41020003a78ab6992fa425e7beeR189