### PR TITLE
Add file set metadata partial

### DIFF
--- a/app/presenters/hyrax/file_set_presenter.rb
+++ b/app/presenters/hyrax/file_set_presenter.rb
@@ -98,7 +98,7 @@ module Hyrax
     ##
     # @return [Array<String>]
     def show_partials
-      ['show_details']
+      %w[show_details metadata]
     end
 
     private

--- a/app/views/hyrax/file_sets/_metadata.html.erb
+++ b/app/views/hyrax/file_sets/_metadata.html.erb
@@ -1,0 +1,35 @@
+<h2><%= t('.metadata') %></h2>
+<dl class="file-show-term file-show-details">
+  <% if Hyrax.config.flexible? %>
+    <% view_options_for(@presenter).each do |field, options| %>
+      <% next if options["admin_only"] && !current_user&.admin? %>
+      <% next if field == :admin_note && !@presenter.editor? %>
+      <% values = Array(@presenter.try(field)).reject(&:blank?) %>
+      <% next if values.empty? %>
+      <% label = options["display_label"][I18n.locale.to_s] || t(options["display_label"]["default"]) %>
+      <div class="row">
+        <dt class="col-5"><%= label %></dt>
+        <dd class="col-7"><%= auto_link(values.join(', '), html: { target: '_blank' }) %></dd>
+      </div>
+    <% end %>
+  <% else %>
+    <% { description: nil, creator: nil, license: nil, subject: nil, keyword: nil,
+         date_created: nil, related_url: nil, resource_type: nil }.each_key do |field| %>
+      <% values = Array(@presenter.try(field)).reject(&:blank?) %>
+      <% next if values.empty? %>
+      <div class="row">
+        <dt class="col-5"><%= t("blacklight.search.fields.show.#{field}_tesim", default: field.to_s.humanize) %></dt>
+        <dd class="col-7"><%= auto_link(values.join(', '), html: { target: '_blank' }) %></dd>
+      </div>
+    <% end %>
+  <% end %>
+
+  <% [:embargo_release_date, :lease_expiration_date].each do |field| %>
+    <% value = @presenter.try(field) %>
+    <% next unless value.present? %>
+    <div class="row">
+      <dt class="col-5"><%= t("blacklight.search.fields.show.#{field}_dtsi", default: field.to_s.humanize) %></dt>
+      <dd class="col-7"><%= value %></dd>
+    </div>
+  <% end %>
+</dl>

--- a/config/locales/hyrax.de.yml
+++ b/config/locales/hyrax.de.yml
@@ -1370,6 +1370,8 @@ de:
         file_details: Dateidetails
         fixity_check: Beständigkeit überprüfen
         not_yet_characterized: Noch nicht charakterisiert
+      metadata:
+        metadata: Metadaten
       versioning:
         choose_file: Neue Dateiversion wählen
         current: Aktuelle Version

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -1358,6 +1358,8 @@ en:
         file_details: File Details
         fixity_check: Fixity Check
         not_yet_characterized: Not Yet Characterized
+      metadata:
+        metadata: Metadata
       versioning:
         choose_file: Choose New Version File
         current: Current Version

--- a/config/locales/hyrax.es.yml
+++ b/config/locales/hyrax.es.yml
@@ -1379,6 +1379,8 @@ es:
         file_details: Los Detalles Del Archivo
         fixity_check: La Fijeza De Verificación
         not_yet_characterized: Aún No Se Caracteriza
+      metadata:
+        metadata: Metadatos
       versioning:
         choose_file: Elija el archivo de nueva versión
         current: Versión actual

--- a/config/locales/hyrax.fr.yml
+++ b/config/locales/hyrax.fr.yml
@@ -1377,6 +1377,8 @@ fr:
         file_details: Description du fichier
         fixity_check: Vérification de la fixité
         not_yet_characterized: Pas encore caractérisé
+      metadata:
+        metadata: Métadonnées
       versioning:
         choose_file: Choisissez un nouveau fichier de version
         current: Version actuelle

--- a/config/locales/hyrax.it.yml
+++ b/config/locales/hyrax.it.yml
@@ -1376,6 +1376,8 @@ it:
         file_details: Dettagli File
         fixity_check: Fissità Di Controllo
         not_yet_characterized: Non Ancora Caratterizzati
+      metadata:
+        metadata: Metadati
       versioning:
         choose_file: Scegli New Version File
         current: Versione attuale

--- a/config/locales/hyrax.pt-BR.yml
+++ b/config/locales/hyrax.pt-BR.yml
@@ -1369,6 +1369,8 @@ pt-BR:
         file_details: Detalhes Do Ficheiro
         fixity_check: Fixidez De Seleção
         not_yet_characterized: Ainda Não Caracterizados
+      metadata:
+        metadata: Metadados
       versioning:
         choose_file: Escolha o arquivo da nova versão
         current: Versão corrente

--- a/config/locales/hyrax.zh.yml
+++ b/config/locales/hyrax.zh.yml
@@ -1374,6 +1374,8 @@ zh:
         file_details: 文件的详细信息
         fixity_check: 固定性检查
         not_yet_characterized: 没有特征
+      metadata:
+        metadata: 元数据
       versioning:
         choose_file: 选择新版本文件
         current: 当前版本

--- a/spec/views/hyrax/file_sets/_metadata.html.erb_spec.rb
+++ b/spec/views/hyrax/file_sets/_metadata.html.erb_spec.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+RSpec.describe 'hyrax/file_sets/_metadata.html.erb', type: :view do
+  let(:doc) do
+    {
+      'has_model_ssim' => ['FileSet'],
+      :id => '123',
+      'creator_tesim' => ['Jane Smith'],
+      'keyword_tesim' => ['cats', 'dogs'],
+      'license_tesim' => ['https://creativecommons.org/licenses/by/4.0/']
+    }
+  end
+  let(:solr_doc) { SolrDocument.new(doc) }
+  let(:ability) { double }
+  let(:presenter) { Hyrax::FileSetPresenter.new(solr_doc, ability) }
+
+  before do
+    assign(:presenter, presenter)
+  end
+
+  context 'when not using flexible metadata' do
+    before do
+      allow(Hyrax.config).to receive(:flexible?).and_return(false)
+      render
+    end
+
+    it 'renders creator' do
+      expect(rendered).to have_selector('dd', text: 'Jane Smith')
+    end
+
+    it 'renders multiple keyword values joined' do
+      expect(rendered).to have_selector('dd', text: 'cats, dogs')
+    end
+
+    it 'renders license as a link' do
+      expect(rendered).to have_selector('dd a[href="https://creativecommons.org/licenses/by/4.0/"]')
+    end
+  end
+
+  context 'when using flexible metadata' do
+    before do
+      allow(Hyrax.config).to receive(:flexible?).and_return(true)
+      allow(view).to receive(:view_options_for).and_return(
+        {
+          creator: { 'display_label' => { 'en' => 'Creator', 'default' => 'Creator' } },
+          keyword: { 'display_label' => { 'en' => 'Keyword', 'default' => 'Keyword' } },
+          license: { 'display_label' => { 'en' => 'License', 'default' => 'License' } }
+        }
+      )
+      render
+    end
+
+    it 'renders creator from flexible schema' do
+      expect(rendered).to have_selector('dd', text: 'Jane Smith')
+    end
+
+    it 'renders multiple keyword values joined' do
+      expect(rendered).to have_selector('dd', text: 'cats, dogs')
+    end
+
+    it 'renders license as a link' do
+      expect(rendered).to have_selector('dd a[href="https://creativecommons.org/licenses/by/4.0/"]')
+    end
+  end
+end


### PR DESCRIPTION
### Screenshot

<img width="1138" height="823" alt="image" src="https://github.com/user-attachments/assets/5d1a13cf-3afa-42d0-8db9-835530693ed6" />

### Summary

Add a metadata partial for the file set show page.

### Guidance for testing, such as acceptance criteria or new user interface behaviors:

* Navigate to a file set show page
* Add some metadata by editing the file set form
* Confirm that there are metadata fields displaying on the show page
  -  supported: description, creator, license, subject, keyword, date_created, related_url, resource_type

### Type of change (for release notes)

- `notes-bugfix` Bug Fixes

### Detailed Description

## Add file set metadata partial

c035bca4c4894b6d3ee86894f82d50afed691e54

This commit will add a file set metadata partial to display metadata
fields added to the file set show page.  The non-flexible path fields
are based on what is currently being indexed according to the
`file_set_metadata.yaml`.  Flexible path fields are based on the m3
profile.

### Changes proposed in this pull request:
* Add file set metadata to file set show page
* Add i18n support

@samvera/hyrax-code-reviewers
