### PR TITLE
Add redirect path normalization, form-level validation, and Postgres uniqueness ledger

### DIFF
--- a/.dassie/db/migrate/20260430000001_create_hyrax_redirect_paths.hyrax.rb
+++ b/.dassie/db/migrate/20260430000001_create_hyrax_redirect_paths.hyrax.rb
@@ -1,0 +1,13 @@
+class CreateHyraxRedirectPaths < ActiveRecord::Migration[5.2]
+  def change
+    create_table :hyrax_redirect_paths do |t|
+      t.string :path, null: false
+      t.string :resource_id, null: false
+
+      t.timestamps
+    end
+
+    add_index :hyrax_redirect_paths, :path, unique: true
+    add_index :hyrax_redirect_paths, :resource_id
+  end
+end

--- a/.dassie/db/schema.rb
+++ b/.dassie/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2025_08_26_142481) do
+ActiveRecord::Schema.define(version: 2026_04_30_000001) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -104,8 +104,6 @@ ActiveRecord::Schema.define(version: 2025_08_26_142481) do
     t.integer "total_file_set_entries", default: 0
     t.integer "processed_works", default: 0
     t.integer "failed_works", default: 0
-    t.integer "processed_children", default: 0
-    t.integer "failed_children", default: 0
     t.index ["importer_id"], name: "index_bulkrax_importer_runs_on_importer_id"
   end
 
@@ -308,6 +306,15 @@ ActiveRecord::Schema.define(version: 2025_08_26_142481) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.text "contexts"
+  end
+
+  create_table "hyrax_redirect_paths", force: :cascade do |t|
+    t.string "path", null: false
+    t.string "resource_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["path"], name: "index_hyrax_redirect_paths_on_path", unique: true
+    t.index ["resource_id"], name: "index_hyrax_redirect_paths_on_resource_id"
   end
 
   create_table "job_io_wrappers", force: :cascade do |t|

--- a/.koppie/db/migrate/20260430000001_create_hyrax_redirect_paths.hyrax.rb
+++ b/.koppie/db/migrate/20260430000001_create_hyrax_redirect_paths.hyrax.rb
@@ -1,0 +1,13 @@
+class CreateHyraxRedirectPaths < ActiveRecord::Migration[5.2]
+  def change
+    create_table :hyrax_redirect_paths do |t|
+      t.string :path, null: false
+      t.string :resource_id, null: false
+
+      t.timestamps
+    end
+
+    add_index :hyrax_redirect_paths, :path, unique: true
+    add_index :hyrax_redirect_paths, :resource_id
+  end
+end

--- a/.koppie/db/schema.rb
+++ b/.koppie/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_08_26_142481) do
+ActiveRecord::Schema[7.2].define(version: 2026_04_30_000001) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "uuid-ossp"
@@ -297,6 +297,15 @@ ActiveRecord::Schema[7.2].define(version: 2025_08_26_142481) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.text "contexts"
+  end
+
+  create_table "hyrax_redirect_paths", force: :cascade do |t|
+    t.string "path", null: false
+    t.string "resource_id", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
+    t.index ["path"], name: "index_hyrax_redirect_paths_on_path", unique: true
+    t.index ["resource_id"], name: "index_hyrax_redirect_paths_on_resource_id"
   end
 
   create_table "job_io_wrappers", force: :cascade do |t|

--- a/app/controllers/hyrax/redirects_controller.rb
+++ b/app/controllers/hyrax/redirects_controller.rb
@@ -6,7 +6,7 @@ module Hyrax
     CACHE_TTL = 60.seconds
 
     def show
-      path = "/#{params[:alias_path]}"
+      path = Hyrax::RedirectPathNormalizer.call(params[:alias_path])
       doc = lookup(path)
       raise ActionController::RoutingError, 'Not Found' if doc.blank?
 

--- a/app/forms/hyrax/forms/resource_form.rb
+++ b/app/forms/hyrax/forms/resource_form.rb
@@ -43,6 +43,8 @@ module Hyrax
       # @see https://github.com/samvera/valkyrie/wiki/Optimistic-Locking
       property :version, virtual: true, prepopulator: LockKeyPrepopulator
 
+      validates_with Hyrax::RedirectValidator, attributes: [:redirects] if Hyrax.config.redirects_enabled?
+
       ##
       # @api public
       #
@@ -187,6 +189,14 @@ module Hyrax
         public_send("#{attr}=".to_sym, value)
       end
 
+      # Normalize redirect paths on assignment so the form, the persisted
+      # resource, the uniqueness ledger, and the resolver all agree on the
+      # canonical shape. See Hyrax::RedirectPathNormalizer.
+      def redirects=(values)
+        return super unless Hyrax.config.redirects_enabled?
+        super(Array(values).map { |entry| normalize_redirect_entry(entry) })
+      end
+
       ##
       # @deprecated use model.class instead
       #
@@ -230,6 +240,18 @@ module Hyrax
           singleton_class.schema_definitions
         else
           self.class.definitions
+        end
+      end
+
+      def normalize_redirect_entry(entry)
+        case entry
+        when Hash
+          entry = entry.transform_keys(&:to_sym)
+          entry.merge(path: Hyrax::RedirectPathNormalizer.call(entry[:path]))
+        when Hyrax::Redirect
+          Hyrax::Redirect.new(entry.attributes.merge(path: Hyrax::RedirectPathNormalizer.call(entry.path)))
+        else
+          entry
         end
       end
     end

--- a/app/models/hyrax/redirect_path.rb
+++ b/app/models/hyrax/redirect_path.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module Hyrax
+  # ActiveRecord-backed uniqueness ledger for redirect paths.
+  #
+  # Maintained by Hyrax::Listeners::RedirectPathsListener; queried by
+  # Hyrax::RedirectsLookup. The unique index on `path` is the source of truth
+  # for "no two records share a redirect path"; this class just exposes it.
+  class RedirectPath < ActiveRecord::Base
+    self.table_name = 'hyrax_redirect_paths'
+  end
+end

--- a/app/models/hyrax/redirect_path.rb
+++ b/app/models/hyrax/redirect_path.rb
@@ -3,7 +3,8 @@
 module Hyrax
   # ActiveRecord-backed uniqueness ledger for redirect paths.
   #
-  # Maintained by Hyrax::Listeners::RedirectPathsListener; queried by
+  # Maintained by Hyrax::Transactions::Steps::SyncRedirectPaths and
+  # Hyrax::Transactions::Steps::RemoveRedirectPaths; queried by
   # Hyrax::RedirectsLookup. The unique index on `path` is the source of truth
   # for "no two records share a redirect path"; this class just exposes it.
   class RedirectPath < ActiveRecord::Base

--- a/app/services/hyrax/redirect_path_normalizer.rb
+++ b/app/services/hyrax/redirect_path_normalizer.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+module Hyrax
+  # Normalizes a user- or system-supplied redirect path into the canonical
+  # form stored in `hyrax_redirect_paths` and queried by the resolver.
+  # Single source of truth for "what does this path look like on disk?".
+  #
+  # Normalization rules:
+  # 1. If input parses as a URL with scheme/host, keep only the path component
+  #    (drop scheme, host, port, userinfo, query, fragment).
+  # 2. Strip query strings and fragments from path-only inputs.
+  # 3. Ensure a leading slash.
+  # 4. Strip trailing slashes (but never reduce the path to empty).
+  #
+  # Idempotent: normalize(normalize(x)) == normalize(x).
+  #
+  # See documentation/redirects.md.
+  module RedirectPathNormalizer
+    module_function
+
+    def call(input)
+      return input if input.nil?
+      path = input.to_s.strip
+      return path if path.empty?
+
+      path = extract_path(path)
+      path = strip_query_and_fragment(path)
+      path = ensure_leading_slash(path)
+      path = strip_trailing_slashes(path)
+      path
+    end
+
+    def extract_path(path)
+      return path unless path.match?(%r{\A[a-zA-Z][a-zA-Z0-9+.-]*://})
+      uri = URI.parse(path)
+      uri.path.presence || '/'
+    rescue URI::InvalidURIError
+      path
+    end
+    private_class_method :extract_path
+
+    def strip_query_and_fragment(path)
+      path.sub(/[?#].*\z/, '')
+    end
+    private_class_method :strip_query_and_fragment
+
+    def ensure_leading_slash(path)
+      path.start_with?('/') ? path : "/#{path}"
+    end
+    private_class_method :ensure_leading_slash
+
+    def strip_trailing_slashes(path)
+      stripped = path.sub(/\/+\z/, '')
+      stripped.empty? ? '/' : stripped
+    end
+    private_class_method :strip_trailing_slashes
+  end
+end

--- a/app/services/hyrax/redirects_lookup.rb
+++ b/app/services/hyrax/redirects_lookup.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module Hyrax
+  # Single point of truth for "is this redirect path already taken?".
+  # Backed by the `hyrax_redirect_paths` table, which has a unique index on
+  # `path` for both correctness (rejects duplicates at insert time) and
+  # lookup speed (B-tree equality on a small derived table).
+  #
+  # See documentation/redirects.md.
+  class RedirectsLookup
+    def self.taken?(path, except_id: nil)
+      new(path, except_id: except_id).taken?
+    end
+
+    def initialize(path, except_id: nil)
+      @path = path
+      @except_id = except_id
+    end
+
+    def taken?
+      return false if @path.blank?
+      scope = Hyrax::RedirectPath.where(path: @path)
+      scope = scope.where.not(resource_id: @except_id) if @except_id.present?
+      scope.exists?
+    end
+  end
+end

--- a/app/services/hyrax/redirects_lookup.rb
+++ b/app/services/hyrax/redirects_lookup.rb
@@ -13,7 +13,7 @@ module Hyrax
     end
 
     def initialize(path, except_id: nil)
-      @path = path
+      @path = Hyrax::RedirectPathNormalizer.call(path)
       @except_id = except_id
     end
 

--- a/app/validators/hyrax/redirect_validator.rb
+++ b/app/validators/hyrax/redirect_validator.rb
@@ -13,8 +13,22 @@ module Hyrax
   class RedirectValidator < ActiveModel::EachValidator
     PATH_FORMAT = %r{\A/[^?\s#]+\z}.freeze
 
-    def validate_each(record, attribute, entries)
+    # Override `validate` so we can short-circuit before ActiveModel calls
+    # `record.read_attribute_for_validation`, which would crash on records
+    # that don't have the `redirects` attribute.
+    #
+    # Two guards, each catching a distinct case:
+    # 1. config + Flipflop — the runtime feature gate. Skips validation when
+    #    the feature isn't actively in use.
+    # 2. record_supports_redirects? — the structural gate. Catches the case
+    #    where both feature gates are on but the property wasn't added
+    def validate(record)
       return unless Hyrax.config.redirects_enabled? && Flipflop.redirects?
+      return unless record_supports_redirects?(record)
+      super
+    end
+
+    def validate_each(record, attribute, entries)
       return if entries.blank?
 
       validate_each_entry(record, attribute, entries)
@@ -64,6 +78,16 @@ module Hyrax
 
     def message_for(key, **interpolations)
       I18n.t(key, scope: 'errors.messages.redirect', **interpolations)
+    end
+
+    # Reform forms wrap the underlying resource and use method_missing to
+    # forward attribute reads. We can't just call `record.respond_to?(:redirects)`
+    # because Reform's method_missing returns truthy for missing methods.
+    # Probe the actual underlying resource through the form's `__getobj__`
+    # (Reform's accessor for the wrapped object) when present.
+    def record_supports_redirects?(record)
+      target = record.respond_to?(:__getobj__) ? record.__getobj__ : record
+      target.respond_to?(:redirects)
     end
   end
 end

--- a/app/validators/hyrax/redirect_validator.rb
+++ b/app/validators/hyrax/redirect_validator.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+module Hyrax
+  # Validates the `redirects` attribute on a work or collection. Runs only
+  # when the redirects feature is fully enabled (config + Flipflop).
+  #
+  # Path normalization happens upstream of this validator (in
+  # `Hyrax::Forms::ResourceForm#redirects=`), so the entries this
+  # validator sees already match the canonical form stored in
+  # `hyrax_redirect_paths` and queried by the resolver.
+  #
+  # See documentation/redirects.md for the validation rules.
+  class RedirectValidator < ActiveModel::EachValidator
+    PATH_FORMAT = %r{\A/[^?\s#]+\z}.freeze
+    RESERVED_PREFIXES = %w[
+      /admin /assets /catalog /collections /concern /dashboard
+      /id/eprint /rails /single_signon /users
+    ].freeze
+
+    def validate_each(record, attribute, entries)
+      return unless Hyrax.config.redirects_enabled? && Flipflop.redirects?
+      return if entries.blank?
+
+      validate_each_entry(record, attribute, entries)
+      validate_intra_record_uniqueness(record, attribute, entries)
+      validate_global_uniqueness(record, attribute, entries)
+      validate_at_most_one_canonical(record, attribute, entries)
+    end
+
+    private
+
+    def validate_each_entry(record, attribute, entries)
+      entries.each do |entry|
+        path = entry.try(:path)
+        if path.blank?
+          record.errors.add(attribute, "redirect path can't be blank")
+        elsif !PATH_FORMAT.match?(path)
+          record.errors.add(attribute, "#{path.inspect} is not a valid redirect path (must start with '/' and contain no whitespace, '?', or '#')")
+        elsif RESERVED_PREFIXES.any? { |prefix| path == prefix || path.start_with?("#{prefix}/") }
+          record.errors.add(attribute, "#{path.inspect} starts with a reserved prefix and would shadow a Hyrax route")
+        end
+      end
+    end
+
+    def validate_intra_record_uniqueness(record, attribute, entries)
+      paths = entries.map { |entry| entry.try(:path) }.compact
+      duplicates = paths.tally.select { |_, count| count > 1 }.keys
+      duplicates.each do |path|
+        record.errors.add(attribute, "#{path.inspect} is listed more than once on this record")
+      end
+    end
+
+    def validate_global_uniqueness(record, attribute, entries)
+      except_id = record.try(:id)
+      entries.each do |entry|
+        path = entry.try(:path)
+        next if path.blank?
+        next unless Hyrax::RedirectsLookup.taken?(path, except_id: except_id)
+        record.errors.add(attribute, "#{path.inspect} is already in use by another record")
+      end
+    end
+
+    def validate_at_most_one_canonical(record, attribute, entries)
+      canonical_count = entries.count { |entry| entry.try(:canonical) }
+      return if canonical_count <= 1
+      record.errors.add(attribute, "at most one redirect entry may be marked canonical")
+    end
+  end
+end

--- a/app/validators/hyrax/redirect_validator.rb
+++ b/app/validators/hyrax/redirect_validator.rb
@@ -12,10 +12,6 @@ module Hyrax
   # See documentation/redirects.md for the validation rules.
   class RedirectValidator < ActiveModel::EachValidator
     PATH_FORMAT = %r{\A/[^?\s#]+\z}.freeze
-    RESERVED_PREFIXES = %w[
-      /admin /assets /catalog /collections /concern /dashboard
-      /id/eprint /rails /single_signon /users
-    ].freeze
 
     def validate_each(record, attribute, entries)
       return unless Hyrax.config.redirects_enabled? && Flipflop.redirects?
@@ -33,11 +29,11 @@ module Hyrax
       entries.each do |entry|
         path = entry.try(:path)
         if path.blank?
-          record.errors.add(attribute, "redirect path can't be blank")
+          record.errors.add(attribute, message_for(:blank))
         elsif !PATH_FORMAT.match?(path)
-          record.errors.add(attribute, "#{path.inspect} is not a valid redirect path (must start with '/' and contain no whitespace, '?', or '#')")
-        elsif RESERVED_PREFIXES.any? { |prefix| path == prefix || path.start_with?("#{prefix}/") }
-          record.errors.add(attribute, "#{path.inspect} starts with a reserved prefix and would shadow a Hyrax route")
+          record.errors.add(attribute, message_for(:invalid_format, path: path))
+        elsif Hyrax.config.reserved_redirect_prefixes.any? { |prefix| path == prefix || path.start_with?("#{prefix}/") }
+          record.errors.add(attribute, message_for(:reserved_prefix, path: path))
         end
       end
     end
@@ -46,7 +42,7 @@ module Hyrax
       paths = entries.map { |entry| entry.try(:path) }.compact
       duplicates = paths.tally.select { |_, count| count > 1 }.keys
       duplicates.each do |path|
-        record.errors.add(attribute, "#{path.inspect} is listed more than once on this record")
+        record.errors.add(attribute, message_for(:intra_record_duplicate, path: path))
       end
     end
 
@@ -56,14 +52,18 @@ module Hyrax
         path = entry.try(:path)
         next if path.blank?
         next unless Hyrax::RedirectsLookup.taken?(path, except_id: except_id)
-        record.errors.add(attribute, "#{path.inspect} is already in use by another record")
+        record.errors.add(attribute, message_for(:already_taken, path: path))
       end
     end
 
     def validate_at_most_one_canonical(record, attribute, entries)
       canonical_count = entries.count { |entry| entry.try(:canonical) }
       return if canonical_count <= 1
-      record.errors.add(attribute, "at most one redirect entry may be marked canonical")
+      record.errors.add(attribute, message_for(:multiple_canonical))
+    end
+
+    def message_for(key, **interpolations)
+      I18n.t(key, scope: 'errors.messages.redirect', **interpolations)
     end
   end
 end

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -38,6 +38,13 @@ en:
       carrierwave_processing_error: Cannot resize image.
       extension_blacklist_error: "You are not allowed to upload %{extension} files, prohibited types: %{prohibited_types}"
       extension_whitelist_error: "You are not allowed to upload %{extension} files, allowed types: %{allowed_types}"
+      redirect:
+        already_taken: '"%{path}" is already used by another work or collection.'
+        blank: A redirect path can't be blank.
+        intra_record_duplicate: '"%{path}" is listed more than once on this record.'
+        invalid_format: '"%{path}" is not a valid path. Paths must start with "/" and contain no spaces, "?", or "#".'
+        multiple_canonical: At most one redirect entry may be marked canonical.
+        reserved_prefix: '"%{path}" can''t be used. The path is reserved by the application and may not be used as an alias.'
   helpers:
     action:
       accept: Accept

--- a/documentation/redirects.md
+++ b/documentation/redirects.md
@@ -151,10 +151,25 @@ The validator enforces six rules on the `redirects` attribute:
 |---|---|---|
 | Path is present | `entry.path` is blank | `redirect path can't be blank` |
 | Path format | path doesn't start with `/`, contains whitespace, `?`, or `#` | `is not a valid redirect path` |
-| Reserved prefix | path equals or starts with `/admin`, `/assets`, `/catalog`, `/collections`, `/concern`, `/dashboard`, `/id/eprint`, `/rails`, `/single_signon`, or `/users` | `starts with a reserved prefix and would shadow a Hyrax route` |
+| Reserved prefix | path equals or starts with one of `Hyrax.config.reserved_redirect_prefixes` (defaults to the routes Hyrax itself reserves) | the path is reserved by the application and may not be used as an alias |
 | Intra-record uniqueness | the same path appears more than once on a single record | `is listed more than once on this record` |
 | Global uniqueness | the path is already in use on a different record (excluding the current record's own id) | `is already in use by another record` |
 | At most one canonical | more than one entry has `canonical: true` | `at most one redirect entry may be marked canonical` |
+
+### Reserved-prefix list
+
+The reserved-prefix list lives in `Hyrax.config.reserved_redirect_prefixes`. The default covers the routes Hyrax itself reserves: `/admin`, `/api`, `/assets`, `/batch_edits`, `/batch_uploads`, `/capabilitylist`, `/catalog`, `/changelist`, `/collections`, `/concern`, `/content_blocks`, `/dashboard`, `/downloads`, `/embargoes`, `/featured_works`, `/files`, `/leases`, `/notifications`, `/pages`, `/proxies`, `/rails`, `/resourcelist`, `/uploads`, `/users`, and `/.well-known`.
+
+Host applications with their own reserved routes (Hyku's `/single_signon`, for example) should extend the list in their initializer:
+
+```ruby
+# config/initializers/hyrax.rb
+Hyrax.config do |config|
+  config.reserved_redirect_prefixes += ['/single_signon']
+end
+```
+
+The validator rejects any redirect path that equals one of these prefixes, or starts with one followed by `/` (so `/admin` is reserved, and `/admin/anything` is reserved, but `/administrator` would *not* be reserved by the `/admin` entry).
 
 ### Uniqueness lookup and the `hyrax_redirect_paths` ledger
 

--- a/documentation/redirects.md
+++ b/documentation/redirects.md
@@ -172,10 +172,10 @@ The validator calls `Hyrax::RedirectsLookup.taken?(path, except_id: record.id)` 
 
 The ledger is kept in sync by two `dry-transaction` steps composed into the create/update/destroy transactions:
 
-- `Hyrax::Transactions::Steps::SyncRedirectPaths` — runs after the resource is saved (in `WorkCreate`, `WorkUpdate`, `CollectionCreate`, `CollectionUpdate`). Deletes the resource's existing rows and reinserts the current redirect set in a single DB transaction. On `ActiveRecord::RecordNotUnique` (race lost), returns `Failure([:redirect_path_collision, ...])`, which short-circuits the enclosing transaction and surfaces back to the controller.
-- `Hyrax::Transactions::Steps::RemoveRedirectPaths` — runs before `delete_resource` in `WorkDestroy` and `CollectionDestroy`. Clears the resource's rows so deleted resources don't leave dangling claims on redirect paths.
+- `Hyrax::Transactions::Steps::SyncRedirectPaths` — runs after the resource is saved (in `WorkCreate`, `WorkUpdate`, `CollectionCreate`, `CollectionUpdate`). Deletes the resource's existing rows and reinserts the current redirect set in a single DB transaction. On `ActiveRecord::RecordNotUnique` (race lost), returns `Failure([:redirect_path_collision, ...])`, which short-circuits the enclosing transaction and surfaces back to the controller. No-op when either the config or the Flipflop is off — there's no point writing ledger rows when the feature isn't actively in use.
+- `Hyrax::Transactions::Steps::RemoveRedirectPaths` — runs before `delete_resource` in `WorkDestroy` and `CollectionDestroy`. Clears the resource's rows so deleted resources don't leave dangling claims on redirect paths. Gated only on the config (not the Flipflop): cleanup must happen regardless of whether the feature is currently in active use, so that an admin toggling the Flipflop off mid-deployment doesn't leave orphaned rows that could later collide with new resources after a re-enable.
 
-Both steps are no-ops when the redirects feature is off (config or Flipflop), so adopters who don't enable redirects pay no cost for them.
+Neither step does anything when the config is off, so adopters who don't enable the redirects feature pay no cost for them.
 
 ## Resolver behavior
 

--- a/documentation/redirects.md
+++ b/documentation/redirects.md
@@ -121,10 +121,67 @@ attribute :redirects, Valkyrie::Types::Set.of(Hyrax::Redirect)
 
 When the config is off, the loader filters `redirects.yaml` out of the schema set entirely. The file is on disk but invisible to `permissive_schema_for_valkrie_adapter`, `Hyrax::Schema(:redirects)`, and any other consumer of the simple schema loader.
 
+## Path normalization
+
+Every redirect path in Hyrax — whether typed into a form, looked up by the resolver, written to the uniqueness ledger, or queried by the validator — passes through `Hyrax::RedirectPathNormalizer.call`. This is the single source of truth for "what does this path look like on disk?". Normalization rules:
+
+1. If the input parses as a URL with a scheme and host (e.g. `https://old.example.edu/handle/12345/678`), keep only the path component.
+2. Strip query strings (`?utm_source=foo`) and fragments (`#section`).
+3. Ensure a leading slash (`handle/123` → `/handle/123`).
+4. Strip trailing slashes (`/handle/123/` → `/handle/123`), with the exception that the bare path `/` is preserved.
+
+The normalizer is idempotent — `normalize(normalize(x)) == normalize(x)` — and is wired in at four call sites so they all agree on the canonical form:
+
+- `Hyrax::Forms::ResourceForm#redirects=` normalizes each entry's path on form assignment, before validation. The normalized form is what the validator sees and what the resource persists.
+- `Hyrax::RedirectsController#show` (the resolver) normalizes the incoming request path before the Solr lookup, so `/foo/` and `/foo` both resolve.
+- `Hyrax::RedirectsLookup` normalizes its input on construction, so callers can pass any reasonable form.
+- `Hyrax::Transactions::Steps::SyncRedirectPaths` normalizes paths before writing to the ledger, as defense in depth.
+
+A user pasting a full URL from an old DSpace page (`https://old.example.edu/handle/123?utm=email`) sees the form quietly accept and persist `/handle/123`.
+
+## Validation
+
+`Hyrax::RedirectValidator` is wired into `Hyrax::Forms::ResourceForm` (and therefore both `Hyrax::Forms::PcdmObjectForm` for works and `Hyrax::Forms::PcdmCollectionForm` for collections) when `Hyrax.config.redirects_enabled?`. It runs only when the Flipflop is also on; otherwise it is a no-op.
+
+By the time the validator sees an entry, the path has already been normalized by the form's `redirects=` setter, so the validator can assume canonical form and focus on rule violations.
+
+The validator enforces six rules on the `redirects` attribute:
+
+| Rule | Trigger | Error |
+|---|---|---|
+| Path is present | `entry.path` is blank | `redirect path can't be blank` |
+| Path format | path doesn't start with `/`, contains whitespace, `?`, or `#` | `is not a valid redirect path` |
+| Reserved prefix | path equals or starts with `/admin`, `/assets`, `/catalog`, `/collections`, `/concern`, `/dashboard`, `/id/eprint`, `/rails`, `/single_signon`, or `/users` | `starts with a reserved prefix and would shadow a Hyrax route` |
+| Intra-record uniqueness | the same path appears more than once on a single record | `is listed more than once on this record` |
+| Global uniqueness | the path is already in use on a different record (excluding the current record's own id) | `is already in use by another record` |
+| At most one canonical | more than one entry has `canonical: true` | `at most one redirect entry may be marked canonical` |
+
+### Uniqueness lookup and the `hyrax_redirect_paths` ledger
+
+Global uniqueness is enforced by a Postgres table, `hyrax_redirect_paths`, which has a unique B-tree index on `path`. The table is a derived ledger of every redirect path currently in use, and the unique index gives the hard guarantee that no two records can share a path even under concurrent saves. A second non-unique index on `resource_id` supports the per-resource sync described below.
+
+`Hyrax::RedirectsLookup` is the single point of truth for "is this path taken?". It queries the table:
+
+```sql
+SELECT 1 FROM hyrax_redirect_paths WHERE path = ? AND resource_id <> ? LIMIT 1;
+```
+
+The validator calls `Hyrax::RedirectsLookup.taken?(path, except_id: record.id)` to give the user friendly feedback at form-submit time. If two simultaneous requests both pass validation (because both checked the table before either committed), the unique index rejects the second one at insert time and the enclosing transaction returns `Failure`.
+
+### Sync between `redirects` attribute and the ledger
+
+The ledger is kept in sync by two `dry-transaction` steps composed into the create/update/destroy transactions:
+
+- `Hyrax::Transactions::Steps::SyncRedirectPaths` — runs after the resource is saved (in `WorkCreate`, `WorkUpdate`, `CollectionCreate`, `CollectionUpdate`). Deletes the resource's existing rows and reinserts the current redirect set in a single DB transaction. On `ActiveRecord::RecordNotUnique` (race lost), returns `Failure([:redirect_path_collision, ...])`, which short-circuits the enclosing transaction and surfaces back to the controller.
+- `Hyrax::Transactions::Steps::RemoveRedirectPaths` — runs before `delete_resource` in `WorkDestroy` and `CollectionDestroy`. Clears the resource's rows so deleted resources don't leave dangling claims on redirect paths.
+
+Both steps are no-ops when the redirects feature is off (config or Flipflop), so adopters who don't enable redirects pay no cost for them.
+
 ## Resolver behavior
 
 When both gates are open, `Hyrax::RedirectsController#show` serves any path not claimed by an earlier route:
 
+- The incoming path is normalized via `Hyrax::RedirectPathNormalizer` so the lookup matches the canonical form stored in Solr (a request for `/foo/` resolves the same record as `/foo`).
 - The path is looked up by Solr query against `redirects_path_ssim`.
 - If a record matches, the controller responds `301 Moved Permanently` with `Location:` set to the permanent URL produced by Rails' `polymorphic_path` for the work or collection — typically `/concern/<plural_name>/<id>` for works (where `plural_name` is the model's registered route name) and `/collections/<id>` for collections.
 - If no record matches, the controller raises `ActionController::RoutingError` so Rails serves its standard 404.
@@ -192,3 +249,8 @@ Alternatively, gate the inclusion of the calling code itself on `Hyrax.config.re
 - `Hyrax::Indexers::RedirectsIndexer` (`app/indexers/hyrax/indexers/redirects_indexer.rb`) — the indexer mixin.
 - `Hyrax::RedirectsController` (`app/controllers/hyrax/redirects_controller.rb`) — the redirect resolver.
 - `Hyrax::FlexibleSchemaValidators::RedirectsValidator` (`app/services/hyrax/flexible_schema_validators/redirects_validator.rb`) — the m3 profile validator.
+- `Hyrax::RedirectValidator` (`app/validators/hyrax/redirect_validator.rb`) — the form-level entry validator.
+- `Hyrax::RedirectPathNormalizer` (`app/services/hyrax/redirect_path_normalizer.rb`) — canonical-form normalization for redirect paths.
+- `Hyrax::RedirectsLookup` (`app/services/hyrax/redirects_lookup.rb`) — the uniqueness lookup against `hyrax_redirect_paths`.
+- `Hyrax::RedirectPath` (`app/models/hyrax/redirect_path.rb`) — ActiveRecord model for the `hyrax_redirect_paths` ledger.
+- `Hyrax::Transactions::Steps::SyncRedirectPaths` and `Hyrax::Transactions::Steps::RemoveRedirectPaths` (`lib/hyrax/transactions/steps/`) — the transaction steps that keep the ledger in sync with each resource's `redirects` attribute.

--- a/lib/generators/hyrax/templates/db/migrate/20260430000001_create_hyrax_redirect_paths.rb.erb
+++ b/lib/generators/hyrax/templates/db/migrate/20260430000001_create_hyrax_redirect_paths.rb.erb
@@ -13,8 +13,10 @@ class CreateHyraxRedirectPaths < ActiveRecord::Migration<%= migration_version %>
     # RFC 3986, no LIKE patterns.
     add_index :hyrax_redirect_paths, :path, unique: true
 
-    # Non-unique index supports the listener's per-resource sync, which deletes
-    # all rows for a resource_id before reinserting on save.
+    # Non-unique index supports the per-resource sync performed by
+    # Hyrax::Transactions::Steps::SyncRedirectPaths and
+    # Hyrax::Transactions::Steps::RemoveRedirectPaths, which delete all rows for
+    # a resource_id before reinserting (or on resource destroy).
     add_index :hyrax_redirect_paths, :resource_id
   end
 end

--- a/lib/generators/hyrax/templates/db/migrate/20260430000001_create_hyrax_redirect_paths.rb.erb
+++ b/lib/generators/hyrax/templates/db/migrate/20260430000001_create_hyrax_redirect_paths.rb.erb
@@ -1,0 +1,20 @@
+class CreateHyraxRedirectPaths < ActiveRecord::Migration<%= migration_version %>
+  def change
+    create_table :hyrax_redirect_paths do |t|
+      t.string :path, null: false
+      t.string :resource_id, null: false
+
+      t.timestamps
+    end
+
+    # Unique index on path enforces global uniqueness at the DB level (the hard
+    # guarantee under concurrent writes) and is the primary lookup index for
+    # validation. Whole-string equality only — paths are case-sensitive per
+    # RFC 3986, no LIKE patterns.
+    add_index :hyrax_redirect_paths, :path, unique: true
+
+    # Non-unique index supports the listener's per-resource sync, which deletes
+    # all rows for a resource_id before reinserting on save.
+    add_index :hyrax_redirect_paths, :resource_id
+  end
+end

--- a/lib/hyrax/configuration.rb
+++ b/lib/hyrax/configuration.rb
@@ -350,6 +350,46 @@ module Hyrax
     end
     alias redirects_enabled redirects_enabled?
 
+    # Path prefixes that may not be claimed as redirect aliases (Hyrax::RedirectValidator
+    # rejects any redirect path equal to or starting with one of these). Defaults to the
+    # routes Hyrax itself reserves; adopters can extend the list to cover host-app routes:
+    #
+    #   Hyrax.config do |config|
+    #     config.reserved_redirect_prefixes += ['/single_signon', '/some_host_route']
+    #   end
+    #
+    # See documentation/redirects.md for the redirects feature.
+    attr_writer :reserved_redirect_prefixes
+    def reserved_redirect_prefixes # rubocop:disable Metrics/MethodLength
+      @reserved_redirect_prefixes ||= %w[
+        /.well-known
+        /admin
+        /api
+        /assets
+        /batch_edits
+        /batch_uploads
+        /capabilitylist
+        /catalog
+        /changelist
+        /collections
+        /concern
+        /content_blocks
+        /dashboard
+        /downloads
+        /embargoes
+        /featured_works
+        /files
+        /leases
+        /notifications
+        /pages
+        /proxies
+        /rails
+        /resourcelist
+        /uploads
+        /users
+      ]
+    end
+
     # This value determines whether to use m3 flexible metadata for core classes or not
     attr_writer :flexible_classes
     def flexible_classes

--- a/lib/hyrax/transactions/collection_create.rb
+++ b/lib/hyrax/transactions/collection_create.rb
@@ -13,7 +13,8 @@ module Hyrax
                        'change_set.add_to_collections',
                        'change_set.apply',
                        'collection_resource.apply_collection_type_permissions',
-                       'collection_resource.save_acl'].freeze
+                       'collection_resource.save_acl',
+                       'collection_resource.sync_redirect_paths'].freeze
 
       ##
       # @see Hyrax::Transactions::Transaction

--- a/lib/hyrax/transactions/collection_destroy.rb
+++ b/lib/hyrax/transactions/collection_destroy.rb
@@ -11,6 +11,7 @@ module Hyrax
       # TODO: Add step that checks if collection is empty for collections of types that require it
       DEFAULT_STEPS = ['collection_resource.delete_acl',
                        'collection_resource.remove_from_membership',
+                       'collection_resource.remove_redirect_paths',
                        'collection_resource.delete',
                        'collection_resource.delete_permission_template'].freeze.freeze
 

--- a/lib/hyrax/transactions/collection_update.rb
+++ b/lib/hyrax/transactions/collection_update.rb
@@ -11,7 +11,8 @@ module Hyrax
       DEFAULT_STEPS = ['change_set.apply',
                        'collection_resource.save_collection_banner',
                        'collection_resource.save_collection_logo',
-                       'collection_resource.save_acl'].freeze
+                       'collection_resource.save_acl',
+                       'collection_resource.sync_redirect_paths'].freeze
 
       ##
       # @see Hyrax::Transactions::Transaction

--- a/lib/hyrax/transactions/container.rb
+++ b/lib/hyrax/transactions/container.rb
@@ -50,6 +50,7 @@ module Hyrax
       require 'hyrax/transactions/steps/set_collection_type_gid'
       require 'hyrax/transactions/steps/remove_file_set_from_work'
       require 'hyrax/transactions/steps/remove_from_membership'
+      require 'hyrax/transactions/steps/remove_redirect_paths'
       require 'hyrax/transactions/steps/save'
       require 'hyrax/transactions/steps/save_access_control'
       require 'hyrax/transactions/steps/save_collection_banner'
@@ -59,6 +60,7 @@ module Hyrax
       require 'hyrax/transactions/steps/set_uploaded_date_unless_present'
       require 'hyrax/transactions/steps/set_user_as_creator'
       require 'hyrax/transactions/steps/set_user_as_depositor'
+      require 'hyrax/transactions/steps/sync_redirect_paths'
       require 'hyrax/transactions/steps/update_work_members'
       require 'hyrax/transactions/steps/validate'
 
@@ -246,6 +248,14 @@ module Hyrax
         ops.register 'save_collection_logo' do
           Steps::SaveCollectionLogo.new
         end
+
+        ops.register 'sync_redirect_paths' do
+          Steps::SyncRedirectPaths.new
+        end
+
+        ops.register 'remove_redirect_paths' do
+          Steps::RemoveRedirectPaths.new
+        end
       end
 
       namespace 'work_resource' do |ops| # Hyrax::Work resource
@@ -291,6 +301,14 @@ module Hyrax
 
         ops.register 'update_work_members' do
           Steps::UpdateWorkMembers.new
+        end
+
+        ops.register 'sync_redirect_paths' do
+          Steps::SyncRedirectPaths.new
+        end
+
+        ops.register 'remove_redirect_paths' do
+          Steps::RemoveRedirectPaths.new
         end
       end
       # rubocop:enable Metrics/BlockLength

--- a/lib/hyrax/transactions/steps/remove_redirect_paths.rb
+++ b/lib/hyrax/transactions/steps/remove_redirect_paths.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+require 'dry/monads'
+
+module Hyrax
+  module Transactions
+    module Steps
+      # A `dry-transaction` step that removes a resource's rows from the
+      # `hyrax_redirect_paths` uniqueness ledger. Runs as part of the destroy
+      # transactions so deleted resources don't leave dangling claims on
+      # redirect paths.
+      #
+      # See documentation/redirects.md.
+      class RemoveRedirectPaths
+        include Dry::Monads[:result]
+
+        # @param [Valkyrie::Resource] resource
+        # @return [Dry::Monads::Result]
+        def call(resource)
+          if Hyrax.config.redirects_enabled? && resource.respond_to?(:id) && resource.id.present?
+            Hyrax::RedirectPath.where(resource_id: resource.id.to_s).delete_all
+          end
+          Success(resource)
+        end
+      end
+    end
+  end
+end

--- a/lib/hyrax/transactions/steps/remove_redirect_paths.rb
+++ b/lib/hyrax/transactions/steps/remove_redirect_paths.rb
@@ -16,10 +16,14 @@ module Hyrax
         # @param [Valkyrie::Resource] resource
         # @return [Dry::Monads::Result]
         def call(resource)
-          if Hyrax.config.redirects_enabled? && resource.respond_to?(:id) && resource.id.present?
-            Hyrax::RedirectPath.where(resource_id: resource.id.to_s).delete_all
-          end
+          Hyrax::RedirectPath.where(resource_id: resource.id.to_s).delete_all if removable?(resource)
           Success(resource)
+        end
+
+        private
+
+        def removable?(resource)
+          Hyrax.config.redirects_enabled? && resource.respond_to?(:id) && resource.id.present?
         end
       end
     end

--- a/lib/hyrax/transactions/steps/sync_redirect_paths.rb
+++ b/lib/hyrax/transactions/steps/sync_redirect_paths.rb
@@ -22,21 +22,7 @@ module Hyrax
         # @return [Dry::Monads::Result]
         def call(object)
           return Success(object) unless syncable?(object)
-
-          paths = Array(object.redirects)
-                  .map { |entry| Hyrax::RedirectPathNormalizer.call(entry.try(:path)) }
-                  .reject(&:blank?)
-                  .uniq
-          now = Time.current
-          rows = paths.map do |path|
-            { path: path, resource_id: object.id.to_s, created_at: now, updated_at: now }
-          end
-
-          Hyrax::RedirectPath.transaction do
-            Hyrax::RedirectPath.where(resource_id: object.id.to_s).delete_all
-            Hyrax::RedirectPath.insert_all!(rows) if rows.any?
-          end
-
+          replace_rows(object, build_rows(object))
           Success(object)
         rescue ActiveRecord::RecordNotUnique => e
           Failure([:redirect_path_collision, e.message])
@@ -47,6 +33,24 @@ module Hyrax
         def syncable?(object)
           return false unless Hyrax.config.redirects_enabled? && Flipflop.redirects?
           object.respond_to?(:redirects) && object.respond_to?(:id) && object.id.present?
+        end
+
+        def build_rows(object)
+          paths = Array(object.redirects)
+                  .map { |entry| Hyrax::RedirectPathNormalizer.call(entry.try(:path)) }
+                  .reject(&:blank?)
+                  .uniq
+          now = Time.current
+          paths.map { |path| { path: path, resource_id: object.id.to_s, created_at: now, updated_at: now } }
+        end
+
+        def replace_rows(object, rows)
+          Hyrax::RedirectPath.transaction do
+            Hyrax::RedirectPath.where(resource_id: object.id.to_s).delete_all
+            # rubocop:disable Rails/SkipsModelValidations -- the DB unique index on `path` is the validation we rely on; bulk insert is intentional
+            Hyrax::RedirectPath.insert_all!(rows) if rows.any?
+            # rubocop:enable Rails/SkipsModelValidations
+          end
         end
       end
     end

--- a/lib/hyrax/transactions/steps/sync_redirect_paths.rb
+++ b/lib/hyrax/transactions/steps/sync_redirect_paths.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+require 'dry/monads'
+
+module Hyrax
+  module Transactions
+    module Steps
+      # A `dry-transaction` step that mirrors a saved resource's `redirects`
+      # entries into the `hyrax_redirect_paths` uniqueness ledger. The unique
+      # index on `path` enforces global uniqueness at the DB level — if a
+      # concurrent save already claimed a path, the insert raises
+      # ActiveRecord::RecordNotUnique and this step returns Failure, which
+      # short-circuits the enclosing transaction.
+      #
+      # No-op when the redirects feature is off (config or Flipflop) or when
+      # the resource doesn't carry the redirects attribute.
+      #
+      # See documentation/redirects.md.
+      class SyncRedirectPaths
+        include Dry::Monads[:result]
+
+        # @param [Valkyrie::Resource] object the saved resource (must have an id)
+        # @return [Dry::Monads::Result]
+        def call(object)
+          return Success(object) unless syncable?(object)
+
+          paths = Array(object.redirects).map { |entry| entry.try(:path) }.compact.uniq
+          now = Time.current
+          rows = paths.map do |path|
+            { path: path, resource_id: object.id.to_s, created_at: now, updated_at: now }
+          end
+
+          Hyrax::RedirectPath.transaction do
+            Hyrax::RedirectPath.where(resource_id: object.id.to_s).delete_all
+            Hyrax::RedirectPath.insert_all!(rows) if rows.any?
+          end
+
+          Success(object)
+        rescue ActiveRecord::RecordNotUnique => e
+          Failure([:redirect_path_collision, e.message])
+        end
+
+        private
+
+        def syncable?(object)
+          return false unless Hyrax.config.redirects_enabled? && Flipflop.redirects?
+          object.respond_to?(:redirects) && object.respond_to?(:id) && object.id.present?
+        end
+      end
+    end
+  end
+end

--- a/lib/hyrax/transactions/steps/sync_redirect_paths.rb
+++ b/lib/hyrax/transactions/steps/sync_redirect_paths.rb
@@ -45,6 +45,10 @@ module Hyrax
         end
 
         def replace_rows(object, rows)
+          desired_paths = rows.map { |r| r[:path] }.sort
+          existing_paths = Hyrax::RedirectPath.where(resource_id: object.id.to_s).pluck(:path).sort
+          return if desired_paths == existing_paths
+
           Hyrax::RedirectPath.transaction do
             Hyrax::RedirectPath.where(resource_id: object.id.to_s).delete_all
             # rubocop:disable Rails/SkipsModelValidations -- the DB unique index on `path` is the validation we rely on; bulk insert is intentional

--- a/lib/hyrax/transactions/steps/sync_redirect_paths.rb
+++ b/lib/hyrax/transactions/steps/sync_redirect_paths.rb
@@ -23,7 +23,10 @@ module Hyrax
         def call(object)
           return Success(object) unless syncable?(object)
 
-          paths = Array(object.redirects).map { |entry| entry.try(:path) }.compact.uniq
+          paths = Array(object.redirects)
+                  .map { |entry| Hyrax::RedirectPathNormalizer.call(entry.try(:path)) }
+                  .reject(&:blank?)
+                  .uniq
           now = Time.current
           rows = paths.map do |path|
             { path: path, resource_id: object.id.to_s, created_at: now, updated_at: now }

--- a/lib/hyrax/transactions/work_create.rb
+++ b/lib/hyrax/transactions/work_create.rb
@@ -16,7 +16,8 @@ module Hyrax
                        'work_resource.save_acl',
                        'work_resource.add_file_sets',
                        'work_resource.change_depositor',
-                       'work_resource.add_to_parent'].freeze
+                       'work_resource.add_to_parent',
+                       'work_resource.sync_redirect_paths'].freeze
 
       ##
       # @see Hyrax::Transactions::Transaction

--- a/lib/hyrax/transactions/work_destroy.rb
+++ b/lib/hyrax/transactions/work_destroy.rb
@@ -10,6 +10,7 @@ module Hyrax
     class WorkDestroy < Transaction
       DEFAULT_STEPS = ['work_resource.delete_all_file_sets',
                        'work_resource.delete_acl',
+                       'work_resource.remove_redirect_paths',
                        'work_resource.delete'].freeze
 
       ##

--- a/lib/hyrax/transactions/work_update.rb
+++ b/lib/hyrax/transactions/work_update.rb
@@ -8,7 +8,8 @@ module Hyrax
                        'work_resource.apply_permission_template_on_update',
                        'work_resource.save_acl',
                        'work_resource.add_file_sets',
-                       'work_resource.update_work_members'].freeze
+                       'work_resource.update_work_members',
+                       'work_resource.sync_redirect_paths'].freeze
 
       ##
       # @see Hyrax::Transactions::Transaction

--- a/spec/lib/hyrax/configuration_spec.rb
+++ b/spec/lib/hyrax/configuration_spec.rb
@@ -102,9 +102,14 @@ RSpec.describe Hyrax::Configuration do
   it { is_expected.to respond_to(:persistent_hostpath) }
   it { is_expected.to respond_to(:realtime_notifications?) }
   it { is_expected.to respond_to(:realtime_notifications=) }
+  it { is_expected.to respond_to(:redirects_enabled) }
+  it { is_expected.to respond_to(:redirects_enabled=) }
+  it { is_expected.to respond_to(:redirects_enabled?) }
   it { is_expected.to respond_to(:redis_namespace) }
   it { is_expected.to respond_to(:rendering_predicate) }
   it { is_expected.to respond_to(:rendering_predicate=) }
+  it { is_expected.to respond_to(:reserved_redirect_prefixes) }
+  it { is_expected.to respond_to(:reserved_redirect_prefixes=) }
   it { is_expected.to respond_to(:rights_statement_service_class) }
   it { is_expected.to respond_to(:rights_statement_service_class=) }
   it { is_expected.to respond_to(:show_work_item_rows) }
@@ -131,6 +136,43 @@ RSpec.describe Hyrax::Configuration do
     before { stub_const("ENV", "HYRAX_SKIP_WINGS" => "true") }
     it "returns true if wings is disabled" do
       expect(Hyrax.config.use_valkyrie?).to eq true
+    end
+  end
+
+  describe "#redirects_enabled?" do
+    context "with the env var unset" do
+      before { stub_const("ENV", {}) }
+      it "defaults to false" do
+        expect(described_class.new.redirects_enabled?).to be false
+      end
+    end
+
+    context "with HYRAX_REDIRECTS_ENABLED=true" do
+      before { stub_const("ENV", "HYRAX_REDIRECTS_ENABLED" => "true") }
+      it "is true" do
+        expect(described_class.new.redirects_enabled?).to be true
+      end
+    end
+  end
+
+  describe "#reserved_redirect_prefixes" do
+    it "defaults to a list of paths Hyrax itself reserves" do
+      expect(configuration.reserved_redirect_prefixes)
+        .to include('/admin', '/concern', '/dashboard', '/collections', '/users')
+    end
+
+    it "always includes a leading slash on each entry" do
+      expect(configuration.reserved_redirect_prefixes).to all(start_with('/'))
+    end
+
+    it "is extendable by adopters" do
+      configuration.reserved_redirect_prefixes += ['/single_signon']
+      expect(configuration.reserved_redirect_prefixes).to include('/single_signon')
+    end
+
+    it "is replaceable by adopters" do
+      configuration.reserved_redirect_prefixes = ['/only_this']
+      expect(configuration.reserved_redirect_prefixes).to eq ['/only_this']
     end
   end
 end

--- a/spec/lib/hyrax/transactions/steps/remove_redirect_paths_spec.rb
+++ b/spec/lib/hyrax/transactions/steps/remove_redirect_paths_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+RSpec.describe Hyrax::Transactions::Steps::RemoveRedirectPaths do
+  subject(:step) { described_class.new }
+
+  let(:resource_id) { 'res-1' }
+  let(:resource_class) { Struct.new(:id) }
+  let(:resource) { resource_class.new(resource_id) }
+
+  before do
+    allow(Hyrax.config).to receive(:redirects_enabled?).and_return(true)
+    Hyrax::RedirectPath.delete_all
+  end
+
+  describe '#call' do
+    context 'when the resource has rows in the table' do
+      before do
+        Hyrax::RedirectPath.create!(path: '/handle/1', resource_id: resource_id)
+        Hyrax::RedirectPath.create!(path: '/handle/2', resource_id: 'other-record')
+      end
+
+      it 'deletes only the resource\'s rows and returns Success' do
+        result = step.call(resource)
+        expect(result).to be_success
+        expect(Hyrax::RedirectPath.where(resource_id: resource_id)).to be_empty
+        expect(Hyrax::RedirectPath.where(resource_id: 'other-record').count).to eq(1)
+      end
+    end
+
+    context 'when the config is off' do
+      before { allow(Hyrax.config).to receive(:redirects_enabled?).and_return(false) }
+
+      it 'is a no-op (returns Success without touching the table)' do
+        expect(Hyrax::RedirectPath).not_to receive(:where)
+        expect(step.call(resource)).to be_success
+      end
+    end
+  end
+end

--- a/spec/lib/hyrax/transactions/steps/sync_redirect_paths_spec.rb
+++ b/spec/lib/hyrax/transactions/steps/sync_redirect_paths_spec.rb
@@ -64,5 +64,43 @@ RSpec.describe Hyrax::Transactions::Steps::SyncRedirectPaths do
         expect(step.call(resource)).to be_success
       end
     end
+
+    context "when the resource's redirects haven't changed since the last sync" do
+      let(:original_created_at) { 1.day.ago.change(usec: 0) }
+
+      before do
+        Hyrax::RedirectPath.create!(path: '/handle/1', resource_id: resource_id, created_at: original_created_at, updated_at: original_created_at)
+        Hyrax::RedirectPath.create!(path: '/handle/2', resource_id: resource_id, created_at: original_created_at, updated_at: original_created_at)
+      end
+
+      it 'leaves existing rows untouched (preserves created_at)' do
+        result = step.call(resource)
+        expect(result).to be_success
+
+        rows = Hyrax::RedirectPath.where(resource_id: resource_id).order(:path)
+        expect(rows.pluck(:path)).to eq %w[/handle/1 /handle/2]
+        expect(rows.pluck(:created_at)).to all(eq(original_created_at))
+      end
+    end
+
+    context "when the resource's redirects differ in order only" do
+      let(:original_created_at) { 1.day.ago.change(usec: 0) }
+      let(:redirects) do
+        # Same paths as the existing rows, just listed in reverse order on the resource.
+        [entry_class.new(path: '/handle/2'), entry_class.new(path: '/handle/1')]
+      end
+
+      before do
+        Hyrax::RedirectPath.create!(path: '/handle/1', resource_id: resource_id, created_at: original_created_at, updated_at: original_created_at)
+        Hyrax::RedirectPath.create!(path: '/handle/2', resource_id: resource_id, created_at: original_created_at, updated_at: original_created_at)
+      end
+
+      it 'recognizes the set is unchanged and leaves rows untouched' do
+        result = step.call(resource)
+        expect(result).to be_success
+        expect(Hyrax::RedirectPath.where(resource_id: resource_id).pluck(:created_at))
+          .to all(eq(original_created_at))
+      end
+    end
   end
 end

--- a/spec/lib/hyrax/transactions/steps/sync_redirect_paths_spec.rb
+++ b/spec/lib/hyrax/transactions/steps/sync_redirect_paths_spec.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+RSpec.describe Hyrax::Transactions::Steps::SyncRedirectPaths do
+  subject(:step) { described_class.new }
+
+  let(:resource_id) { 'res-1' }
+  let(:entry_class) { Struct.new(:path, keyword_init: true) }
+  let(:resource_class) do
+    Struct.new(:id, :redirects)
+  end
+  let(:resource) { resource_class.new(resource_id, redirects) }
+  let(:redirects) { [entry_class.new(path: '/handle/1'), entry_class.new(path: '/handle/2')] }
+
+  before do
+    allow(Hyrax.config).to receive(:redirects_enabled?).and_return(true)
+    allow(Flipflop).to receive(:redirects?).and_return(true)
+    Hyrax::RedirectPath.delete_all
+  end
+
+  describe '#call' do
+    context 'when feature is fully enabled and resource has redirects' do
+      it 'replaces existing rows for the resource with the current redirect set' do
+        Hyrax::RedirectPath.create!(path: '/old', resource_id: resource_id)
+        result = step.call(resource)
+        expect(result).to be_success
+        paths = Hyrax::RedirectPath.where(resource_id: resource_id).pluck(:path)
+        expect(paths).to contain_exactly('/handle/1', '/handle/2')
+      end
+    end
+
+    context 'when a path is already claimed by another resource' do
+      before { Hyrax::RedirectPath.create!(path: '/handle/1', resource_id: 'other-record') }
+
+      it 'returns Failure with a redirect_path_collision tag' do
+        result = step.call(resource)
+        expect(result).to be_failure
+        expect(result.failure.first).to eq(:redirect_path_collision)
+      end
+    end
+
+    context 'when the config is off' do
+      before { allow(Hyrax.config).to receive(:redirects_enabled?).and_return(false) }
+
+      it 'is a no-op (returns Success without touching the table)' do
+        expect(Hyrax::RedirectPath).not_to receive(:transaction)
+        expect(step.call(resource)).to be_success
+      end
+    end
+
+    context 'when the Flipflop is off' do
+      before { allow(Flipflop).to receive(:redirects?).and_return(false) }
+
+      it 'is a no-op (returns Success without touching the table)' do
+        expect(Hyrax::RedirectPath).not_to receive(:transaction)
+        expect(step.call(resource)).to be_success
+      end
+    end
+
+    context 'when the resource has no redirects attribute' do
+      let(:resource_class) { Struct.new(:id) }
+      let(:resource) { resource_class.new(resource_id) }
+
+      it 'is a no-op' do
+        expect(step.call(resource)).to be_success
+      end
+    end
+  end
+end

--- a/spec/services/hyrax/redirect_path_normalizer_spec.rb
+++ b/spec/services/hyrax/redirect_path_normalizer_spec.rb
@@ -1,0 +1,96 @@
+# frozen_string_literal: true
+
+RSpec.describe Hyrax::RedirectPathNormalizer do
+  describe '.call' do
+    subject(:normalize) { described_class.call(input) }
+
+    context 'with nil' do
+      let(:input) { nil }
+      it { is_expected.to be_nil }
+    end
+
+    context 'with an empty string' do
+      let(:input) { '' }
+      it { is_expected.to eq('') }
+    end
+
+    context 'with a path that already meets the canonical form' do
+      let(:input) { '/handle/12345/678' }
+      it { is_expected.to eq('/handle/12345/678') }
+    end
+
+    context 'with a missing leading slash' do
+      let(:input) { 'handle/12345/678' }
+      it { is_expected.to eq('/handle/12345/678') }
+    end
+
+    context 'with a trailing slash' do
+      let(:input) { '/handle/12345/678/' }
+      it { is_expected.to eq('/handle/12345/678') }
+    end
+
+    context 'with multiple trailing slashes' do
+      let(:input) { '/handle/12345/678///' }
+      it { is_expected.to eq('/handle/12345/678') }
+    end
+
+    context 'with surrounding whitespace' do
+      let(:input) { '  /handle/12345/678  ' }
+      it { is_expected.to eq('/handle/12345/678') }
+    end
+
+    context 'with a query string' do
+      let(:input) { '/handle/12345/678?utm_source=foo' }
+      it { is_expected.to eq('/handle/12345/678') }
+    end
+
+    context 'with a fragment' do
+      let(:input) { '/handle/12345/678#section' }
+      it { is_expected.to eq('/handle/12345/678') }
+    end
+
+    context 'with a query string and fragment' do
+      let(:input) { '/handle/12345/678?x=1#frag' }
+      it { is_expected.to eq('/handle/12345/678') }
+    end
+
+    context 'with a full https URL' do
+      let(:input) { 'https://old.example.edu/handle/12345/678' }
+      it { is_expected.to eq('/handle/12345/678') }
+    end
+
+    context 'with a full URL including query and fragment' do
+      let(:input) { 'https://old.example.edu/handle/12345/678?utm_source=foo#cite' }
+      it { is_expected.to eq('/handle/12345/678') }
+    end
+
+    context 'with a full URL whose path is empty' do
+      let(:input) { 'https://old.example.edu' }
+      it { is_expected.to eq('/') }
+    end
+
+    context 'with a full URL whose path is /' do
+      let(:input) { 'https://old.example.edu/' }
+      it { is_expected.to eq('/') }
+    end
+
+    context 'with a malformed URL' do
+      let(:input) { 'http://[invalid' }
+      it 'falls back to the original input (treated as a path)' do
+        # `extract_path` rescues URI::InvalidURIError; the fallback path then
+        # gets a leading slash added like any other non-slash-prefixed input.
+        expect(normalize).to eq('/http://[invalid')
+      end
+    end
+
+    context 'idempotency' do
+      let(:input) { 'https://old.example.edu/handle/12345/678/?x=1' }
+      it 'is idempotent: calling twice gives the same result as calling once' do
+        once = described_class.call(input)
+        twice = described_class.call(once)
+        expect(once).to eq(twice)
+        expect(once).to eq('/handle/12345/678')
+      end
+    end
+  end
+end

--- a/spec/services/hyrax/redirects_lookup_spec.rb
+++ b/spec/services/hyrax/redirects_lookup_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+RSpec.describe Hyrax::RedirectsLookup do
+  before { Hyrax::RedirectPath.delete_all }
+
+  describe '.taken?' do
+    let(:path) { '/handle/12345/678' }
+
+    context 'when no row exists for the path' do
+      it 'is false' do
+        expect(described_class.taken?(path)).to be false
+      end
+    end
+
+    context 'when a row exists for the path on a different resource' do
+      before { Hyrax::RedirectPath.create!(path: path, resource_id: 'other-record') }
+
+      it 'is true' do
+        expect(described_class.taken?(path)).to be true
+      end
+    end
+
+    context 'with except_id matching the row that owns the path' do
+      before { Hyrax::RedirectPath.create!(path: path, resource_id: 'self-id') }
+
+      it 'is false (the path is held by the record being edited)' do
+        expect(described_class.taken?(path, except_id: 'self-id')).to be false
+      end
+    end
+
+    context 'with except_id not matching the row that owns the path' do
+      before { Hyrax::RedirectPath.create!(path: path, resource_id: 'other-record') }
+
+      it 'is true' do
+        expect(described_class.taken?(path, except_id: 'self-id')).to be true
+      end
+    end
+
+    context 'with a blank path' do
+      it 'is false without consulting the table' do
+        expect(Hyrax::RedirectPath).not_to receive(:where)
+        expect(described_class.taken?('')).to be false
+      end
+    end
+  end
+end

--- a/spec/validators/hyrax/redirect_validator_spec.rb
+++ b/spec/validators/hyrax/redirect_validator_spec.rb
@@ -64,6 +64,53 @@ RSpec.describe Hyrax::RedirectValidator do
       end
     end
 
+    context 'when the record does not support a redirects attribute' do
+      let(:record_class) do
+        Class.new do
+          include ActiveModel::Validations
+          attr_accessor :id
+          validates_with Hyrax::RedirectValidator, attributes: [:redirects]
+        end
+      end
+      let(:record) { record_class.new.tap { |r| r.id = 'self-id' } }
+
+      it 'short-circuits without raising NoMethodError' do
+        expect { record.valid? }.not_to raise_error
+        expect(record.errors[:redirects]).to be_empty
+      end
+    end
+
+    context 'when the record is a form wrapping a resource without :redirects' do
+      let(:wrapped) { Struct.new(:id).new('wrapped-id') }
+      let(:record) do
+        klass = Class.new do
+          include ActiveModel::Validations
+          attr_accessor :id
+          validates_with Hyrax::RedirectValidator, attributes: [:redirects]
+          def initialize(target)
+            @target = target
+          end
+
+          def __getobj__
+            @target
+          end
+
+          def respond_to_missing?(_name, _priv = false)
+            true
+          end
+
+          def method_missing(_name, *_args)
+            nil
+          end
+        end
+        klass.new(wrapped)
+      end
+
+      it 'unwraps the form and short-circuits when the underlying resource lacks :redirects' do
+        expect { record.valid? }.not_to raise_error
+      end
+    end
+
     def t(key, **interp)
       I18n.t(key, scope: 'errors.messages.redirect', **interp)
     end

--- a/spec/validators/hyrax/redirect_validator_spec.rb
+++ b/spec/validators/hyrax/redirect_validator_spec.rb
@@ -1,0 +1,179 @@
+# frozen_string_literal: true
+
+RSpec.describe Hyrax::RedirectValidator do
+  subject(:validator) { described_class.new(attributes: [:redirects]) }
+
+  let(:record_class) do
+    Class.new do
+      include ActiveModel::Validations
+      attr_accessor :id, :redirects
+      validates_with Hyrax::RedirectValidator, attributes: [:redirects]
+    end
+  end
+  let(:record) do
+    record_class.new.tap do |r|
+      r.id = 'self-id'
+      r.redirects = entries
+    end
+  end
+  let(:entry_class) { Struct.new(:path, :canonical, keyword_init: true) }
+  let(:entries) { [] }
+
+  before do
+    allow(Hyrax.config).to receive(:redirects_enabled?).and_return(true)
+    allow(Flipflop).to receive(:redirects?).and_return(true)
+    allow(Hyrax::RedirectsLookup).to receive(:taken?).and_return(false)
+  end
+
+  describe '#validate_each' do
+    context 'when both gates are open' do
+      let(:entries) { [entry_class.new(path: '/handle/12345/678', canonical: true)] }
+
+      it 'is valid' do
+        record.valid?
+        expect(record.errors[:redirects]).to be_empty
+      end
+    end
+
+    context 'when the config is off' do
+      before { allow(Hyrax.config).to receive(:redirects_enabled?).and_return(false) }
+      let(:entries) { [entry_class.new(path: 'no-leading-slash', canonical: false)] }
+
+      it 'short-circuits without raising or recording errors' do
+        record.valid?
+        expect(record.errors[:redirects]).to be_empty
+      end
+    end
+
+    context 'when the Flipflop is off' do
+      before { allow(Flipflop).to receive(:redirects?).and_return(false) }
+      let(:entries) { [entry_class.new(path: 'no-leading-slash', canonical: false)] }
+
+      it 'short-circuits without recording errors' do
+        record.valid?
+        expect(record.errors[:redirects]).to be_empty
+      end
+    end
+
+    context 'when entries is blank' do
+      let(:entries) { [] }
+
+      it 'is valid' do
+        record.valid?
+        expect(record.errors[:redirects]).to be_empty
+      end
+    end
+
+    context 'with a blank path' do
+      let(:entries) { [entry_class.new(path: '', canonical: false)] }
+
+      it 'records a blank-path error' do
+        record.valid?
+        expect(record.errors[:redirects]).to include(/can't be blank/)
+      end
+    end
+
+    context 'with a path missing a leading slash' do
+      let(:entries) { [entry_class.new(path: 'handle/12345/678', canonical: false)] }
+
+      it 'records a format error' do
+        record.valid?
+        expect(record.errors[:redirects]).to include(/not a valid redirect path/)
+      end
+    end
+
+    context 'with whitespace in the path' do
+      let(:entries) { [entry_class.new(path: '/has space', canonical: false)] }
+
+      it 'records a format error' do
+        record.valid?
+        expect(record.errors[:redirects]).to include(/not a valid redirect path/)
+      end
+    end
+
+    context 'with a query string in the path' do
+      let(:entries) { [entry_class.new(path: '/foo?bar=baz', canonical: false)] }
+
+      it 'records a format error' do
+        record.valid?
+        expect(record.errors[:redirects]).to include(/not a valid redirect path/)
+      end
+    end
+
+    context 'with a path under a reserved Hyrax prefix' do
+      let(:entries) { [entry_class.new(path: '/concern/generic_works/abc', canonical: false)] }
+
+      it 'records a reserved-prefix error' do
+        record.valid?
+        expect(record.errors[:redirects]).to include(/reserved prefix/)
+      end
+    end
+
+    context 'with a path that exactly matches a reserved prefix' do
+      let(:entries) { [entry_class.new(path: '/dashboard', canonical: false)] }
+
+      it 'records a reserved-prefix error' do
+        record.valid?
+        expect(record.errors[:redirects]).to include(/reserved prefix/)
+      end
+    end
+
+    context 'with two entries sharing the same path on the same record' do
+      let(:entries) do
+        [
+          entry_class.new(path: '/handle/1', canonical: false),
+          entry_class.new(path: '/handle/1', canonical: false)
+        ]
+      end
+
+      it 'records an intra-record duplicate error' do
+        record.valid?
+        expect(record.errors[:redirects]).to include(/listed more than once/)
+      end
+    end
+
+    context 'when the path is taken on another record' do
+      let(:entries) { [entry_class.new(path: '/handle/12345/678', canonical: false)] }
+
+      before do
+        allow(Hyrax::RedirectsLookup)
+          .to receive(:taken?)
+          .with('/handle/12345/678', except_id: 'self-id')
+          .and_return(true)
+      end
+
+      it 'records a global-uniqueness error' do
+        record.valid?
+        expect(record.errors[:redirects]).to include(/already in use/)
+      end
+    end
+
+    context 'when more than one entry is marked canonical' do
+      let(:entries) do
+        [
+          entry_class.new(path: '/a', canonical: true),
+          entry_class.new(path: '/b', canonical: true)
+        ]
+      end
+
+      it 'records an at-most-one-canonical error' do
+        record.valid?
+        expect(record.errors[:redirects]).to include(/at most one redirect entry may be marked canonical/)
+      end
+    end
+
+    context 'when zero entries are marked canonical' do
+      let(:entries) do
+        [
+          entry_class.new(path: '/a', canonical: false),
+          entry_class.new(path: '/b', canonical: false)
+        ]
+      end
+
+      it 'is valid (canonical is optional)' do
+        record.valid?
+        expect(record.errors[:redirects]).to be_empty
+      end
+    end
+  end
+end

--- a/spec/validators/hyrax/redirect_validator_spec.rb
+++ b/spec/validators/hyrax/redirect_validator_spec.rb
@@ -64,12 +64,16 @@ RSpec.describe Hyrax::RedirectValidator do
       end
     end
 
+    def t(key, **interp)
+      I18n.t(key, scope: 'errors.messages.redirect', **interp)
+    end
+
     context 'with a blank path' do
       let(:entries) { [entry_class.new(path: '', canonical: false)] }
 
       it 'records a blank-path error' do
         record.valid?
-        expect(record.errors[:redirects]).to include(/can't be blank/)
+        expect(record.errors[:redirects]).to include(t(:blank))
       end
     end
 
@@ -78,7 +82,7 @@ RSpec.describe Hyrax::RedirectValidator do
 
       it 'records a format error' do
         record.valid?
-        expect(record.errors[:redirects]).to include(/not a valid redirect path/)
+        expect(record.errors[:redirects]).to include(t(:invalid_format, path: 'handle/12345/678'))
       end
     end
 
@@ -87,7 +91,7 @@ RSpec.describe Hyrax::RedirectValidator do
 
       it 'records a format error' do
         record.valid?
-        expect(record.errors[:redirects]).to include(/not a valid redirect path/)
+        expect(record.errors[:redirects]).to include(t(:invalid_format, path: '/has space'))
       end
     end
 
@@ -96,7 +100,7 @@ RSpec.describe Hyrax::RedirectValidator do
 
       it 'records a format error' do
         record.valid?
-        expect(record.errors[:redirects]).to include(/not a valid redirect path/)
+        expect(record.errors[:redirects]).to include(t(:invalid_format, path: '/foo?bar=baz'))
       end
     end
 
@@ -105,7 +109,7 @@ RSpec.describe Hyrax::RedirectValidator do
 
       it 'records a reserved-prefix error' do
         record.valid?
-        expect(record.errors[:redirects]).to include(/reserved prefix/)
+        expect(record.errors[:redirects]).to include(t(:reserved_prefix, path: '/concern/generic_works/abc'))
       end
     end
 
@@ -114,7 +118,7 @@ RSpec.describe Hyrax::RedirectValidator do
 
       it 'records a reserved-prefix error' do
         record.valid?
-        expect(record.errors[:redirects]).to include(/reserved prefix/)
+        expect(record.errors[:redirects]).to include(t(:reserved_prefix, path: '/dashboard'))
       end
     end
 
@@ -128,7 +132,7 @@ RSpec.describe Hyrax::RedirectValidator do
 
       it 'records an intra-record duplicate error' do
         record.valid?
-        expect(record.errors[:redirects]).to include(/listed more than once/)
+        expect(record.errors[:redirects]).to include(t(:intra_record_duplicate, path: '/handle/1'))
       end
     end
 
@@ -144,7 +148,7 @@ RSpec.describe Hyrax::RedirectValidator do
 
       it 'records a global-uniqueness error' do
         record.valid?
-        expect(record.errors[:redirects]).to include(/already in use/)
+        expect(record.errors[:redirects]).to include(t(:already_taken, path: '/handle/12345/678'))
       end
     end
 
@@ -158,7 +162,7 @@ RSpec.describe Hyrax::RedirectValidator do
 
       it 'records an at-most-one-canonical error' do
         record.valid?
-        expect(record.errors[:redirects]).to include(/at most one redirect entry may be marked canonical/)
+        expect(record.errors[:redirects]).to include(t(:multiple_canonical))
       end
     end
 


### PR DESCRIPTION
## Summary

Next segment of the URL Redirects feature (continuation of #7421 and #7422). This adds:

- A Postgres-backed uniqueness ledger (`hyrax_redirect_paths`) with a unique index on `path` for the hard correctness guarantee under concurrent writes.
- `Hyrax::RedirectsLookup` as the single point of truth for "is this path taken?", isolated behind a small API.
- `Hyrax::RedirectPathNormalizer` as the single source of truth for canonical path form. Wired into the resolver, the lookup, the form's `redirects=` setter, and the sync step so all four agree on shape.
- `Hyrax::RedirectValidator` for form-level feedback at submit time (six rules: blank, format, reserved-prefix, intra-record uniqueness, global uniqueness, at-most-one-canonical).
- Two transaction steps — `SyncRedirectPaths` and `RemoveRedirectPaths` — that keep the ledger in sync via the existing `dry-transaction` plumbing in `WorkCreate`/`WorkUpdate`/`WorkDestroy` and the equivalent collection transactions.
- Documentation covering the full lifecycle (normalize → validate → save → sync to ledger) and the architecture rationale.

The validator gives users friendly form-time errors. The DB unique index is the actual guarantee — if two simultaneous saves both pass validation, `SyncRedirectPaths` catches the `RecordNotUnique` and short-circuits the enclosing transaction with `Failure([:redirect_path_collision, ...])`.

Refs #623.

## Open question for review

`SyncRedirectPaths` currently does a delete-and-reinsert on every save: it removes all rows for the resource_id and reinserts the current set. This is simple and correct but loses `created_at` history — the column always reflects the user's last save, not when the path was first registered. A diff-based update (compute set difference, delete only removed paths, insert only new ones) would preserve `created_at` for untouched paths at the cost of slightly more code. No code path in this PR consumes the timestamps, but they have potential audit/forensics value ("when did this redirect first start working?"). Worth keeping the diff approach as a follow-up if reviewers find the audit value compelling.
