### PR TITLE
Fix duration in millisecond handling

### DIFF
--- a/app/presenters/hyrax/displays_content.rb
+++ b/app/presenters/hyrax/displays_content.rb
@@ -103,13 +103,15 @@ module Hyrax
       }]
     end
 
-    # rubocop:disable Metrics/AbcSize
+    # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
     def conformed_duration
       duration_string = Array(object.duration).first
       return nil if duration_string.blank?
 
-      # Handle plain numeric values (e.g., "25 s", "120")
-      return duration_string.to_f unless duration_string.include?(':')
+      # Handle values with explicit seconds unit (e.g., "25 s")
+      return duration_string.to_f if duration_string.match?(/\A[\d.]+\s*s\z/)
+      # Handle plain millisecond values (e.g., "120000")
+      return duration_string.to_f / 1000.0 unless duration_string.include?(':')
 
       # Parse time-formatted strings
       parts = duration_string.split(':').map(&:to_i)
@@ -125,7 +127,7 @@ module Hyrax
         duration_string.to_f # fallback
       end
     end
-    # rubocop:enable Metrics/AbcSize
+    # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
   end
   # rubocop:enable Metrics/ModuleLength
 end

--- a/spec/presenters/hyrax/iiif_manifest_presenter_spec.rb
+++ b/spec/presenters/hyrax/iiif_manifest_presenter_spec.rb
@@ -304,18 +304,48 @@ RSpec.describe Hyrax::IiifManifestPresenter, :clean_repo do
                           mime_type: 'video/mp4')
         end
 
-        context 'with duration in seconds' do
+        context 'with duration as plain milliseconds' do
           let(:solr_doc) do
             original_file_metadata
             solr_hash = Hyrax::Indexers::ResourceIndexer.for(resource: file_set).to_solr
             solr_hash['mime_type_ssi'] = 'video/mp4'
-            solr_hash['duration_tesim'] = ['120']
+            solr_hash['duration_tesim'] = ['120000']
             SolrDocument.new(solr_hash)
           end
 
-          it 'converts to float' do
+          it 'converts milliseconds to seconds' do
             content = presenter.display_content
             expect(content.duration).to eq(120.0)
+          end
+        end
+
+        context 'with duration as plain milliseconds (large value)' do
+          let(:solr_doc) do
+            original_file_metadata
+            solr_hash = Hyrax::Indexers::ResourceIndexer.for(resource: file_set).to_solr
+            solr_hash['mime_type_ssi'] = 'video/mp4'
+            solr_hash['duration_tesim'] = ['30527']
+            SolrDocument.new(solr_hash)
+          end
+
+          it 'converts milliseconds to seconds' do
+            content = presenter.display_content
+            expect(content.duration).to eq(30.527)
+          end
+        end
+
+        context 'with duration in seconds with unit suffix' do
+          let(:solr_doc) do
+            original_file_metadata
+            solr_hash = Hyrax::Indexers::ResourceIndexer.for(resource: file_set).to_solr
+            solr_hash['mime_type_ssi'] = 'video/mp4'
+            solr_hash['duration_tesim'] = ['25 s']
+            SolrDocument.new(solr_hash)
+          end
+
+          it 'converts to seconds' do
+            content = presenter.display_content
+            expect(content.duration).to eq(25.0)
           end
         end
 


### PR DESCRIPTION
This commit addresses an issue where durations specified in milliseconds were not being correctly interpreted.  The code now checks for values with explicit seconds units (e.g., "25 s") and plain millisecond values (e.g., "120000") and converts them to seconds appropriately.  This ensures that durations are accurately represented.  I didn't originally catch this because it seems to work fine in the UV on nurax but wasn't working correctly in Hyku.

As a side note, I'm not entirely sure that
the "25 s" format is still an issue with fits but I've added it just in case.

### Fixes
- https://github.com/samvera/hyku/issues/2934