### PR TITLE
Extract Hyrax.config.redirects_active? helper

### DIFF
--- a/app/helpers/hyrax/collections_helper.rb
+++ b/app/helpers/hyrax/collections_helper.rb
@@ -154,7 +154,7 @@ module Hyrax
     # @return [Boolean] true when the redirects feature is fully enabled
     #   (config + Flipflop). Drives the Aliases tab on the collection edit form.
     def collection_redirectable?
-      Hyrax.config.redirects_enabled? && Flipflop.redirects?
+      Hyrax.config.redirects_active?
     end
 
     ##

--- a/app/helpers/hyrax/work_form_helper.rb
+++ b/app/helpers/hyrax/work_form_helper.rb
@@ -106,7 +106,7 @@ module Hyrax
     # @param _form [Hyrax::Forms::ResourceForm, Hyrax::Forms::WorkForm]
     # @return [Boolean] true when the redirects tab should appear on this form
     def redirects_tab?(_form)
-      Hyrax.config.redirects_enabled? && Flipflop.redirects?
+      Hyrax.config.redirects_active?
     end
   end
 end

--- a/app/validators/hyrax/redirect_validator.rb
+++ b/app/validators/hyrax/redirect_validator.rb
@@ -23,7 +23,7 @@ module Hyrax
     # 2. record_supports_redirects? — the structural gate. Catches the case
     #    where both feature gates are on but the property wasn't added
     def validate(record)
-      return unless Hyrax.config.redirects_enabled? && Flipflop.redirects?
+      return unless Hyrax.config.redirects_active?
       return unless record_supports_redirects?(record)
       super
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -282,6 +282,6 @@ Hyrax::Engine.routes.draw do
 
   # Catch-all redirect resolver — must be last. See documentation/redirects.md.
   get '*alias_path', to: 'redirects#show',
-                     constraints: ->(_req) { Hyrax.config.redirects_enabled? && Flipflop.redirects? },
+                     constraints: ->(_req) { Hyrax.config.redirects_active? },
                      format: false
 end

--- a/documentation/redirects.md
+++ b/documentation/redirects.md
@@ -249,11 +249,13 @@ The schema include on `Hyrax::Work` and `Hyrax::PcdmCollection` runs at class-lo
 
 ### Calling `Flipflop.redirects?`
 
-The `:redirects` Flipflop feature is only registered when `Hyrax.config.redirects_enabled?` is true. When the config is off, calling `Flipflop.redirects?` raises `NoMethodError`. Any new code that consults the feature flag must short-circuit on the config first:
+The `:redirects` Flipflop feature is only registered when `Hyrax.config.redirects_enabled?` is true. When the config is off, calling `Flipflop.redirects?` raises `NoMethodError`. New code that needs the combined gate should call:
 
 ```ruby
-Hyrax.config.redirects_enabled? && Flipflop.redirects?
+Hyrax.config.redirects_active?
 ```
+
+`redirects_active?` returns `redirects_enabled? && Flipflop.redirects?` and short-circuits on the config so the Flipflop call is safe.
 
 Alternatively, gate the inclusion of the calling code itself on `Hyrax.config.redirects_enabled?` (as the indexer mixin does in `Hyrax::Indexers::PcdmObjectIndexer` and `Hyrax::Indexers::PcdmCollectionIndexer`); then the body can check `Flipflop.redirects?` alone because it only runs when the feature is registered.
 

--- a/lib/hyrax/configuration.rb
+++ b/lib/hyrax/configuration.rb
@@ -350,6 +350,15 @@ module Hyrax
     end
     alias redirects_enabled redirects_enabled?
 
+    # @return [Boolean] true when both the structural config and the runtime
+    #   Flipflop are on. Single source of truth for "is the redirects feature
+    #   actively in use right now?". Short-circuits on the config so the
+    #   Flipflop call is safe (the :redirects feature is only registered when
+    #   the config is on; calling Flipflop.redirects? otherwise raises).
+    def redirects_active?
+      redirects_enabled? && Flipflop.redirects?
+    end
+
     # Path prefixes that may not be claimed as redirect aliases (Hyrax::RedirectValidator
     # rejects any redirect path equal to or starting with one of these). Defaults to the
     # routes Hyrax itself reserves; adopters can extend the list to cover host-app routes:

--- a/spec/lib/hyrax/configuration_spec.rb
+++ b/spec/lib/hyrax/configuration_spec.rb
@@ -102,6 +102,7 @@ RSpec.describe Hyrax::Configuration do
   it { is_expected.to respond_to(:persistent_hostpath) }
   it { is_expected.to respond_to(:realtime_notifications?) }
   it { is_expected.to respond_to(:realtime_notifications=) }
+  it { is_expected.to respond_to(:redirects_active?) }
   it { is_expected.to respond_to(:redirects_enabled) }
   it { is_expected.to respond_to(:redirects_enabled=) }
   it { is_expected.to respond_to(:redirects_enabled?) }
@@ -151,6 +152,35 @@ RSpec.describe Hyrax::Configuration do
       before { stub_const("ENV", "HYRAX_REDIRECTS_ENABLED" => "true") }
       it "is true" do
         expect(described_class.new.redirects_enabled?).to be true
+      end
+    end
+  end
+
+  describe "#redirects_active?" do
+    context "when both gates are open" do
+      before do
+        allow(configuration).to receive(:redirects_enabled?).and_return(true)
+        allow(Flipflop).to receive(:redirects?).and_return(true)
+      end
+
+      it { expect(configuration.redirects_active?).to be true }
+    end
+
+    context "when the config is on but the Flipflop is off" do
+      before do
+        allow(configuration).to receive(:redirects_enabled?).and_return(true)
+        allow(Flipflop).to receive(:redirects?).and_return(false)
+      end
+
+      it { expect(configuration.redirects_active?).to be false }
+    end
+
+    context "when the config is off" do
+      before { allow(configuration).to receive(:redirects_enabled?).and_return(false) }
+
+      it "is false without consulting Flipflop (so callers don't need to know about the registration order)" do
+        expect(Flipflop).not_to receive(:redirects?)
+        expect(configuration.redirects_active?).to be false
       end
     end
   end


### PR DESCRIPTION
### Fixes

Refs #643

### Summary

Adds a config helper to consolidate duplication of the two redirects gating mechanisms, replacing use of the dual gating throughout the code.
