### PR TITLE
Use textual labels for public catalog sort options

### DIFF
--- a/.dassie/app/controllers/catalog_controller.rb
+++ b/.dassie/app/controllers/catalog_controller.rb
@@ -292,10 +292,10 @@ class CatalogController < ApplicationController
     # except in the relevancy case).
     # label is key, solr field is value
     config.add_sort_field "score desc, #{uploaded_field} desc", label: "relevance"
-    config.add_sort_field "#{uploaded_field} desc", label: "date uploaded \u25BC"
-    config.add_sort_field "#{uploaded_field} asc", label: "date uploaded \u25B2"
-    config.add_sort_field "#{modified_field} desc", label: "date modified \u25BC"
-    config.add_sort_field "#{modified_field} asc", label: "date modified \u25B2"
+    config.add_sort_field "#{uploaded_field} desc", label: "date uploaded (newest first)"
+    config.add_sort_field "#{uploaded_field} asc", label: "date uploaded (oldest first)"
+    config.add_sort_field "#{modified_field} desc", label: "date modified (newest first)"
+    config.add_sort_field "#{modified_field} asc", label: "date modified (oldest first)"
 
     # If there are more than this many search results, no spelling ("did you
     # mean") suggestion is offered.

--- a/.koppie/app/controllers/catalog_controller.rb
+++ b/.koppie/app/controllers/catalog_controller.rb
@@ -295,10 +295,10 @@ class CatalogController < ApplicationController
     # except in the relevancy case).
     # label is key, solr field is value
     config.add_sort_field "score desc, #{uploaded_field} desc", label: "relevance"
-    config.add_sort_field "#{uploaded_field} desc", label: "date uploaded \u25BC"
-    config.add_sort_field "#{uploaded_field} asc", label: "date uploaded \u25B2"
-    config.add_sort_field "#{modified_field} desc", label: "date modified \u25BC"
-    config.add_sort_field "#{modified_field} asc", label: "date modified \u25B2"
+    config.add_sort_field "#{uploaded_field} desc", label: "date uploaded (newest first)"
+    config.add_sort_field "#{uploaded_field} asc", label: "date uploaded (oldest first)"
+    config.add_sort_field "#{modified_field} desc", label: "date modified (newest first)"
+    config.add_sort_field "#{modified_field} asc", label: "date modified (oldest first)"
 
     # If there are more than this many search results, no spelling ("did you
     # mean") suggestion is offered.

--- a/lib/generators/hyrax/templates/catalog_controller.rb
+++ b/lib/generators/hyrax/templates/catalog_controller.rb
@@ -285,10 +285,10 @@ class CatalogController < ApplicationController
     # except in the relevancy case).
     # label is key, solr field is value
     config.add_sort_field "score desc, #{uploaded_field} desc", label: "relevance"
-    config.add_sort_field "#{uploaded_field} desc", label: "date uploaded \u25BC"
-    config.add_sort_field "#{uploaded_field} asc", label: "date uploaded \u25B2"
-    config.add_sort_field "#{modified_field} desc", label: "date modified \u25BC"
-    config.add_sort_field "#{modified_field} asc", label: "date modified \u25B2"
+    config.add_sort_field "#{uploaded_field} desc", label: "date uploaded (newest first)"
+    config.add_sort_field "#{uploaded_field} asc", label: "date uploaded (oldest first)"
+    config.add_sort_field "#{modified_field} desc", label: "date modified (newest first)"
+    config.add_sort_field "#{modified_field} asc", label: "date modified (oldest first)"
 
     # If there are more than this many search results, no spelling ("did you
     # mean") suggestion is offered.

--- a/spec/features/collection_spec.rb
+++ b/spec/features/collection_spec.rb
@@ -115,7 +115,7 @@ RSpec.describe 'collection', type: :feature do
 
       expect(page).to have_css(".pagination")
 
-      select('date modified ▲', from: 'Sort')
+      select('date modified (oldest first)', from: 'Sort')
       click_button 'Refresh'
 
       expect(page).to have_text(/Test Resource 0.+1.+2.+3.+4.+5.+6.+7.+8.+9/m)


### PR DESCRIPTION
### Fixes

Fixes #issuenumber ; refs #issuenumber

### Summary

Closes #7235

Replaces arrow-glyph sort labels in the public catalog with visible textual labels:

- date uploaded (newest first)
- date uploaded (oldest first)
- date modified (newest first)
- date modified (oldest first)

Also updates the related collection feature spec to use the new label text.

Local verification:
- Dassie: verified on http://localhost:3000/catalog
- Koppie: verified on http://localhost:3001/catalog
- Sirenia: verified on http://localhost:3002/catalog


@samvera/hyrax-code-reviewers
