### PR TITLE
624 aliases tab work form

### DIFF
--- a/app/forms/hyrax/forms/resource_form.rb
+++ b/app/forms/hyrax/forms/resource_form.rb
@@ -44,6 +44,7 @@ module Hyrax
       property :version, virtual: true, prepopulator: LockKeyPrepopulator
 
       validates_with Hyrax::RedirectValidator, attributes: [:redirects] if Hyrax.config.redirects_enabled?
+      property :redirects_attributes, virtual: true, populator: :redirects_populator if Hyrax.config.redirects_enabled?
 
       ##
       # @api public
@@ -195,6 +196,24 @@ module Hyrax
       def redirects=(values)
         return super unless Hyrax.config.redirects_enabled?
         super(Array(values).map { |entry| normalize_redirect_entry(entry) })
+      end
+
+      # Populator for the nested-attributes payload posted by the Aliases
+      # tab. Each form submission rebuilds the `redirects` list from the
+      # visible rows; rows marked `_destroy` are dropped, blank rows are
+      # ignored. The `redirects=` setter then normalizes paths and the
+      # validator runs against the result.
+      #
+      # No-ops when the Flipflop is off so a stale or out-of-band post of
+      # redirects_attributes can't mutate (or clear) existing redirects on
+      # a resource while the runtime feature is disabled. Existing entries
+      # on the resource are preserved untouched.
+      def redirects_populator(fragment:, **_options)
+        return unless Flipflop.redirects?
+        entries = Array(fragment&.values)
+                  .reject { |row| row['_destroy'].to_s == 'true' || row['path'].to_s.strip.empty? }
+                  .map { |row| { path: row['path'], canonical: row['canonical'].to_s == 'true' } }
+        self.redirects = entries
       end
 
       ##

--- a/app/helpers/hyrax/collections_helper.rb
+++ b/app/helpers/hyrax/collections_helper.rb
@@ -151,6 +151,13 @@ module Hyrax
     end
 
     ##
+    # @return [Boolean] true when the redirects feature is fully enabled
+    #   (config + Flipflop). Drives the Aliases tab on the collection edit form.
+    def collection_redirectable?
+      Hyrax.config.redirects_enabled? && Flipflop.redirects?
+    end
+
+    ##
     # @note this helper is primarily intended for use with blacklight facet
     #   fields. it assumes we index a `collection_type_gid` and the helper
     #   can be passed as as a `helper_method:` to `add_facet_field`.

--- a/app/helpers/hyrax/collections_helper.rb
+++ b/app/helpers/hyrax/collections_helper.rb
@@ -154,7 +154,7 @@ module Hyrax
     # @return [Boolean] true when the redirects feature is fully enabled
     #   (config + Flipflop). Drives the Aliases tab on the collection edit form.
     def collection_redirectable?
-      Hyrax.config.redirects_enabled? && Flipflop.redirects?
+      Hyrax.config.redirects_active?
     end
 
     ##

--- a/app/helpers/hyrax/work_form_helper.rb
+++ b/app/helpers/hyrax/work_form_helper.rb
@@ -106,7 +106,7 @@ module Hyrax
     # @param _form [Hyrax::Forms::ResourceForm, Hyrax::Forms::WorkForm]
     # @return [Boolean] true when the redirects tab should appear on this form
     def redirects_tab?(_form)
-      Hyrax.config.redirects_enabled? && Flipflop.redirects?
+      Hyrax.config.redirects_active?
     end
   end
 end

--- a/app/helpers/hyrax/work_form_helper.rb
+++ b/app/helpers/hyrax/work_form_helper.rb
@@ -30,11 +30,13 @@ module Hyrax
     # @param form [Hyrax::Forms::WorkForm, Hyrax::Forms::ResourceForm]
     # @return [Array<String>] the list of names of tabs to be rendered in the form
     def form_tabs_for(form:)
-      if form.instance_of? Hyrax::Forms::BatchUploadForm
-        %w[files metadata relationships]
-      else
-        %w[metadata files relationships]
-      end
+      tabs = if form.instance_of? Hyrax::Forms::BatchUploadForm
+               %w[files metadata relationships]
+             else
+               %w[metadata files relationships]
+             end
+      tabs << 'redirects' if redirects_tab?(form)
+      tabs
     end
 
     ##
@@ -96,6 +98,15 @@ module Hyrax
       file_sets.each_with_object({}) do |presenter, hash|
         hash[presenter.title_or_label] = presenter.id
       end
+    end
+
+    ##
+    # @api private
+    #
+    # @param _form [Hyrax::Forms::ResourceForm, Hyrax::Forms::WorkForm]
+    # @return [Boolean] true when the redirects tab should appear on this form
+    def redirects_tab?(_form)
+      Hyrax.config.redirects_enabled? && Flipflop.redirects?
     end
   end
 end

--- a/app/validators/hyrax/redirect_validator.rb
+++ b/app/validators/hyrax/redirect_validator.rb
@@ -23,7 +23,7 @@ module Hyrax
     # 2. record_supports_redirects? — the structural gate. Catches the case
     #    where both feature gates are on but the property wasn't added
     def validate(record)
-      return unless Hyrax.config.redirects_enabled? && Flipflop.redirects?
+      return unless Hyrax.config.redirects_active?
       return unless record_supports_redirects?(record)
       super
     end

--- a/app/views/hyrax/base/_form_redirects.html.erb
+++ b/app/views/hyrax/base/_form_redirects.html.erb
@@ -1,0 +1,55 @@
+<%# Aliases tab — see documentation/redirects.md %>
+<h2 class="h3 mt-4"><%= t('hyrax.works.form.redirects.heading') %></h2>
+
+<p><%= t('hyrax.works.form.redirects.help_html').html_safe %></p>
+
+<% if f.object.errors[:redirects].any? %>
+  <div role="alert" aria-live="polite">
+    <h3 class="sr-only"><%= t('hyrax.works.form.redirects.errors_heading') %></h3>
+    <% f.object.errors[:redirects].each do |msg| %>
+      <p class="message has-warning"><%= msg %></p>
+    <% end %>
+  </div>
+<% end %>
+
+<table class="table table-striped">
+  <caption class="sr-only"><%= t('hyrax.works.form.redirects.caption') %></caption>
+  <thead>
+    <tr>
+      <th scope="col"><%= t('hyrax.works.form.redirects.header.path') %></th>
+      <th scope="col" class="sr-only"><%= t('hyrax.works.form.redirects.header.actions') %></th>
+    </tr>
+  </thead>
+  <tbody>
+    <% rows = Array(f.object.redirects) + [Hyrax::Redirect.new(path: nil)] %>
+    <% rows.each_with_index do |entry, index| %>
+      <% input_id = "#{f.object_name}_redirects_attributes_#{index}_path" %>
+      <% label_text = entry.path.present? ? t('hyrax.works.form.redirects.path_label') : t('hyrax.works.form.redirects.new_path_label') %>
+      <tr>
+        <td>
+          <%= label_tag input_id, label_text, class: 'sr-only' %>
+          <div class="input-group">
+            <div class="input-group-prepend">
+              <span class="input-group-text"><%= main_app.root_url.chomp('/') %></span>
+            </div>
+            <%= text_field_tag "#{f.object_name}[redirects_attributes][#{index}][path]",
+                               entry.path,
+                               id: input_id,
+                               class: 'form-control',
+                               placeholder: t('hyrax.works.form.redirects.placeholder.path') %>
+          </div>
+        </td>
+        <td class="text-right" style="width: 1%;">
+          <% if entry.path.present? %>
+            <button type="button"
+                    class="btn close"
+                    aria-label="<%= t('hyrax.works.form.redirects.remove_with_path_label', path: entry.path) %>"
+                    onclick="this.closest('tr').remove()">
+              <span aria-hidden="true">&times;</span>
+            </button>
+          <% end %>
+        </td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/app/views/hyrax/dashboard/collections/_form.html.erb
+++ b/app/views/hyrax/dashboard/collections/_form.html.erb
@@ -28,6 +28,13 @@
         </a>
       </li>
       <% end %>
+      <% if collection_redirectable? %>
+      <li class="nav-item" role="presentation">
+        <a href="#redirects" role="tab" data-toggle="tab" class="nav-link nav-safety-confirm">
+          <%= t('.tabs.redirects') %>
+        </a>
+      </li>
+      <% end %>
     <% end %>
   </ul>
 
@@ -105,6 +112,16 @@
             <div class="card labels" id="collection_permissions" data-param-key="<%= f.object.model_name.param_key %>">
               <div class="card-body">
                 <%= render 'form_share', f: f %>
+              </div>
+            </div>
+          </div>
+        <% end %>
+
+        <% if collection_redirectable? %>
+          <div id="redirects" class="tab-pane">
+            <div class="card labels">
+              <div class="card-body">
+                <%= render 'hyrax/base/form_redirects', f: f %>
               </div>
             </div>
           </div>

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -925,6 +925,7 @@ en:
             branding: Branding
             description: Description
             discovery: Discovery
+            redirects: Aliases
             relationships: Relationships
             sharing: Sharing
         form_branding:
@@ -1816,7 +1817,7 @@ en:
             actions: Actions
             path: Path
           heading: URL Aliases
-          help_html: 'Register legacy URL paths that should redirect to this work. Each path will resolve from this site''s root. Reserved Hyrax routes (e.g. <code>/concern</code>, <code>/dashboard</code>) cannot be used.'
+          help_html: 'Register legacy URL paths that should redirect to this record. Each path will resolve from this site''s root. Reserved Hyrax routes (e.g. <code>/concern</code>, <code>/dashboard</code>) cannot be used.'
           new_path_label: New alias path
           path_label: Alias path
           placeholder:

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -1809,9 +1809,24 @@ en:
         in_collections: Collections
         in_other_works: This Work in Other Works
         in_this_work: Other Works in this Work
+        redirects:
+          caption: List of URL aliases for this resource
+          errors_heading: Please correct the following alias errors
+          header:
+            actions: Actions
+            path: Path
+          heading: URL Aliases
+          help_html: 'Register legacy URL paths that should redirect to this work. Each path will resolve from this site''s root. Reserved Hyrax routes (e.g. <code>/concern</code>, <code>/dashboard</code>) cannot be used.'
+          new_path_label: New alias path
+          path_label: Alias path
+          placeholder:
+            path: Enter a legacy path...
+          remove_label: Remove
+          remove_with_path_label: 'Remove %{path}'
         tab:
           files: Files
           metadata: Descriptions
+          redirects: Aliases
           relationships: Relationships
           share: Sharing
         visibility_until: until

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -282,6 +282,6 @@ Hyrax::Engine.routes.draw do
 
   # Catch-all redirect resolver — must be last. See documentation/redirects.md.
   get '*alias_path', to: 'redirects#show',
-                     constraints: ->(_req) { Hyrax.config.redirects_enabled? && Flipflop.redirects? },
+                     constraints: ->(_req) { Hyrax.config.redirects_active? },
                      format: false
 end

--- a/documentation/redirects.md
+++ b/documentation/redirects.md
@@ -249,11 +249,13 @@ The schema include on `Hyrax::Work` and `Hyrax::PcdmCollection` runs at class-lo
 
 ### Calling `Flipflop.redirects?`
 
-The `:redirects` Flipflop feature is only registered when `Hyrax.config.redirects_enabled?` is true. When the config is off, calling `Flipflop.redirects?` raises `NoMethodError`. Any new code that consults the feature flag must short-circuit on the config first:
+The `:redirects` Flipflop feature is only registered when `Hyrax.config.redirects_enabled?` is true. When the config is off, calling `Flipflop.redirects?` raises `NoMethodError`. New code that needs the combined gate should call:
 
 ```ruby
-Hyrax.config.redirects_enabled? && Flipflop.redirects?
+Hyrax.config.redirects_active?
 ```
+
+`redirects_active?` returns `redirects_enabled? && Flipflop.redirects?` and short-circuits on the config so the Flipflop call is safe.
 
 Alternatively, gate the inclusion of the calling code itself on `Hyrax.config.redirects_enabled?` (as the indexer mixin does in `Hyrax::Indexers::PcdmObjectIndexer` and `Hyrax::Indexers::PcdmCollectionIndexer`); then the body can check `Flipflop.redirects?` alone because it only runs when the feature is registered.
 

--- a/lib/hyrax/configuration.rb
+++ b/lib/hyrax/configuration.rb
@@ -350,6 +350,15 @@ module Hyrax
     end
     alias redirects_enabled redirects_enabled?
 
+    # @return [Boolean] true when both the structural config and the runtime
+    #   Flipflop are on. Single source of truth for "is the redirects feature
+    #   actively in use right now?". Short-circuits on the config so the
+    #   Flipflop call is safe (the :redirects feature is only registered when
+    #   the config is on; calling Flipflop.redirects? otherwise raises).
+    def redirects_active?
+      redirects_enabled? && Flipflop.redirects?
+    end
+
     # Path prefixes that may not be claimed as redirect aliases (Hyrax::RedirectValidator
     # rejects any redirect path equal to or starting with one of these). Defaults to the
     # routes Hyrax itself reserves; adopters can extend the list to cover host-app routes:

--- a/spec/helpers/hyrax/collections_helper_spec.rb
+++ b/spec/helpers/hyrax/collections_helper_spec.rb
@@ -244,4 +244,33 @@ RSpec.describe Hyrax::CollectionsHelper, :clean_repo do
       end
     end
   end
+
+  describe '#collection_redirectable?' do
+    context 'when both gates are open' do
+      before do
+        allow(Hyrax.config).to receive(:redirects_enabled?).and_return(true)
+        allow(Flipflop).to receive(:redirects?).and_return(true)
+      end
+
+      it { expect(helper.collection_redirectable?).to be true }
+    end
+
+    context 'when the config is on but the Flipflop is off' do
+      before do
+        allow(Hyrax.config).to receive(:redirects_enabled?).and_return(true)
+        allow(Flipflop).to receive(:redirects?).and_return(false)
+      end
+
+      it { expect(helper.collection_redirectable?).to be false }
+    end
+
+    context 'when the config is off' do
+      before { allow(Hyrax.config).to receive(:redirects_enabled?).and_return(false) }
+
+      it 'is false without consulting Flipflop' do
+        expect(Flipflop).not_to receive(:redirects?)
+        expect(helper.collection_redirectable?).to be false
+      end
+    end
+  end
 end

--- a/spec/helpers/hyrax/work_form_helper_spec.rb
+++ b/spec/helpers/hyrax/work_form_helper_spec.rb
@@ -32,6 +32,46 @@ RSpec.describe Hyrax::WorkFormHelper do
         expect(form_tabs_for(form: form)).to eq ["files", "metadata", "relationships"]
       end
     end
+
+    context 'when the redirects feature is fully enabled' do
+      let(:work) { build(:hyrax_work) }
+      let(:form) { Hyrax::Forms::ResourceForm.for(resource: work) }
+
+      before do
+        allow(Hyrax.config).to receive(:redirects_enabled?).and_return(true)
+        allow(Flipflop).to receive(:redirects?).and_return(true)
+      end
+
+      it 'appends the redirects tab' do
+        expect(form_tabs_for(form: form)).to eq %w[metadata files relationships redirects]
+      end
+    end
+
+    context 'when the redirects config is on but the Flipflop is off' do
+      let(:work) { build(:hyrax_work) }
+      let(:form) { Hyrax::Forms::ResourceForm.for(resource: work) }
+
+      before do
+        allow(Hyrax.config).to receive(:redirects_enabled?).and_return(true)
+        allow(Flipflop).to receive(:redirects?).and_return(false)
+      end
+
+      it 'omits the redirects tab' do
+        expect(form_tabs_for(form: form)).to eq %w[metadata files relationships]
+      end
+    end
+
+    context 'when the redirects config is off' do
+      let(:work) { build(:hyrax_work) }
+      let(:form) { Hyrax::Forms::ResourceForm.for(resource: work) }
+
+      before { allow(Hyrax.config).to receive(:redirects_enabled?).and_return(false) }
+
+      it 'omits the redirects tab without consulting Flipflop' do
+        expect(Flipflop).not_to receive(:redirects?)
+        expect(form_tabs_for(form: form)).to eq %w[metadata files relationships]
+      end
+    end
   end
 
   describe '.form_tab_label_for' do

--- a/spec/lib/hyrax/configuration_spec.rb
+++ b/spec/lib/hyrax/configuration_spec.rb
@@ -102,6 +102,7 @@ RSpec.describe Hyrax::Configuration do
   it { is_expected.to respond_to(:persistent_hostpath) }
   it { is_expected.to respond_to(:realtime_notifications?) }
   it { is_expected.to respond_to(:realtime_notifications=) }
+  it { is_expected.to respond_to(:redirects_active?) }
   it { is_expected.to respond_to(:redirects_enabled) }
   it { is_expected.to respond_to(:redirects_enabled=) }
   it { is_expected.to respond_to(:redirects_enabled?) }
@@ -151,6 +152,35 @@ RSpec.describe Hyrax::Configuration do
       before { stub_const("ENV", "HYRAX_REDIRECTS_ENABLED" => "true") }
       it "is true" do
         expect(described_class.new.redirects_enabled?).to be true
+      end
+    end
+  end
+
+  describe "#redirects_active?" do
+    context "when both gates are open" do
+      before do
+        allow(configuration).to receive(:redirects_enabled?).and_return(true)
+        allow(Flipflop).to receive(:redirects?).and_return(true)
+      end
+
+      it { expect(configuration.redirects_active?).to be true }
+    end
+
+    context "when the config is on but the Flipflop is off" do
+      before do
+        allow(configuration).to receive(:redirects_enabled?).and_return(true)
+        allow(Flipflop).to receive(:redirects?).and_return(false)
+      end
+
+      it { expect(configuration.redirects_active?).to be false }
+    end
+
+    context "when the config is off" do
+      before { allow(configuration).to receive(:redirects_enabled?).and_return(false) }
+
+      it "is false without consulting Flipflop (so callers don't need to know about the registration order)" do
+        expect(Flipflop).not_to receive(:redirects?)
+        expect(configuration.redirects_active?).to be false
       end
     end
   end


### PR DESCRIPTION
## Summary
Refs #624, #625

Implements the user-facing UI for the URL Redirects feature on the work and collection edit forms. Builds on the validation, normalization, and ledger-sync infrastructure.

- **Aliases tab on the work edit form** (#624). Visible whenever the redirects feature is fully enabled (config + Flipflop). Renders existing redirect entries with a per-row remove control and a trailing blank row for adding new aliases on the next save.
- **Aliases tab on the collection edit form** (#625). Mirrors the work-form tab; reuses the `_form_redirects.html.erb` partial — no duplicate UI markup. Form-side wiring (populator, validator, normalizer, sync step) is shared via `Hyrax::Forms::ResourceForm`, so this slice adds only the UI surface.
- **Server-only flow** — no JavaScript dependency for adds (trailing blank row becomes the new entry on submit) or removes (inline `onclick` removes the `<tr>`; populator drops the missing row server-side).
- **UX**: input-group prefix shows the site root so users can see the full URL the path resolves from. Gray-X close button matches the Sharing tab convention.
- **Accessibility**: sr-only labels on every input, error region with `role="alert"` and `aria-live="polite"`, per-row remove buttons with the path included in the `aria-label`.

## Screenshots

Sample of tab:

<img width="891" height="559" alt="Screenshot 2026-05-01 at 1 50 04 PM" src="https://github.com/user-attachments/assets/cb6d02a3-a8f4-4d85-9408-96f9fd4bc5f2" />
