### PR TITLE
Fix fa fa-cube(s) in translations

### DIFF
--- a/config/locales/hyrax.de.yml
+++ b/config/locales/hyrax.de.yml
@@ -1420,8 +1420,8 @@ de:
         tab_label: Zuletzt hochgeladen
         title: Zuletzt hochgeladen
     icons:
-      collection: Fa-würfel
-      default: Fa fa-würfel
+      collection: fa fa-cube
+      default: fa fa-cube
     leases:
       edit:
         header:

--- a/config/locales/hyrax.fr.yml
+++ b/config/locales/hyrax.fr.yml
@@ -1427,8 +1427,8 @@ fr:
         tab_label: Chargé récemment
         title: Chargé récemment
     icons:
-      collection: Fa fa-cubes
-      default: Fa fa-cube
+      collection: fa fa-cubes
+      default: fa fa-cube
     leases:
       edit:
         header:

--- a/config/locales/hyrax.it.yml
+++ b/config/locales/hyrax.it.yml
@@ -1426,8 +1426,8 @@ it:
         tab_label: Recentemente caricati
         title: Recentemente caricati
     icons:
-      collection: Fa fa-cubetti
-      default: Fa fa-cubo
+      collection: fa fa-cubes
+      default: fa fa-cube
     leases:
       edit:
         header:


### PR DESCRIPTION
The fa fa-cube and fa fa-cubes icons were translated in some of the yml files when they should not have been.