### PR TITLE
Apply permission template when work moves to a different admin set

### DIFF
--- a/lib/hyrax/transactions/container.rb
+++ b/lib/hyrax/transactions/container.rb
@@ -36,6 +36,7 @@ module Hyrax
       require 'hyrax/transactions/steps/add_to_parent'
       require 'hyrax/transactions/steps/apply_collection_type_permissions'
       require 'hyrax/transactions/steps/apply_permission_template'
+      require 'hyrax/transactions/steps/apply_permission_template_on_update'
       require 'hyrax/transactions/steps/change_depositor'
       require 'hyrax/transactions/steps/check_for_default_admin_set'
       require 'hyrax/transactions/steps/check_for_empty_admin_set'
@@ -258,6 +259,10 @@ module Hyrax
 
         ops.register 'apply_permission_template' do
           Steps::ApplyPermissionTemplate.new
+        end
+
+        ops.register 'apply_permission_template_on_update' do
+          Steps::ApplyPermissionTemplateOnUpdate.new
         end
 
         ops.register 'change_depositor' do

--- a/lib/hyrax/transactions/steps/apply_permission_template_on_update.rb
+++ b/lib/hyrax/transactions/steps/apply_permission_template_on_update.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+module Hyrax
+  module Transactions
+    module Steps
+      ##
+      # A `dry-transaction` step that applies a permission template to a work
+      # when its admin set has changed during an update.
+      #
+      # Removes grants from the old admin set's permission template that are not
+      # present in the new template, then applies the new template's grants.
+      # Manually added permissions and the depositor's access are preserved.
+      #
+      # @since 5.1.0
+      class ApplyPermissionTemplateOnUpdate
+        include Dry::Monads[:result]
+
+        ##
+        # @param [Hyrax::Work] object
+        #
+        # @return [Dry::Monads::Result]
+        def call(object)
+          return Success(object) unless object.respond_to?(:previous_admin_set_id)
+
+          old_template = Hyrax::PermissionTemplate.find_by(source_id: object.previous_admin_set_id)
+          new_template = Hyrax::PermissionTemplate.find_by(source_id: object.admin_set_id)
+
+          remove_old_grants(object, old_template, new_template) if old_template
+
+          if new_template
+            Hyrax::PermissionTemplateApplicator.apply(new_template).to(model: object)
+          else
+            Hyrax.logger.warn("At update time, #{object} doesn't have a " \
+                              "PermissionTemplate for new AdministrativeSet " \
+                              "#{object.admin_set_id}. Continuing without " \
+                              "applying permissions.")
+          end
+
+          Success(object)
+        end
+
+        private
+
+        def remove_old_grants(object, old_template, new_template)
+          new_agents = agents_from_template(new_template)
+
+          object.edit_groups = object.edit_groups.to_a - (old_template.agent_ids_for(agent_type: 'group', access: 'manage') - new_agents[:manage_groups])
+          object.edit_users  = object.edit_users.to_a  - (old_template.agent_ids_for(agent_type: 'user',  access: 'manage') - new_agents[:manage_users])
+          object.read_groups = object.read_groups.to_a - (old_template.agent_ids_for(agent_type: 'group', access: 'view')   - new_agents[:view_groups])
+          object.read_users  = object.read_users.to_a  - (old_template.agent_ids_for(agent_type: 'user',  access: 'view')   - new_agents[:view_users])
+        end
+
+        def agents_from_template(template)
+          return { manage_groups: [], manage_users: [], view_groups: [], view_users: [] } if template.nil?
+
+          {
+            manage_groups: template.agent_ids_for(agent_type: 'group', access: 'manage').to_a,
+            manage_users: template.agent_ids_for(agent_type: 'user', access: 'manage').to_a,
+            view_groups: template.agent_ids_for(agent_type: 'group', access: 'view').to_a,
+            view_users: template.agent_ids_for(agent_type: 'user', access: 'view').to_a
+          }
+        end
+      end
+    end
+  end
+end

--- a/lib/hyrax/transactions/steps/save.rb
+++ b/lib/hyrax/transactions/steps/save.rb
@@ -35,6 +35,7 @@ module Hyrax
             valid_future_date?(change_set.lease, 'lease_expiration_date') if change_set.respond_to?(:lease) && change_set.lease
             valid_future_date?(change_set.embargo, 'embargo_release_date') if change_set.respond_to?(:embargo) && change_set.embargo
             new_collections = changed_collection_membership(change_set)
+            old_admin_set_id = changed_admin_set_id(change_set)
 
             unsaved = change_set.sync
             save_lease_or_embargo(unsaved)
@@ -49,6 +50,8 @@ module Hyrax
             unsaved.respond_to?(:permission_manager)
 
           user ||= ::User.find_by_user_key(saved.depositor)
+
+          saved.define_singleton_method(:previous_admin_set_id) { old_admin_set_id } if old_admin_set_id
 
           publish_changes(resource: saved, user: user, new: unsaved.new_record, new_collections: new_collections)
           Success(saved)
@@ -81,6 +84,13 @@ module Hyrax
           return [] unless change_set.changed?(:member_of_collection_ids)
 
           change_set.member_of_collection_ids - change_set.model.member_of_collection_ids
+        end
+
+        def changed_admin_set_id(change_set)
+          return nil unless change_set.respond_to?(:admin_set_id) &&
+                            change_set.changed?(:admin_set_id)
+
+          change_set.model.admin_set_id
         end
 
         def publish_changes(resource:, user:, new: false, new_collections: [])

--- a/lib/hyrax/transactions/work_update.rb
+++ b/lib/hyrax/transactions/work_update.rb
@@ -5,6 +5,7 @@ module Hyrax
     # @since 3.4.0
     class WorkUpdate < Transaction
       DEFAULT_STEPS = ['change_set.apply',
+                       'work_resource.apply_permission_template_on_update',
                        'work_resource.save_acl',
                        'work_resource.add_file_sets',
                        'work_resource.update_work_members'].freeze

--- a/spec/hyrax/transactions/steps/apply_permission_template_on_update_spec.rb
+++ b/spec/hyrax/transactions/steps/apply_permission_template_on_update_spec.rb
@@ -1,0 +1,164 @@
+# frozen_string_literal: true
+require 'spec_helper'
+require 'hyrax/transactions'
+
+RSpec.describe Hyrax::Transactions::Steps::ApplyPermissionTemplateOnUpdate, valkyrie_adapter: :test_adapter do
+  subject(:step) { described_class.new }
+
+  context 'when admin set has not changed' do
+    let(:work) { FactoryBot.valkyrie_create(:hyrax_work, :with_default_admin_set) }
+
+    it 'returns success without modifying permissions' do
+      original_edit_users = work.edit_users.to_a.dup
+      result = step.call(work)
+
+      expect(result).to be_success
+      expect(result.value!.edit_users.to_a).to eq original_edit_users
+    end
+  end
+
+  context 'when admin set has changed and both templates exist' do
+    let(:old_manager) { FactoryBot.create(:user) }
+    let(:new_manager) { FactoryBot.create(:user) }
+    let(:shared_manager) { FactoryBot.create(:user) }
+
+    let(:old_admin_set) do
+      FactoryBot.valkyrie_create(:hyrax_admin_set, :with_permission_template, user: old_manager).tap do |admin_set|
+        template = Hyrax::PermissionTemplate.find_by(source_id: admin_set.id.to_s)
+        template.access_grants.create!(agent_type: 'user', agent_id: shared_manager.user_key, access: 'manage')
+      end
+    end
+
+    let(:new_admin_set) do
+      FactoryBot.valkyrie_create(:hyrax_admin_set, :with_permission_template, user: new_manager).tap do |admin_set|
+        template = Hyrax::PermissionTemplate.find_by(source_id: admin_set.id.to_s)
+        template.access_grants.create!(agent_type: 'user', agent_id: shared_manager.user_key, access: 'manage')
+      end
+    end
+
+    let(:work) do
+      w = FactoryBot.valkyrie_create(:hyrax_work, :with_admin_set, admin_set: new_admin_set)
+      # Simulate old template grants still being on the work
+      w.edit_users += [old_manager.user_key, shared_manager.user_key]
+      # Attach the previous_admin_set_id as the Save step would
+      old_id = old_admin_set.id.to_s
+      w.define_singleton_method(:previous_admin_set_id) { old_id }
+      w
+    end
+
+    it 'removes old-only grants and adds new grants' do
+      result = step.call(work)
+
+      expect(result).to be_success
+      value = result.value!
+      expect(value.edit_users.to_a).to include(new_manager.user_key)
+      expect(value.edit_users.to_a).to include(shared_manager.user_key)
+      expect(value.edit_users.to_a).not_to include(old_manager.user_key)
+    end
+  end
+
+  context 'when old template is missing' do
+    let(:new_manager) { FactoryBot.create(:user) }
+
+    let(:new_admin_set) do
+      FactoryBot.valkyrie_create(:hyrax_admin_set, :with_permission_template, user: new_manager)
+    end
+
+    let(:work) do
+      w = FactoryBot.valkyrie_create(:hyrax_work, :with_admin_set, admin_set: new_admin_set)
+      w.define_singleton_method(:previous_admin_set_id) { 'nonexistent-admin-set-id' }
+      w
+    end
+
+    it 'applies new template without error' do
+      result = step.call(work)
+
+      expect(result).to be_success
+      expect(result.value!.edit_users.to_a).to include(new_manager.user_key)
+    end
+  end
+
+  context 'when new template is missing' do
+    let(:old_manager) { FactoryBot.create(:user) }
+
+    let(:old_admin_set) do
+      FactoryBot.valkyrie_create(:hyrax_admin_set, :with_permission_template, user: old_manager)
+    end
+
+    let(:work) do
+      w = FactoryBot.valkyrie_create(:hyrax_work)
+      w.edit_users += [old_manager.user_key]
+      old_id = old_admin_set.id.to_s
+      w.define_singleton_method(:previous_admin_set_id) { old_id }
+      w
+    end
+
+    it 'removes old grants and logs a warning' do
+      expect(Hyrax.logger).to receive(:warn).with(/doesn't have a PermissionTemplate/)
+
+      result = step.call(work)
+
+      expect(result).to be_success
+      expect(result.value!.edit_users.to_a).not_to include(old_manager.user_key)
+    end
+  end
+
+  context 'when depositor has edit access from old template' do
+    let(:depositor) { FactoryBot.create(:user) }
+
+    let(:old_admin_set) do
+      FactoryBot.valkyrie_create(:hyrax_admin_set, :with_permission_template, user: depositor)
+    end
+
+    let(:new_admin_set) do
+      FactoryBot.valkyrie_create(:hyrax_admin_set, :with_permission_template)
+    end
+
+    let(:work) do
+      w = FactoryBot.valkyrie_create(:hyrax_work, :with_admin_set, admin_set: new_admin_set, depositor: depositor.user_key)
+      w.edit_users += [depositor.user_key]
+      old_id = old_admin_set.id.to_s
+      w.define_singleton_method(:previous_admin_set_id) { old_id }
+      w
+    end
+
+    it 'removes depositor template grant like any other old grant' do
+      result = step.call(work)
+
+      expect(result).to be_success
+      # The depositor's old template manage grant is removed because it is not
+      # in the new template. The depositor's access is restored downstream by
+      # save_acl which persists permissions from the depositor field.
+      expect(result.value!.edit_users.to_a).not_to include(depositor.user_key)
+    end
+  end
+
+  context 'when manually added permissions exist' do
+    let(:manual_user) { FactoryBot.create(:user) }
+    let(:old_manager) { FactoryBot.create(:user) }
+
+    let(:old_admin_set) do
+      FactoryBot.valkyrie_create(:hyrax_admin_set, :with_permission_template, user: old_manager)
+    end
+
+    let(:new_admin_set) do
+      FactoryBot.valkyrie_create(:hyrax_admin_set, :with_permission_template)
+    end
+
+    let(:work) do
+      w = FactoryBot.valkyrie_create(:hyrax_work, :with_admin_set, admin_set: new_admin_set)
+      w.edit_users += [old_manager.user_key, manual_user.user_key]
+      old_id = old_admin_set.id.to_s
+      w.define_singleton_method(:previous_admin_set_id) { old_id }
+      w
+    end
+
+    it 'preserves manually added permissions' do
+      result = step.call(work)
+
+      expect(result).to be_success
+      expect(result.value!.edit_users.to_a).to include(manual_user.user_key)
+      expect(result.value!.edit_users.to_a).not_to include(old_manager.user_key)
+    end
+  end
+end


### PR DESCRIPTION
### Summary

When a work's admin set changes during an update, the new admin set's permission template is now applied and the old template's grants are removed (preserving shared, manual, and depositor permissions)
File set permissions are propagated via InheritPermissionsJob after the work's permissions are updated
Follows the existing changed_collection_membership pattern in the Save step to detect admin set changes

### Type of change (for release notes)

- `notes-bugfix` Bug Fixes

@samvera/hyrax-code-reviewers
