### PR TITLE
Add structured `redirects` metadata field to works and collections

### DIFF
--- a/app/indexers/hyrax/indexers/pcdm_collection_indexer.rb
+++ b/app/indexers/hyrax/indexers/pcdm_collection_indexer.rb
@@ -10,7 +10,7 @@ module Hyrax
       include Hyrax::LocationIndexer
       include Hyrax::ThumbnailIndexer
       include Hyrax::Indexer(:core_metadata) if Hyrax.config.collection_include_metadata?
-      include Hyrax::Indexers::RedirectsIndexer
+      include Hyrax::Indexers::RedirectsIndexer if Hyrax.config.redirects_enabled?
       check_if_flexible(Hyrax::PcdmCollection)
 
       self.thumbnail_path_service = CollectionThumbnailPathService

--- a/app/indexers/hyrax/indexers/pcdm_collection_indexer.rb
+++ b/app/indexers/hyrax/indexers/pcdm_collection_indexer.rb
@@ -10,6 +10,7 @@ module Hyrax
       include Hyrax::LocationIndexer
       include Hyrax::ThumbnailIndexer
       include Hyrax::Indexer(:core_metadata) if Hyrax.config.collection_include_metadata?
+      include Hyrax::Indexers::RedirectsIndexer
       check_if_flexible(Hyrax::PcdmCollection)
 
       self.thumbnail_path_service = CollectionThumbnailPathService

--- a/app/indexers/hyrax/indexers/pcdm_object_indexer.rb
+++ b/app/indexers/hyrax/indexers/pcdm_object_indexer.rb
@@ -10,7 +10,7 @@ module Hyrax
       include Hyrax::LocationIndexer
       include Hyrax::ThumbnailIndexer
       include Hyrax::WorkflowIndexer
-      include Hyrax::Indexers::RedirectsIndexer
+      include Hyrax::Indexers::RedirectsIndexer if Hyrax.config.redirects_enabled?
 
       def to_solr # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength
         super.tap do |solr_doc|

--- a/app/indexers/hyrax/indexers/pcdm_object_indexer.rb
+++ b/app/indexers/hyrax/indexers/pcdm_object_indexer.rb
@@ -10,6 +10,7 @@ module Hyrax
       include Hyrax::LocationIndexer
       include Hyrax::ThumbnailIndexer
       include Hyrax::WorkflowIndexer
+      include Hyrax::Indexers::RedirectsIndexer
 
       def to_solr # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength
         super.tap do |solr_doc|

--- a/app/indexers/hyrax/indexers/redirects_indexer.rb
+++ b/app/indexers/hyrax/indexers/redirects_indexer.rb
@@ -7,9 +7,8 @@ module Hyrax
     # resources that carry a `redirects` attribute. The redirect resolver
     # (`Hyrax::RedirectsController`) queries this field by path.
     #
-    # Safe to include unconditionally on resource indexers — when the resource
-    # has no `redirects` attribute (or an empty value), the Solr field is
-    # set to an empty array.
+    # Safe to include unconditionally on resource indexers — the Solr field
+    # is only written when the `:redirects` Flipflop feature is enabled.
     #
     # @example
     #   class WorkIndexer < Hyrax::Indexers::PcdmObjectIndexer
@@ -18,6 +17,7 @@ module Hyrax
     module RedirectsIndexer
       def to_solr(*args)
         super.tap do |document|
+          next document unless Flipflop.redirects?
           document['redirects_path_ssim'] = Array(resource.try(:redirects))
                                             .map { |entry| entry.try(:path) }
                                             .compact

--- a/app/indexers/hyrax/indexers/redirects_indexer.rb
+++ b/app/indexers/hyrax/indexers/redirects_indexer.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module Hyrax
+  module Indexers
+    ##
+    # Indexer mixin that emits the `redirects_path_ssim` Solr field for
+    # resources that carry a `redirects` attribute. The redirect resolver
+    # (`Hyrax::RedirectsController`) queries this field by path.
+    #
+    # Safe to include unconditionally on resource indexers — when the resource
+    # has no `redirects` attribute (or an empty value), the Solr field is
+    # set to an empty array.
+    #
+    # @example
+    #   class WorkIndexer < Hyrax::Indexers::PcdmObjectIndexer
+    #     include Hyrax::Indexers::RedirectsIndexer
+    #   end
+    module RedirectsIndexer
+      def to_solr(*args)
+        super.tap do |document|
+          document['redirects_path_ssim'] = Array(resource.try(:redirects))
+                                            .map { |entry| entry.try(:path) }
+                                            .compact
+        end
+      end
+    end
+  end
+end

--- a/app/indexers/hyrax/indexers/redirects_indexer.rb
+++ b/app/indexers/hyrax/indexers/redirects_indexer.rb
@@ -21,9 +21,8 @@ module Hyrax
       def to_solr(*args)
         super.tap do |document|
           next document unless Flipflop.redirects?
-          document['redirects_path_ssim'] = Array(resource.try(:redirects))
-                                            .map { |entry| entry.try(:path) }
-                                            .compact
+          next document unless resource.respond_to?(:redirects)
+          document['redirects_path_ssim'] = Array(resource.redirects).map(&:path).compact
         end
       end
     end

--- a/app/indexers/hyrax/indexers/redirects_indexer.rb
+++ b/app/indexers/hyrax/indexers/redirects_indexer.rb
@@ -7,12 +7,15 @@ module Hyrax
     # resources that carry a `redirects` attribute. The redirect resolver
     # (`Hyrax::RedirectsController`) queries this field by path.
     #
-    # Safe to include unconditionally on resource indexers — the Solr field
-    # is only written when the `:redirects` Flipflop feature is enabled.
+    # Include this mixin only in apps where `Hyrax.config.redirects_enabled?`
+    # is true (the inclusion site is the config gate). The mixin's body
+    # then needs only the Flipflop check — when the config is on, the
+    # `:redirects` feature is registered and `Flipflop.redirects?` is safe
+    # to call.
     #
     # @example
     #   class WorkIndexer < Hyrax::Indexers::PcdmObjectIndexer
-    #     include Hyrax::Indexers::RedirectsIndexer
+    #     include Hyrax::Indexers::RedirectsIndexer if Hyrax.config.redirects_enabled?
     #   end
     module RedirectsIndexer
       def to_solr(*args)

--- a/app/models/hyrax/pcdm_collection.rb
+++ b/app/models/hyrax/pcdm_collection.rb
@@ -41,22 +41,8 @@ module Hyrax
   #
   class PcdmCollection < Hyrax::Resource
     include Hyrax::Schema(:core_metadata) if Hyrax.config.collection_include_metadata?
-    # The `redirects` attribute is registered directly on the resource class
-    # (not via a schema YAML) so it is uniformly available across both
-    # metadata modes (`flexible: false` and `flexible: true`). The attribute
-    # is always defined; the `:redirects` Flipflop gates the user-facing
-    # surfaces — the catch-all route, the controller, the form tab, the
-    # validators — at request time, where the per-tenant Flipflop strategy
-    # has the context it needs to answer correctly. Class-load-time gating
-    # is not used here because (a) the Flipflop facade isn't initialized
-    # when this class loads under Bulkrax's initializer, and (b) class
-    # definitions can't vary per tenant in any case.
-    #
-    # Set (rather than Array) so instance round-trips through assignment
-    # don't re-invoke the Dry::Struct constructor on existing entries
-    # (Array.of(Resource) raises "can't convert Object into Hash" on
-    # collection.redirects = collection.redirects).
-    attribute :redirects, Valkyrie::Types::Set.of(Hyrax::Redirect)
+    # See documentation/redirects.md for the redirects feature.
+    include Hyrax::Schema(:redirects) if Hyrax.config.collection_include_metadata? && Hyrax.config.redirects_enabled?
 
     attribute :collection_type_gid, Valkyrie::Types::String
     attribute :member_ids, Valkyrie::Types::Array.of(Valkyrie::Types::ID).meta(ordered: true)

--- a/app/models/hyrax/pcdm_collection.rb
+++ b/app/models/hyrax/pcdm_collection.rb
@@ -41,6 +41,22 @@ module Hyrax
   #
   class PcdmCollection < Hyrax::Resource
     include Hyrax::Schema(:core_metadata) if Hyrax.config.collection_include_metadata?
+    # The `redirects` attribute is registered directly on the resource class
+    # (not via a schema YAML) so it is uniformly available across both
+    # metadata modes (`flexible: false` and `flexible: true`). The attribute
+    # is always defined; the `:redirects` Flipflop gates the user-facing
+    # surfaces — the catch-all route, the controller, the form tab, the
+    # validators — at request time, where the per-tenant Flipflop strategy
+    # has the context it needs to answer correctly. Class-load-time gating
+    # is not used here because (a) the Flipflop facade isn't initialized
+    # when this class loads under Bulkrax's initializer, and (b) class
+    # definitions can't vary per tenant in any case.
+    #
+    # Set (rather than Array) so instance round-trips through assignment
+    # don't re-invoke the Dry::Struct constructor on existing entries
+    # (Array.of(Resource) raises "can't convert Object into Hash" on
+    # collection.redirects = collection.redirects).
+    attribute :redirects, Valkyrie::Types::Set.of(Hyrax::Redirect)
 
     attribute :collection_type_gid, Valkyrie::Types::String
     attribute :member_ids, Valkyrie::Types::Array.of(Valkyrie::Types::ID).meta(ordered: true)

--- a/app/models/hyrax/redirect.rb
+++ b/app/models/hyrax/redirect.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module Hyrax
+  ##
+  # The Valkyrie model for a single URL redirect entry on a work or collection.
+  #
+  # A work or collection has zero or more `redirects`. Each entry holds a path
+  # (the lookup key for the redirect resolver), a `canonical` flag (at most one
+  # entry per record may be true), and an optional `sequence` for display
+  # ordering in the admin UI.
+  #
+  # @example
+  #   work.redirects = [
+  #     Hyrax::Redirect.new(path: '/handle/12345/678', canonical: false),
+  #     Hyrax::Redirect.new(path: '/robs-cat-study', canonical: true, sequence: 0)
+  #   ]
+  #
+  # @see Hyrax::RedirectsController for the resolution path
+  class Redirect < Valkyrie::Resource
+    attribute :path,      Valkyrie::Types::String
+    attribute :canonical, Valkyrie::Types::Bool.default(false)
+    attribute :sequence,  Valkyrie::Types::Integer.optional
+  end
+end

--- a/app/models/hyrax/work.rb
+++ b/app/models/hyrax/work.rb
@@ -95,22 +95,8 @@ module Hyrax
   #   for a historical perspective.
   class Work < Hyrax::Resource
     include Hyrax::Schema(:core_metadata) if Hyrax.config.work_default_metadata
-    # The `redirects` attribute is registered directly on the resource class
-    # (not via a schema YAML) so it is uniformly available across both
-    # metadata modes (`flexible: false` and `flexible: true`). The attribute
-    # is always defined; the `:redirects` Flipflop gates the user-facing
-    # surfaces — the catch-all route, the controller, the form tab, the
-    # validators — at request time, where the per-tenant Flipflop strategy
-    # has the context it needs to answer correctly. Class-load-time gating
-    # is not used here because (a) the Flipflop facade isn't initialized
-    # when this class loads under Bulkrax's initializer, and (b) class
-    # definitions can't vary per tenant in any case.
-    #
-    # Set (rather than Array) so instance round-trips through assignment
-    # don't re-invoke the Dry::Struct constructor on existing entries
-    # (Array.of(Resource) raises "can't convert Object into Hash" on
-    # work.redirects = work.redirects).
-    attribute :redirects, Valkyrie::Types::Set.of(Hyrax::Redirect)
+    # See documentation/redirects.md for the redirects feature.
+    include Hyrax::Schema(:redirects) if Hyrax.config.work_default_metadata && Hyrax.config.redirects_enabled?
 
     attribute :admin_set_id,             Valkyrie::Types::ID
     attribute :member_ids,               Valkyrie::Types::Array.of(Valkyrie::Types::ID).meta(ordered: true)

--- a/app/models/hyrax/work.rb
+++ b/app/models/hyrax/work.rb
@@ -95,6 +95,22 @@ module Hyrax
   #   for a historical perspective.
   class Work < Hyrax::Resource
     include Hyrax::Schema(:core_metadata) if Hyrax.config.work_default_metadata
+    # The `redirects` attribute is registered directly on the resource class
+    # (not via a schema YAML) so it is uniformly available across both
+    # metadata modes (`flexible: false` and `flexible: true`). The attribute
+    # is always defined; the `:redirects` Flipflop gates the user-facing
+    # surfaces — the catch-all route, the controller, the form tab, the
+    # validators — at request time, where the per-tenant Flipflop strategy
+    # has the context it needs to answer correctly. Class-load-time gating
+    # is not used here because (a) the Flipflop facade isn't initialized
+    # when this class loads under Bulkrax's initializer, and (b) class
+    # definitions can't vary per tenant in any case.
+    #
+    # Set (rather than Array) so instance round-trips through assignment
+    # don't re-invoke the Dry::Struct constructor on existing entries
+    # (Array.of(Resource) raises "can't convert Object into Hash" on
+    # work.redirects = work.redirects).
+    attribute :redirects, Valkyrie::Types::Set.of(Hyrax::Redirect)
 
     attribute :admin_set_id,             Valkyrie::Types::ID
     attribute :member_ids,               Valkyrie::Types::Array.of(Valkyrie::Types::ID).meta(ordered: true)

--- a/app/services/hyrax/flexible_schema_validator_service.rb
+++ b/app/services/hyrax/flexible_schema_validator_service.rb
@@ -38,6 +38,7 @@ module Hyrax
       validate_label_prop
       validate_core_metadata
       validate_sort_properties
+      validate_redirects
     end
 
     # The default JSON schema used when no custom schema is provided.
@@ -117,6 +118,18 @@ module Hyrax
     # @return [void]
     def validate_sort_properties
       FlexibleSchemaValidators::SortPropertiesValidator.new(profile, @warnings).validate!
+    end
+
+    # Validates that the `redirects` property is declared on every work and
+    # collection class when both `Hyrax.config.redirects_enabled?` and
+    # `Flipflop.redirects?` are true. When either gate is closed, this
+    # validator is a no-op.
+    #
+    # @return [void]
+    def validate_redirects
+      FlexibleSchemaValidators::RedirectsValidator.new(
+        profile: profile, errors: @errors, warnings: @warnings
+      ).validate!
     end
 
     # Validates that a `label` property exists and that it is available on

--- a/app/services/hyrax/flexible_schema_validators/redirects_validator.rb
+++ b/app/services/hyrax/flexible_schema_validators/redirects_validator.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+module Hyrax
+  module FlexibleSchemaValidators
+    ##
+    # @api private
+    #
+    # Validates the `redirects` property in an m3 profile against the
+    # two-layer feature gating (config + Flipflop):
+    #
+    # | config | flipflop | property | result                              |
+    # |--------|----------|----------|-------------------------------------|
+    # | off    | n/a      | present  | warn (property will be ignored)     |
+    # | off    | n/a      | absent   | silent                              |
+    # | on     | off      | present  | warn (property is loaded but unused)|
+    # | on     | off      | absent   | silent                              |
+    # | on     | on       | absent   | error (property is required)        |
+    # | on     | on       | present  | check available_on.class and pass   |
+    # |        |          |          | or error if work/collection missing |
+    class RedirectsValidator
+      REQUIRED_CLASSES = %w[Hyrax::Work Hyrax::PcdmCollection].freeze
+
+      ##
+      # @param profile [Hash] the flexible metadata profile
+      # @param errors [Array<String>] an array to append errors to
+      # @param warnings [Array<String>] an array to append warnings to
+      def initialize(profile:, errors:, warnings: [])
+        @profile = profile
+        @errors = errors
+        @warnings = warnings
+      end
+
+      # Validate the profile against the redirects requirements and append
+      # any human-readable error messages to {#errors} (or warnings to
+      # {#warnings} for the dead-property cases).
+      #
+      # @return [void]
+      def validate!
+        return validate_when_config_off unless Hyrax.config.redirects_enabled?
+        return validate_when_flipflop_off unless Flipflop.redirects?
+
+        validate_when_enabled
+      end
+
+      private
+
+      def redirects_property
+        @redirects_property ||= @profile&.dig('properties', 'redirects')
+      end
+
+      def validate_when_config_off
+        return if redirects_property.blank?
+        warn_dead_property('Hyrax.config.redirects_enabled? is false')
+      end
+
+      def validate_when_flipflop_off
+        return if redirects_property.blank?
+        warn_dead_property('the :redirects feature flag is off for this tenant')
+      end
+
+      def validate_when_enabled
+        if redirects_property.blank?
+          @errors << 'm3 profile must declare a `redirects` property when the redirects feature is enabled'
+          return
+        end
+
+        available_on = Array(redirects_property.dig('available_on', 'class'))
+        missing = REQUIRED_CLASSES - available_on
+        return if missing.empty?
+
+        @errors << "m3 profile `redirects` property must be available on: #{missing.join(', ')}"
+      end
+
+      def warn_dead_property(reason)
+        @warnings << "m3 profile declares a `redirects` property but #{reason}; " \
+                     'the property will be ignored'
+      end
+    end
+  end
+end

--- a/app/services/hyrax/schema_loader.rb
+++ b/app/services/hyrax/schema_loader.rb
@@ -106,12 +106,16 @@ module Hyrax
       # @return [Dry::Types::Type]
       def type
         member_type = type_for(config['type'])
+        nested_resource = member_type.is_a?(Class) && member_type < Valkyrie::Resource
+
+        raise ArgumentError, "nested resource members require `multiple: true` (got #{member_type})" if nested_resource && !multiple?
+
         collection_type = if multiple?
                             # When the entries are nested Hyrax resources (e.g. Hyrax::Redirect),
                             # use Set so reading-and-writing the same value back works.
                             # Array of resources would crash on `record.foo = record.foo`
                             # because it tries to rebuild each entry from a hash.
-                            if member_type.is_a?(Class) && member_type < Valkyrie::Resource
+                            if nested_resource
                               Valkyrie::Types::Set.constructor(&Coerce)
                             else
                               Valkyrie::Types::Array.constructor(&Coerce)

--- a/app/services/hyrax/schema_loader.rb
+++ b/app/services/hyrax/schema_loader.rb
@@ -105,13 +105,31 @@ module Hyrax
       ##
       # @return [Dry::Types::Type]
       def type
+        member_type = type_for(config['type'])
         collection_type = if multiple?
-                            Valkyrie::Types::Array.constructor { |v| Array(v).select(&:present?) }
+                            # When the entries are nested Hyrax resources (e.g. Hyrax::Redirect),
+                            # use Set so reading-and-writing the same value back works.
+                            # Array of resources would crash on `record.foo = record.foo`
+                            # because it tries to rebuild each entry from a hash.
+                            if member_type.is_a?(Class) && member_type < Valkyrie::Resource
+                              Valkyrie::Types::Set.constructor(&Coerce)
+                            else
+                              Valkyrie::Types::Array.constructor(&Coerce)
+                            end
                           else
                             Identity
                           end
 
-        collection_type.of(type_for(config['type']))
+        collection_type.of(member_type)
+      end
+
+      # Cleans up the input before the type system sees it: drops the
+      # "no value provided" placeholder dry-types uses internally, then
+      # removes blanks. Without dropping the placeholder, it leaks into
+      # member coercion and breaks nested-resource attributes.
+      Coerce = lambda do |value|
+        return [] if value.equal?(Dry::Types::Undefined)
+        Array(value).reject { |v| v.equal?(Dry::Types::Undefined) }.select(&:present?)
       end
 
       # Determine whether this attribute allows multiple values.
@@ -146,10 +164,19 @@ module Hyrax
       private
 
       ##
-      # Maps a configuration string value to a `Valkyrie::Type`.
+      # Resolves a `type:` value from a schema YAML to the actual class to use.
+      #
+      # Looks for the type in this order:
+      #   1. The shortcuts `id`, `uri`, and `date_time`.
+      #   2. A primitive type under `Valkyrie::Types::*` (e.g. `string` → `Valkyrie::Types::String`).
+      #   3. A `Valkyrie::Resource` class. Short names are looked up under `Hyrax::*`
+      #      (so `type: redirect` finds `Hyrax::Redirect`); fully-qualified names like
+      #      `MyApp::Citation` are looked up as-is.
+      #
+      # Raises `ArgumentError` if nothing matches.
       #
       # @param [String]
-      # @return [Dry::Types::Type]
+      # @return [Dry::Types::Type, Class]
       def type_for(type)
         case type
         when 'id'
@@ -159,12 +186,32 @@ module Hyrax
         when 'date_time'
           Valkyrie::Types::DateTime
         else
-          begin
-            "Valkyrie::Types::#{type.capitalize}".constantize
-          rescue NameError
-            raise ArgumentError, "Unrecognized type: #{type}"
-          end
+          "Valkyrie::Types::#{type.classify}".safe_constantize ||
+            nested_resource_type(type) ||
+            raise(ArgumentError, "Unrecognized type: #{type}")
         end
+      end
+
+      ##
+      # Looks up a `Valkyrie::Resource` class by name. Returns nil if the
+      # name doesn't resolve to one.
+      #
+      # A short name like `redirect` is checked under `Hyrax::*` first
+      # (`Hyrax::Redirect`), then at the top level (`Redirect`). A name
+      # with `::` in it is taken as-is (`MyApp::Citation`). Anything that
+      # resolves to something other than a `Valkyrie::Resource` class is
+      # rejected, so non-resource classes don't accidentally get used as
+      # nested-attribute types.
+      #
+      # @param [String] type
+      # @return [Class, nil] a Valkyrie::Resource subclass, or nil if no match
+      def nested_resource_type(type)
+        candidates = type.include?('::') ? [type] : ["Hyrax::#{type.classify}", type.classify]
+        candidates.each do |name|
+          klass = name.safe_constantize
+          return klass if klass.is_a?(Class) && klass < Valkyrie::Resource
+        end
+        nil
       end
     end
 

--- a/app/services/hyrax/simple_schema_loader.rb
+++ b/app/services/hyrax/simple_schema_loader.rb
@@ -36,6 +36,8 @@ module Hyrax
     # @param [#to_s] schema_name
     # @return [Hash]
     def schema_config(schema_name)
+      raise(UndefinedSchemaError, "No schema defined: #{schema_name}") if disabled_schemas.include?(schema_name.to_s)
+
       schema_config_path = config_paths(schema_name).find { |path| File.exist? path }
       raise(UndefinedSchemaError, "No schema defined: #{schema_name}") unless schema_config_path
 
@@ -49,7 +51,21 @@ module Hyrax
     def metadata_files
       file_name_arr = []
       config_search_paths.each { |root_path| file_name_arr += Dir.entries(root_path.to_s + "/config/metadata/") }
-      file_name_arr.reject { |fn| !fn.include?('.yaml') }.uniq.map { |y| y.gsub('.yaml', '') }
+      file_name_arr
+        .reject { |fn| !fn.include?('.yaml') }
+        .uniq
+        .map { |y| y.gsub('.yaml', '') }
+        .reject { |schema_name| disabled_schemas.include?(schema_name) }
+    end
+
+    # Names of schemas in `config/metadata/` that the host app has not
+    # opted in to. {#metadata_files} skips them and {#schema_config}
+    # raises `UndefinedSchemaError` for them, so they behave as if the
+    # YAML did not exist.
+    def disabled_schemas
+      disabled = []
+      disabled << 'redirects' unless Hyrax.config.redirects_enabled?
+      disabled
     end
 
     def predicate_pairs(ret_hsh, schema_name)

--- a/config/features.rb
+++ b/config/features.rb
@@ -66,10 +66,13 @@ Flipflop.configure do
             description: "Depositors may transfer their works to another user"
   end
 
-  group :experimental_features do
-    feature :redirects,
-            default: false,
-            description: "Enable per-record URL redirects from legacy paths to the canonical Hyku URL."
+  # See documentation/redirects.md for the redirects feature.
+  if Hyrax.config.redirects_enabled?
+    group :experimental_features do
+      feature :redirects,
+              default: false,
+              description: "Enable per-record URL redirects from legacy paths to the canonical Hyku URL."
+    end
   end
 
 rescue Flipflop::StrategyError, Flipflop::FeatureError => err

--- a/config/metadata/redirects.yaml
+++ b/config/metadata/redirects.yaml
@@ -1,0 +1,10 @@
+---
+attributes:
+  redirects:
+    type: redirect
+    multiple: true
+    form:
+      primary: false
+    predicate: http://samvera.org/ns/hyku/redirects
+    mappings:
+      simple_dc_pmh: ~

--- a/documentation/flexible_metadata.md
+++ b/documentation/flexible_metadata.md
@@ -44,6 +44,10 @@ For comprehensive information about flexible metadata, including:
 
 See the official [Flexible Metadata Documentation](https://samvera.atlassian.net/wiki/spaces/hyraxdocs/pages/3382542341/Flexible+Metadata) on the Samvera Confluence.
 
+## Related features
+
+- **URL Redirects** (`HYRAX_REDIRECTS_ENABLED`): when enabled, the redirects feature requires a `redirects` property in the m3 profile (when also Flipflop-enabled per tenant). See [`documentation/redirects.md`](redirects.md) for the full schema and gating model.
+
 ## Flexible TODOs
 * add the schema loader
 * add the flexible schema model

--- a/documentation/redirects.md
+++ b/documentation/redirects.md
@@ -1,0 +1,164 @@
+# URL Redirects
+
+Hyrax can register arbitrary URL paths as redirects to a work or collection's canonical URL. This is the migration safety net for institutions moving from DSpace, CONTENTdm, Islandora, bepress, or any other repository system whose URLs are cited in published scholarship, embedded in LibGuides, indexed by search engines, and bookmarked by researchers — those URLs need to keep resolving after the move.
+
+This feature is **disabled by default** and must be explicitly enabled in two layers.
+
+## Two-layer feature gating
+
+The redirects feature is gated by **two** independent switches:
+
+1. **`Hyrax.config.redirects_enabled?`** — application-level config. Controls whether the schema and properties exist in this Hyrax application at all. Set in `config/initializers/hyrax.rb` or via the `HYRAX_REDIRECTS_ENABLED` environment variable. Default: `false`.
+
+2. **`Flipflop.redirects?`** — per-tenant feature flag. Controls whether *this tenant* uses the registered redirects feature. Only registered when the config is on. Default when registered: `false`. Toggleable per-tenant via the Flipflop admin UI.
+
+| Config | Flipflop | What's true |
+|---|---|---|
+| off | n/a (unregistered) | The schema is not loaded. The Flipflop feature is not registered. No `redirects` attribute on any resource. No indexer. No route. No controller. m3 profile does not require a `redirects` property. The feature is wholly absent. |
+| on | registered, off (default) | The schema is loaded. The `redirects` attribute exists on `Hyrax::Work` and `Hyrax::PcdmCollection`. The indexer is included on resource indexers but emits no Solr field. Routes/controllers/UI gates check Flipflop and stay silent. m3 profile may declare `redirects` (loaded but unused — a warning is emitted on profile validation). |
+| on | on | All of the above, plus: the indexer emits `redirects_path_ssim`. The route/controller/UI engage. m3 profile validation **requires** the `redirects` property to be declared and available on `Hyrax::Work` and `Hyrax::PcdmCollection`. |
+
+The two-layer split is deliberate: the application-level config controls *availability* (the schema is structural — toggling it after data is written would orphan persisted entries), and the per-tenant Flipflop controls *use* (each tenant decides at request time).
+
+## Enabling the config
+
+### Via environment variable
+
+```sh
+export HYRAX_REDIRECTS_ENABLED=true
+```
+
+This is the easiest path for koppie/dassie/sirenia/allinson and for CI environments.
+
+### Via initializer
+
+```ruby
+# config/initializers/hyrax.rb
+Hyrax.config do |config|
+  config.redirects_enabled = true
+end
+```
+
+This is appropriate when an adopter wants the feature unconditionally without depending on the deploy environment.
+
+### What changes when the config is on
+
+- `config/metadata/redirects.yaml` becomes part of the schema set (visible to `Hyrax::SimpleSchemaLoader#permissive_schema_for_valkrie_adapter` and `Hyrax::Schema(:redirects)`).
+- `Hyrax::Work` and `Hyrax::PcdmCollection` include `Hyrax::Schema(:redirects)` (subject to the existing `work_default_metadata` / `collection_include_metadata?` gates so adopters who manage their own work/collection metadata schemas aren't overridden).
+- The `:redirects` Flipflop feature is registered and appears in the admin Flipflop UI.
+- `Hyrax::Indexers::PcdmObjectIndexer` and `Hyrax::Indexers::PcdmCollectionIndexer` include `Hyrax::Indexers::RedirectsIndexer` (the include itself is conditional on this config; when off, the mixin is not added at all).
+- The m3 profile validator runs the redirects-specific check (no error or warning unless the Flipflop is also on, or the profile contains a stale `redirects` property).
+
+### What changes when the config is off
+
+- None of the above happens. Hyrax behaves as if the redirects feature didn't exist.
+
+## Enabling the Flipflop (per tenant)
+
+Once the config is on, the `:redirects` feature appears in the experimental_features group of the Hyrax Flipflop admin UI. Toggling it on for a tenant:
+
+- Causes `Hyrax::Indexers::RedirectsIndexer` to emit the `redirects_path_ssim` field for that tenant's resources.
+- Activates the catch-all redirect route and `Hyrax::RedirectsController` (slice 2; see ticket #622).
+- Causes the m3 profile validator to **require** a `redirects` property in the tenant's flexible metadata profile (when `flexible: true` mode is also active).
+
+If the Flipflop is on but the m3 profile is missing the `redirects` property, the profile fails validation with a clear error message. Adopters running flexible metadata must add a `redirects` property to their m3 profile before enabling the Flipflop.
+
+## m3 profile requirements (`flexible: true` mode)
+
+Adopters running `HYRAX_FLEXIBLE=true` and choosing to use redirects must declare a `redirects` property in their m3 profile. The minimal declaration:
+
+```yaml
+properties:
+  redirects:
+    available_on:
+      class:
+        - Hyrax::Work
+        - Hyrax::PcdmCollection
+    cardinality:
+      minimum: 0
+    type: redirect
+    multiple: true
+    predicate: http://samvera.org/ns/hyku/redirects
+```
+
+The `type: redirect` token resolves to `Hyrax::Redirect`, a `Valkyrie::Resource` with `path`, `canonical`, and `sequence` sub-attributes.
+
+Validation matrix on profile save (with the config on):
+
+| Flipflop | Property | Result |
+|---|---|---|
+| off | absent | silent (tenant hasn't opted in) |
+| off | present | warning (property is loaded but unused) |
+| on | absent | error (property is required) |
+| on | present, missing `Hyrax::Work` or `Hyrax::PcdmCollection` in `available_on.class` | error |
+| on | present, complete | silent (valid) |
+
+When the config is **off**, an m3 profile that declares `redirects` produces a warning rather than an error. The property is dead — it won't be loaded — but Hyrax doesn't refuse to save the profile.
+
+## Schema details (`flexible: false` mode)
+
+In default (non-flexible) mode the schema lives in `config/metadata/redirects.yaml`:
+
+```yaml
+attributes:
+  redirects:
+    type: redirect
+    multiple: true
+    form:
+      primary: false
+    predicate: http://samvera.org/ns/hyku/redirects
+    mappings:
+      simple_dc_pmh: ~
+```
+
+When the config is on, this schema is loaded and `Hyrax::Work` / `Hyrax::PcdmCollection` include it via `Hyrax::Schema(:redirects)`. The schema loader produces:
+
+```ruby
+attribute :redirects, Valkyrie::Types::Set.of(Hyrax::Redirect)
+```
+
+`Set` (rather than `Array`) is used so instance round-trips through assignment don't re-invoke the Dry::Struct constructor on existing entries — `Array.of(Resource)` raises `can't convert Object into Hash` on `work.redirects = work.redirects`.
+
+When the config is off, the loader filters `redirects.yaml` out of the schema set entirely. The file is on disk but invisible to `permissive_schema_for_valkrie_adapter`, `Hyrax::Schema(:redirects)`, and any other consumer of the simple schema loader.
+
+## Reindexing after enabling
+
+Toggling the config or the Flipflop changes what the indexer emits. Existing records need a reindex to have the new field populated (when both gates open) or removed (when either closes):
+
+```sh
+bundle exec rails hyrax:solr:reindex_everything
+```
+
+## Disabling
+
+To fully disable: unset `HYRAX_REDIRECTS_ENABLED` (or set `Hyrax.config.redirects_enabled = false`) and reboot. The schema is no longer loaded, the attribute is no longer included on `Hyrax::Work` / `Hyrax::PcdmCollection`, the Flipflop feature is no longer registered, and the indexer mixin is no longer included. Persisted `redirects` entries on records remain in storage (Postgres / Fedora) but are inaccessible because the attribute no longer exists on the model. Re-enabling restores access.
+
+To disable for a specific tenant only, leave the config on and toggle the `:redirects` Flipflop off in that tenant's admin Flipflop UI.
+
+### Caveats
+
+- **`Hyrax::Redirect` (the resource class) is always defined.** The class file is loaded by Rails autoloading as soon as anything references the constant. It costs effectively nothing when unused. The "wholly absent" effect of disabling the config applies to the schema, the attribute on `Hyrax::Work` / `Hyrax::PcdmCollection`, the Flipflop, the indexer, and the m3 profile validator's enforcement — but not to the constant itself.
+- **The `disabled_schemas` filter only affects `Hyrax::SimpleSchemaLoader`.** Adopters running `flexible: true` whose m3 profile contains a stale `redirects` property will still see the attribute defined on records loaded via `M3SchemaLoader` even if `Hyrax.config.redirects_enabled?` is false. The m3 profile validator emits a warning in that situation ("the property will be ignored"); follow the warning by removing the `redirects` property from the m3 profile or setting the config back on.
+
+## For contributors
+
+### Why a config *and* a Flipflop?
+
+The schema include on `Hyrax::Work` and `Hyrax::PcdmCollection` runs at class-load time, often triggered by Bulkrax's initializer before the Flipflop facade is wired up. `Hyrax.config.redirects_enabled?` is queryable that early; `Flipflop.redirects?` is not. The config gates structural choices (does the attribute exist on the model? does the schema YAML get loaded?); the Flipflop gates per-tenant behavior at request time (does this tenant see the UI? does the indexer emit values?).
+
+### Calling `Flipflop.redirects?`
+
+The `:redirects` Flipflop feature is only registered when `Hyrax.config.redirects_enabled?` is true. When the config is off, calling `Flipflop.redirects?` raises `NoMethodError`. Any new code that consults the feature flag must short-circuit on the config first:
+
+```ruby
+Hyrax.config.redirects_enabled? && Flipflop.redirects?
+```
+
+Alternatively, gate the inclusion of the calling code itself on `Hyrax.config.redirects_enabled?` (as the indexer mixin does in `Hyrax::Indexers::PcdmObjectIndexer` and `Hyrax::Indexers::PcdmCollectionIndexer`); then the body can check `Flipflop.redirects?` alone because it only runs when the feature is registered.
+
+## See also
+
+- `documentation/flexible_metadata.md` — m3 profile fundamentals and how the redirects feature interacts with flexible metadata.
+- `Hyrax::Redirect` (`app/models/hyrax/redirect.rb`) — the Valkyrie::Resource representing a single redirect entry.
+- `Hyrax::Indexers::RedirectsIndexer` (`app/indexers/hyrax/indexers/redirects_indexer.rb`) — the indexer mixin.
+- `Hyrax::FlexibleSchemaValidators::RedirectsValidator` (`app/services/hyrax/flexible_schema_validators/redirects_validator.rb`) — the m3 profile validator.

--- a/documentation/redirects.md
+++ b/documentation/redirects.md
@@ -81,7 +81,7 @@ properties:
     predicate: http://samvera.org/ns/hyku/redirects
 ```
 
-The `type: redirect` token resolves to `Hyrax::Redirect`, a `Valkyrie::Resource` with `path`, `canonical`, and `sequence` sub-attributes.
+The `type: redirect` token resolves to `Hyrax::Redirect`, a `Valkyrie::Resource` with `path`, `canonical`, and `sequence` sub-attributes. `multiple: true` is required for nested-resource members; the schema loader raises `ArgumentError` if a nested-resource property is declared with `multiple: false`.
 
 Validation matrix on profile save (with the config on):
 

--- a/lib/hyrax/configuration.rb
+++ b/lib/hyrax/configuration.rb
@@ -342,6 +342,14 @@ module Hyrax
     end
     alias flexible? flexible
 
+    # See documentation/redirects.md for the redirects feature.
+    attr_writer :redirects_enabled
+    def redirects_enabled?
+      return @redirects_enabled if defined?(@redirects_enabled) && !@redirects_enabled.nil?
+      @redirects_enabled = ActiveModel::Type::Boolean.new.cast(ENV.fetch('HYRAX_REDIRECTS_ENABLED', false))
+    end
+    alias redirects_enabled redirects_enabled?
+
     # This value determines whether to use m3 flexible metadata for core classes or not
     attr_writer :flexible_classes
     def flexible_classes

--- a/lib/hyrax/specs/shared_specs/factories/hyrax_redirect.rb
+++ b/lib/hyrax/specs/shared_specs/factories/hyrax_redirect.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+FactoryBot.define do
+  factory :hyrax_redirect, class: "Hyrax::Redirect" do
+    sequence(:path) { |n| "/legacy/#{n}" }
+    canonical { false }
+
+    trait :canonical do
+      canonical { true }
+    end
+  end
+end

--- a/spec/indexers/hyrax/indexers/redirects_indexer_spec.rb
+++ b/spec/indexers/hyrax/indexers/redirects_indexer_spec.rb
@@ -1,0 +1,91 @@
+# frozen_string_literal: true
+
+RSpec.describe Hyrax::Indexers::RedirectsIndexer do
+  # Minimal Valkyrie::Resource that carries the same `redirects` attribute
+  # shape as Hyrax::Work / Hyrax::PcdmCollection do when the redirects
+  # schema is included. Defined here so the spec runs without depending on
+  # Hyrax.config.redirects_enabled? being toggled in the test env.
+  let(:resource_class) do
+    Class.new(Hyrax::Resource) do
+      def self.name
+        'TestResourceWithRedirects'
+      end
+      attribute :redirects, Valkyrie::Types::Set.of(Hyrax::Redirect)
+    end
+  end
+
+  let(:host_indexer_class) do
+    Class.new(Hyrax::Indexers::ResourceIndexer) do
+      include Hyrax::Indexers::RedirectsIndexer
+    end
+  end
+
+  let(:indexer) { host_indexer_class.new(resource: resource) }
+
+  context 'with the :redirects feature flag on' do
+    before { allow(Flipflop).to receive(:redirects?).and_return(true) }
+
+    context 'for a resource with redirects entries' do
+      let(:resource) do
+        resource_class.new(redirects: [
+                             Hyrax::Redirect.new(path: '/handle/12345/678'),
+                             Hyrax::Redirect.new(path: '/islandora/object/ir:1138')
+                           ])
+      end
+
+      it 'emits redirects_path_ssim with each entry path' do
+        expect(indexer.to_solr['redirects_path_ssim'])
+          .to contain_exactly('/handle/12345/678', '/islandora/object/ir:1138')
+      end
+    end
+
+    context 'for a resource with no redirects entries' do
+      let(:resource) { resource_class.new(redirects: []) }
+
+      it 'emits redirects_path_ssim as an empty array' do
+        expect(indexer.to_solr['redirects_path_ssim']).to eq([])
+      end
+    end
+
+    context 'for a resource without the redirects attribute' do
+      let(:bare_resource_class) do
+        Class.new(Hyrax::Resource) do
+          def self.name
+            'TestResourceWithoutRedirects'
+          end
+        end
+      end
+      let(:resource) { bare_resource_class.new }
+
+      it 'emits redirects_path_ssim as an empty array' do
+        expect(indexer.to_solr['redirects_path_ssim']).to eq([])
+      end
+    end
+
+    context 'when an entry is missing a path' do
+      let(:resource) do
+        resource_class.new(redirects: [
+                             Hyrax::Redirect.new(path: '/handle/12345/678'),
+                             Hyrax::Redirect.new(path: nil)
+                           ])
+      end
+
+      it 'compacts nil paths out of the indexed field' do
+        expect(indexer.to_solr['redirects_path_ssim'])
+          .to contain_exactly('/handle/12345/678')
+      end
+    end
+  end
+
+  context 'with the :redirects feature flag off' do
+    before { allow(Flipflop).to receive(:redirects?).and_return(false) }
+
+    let(:resource) do
+      resource_class.new(redirects: [Hyrax::Redirect.new(path: '/handle/12345/678')])
+    end
+
+    it 'does not emit redirects_path_ssim' do
+      expect(indexer.to_solr).not_to have_key('redirects_path_ssim')
+    end
+  end
+end

--- a/spec/indexers/hyrax/indexers/redirects_indexer_spec.rb
+++ b/spec/indexers/hyrax/indexers/redirects_indexer_spec.rb
@@ -57,8 +57,8 @@ RSpec.describe Hyrax::Indexers::RedirectsIndexer do
       end
       let(:resource) { bare_resource_class.new }
 
-      it 'emits redirects_path_ssim as an empty array' do
-        expect(indexer.to_solr['redirects_path_ssim']).to eq([])
+      it 'does not emit the redirects_path_ssim field' do
+        expect(indexer.to_solr).not_to have_key('redirects_path_ssim')
       end
     end
 

--- a/spec/models/hyrax/redirect_spec.rb
+++ b/spec/models/hyrax/redirect_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require 'valkyrie/specs/shared_specs'
+
+RSpec.describe Hyrax::Redirect do
+  subject(:redirect) { described_class.new }
+
+  it_behaves_like 'a Valkyrie::Resource' do
+    let(:resource_klass) { described_class }
+  end
+
+  describe 'attributes' do
+    it 'accepts a path, canonical flag, and sequence' do
+      r = described_class.new(path: '/handle/12345/678', canonical: true, sequence: 0)
+      expect(r.path).to eq('/handle/12345/678')
+      expect(r.canonical).to be true
+      expect(r.sequence).to eq(0)
+    end
+
+    it 'defaults canonical to false' do
+      r = described_class.new(path: '/foo')
+      expect(r.canonical).to be false
+    end
+
+    it 'allows sequence to be omitted' do
+      r = described_class.new(path: '/foo')
+      expect(r.sequence).to be_nil
+    end
+  end
+end

--- a/spec/services/hyrax/flexible_schema_validators/redirects_validator_spec.rb
+++ b/spec/services/hyrax/flexible_schema_validators/redirects_validator_spec.rb
@@ -1,0 +1,130 @@
+# frozen_string_literal: true
+
+RSpec.describe Hyrax::FlexibleSchemaValidators::RedirectsValidator do
+  subject(:validator) { described_class.new(profile: profile, errors: errors, warnings: warnings) }
+  let(:errors) { [] }
+  let(:warnings) { [] }
+
+  let(:profile_with_redirects) do
+    {
+      'properties' => {
+        'redirects' => {
+          'available_on' => { 'class' => %w[Hyrax::Work Hyrax::PcdmCollection] }
+        }
+      }
+    }
+  end
+
+  let(:profile_without_redirects) do
+    { 'properties' => { 'title' => {} } }
+  end
+
+  describe '#validate!' do
+    context 'when Hyrax.config.redirects_enabled? is false' do
+      before { allow(Hyrax.config).to receive(:redirects_enabled?).and_return(false) }
+
+      context 'and the m3 profile has a `redirects` property' do
+        let(:profile) { profile_with_redirects }
+
+        it 'warns that the property will be ignored' do
+          validator.validate!
+          expect(warnings).to include(/redirects.*Hyrax\.config\.redirects_enabled\? is false/)
+          expect(errors).to be_empty
+        end
+      end
+
+      context 'and the m3 profile has no `redirects` property' do
+        let(:profile) { profile_without_redirects }
+
+        it 'is silent (no errors, no warnings)' do
+          validator.validate!
+          expect(errors).to be_empty
+          expect(warnings).to be_empty
+        end
+      end
+    end
+
+    context 'when Hyrax.config.redirects_enabled? is true and Flipflop.redirects? is false' do
+      before do
+        allow(Hyrax.config).to receive(:redirects_enabled?).and_return(true)
+        allow(Flipflop).to receive(:redirects?).and_return(false)
+      end
+
+      context 'and the m3 profile has a `redirects` property' do
+        let(:profile) { profile_with_redirects }
+
+        it 'warns that the property will be ignored' do
+          validator.validate!
+          expect(warnings).to include(/redirects.*:redirects feature flag is off/)
+          expect(errors).to be_empty
+        end
+      end
+
+      context 'and the m3 profile has no `redirects` property' do
+        let(:profile) { profile_without_redirects }
+
+        it 'is silent (the tenant has not opted in)' do
+          validator.validate!
+          expect(errors).to be_empty
+          expect(warnings).to be_empty
+        end
+      end
+    end
+
+    context 'when both Hyrax.config.redirects_enabled? and Flipflop.redirects? are true' do
+      before do
+        allow(Hyrax.config).to receive(:redirects_enabled?).and_return(true)
+        allow(Flipflop).to receive(:redirects?).and_return(true)
+      end
+
+      context 'and the m3 profile has no `redirects` property' do
+        let(:profile) { profile_without_redirects }
+
+        it 'errors that the property is required' do
+          validator.validate!
+          expect(errors).to include(/m3 profile must declare a `redirects` property/)
+        end
+      end
+
+      context 'and the m3 profile has `redirects` available on the required classes' do
+        let(:profile) { profile_with_redirects }
+
+        it 'is silent' do
+          validator.validate!
+          expect(errors).to be_empty
+          expect(warnings).to be_empty
+        end
+      end
+
+      context 'and the m3 profile has `redirects` but is missing Hyrax::PcdmCollection' do
+        let(:profile) do
+          {
+            'properties' => {
+              'redirects' => { 'available_on' => { 'class' => ['Hyrax::Work'] } }
+            }
+          }
+        end
+
+        it 'errors that the missing class must be in available_on.class' do
+          validator.validate!
+          expect(errors).to include(/`redirects`.*available on.*Hyrax::PcdmCollection/)
+        end
+      end
+
+      context 'and the m3 profile has `redirects` but is missing Hyrax::Work' do
+        let(:profile) do
+          {
+            'properties' => {
+              'redirects' => { 'available_on' => { 'class' => ['Hyrax::PcdmCollection'] } }
+            }
+          }
+        end
+
+        it 'errors that the missing class must be in available_on.class' do
+          validator.validate!
+          expect(errors).to include(/`redirects`.*available on.*Hyrax::Work/)
+        end
+      end
+    end
+  end
+end

--- a/spec/services/hyrax/schema_loader_spec.rb
+++ b/spec/services/hyrax/schema_loader_spec.rb
@@ -114,6 +114,19 @@ RSpec.describe Hyrax::SchemaLoader::AttributeDefinition do
       end
     end
 
+    context 'when a nested Hyrax resource type is declared with multiple: false' do
+      # Single-value nested resources are not supported because the schema
+      # loader's #type would return the bare class rather than a Dry::Types::Type,
+      # producing a downstream shape inconsistency. The loader rejects this
+      # configuration explicitly.
+      let(:config) { { 'type' => 'redirect', 'multiple' => false } }
+
+      it 'raises ArgumentError' do
+        expect { attribute_definition.type }
+          .to raise_error(ArgumentError, /nested resource members require `multiple: true`/)
+      end
+    end
+
     context 'when the type name has multiple words' do
       # The lookup uses String#classify (not capitalize), so multi-word
       # types like `access_control` resolve to `Hyrax::AccessControl`.

--- a/spec/services/hyrax/schema_loader_spec.rb
+++ b/spec/services/hyrax/schema_loader_spec.rb
@@ -101,5 +101,55 @@ RSpec.describe Hyrax::SchemaLoader::AttributeDefinition do
         expect { attribute_definition.type }.to raise_error(ArgumentError, 'Unrecognized type: custom')
       end
     end
+
+    context 'when the type names a nested Hyrax resource class (short form)' do
+      # In a YAML schema, `type: redirect` resolves to `Hyrax::Redirect`,
+      # so adopters can declare nested-resource attributes without
+      # registering anything in the Valkyrie::Types namespace.
+      let(:config) { { 'type' => 'redirect', 'multiple' => true } }
+
+      it 'wraps the nested resource class in a typed array constructor' do
+        expect(attribute_definition.type).to be_a(Dry::Types::Constructor)
+        expect(attribute_definition.type.member).to eq(Hyrax::Redirect)
+      end
+    end
+
+    context 'when the type name has multiple words' do
+      # The lookup uses String#classify (not capitalize), so multi-word
+      # types like `access_control` resolve to `Hyrax::AccessControl`.
+      it 'resolves a multi-word type via #classify' do
+        expect(attribute_definition.send(:type_for, 'access_control')).to eq(Hyrax::AccessControl)
+      end
+    end
+
+    context 'when the type is a fully-qualified class name' do
+      # Adopters with their own namespace can write `type: MyApp::Citation`
+      # in YAML and the loader will resolve it directly.
+      it 'returns the named class' do
+        expect(attribute_definition.send(:type_for, 'Hyrax::Redirect')).to eq(Hyrax::Redirect)
+      end
+    end
+
+    context 'when the type name matches a class that is not a Valkyrie::Resource' do
+      # ::StringIO is a real class but not a resource. Resolution must reject
+      # it rather than silently use it as a nested-attribute type.
+      let(:config) { { 'type' => 'string_io' } }
+
+      it 'raises ArgumentError' do
+        expect { attribute_definition.type }.to raise_error(ArgumentError, 'Unrecognized type: string_io')
+      end
+    end
+
+    context 'when the type name singularizes via #classify (e.g. "data" -> "Datum")' do
+      # String#classify singularizes, which can surprise. Confirm that an
+      # unrecognized type still raises ArgumentError regardless of inflection
+      # quirks — neither Hyrax::Datum, ::Datum, Valkyrie::Types::Datum, nor
+      # any other resolution short-circuits the safety check.
+      let(:config) { { 'type' => 'data' } }
+
+      it 'raises ArgumentError' do
+        expect { attribute_definition.type }.to raise_error(ArgumentError, 'Unrecognized type: data')
+      end
+    end
   end
 end

--- a/spec/services/hyrax/simple_schema_loader_spec.rb
+++ b/spec/services/hyrax/simple_schema_loader_spec.rb
@@ -145,5 +145,42 @@ RSpec.describe Hyrax::SimpleSchemaLoader do
       expect(permissive_schema.values.all? { |v| v.value.present? }).to be_truthy
       expect(permissive_schema[:sample_attribute].value).to eq("http://hyrax-example.com/sample_attribute")
     end
+
+    context 'when Hyrax.config.redirects_enabled? is true' do
+      before { allow(Hyrax.config).to receive(:redirects_enabled?).and_return(true) }
+
+      it 'includes the redirects predicate in the permissive schema' do
+        expect(permissive_schema.size).to eq(68)
+        expect(permissive_schema[:redirects].value).to eq('http://samvera.org/ns/hyku/redirects')
+      end
+    end
+
+    context 'when Hyrax.config.redirects_enabled? is false' do
+      before { allow(Hyrax.config).to receive(:redirects_enabled?).and_return(false) }
+
+      it 'does not include the redirects predicate' do
+        expect(permissive_schema.keys).not_to include(:redirects)
+      end
+    end
+  end
+
+  describe '#attributes_for with the :redirects schema' do
+    context 'when Hyrax.config.redirects_enabled? is true' do
+      before { allow(Hyrax.config).to receive(:redirects_enabled?).and_return(true) }
+
+      it 'returns the redirects attribute definitions' do
+        attributes = schema_loader.attributes_for(schema: :redirects)
+        expect(attributes.keys).to include(:redirects)
+      end
+    end
+
+    context 'when Hyrax.config.redirects_enabled? is false' do
+      before { allow(Hyrax.config).to receive(:redirects_enabled?).and_return(false) }
+
+      it 'raises UndefinedSchemaError as if the YAML did not exist' do
+        expect { schema_loader.attributes_for(schema: :redirects) }
+          .to raise_error(Hyrax::SchemaLoader::UndefinedSchemaError, /No schema defined: redirects/)
+      end
+    end
   end
 end

--- a/spec/services/hyrax/simple_schema_loader_spec.rb
+++ b/spec/services/hyrax/simple_schema_loader_spec.rb
@@ -150,7 +150,6 @@ RSpec.describe Hyrax::SimpleSchemaLoader do
       before { allow(Hyrax.config).to receive(:redirects_enabled?).and_return(true) }
 
       it 'includes the redirects predicate in the permissive schema' do
-        expect(permissive_schema.size).to eq(68)
         expect(permissive_schema[:redirects].value).to eq('http://samvera.org/ns/hyku/redirects')
       end
     end


### PR DESCRIPTION
# Summary

Implements the data layer for URL Redirects (Phase 1, slice 1): 
Adds the data layer for a new URL Redirects feature: works and collections can carry a list of redirect entries (path + canonical flag + sequence) that downstream slices use to resolve legacy URLs to canonical Hyku URLs

Refs notch8/palni_palci_knapsack#621.

## Files involved: 
- New Hyrax::Redirect Valkyrie::Resource with path, canonical, sequence
- New :redirects schema in config/metadata/redirects.yaml (flexible: false mode)
- New `redirects` property in m3_profile.yaml (flexible: true mode)
- Hyrax::Work and Hyrax::PcdmCollection opt into :redirects (gated on work_default_metadata / collection_include_metadata? to avoid double-defining the attribute when flexible mode is active)
- New Hyrax::Indexers::RedirectsIndexer extracts paths from the nested entries into redirects_path_ssim; included into PcdmObjectIndexer and PcdmCollectionIndexer
- Schema loader's type_for falls back to Hyrax::* namespace when a type isn't found under Valkyrie::Types::*, letting schemas reference nested-resource types declared in Hyrax without monkey-patching the Valkyrie::Types module
- Redirect resource spec and FactoryBot factory

## What's new

- Hyrax::Redirect — a small Valkyrie::Resource with path, canonical, and sequence attributes. Designed to live as a nested entry inside a parent work or collection.
- redirects attribute on Hyrax::Work and Hyrax::PcdmCollection — a multi-valued list of Hyrax::Redirect entries. Available in both Hyrax flexible-metadata modes:
- flexible: false: new config/metadata/redirects.yaml schema, opted into via include Hyrax::Schema(:redirects) (gated on the same work_default_metadata / collection_include_metadata? configs the rest of the schema includes use).
- flexible: true: new redirects property in config/metadata_profiles/m3_profile.yaml with available_on.class listing Hyrax's work and collection classes.
- Solr indexing — Hyrax::Indexers::RedirectsIndexer mixin extracts each entry's path into a redirects_path_ssim field. Included in PcdmObjectIndexer (works) and PcdmCollectionIndexer (collections).

## Generic capability added (not specific to redirects)

- SchemaLoader#type_for now resolves nested-resource types from YAML. A schema entry with type: <name> resolves first as a Valkyrie::Types::* primitive (existing behavior, unchanged), then as a Valkyrie::Resource subclass (new).
- Short forms resolve under Hyrax:: first (type: redirect → Hyrax::Redirect); fully-qualified names work for downstream apps (type: MyApp::Citation).
- Uses String#classify instead of capitalize (so type: access_control would resolve to Hyrax::AccessControl, not Hyrax::Access_control).
- Validates resolved candidates with < Valkyrie::Resource so accidental matches against unrelated classes raise the standard "Unrecognized type" error.

This generic capability is what makes the redirects schema work without monkey-patching Valkyrie::Types, and is reusable for any future nested-resource attribute Hyrax or its consumers want to declare via YAML.


