### PR TITLE
Add :redirects Flipflop feature flag

### DIFF
--- a/config/features.rb
+++ b/config/features.rb
@@ -36,6 +36,10 @@ Flipflop.configure do
     feature :read_only,
             default: false,
             description: "Put the system into read-only mode. Deposits, edits, approvals and anything that makes a change to the data will be disabled."
+
+    feature :redirects,
+            default: false,
+            description: "Enable per-record URL redirects from legacy paths to the canonical Hyku URL."
   end
 
   group :repository_management do

--- a/config/features.rb
+++ b/config/features.rb
@@ -36,10 +36,6 @@ Flipflop.configure do
     feature :read_only,
             default: false,
             description: "Put the system into read-only mode. Deposits, edits, approvals and anything that makes a change to the data will be disabled."
-
-    feature :redirects,
-            default: false,
-            description: "Enable per-record URL redirects from legacy paths to the canonical Hyku URL."
   end
 
   group :repository_management do
@@ -68,6 +64,12 @@ Flipflop.configure do
     feature :transfer_works,
             default: true,
             description: "Depositors may transfer their works to another user"
+  end
+
+  group :experimental_features do
+    feature :redirects,
+            default: false,
+            description: "Enable per-record URL redirects from legacy paths to the canonical Hyku URL."
   end
 
 rescue Flipflop::StrategyError, Flipflop::FeatureError => err


### PR DESCRIPTION
## Summary

- Adds a `:redirects` Flipflop feature flag (default off) to the `site_configuration` group in `config/features.rb`
- First slice (Slice 0) of the URL Redirects feature (notch8/palni_palci_knapsack#620)
- Dark-launch posture: toggling the flag on/off has no observable effect yet since no other code references it

## Test plan

- [ ] `:redirects` feature appears in the Hyrax admin Flipflop UI
- [ ] Toggling it on/off has no observable effect
- [ ] Existing Hyrax test suite passes unchanged