### PR TITLE
Redirects integration fixes

### DIFF
--- a/.dassie/config/routes.rb
+++ b/.dassie/config/routes.rb
@@ -36,4 +36,9 @@ Rails.application.routes.draw do
     end
   end
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
+
+  # Catch-all redirect resolver — must be last. See documentation/redirects.md.
+  get '*alias_path', to: 'hyrax/redirects#show',
+                     constraints: ->(_req) { Hyrax.config.redirects_active? },
+                     format: false
 end

--- a/.koppie/config/routes.rb
+++ b/.koppie/config/routes.rb
@@ -36,4 +36,9 @@ Rails.application.routes.draw do
     end
   end
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
+
+  # Catch-all redirect resolver — must be last. See documentation/redirects.md.
+  get '*alias_path', to: 'hyrax/redirects#show',
+                     constraints: ->(_req) { Hyrax.config.redirects_active? },
+                     format: false
 end

--- a/app/helpers/hyrax/collections_helper.rb
+++ b/app/helpers/hyrax/collections_helper.rb
@@ -151,10 +151,17 @@ module Hyrax
     end
 
     ##
+    # @param form [Hyrax::Forms::PcdmCollectionForm, Object] the collection form
     # @return [Boolean] true when the redirects feature is fully enabled
-    #   (config + Flipflop). Drives the Aliases tab on the collection edit form.
-    def collection_redirectable?
-      Hyrax.config.redirects_active?
+    #   (config + Flipflop) *and* the collection's resource carries the
+    #   `redirects` attribute. The structural check guards against adopter
+    #   collection classes that don't include the schema; without it the tab
+    #   would render and crash on `f.object.redirects`. Drives the Aliases tab
+    #   on the collection edit form.
+    def collection_redirectable?(form)
+      return false unless Hyrax.config.redirects_active?
+      target = form.respond_to?(:model) ? form.model : form
+      target.respond_to?(:redirects)
     end
 
     ##

--- a/app/helpers/hyrax/work_form_helper.rb
+++ b/app/helpers/hyrax/work_form_helper.rb
@@ -103,10 +103,17 @@ module Hyrax
     ##
     # @api private
     #
-    # @param _form [Hyrax::Forms::ResourceForm, Hyrax::Forms::WorkForm]
-    # @return [Boolean] true when the redirects tab should appear on this form
-    def redirects_tab?(_form)
-      Hyrax.config.redirects_active?
+    # @param form [Hyrax::Forms::ResourceForm, Hyrax::Forms::WorkForm]
+    # @return [Boolean] true when the redirects tab should appear on this form.
+    #   Both the runtime feature gates *and* the form's underlying resource
+    #   must carry the `redirects` attribute. The structural check guards
+    #   against adopter work classes that don't include the schema (e.g. Hyku's
+    #   `GenericWorkResource`); without it the tab would render and crash on
+    #   `f.object.redirects`.
+    def redirects_tab?(form)
+      return false unless Hyrax.config.redirects_active?
+      target = form.respond_to?(:model) ? form.model : form
+      target.respond_to?(:redirects)
     end
   end
 end

--- a/app/services/hyrax/flexible_schema_validators/redirects_validator.rb
+++ b/app/services/hyrax/flexible_schema_validators/redirects_validator.rb
@@ -15,11 +15,10 @@ module Hyrax
     # | on     | off      | present  | warn (property is loaded but unused)|
     # | on     | off      | absent   | silent                              |
     # | on     | on       | absent   | error (property is required)        |
-    # | on     | on       | present  | check available_on.class and pass   |
-    # |        |          |          | or error if work/collection missing |
+    # | on     | on       | present  | check available_on.class lists at   |
+    # |        |          |          | least one work or collection class  |
+    # |        |          |          | declared in this profile's classes  |
     class RedirectsValidator
-      REQUIRED_CLASSES = %w[Hyrax::Work Hyrax::PcdmCollection].freeze
-
       ##
       # @param profile [Hash] the flexible metadata profile
       # @param errors [Array<String>] an array to append errors to
@@ -64,11 +63,43 @@ module Hyrax
           return
         end
 
-        available_on = Array(redirects_property.dig('available_on', 'class'))
-        missing = REQUIRED_CLASSES - available_on
-        return if missing.empty?
+        available_on = clean(Array(redirects_property.dig('available_on', 'class')))
+        return if (available_on & profile_work_or_collection_classes).any?
 
-        @errors << "m3 profile `redirects` property must be available on: #{missing.join(', ')}"
+        @errors << 'm3 profile `redirects` property must be available on at least one work or collection class declared in this profile'
+      end
+
+      # Class names declared in this m3 profile's top-level `classes:` block,
+      # filtered to keep only those that represent works or collections.
+      # FileSets, AdminSets, and any non-work/non-collection class are
+      # excluded — redirects only apply to works and collections.
+      def profile_work_or_collection_classes
+        @profile_work_or_collection_classes ||= begin
+          declared = clean(Array(@profile&.dig('classes')&.keys))
+          declared.select { |name| work_or_collection?(name) }
+        end
+      end
+
+      def work_or_collection?(class_name)
+        registered_collection_names.include?(class_name) ||
+          registered_work_names.include?(class_name)
+      end
+
+      def registered_collection_names
+        @registered_collection_names ||= clean(Hyrax::ModelRegistry.collection_class_names)
+      end
+
+      # Adopter-registered work types, plus their `Resource`-suffixed Valkyrie
+      # equivalents. Mirrors how upstream `class_validator` accepts both forms.
+      def registered_work_names
+        @registered_work_names ||= begin
+          works = Array(Hyrax.config.registered_curation_concern_types)
+          clean(works.flat_map { |name| [name, "#{name}Resource"] })
+        end
+      end
+
+      def clean(names)
+        names.map { |name| name.to_s.delete_prefix('::') }
       end
 
       def warn_dead_property(reason)

--- a/app/validators/hyrax/redirect_validator.rb
+++ b/app/validators/hyrax/redirect_validator.rb
@@ -82,11 +82,11 @@ module Hyrax
 
     # Reform forms wrap the underlying resource and use method_missing to
     # forward attribute reads. We can't just call `record.respond_to?(:redirects)`
-    # because Reform's method_missing returns truthy for missing methods.
-    # Probe the actual underlying resource through the form's `__getobj__`
-    # (Reform's accessor for the wrapped object) when present.
+    # because Reform's method_missing/respond_to_missing? returns truthy for
+    # missing methods. Probe the wrapped resource through `form.model`
+    # (Disposable::Twin's accessor for the underlying object) when present.
     def record_supports_redirects?(record)
-      target = record.respond_to?(:__getobj__) ? record.__getobj__ : record
+      target = record.respond_to?(:model) ? record.model : record
       target.respond_to?(:redirects)
     end
   end

--- a/app/views/hyrax/base/_form_redirects.html.erb
+++ b/app/views/hyrax/base/_form_redirects.html.erb
@@ -31,7 +31,7 @@
           <%= label_tag input_id, label_text, class: 'sr-only' %>
           <div class="input-group">
             <div class="input-group-prepend">
-              <span class="input-group-text"><%= main_app.root_url.chomp('/') %></span>
+              <span class="input-group-text"><%= "#{request.protocol}#{request.host_with_port}" %></span>
             </div>
             <%= text_field_tag "#{f.object_name}[redirects_attributes][#{index}][path]",
                                entry.path,

--- a/app/views/hyrax/base/_form_redirects.html.erb
+++ b/app/views/hyrax/base/_form_redirects.html.erb
@@ -1,4 +1,5 @@
 <%# Aliases tab — see documentation/redirects.md %>
+<% return unless redirects_tab?(f.object) %>
 <h2 class="h3 mt-4"><%= t('hyrax.works.form.redirects.heading') %></h2>
 
 <p><%= t('hyrax.works.form.redirects.help_html').html_safe %></p>

--- a/app/views/hyrax/dashboard/collections/_form.html.erb
+++ b/app/views/hyrax/dashboard/collections/_form.html.erb
@@ -28,7 +28,7 @@
         </a>
       </li>
       <% end %>
-      <% if collection_redirectable? %>
+      <% if collection_redirectable?(@form) %>
       <li class="nav-item" role="presentation">
         <a href="#redirects" role="tab" data-toggle="tab" class="nav-link nav-safety-confirm">
           <%= t('.tabs.redirects') %>
@@ -117,7 +117,7 @@
           </div>
         <% end %>
 
-        <% if collection_redirectable? %>
+        <% if collection_redirectable?(f.object) %>
           <div id="redirects" class="tab-pane">
             <div class="card labels">
               <div class="card-body">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -279,9 +279,4 @@ Hyrax::Engine.routes.draw do
   %w[zotero mendeley].each do |action|
     get action, controller: 'static', action: action, as: action
   end
-
-  # Catch-all redirect resolver — must be last. See documentation/redirects.md.
-  get '*alias_path', to: 'redirects#show',
-                     constraints: ->(_req) { Hyrax.config.redirects_active? },
-                     format: false
 end

--- a/documentation/redirects.md
+++ b/documentation/redirects.md
@@ -65,21 +65,41 @@ If the Flipflop is on but the m3 profile is missing the `redirects` property, th
 
 ## m3 profile requirements (`flexible: true` mode)
 
-Adopters running `HYRAX_FLEXIBLE=true` and choosing to use redirects must declare a `redirects` property in their m3 profile. The minimal declaration:
+Adopters running `HYRAX_FLEXIBLE=true` and choosing to use redirects must declare a `redirects` property in their m3 profile. The classes listed in `available_on.class` must also appear in the profile's top-level `classes:` block. A minimal declaration:
 
 ```yaml
+classes:
+  GenericWork:
+    display_label: Work
+  CollectionResource:
+    display_label: Collection
+  # ... and any other classes the deployment uses
+
 properties:
   redirects:
+    display_label:
+      default: URL Aliases
     available_on:
       class:
-        - Hyrax::Work
-        - Hyrax::PcdmCollection
+        - GenericWork          # or any registered curation concern
+        - CollectionResource   # or any registered collection class
     cardinality:
       minimum: 0
     type: redirect
     multiple: true
     predicate: http://samvera.org/ns/hyku/redirects
+    range: http://www.w3.org/2000/01/rdf-schema#Resource
+    form:
+      display: false           # keeps redirects out of the basic metadata form;
+      primary: false           # the dedicated Aliases tab handles editing
 ```
+
+The `available_on.class` list should name the resource classes the adopter uses for works and collections. The validator requires at least one work or collection class be listed, and that class must:
+
+1. Be **declared in this profile's top-level `classes:` block**, and
+2. Be a **registered work or collection class** — either a registered curation concern type (per `Hyrax.config.registered_curation_concern_types`, including its `Resource`-suffixed Valkyrie equivalent) or a registered collection class (per `Hyrax::ModelRegistry.collection_class_names`).
+
+`FileSet`, `AdminSet`, and any class not declared in this profile do not satisfy the check.
 
 The `type: redirect` token resolves to `Hyrax::Redirect`, a `Valkyrie::Resource` with `path`, `canonical`, and `sequence` sub-attributes. `multiple: true` is required for nested-resource members; the schema loader raises `ArgumentError` if a nested-resource property is declared with `multiple: false`.
 
@@ -90,8 +110,8 @@ Validation matrix on profile save (with the config on):
 | off | absent | silent (the feature is not in active use) |
 | off | present | warning (property is loaded but unused) |
 | on | absent | error (property is required) |
-| on | present, missing `Hyrax::Work` or `Hyrax::PcdmCollection` in `available_on.class` | error |
-| on | present, complete | silent (valid) |
+| on | present with no profile-declared work or collection class in `available_on.class` | error |
+| on | present with at least one profile-declared work or collection class | silent (valid) |
 
 When the config is **off**, an m3 profile that declares `redirects` produces a warning rather than an error. The property is dead — it won't be loaded — but Hyrax doesn't refuse to save the profile.
 

--- a/documentation/redirects.md
+++ b/documentation/redirects.md
@@ -194,6 +194,23 @@ Neither step does anything when the config is off, so adopters who don't enable 
 
 ## Resolver behavior
 
+### Route placement
+
+The redirect resolver is wired up as a **catch-all route in the host application's `config/routes.rb`**, not in the Hyrax engine. It must be the **last route in the host application** so every other route — engine mounts, host-specific routes, and `curation_concerns_basic_routes` — gets first crack at matching the request. The install generator appends the route at the end of `config/routes.rb`:
+
+```ruby
+# config/routes.rb (host app, end of file)
+get '*alias_path', to: 'hyrax/redirects#show',
+                   constraints: ->(_req) { Hyrax.config.redirects_active? },
+                   format: false
+```
+
+The constraint lambda is evaluated on every request: when `redirects_active?` is false (config off, or Flipflop off, or both), the catch-all is transparent and Rails returns its default 404 for any path that didn't match an earlier route. When `redirects_active?` is true, the request reaches `Hyrax::RedirectsController#show`.
+
+Adopters with existing installs (predating this feature) need to add the catch-all line manually. Adopters who run a custom catch-all (e.g. a 404 page handler) should put the redirect line *before* their handler, so registered redirects take precedence and unregistered paths fall through to the custom 404.
+
+### What happens at request time
+
 When both gates are open, `Hyrax::RedirectsController#show` serves any path not claimed by an earlier route:
 
 - The incoming path is normalized via `Hyrax::RedirectPathNormalizer` so the lookup matches the canonical form stored in Solr (a request for `/foo/` resolves the same record as `/foo`).

--- a/lib/generators/hyrax/install_generator.rb
+++ b/lib/generators/hyrax/install_generator.rb
@@ -61,7 +61,7 @@ module Hyrax
     end
 
     # The engine routes have to come after the devise routes so that /users/sign_in will work
-    def inject_routes
+    def inject_routes # rubocop:disable Metrics/MethodLength
       # Remove root route that was added by blacklight generator
       gsub_file 'config/routes.rb', /root (:to =>|to:) "catalog#index"/, ''
 
@@ -72,6 +72,19 @@ module Hyrax
         "  resources :welcome, only: 'index'\n"\
         "  root 'hyrax/homepage#index'\n"\
         "  curation_concerns_basic_routes\n"\
+      end
+
+      # Catch-all redirect resolver. Must be the last route in the host
+      # application so that every other route — engine mounts, host-specific
+      # routes, curation concerns — gets first crack at matching the request.
+      # Gated by Hyrax.config.redirects_active? at request time so the route is
+      # transparent when the redirects feature is off.
+      # See documentation/redirects.md.
+      inject_into_file 'config/routes.rb', before: /^end\s*\Z/ do
+        "\n  # Catch-all redirect resolver — must be last. See documentation/redirects.md.\n"\
+        "  get '*alias_path', to: 'hyrax/redirects#show',\n"\
+        "                     constraints: ->(_req) { Hyrax.config.redirects_active? },\n"\
+        "                     format: false\n"
       end
     end
 

--- a/spec/controllers/hyrax/redirects_controller_spec.rb
+++ b/spec/controllers/hyrax/redirects_controller_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe Hyrax::RedirectsController, type: :controller do
-  routes { Hyrax::Engine.routes }
+  routes { Rails.application.routes }
 
   describe '#show' do
     let(:work_id)        { 'abc-123-xyz' }

--- a/spec/helpers/hyrax/collections_helper_spec.rb
+++ b/spec/helpers/hyrax/collections_helper_spec.rb
@@ -246,13 +246,16 @@ RSpec.describe Hyrax::CollectionsHelper, :clean_repo do
   end
 
   describe '#collection_redirectable?' do
-    context 'when both gates are open' do
+    let(:resource) { Struct.new(:redirects).new([]) }
+    let(:form) { Struct.new(:model).new(resource) }
+
+    context 'when both gates are open and the form wraps a resource with :redirects' do
       before do
         allow(Hyrax.config).to receive(:redirects_enabled?).and_return(true)
         allow(Flipflop).to receive(:redirects?).and_return(true)
       end
 
-      it { expect(helper.collection_redirectable?).to be true }
+      it { expect(helper.collection_redirectable?(form)).to be true }
     end
 
     context 'when the config is on but the Flipflop is off' do
@@ -261,7 +264,7 @@ RSpec.describe Hyrax::CollectionsHelper, :clean_repo do
         allow(Flipflop).to receive(:redirects?).and_return(false)
       end
 
-      it { expect(helper.collection_redirectable?).to be false }
+      it { expect(helper.collection_redirectable?(form)).to be false }
     end
 
     context 'when the config is off' do
@@ -269,8 +272,20 @@ RSpec.describe Hyrax::CollectionsHelper, :clean_repo do
 
       it 'is false without consulting Flipflop' do
         expect(Flipflop).not_to receive(:redirects?)
-        expect(helper.collection_redirectable?).to be false
+        expect(helper.collection_redirectable?(form)).to be false
       end
+    end
+
+    context 'when the gates are open but the form wraps a resource without :redirects' do
+      let(:resource) { Struct.new(:id).new('c-1') }
+      let(:form) { Struct.new(:model).new(resource) }
+
+      before do
+        allow(Hyrax.config).to receive(:redirects_enabled?).and_return(true)
+        allow(Flipflop).to receive(:redirects?).and_return(true)
+      end
+
+      it { expect(helper.collection_redirectable?(form)).to be false }
     end
   end
 end

--- a/spec/helpers/hyrax/work_form_helper_spec.rb
+++ b/spec/helpers/hyrax/work_form_helper_spec.rb
@@ -33,13 +33,18 @@ RSpec.describe Hyrax::WorkFormHelper do
       end
     end
 
-    context 'when the redirects feature is fully enabled' do
+    context 'when the redirects feature is fully enabled and the resource carries the attribute' do
       let(:work) { build(:hyrax_work) }
       let(:form) { Hyrax::Forms::ResourceForm.for(resource: work) }
 
       before do
         allow(Hyrax.config).to receive(:redirects_enabled?).and_return(true)
         allow(Flipflop).to receive(:redirects?).and_return(true)
+        # The schema include only runs at class load when HYRAX_REDIRECTS_ENABLED
+        # is set in the env; in the test process it isn't, so simulate the
+        # attribute being present on the underlying resource.
+        allow(work).to receive(:respond_to?).and_call_original
+        allow(work).to receive(:respond_to?).with(:redirects).and_return(true)
       end
 
       it 'appends the redirects tab' do
@@ -69,6 +74,31 @@ RSpec.describe Hyrax::WorkFormHelper do
 
       it 'omits the redirects tab without consulting Flipflop' do
         expect(Flipflop).not_to receive(:redirects?)
+        expect(form_tabs_for(form: form)).to eq %w[metadata files relationships]
+      end
+    end
+
+    context 'when the feature is fully enabled but the form wraps a resource without :redirects' do
+      let(:resource_without_redirects) { Struct.new(:id, :persisted?).new('w-1', true) }
+      let(:form) do
+        klass = Class.new do
+          def initialize(target)
+            @target = target
+          end
+
+          def model
+            @target
+          end
+        end
+        klass.new(resource_without_redirects)
+      end
+
+      before do
+        allow(Hyrax.config).to receive(:redirects_enabled?).and_return(true)
+        allow(Flipflop).to receive(:redirects?).and_return(true)
+      end
+
+      it 'omits the redirects tab so the partial does not render and crash on f.object.redirects' do
         expect(form_tabs_for(form: form)).to eq %w[metadata files relationships]
       end
     end

--- a/spec/helpers/hyrax/work_form_helper_spec.rb
+++ b/spec/helpers/hyrax/work_form_helper_spec.rb
@@ -42,9 +42,12 @@ RSpec.describe Hyrax::WorkFormHelper do
         allow(Flipflop).to receive(:redirects?).and_return(true)
         # The schema include only runs at class load when HYRAX_REDIRECTS_ENABLED
         # is set in the env; in the test process it isn't, so simulate the
-        # attribute being present on the underlying resource.
-        allow(work).to receive(:respond_to?).and_call_original
-        allow(work).to receive(:respond_to?).with(:redirects).and_return(true)
+        # attribute being present on the resource the form wraps. In flexible
+        # mode (e.g. allinson) ResourceForm.for deep-copies the resource via
+        # `resource.class.new(hash)`, so stubbing the original `work` doesn't
+        # affect the form's internal model — stub `form.model` directly.
+        allow(form.model).to receive(:respond_to?).and_call_original
+        allow(form.model).to receive(:respond_to?).with(:redirects).and_return(true)
       end
 
       it 'appends the redirects tab' do

--- a/spec/services/hyrax/flexible_schema_validators/redirects_validator_spec.rb
+++ b/spec/services/hyrax/flexible_schema_validators/redirects_validator_spec.rb
@@ -7,12 +7,17 @@ RSpec.describe Hyrax::FlexibleSchemaValidators::RedirectsValidator do
 
   let(:profile_with_redirects) do
     {
+      'classes' => { 'GenericWork' => {}, 'CollectionResource' => {} },
       'properties' => {
         'redirects' => {
-          'available_on' => { 'class' => %w[Hyrax::Work Hyrax::PcdmCollection] }
+          'available_on' => { 'class' => %w[GenericWork CollectionResource] }
         }
       }
     }
+  end
+
+  before do
+    allow(Hyrax.config).to receive(:registered_curation_concern_types).and_return(['GenericWork'])
   end
 
   let(:profile_without_redirects) do
@@ -96,33 +101,83 @@ RSpec.describe Hyrax::FlexibleSchemaValidators::RedirectsValidator do
         end
       end
 
-      context 'and the m3 profile has `redirects` but is missing Hyrax::PcdmCollection' do
+      context 'and the m3 profile has `redirects` with an adopter-registered work class (Resource-suffixed)' do
         let(:profile) do
           {
+            'classes' => { 'GenericWorkResource' => {} },
             'properties' => {
-              'redirects' => { 'available_on' => { 'class' => ['Hyrax::Work'] } }
+              'redirects' => { 'available_on' => { 'class' => ['GenericWorkResource'] } }
             }
           }
         end
 
-        it 'errors that the missing class must be in available_on.class' do
+        it 'is silent (Resource suffix is accepted alongside the abstract name)' do
           validator.validate!
-          expect(errors).to include(/`redirects`.*available on.*Hyrax::PcdmCollection/)
+          expect(errors).to be_empty
         end
       end
 
-      context 'and the m3 profile has `redirects` but is missing Hyrax::Work' do
+      context 'and the m3 profile lists a class in available_on.class that is not declared in this profile' do
         let(:profile) do
           {
+            'classes' => { 'GenericWork' => {} },
             'properties' => {
-              'redirects' => { 'available_on' => { 'class' => ['Hyrax::PcdmCollection'] } }
+              'redirects' => { 'available_on' => { 'class' => ['SomeOtherWork'] } }
             }
           }
         end
 
-        it 'errors that the missing class must be in available_on.class' do
+        it 'errors (the class is not declared in this profile)' do
           validator.validate!
-          expect(errors).to include(/`redirects`.*available on.*Hyrax::Work/)
+          expect(errors).to include(/declared in this profile/)
+        end
+      end
+
+      context 'and the m3 profile has `redirects` available only on a non-work, non-collection class declared in the profile' do
+        let(:profile) do
+          {
+            'classes' => { 'Hyrax::FileSet' => {} },
+            'properties' => {
+              'redirects' => { 'available_on' => { 'class' => ['Hyrax::FileSet'] } }
+            }
+          }
+        end
+
+        it 'errors that the property must be available on at least one work or collection class' do
+          validator.validate!
+          expect(errors).to include(/work or collection class/)
+        end
+      end
+
+      context 'and the m3 profile has `redirects` with an empty available_on.class' do
+        let(:profile) do
+          {
+            'classes' => { 'GenericWork' => {} },
+            'properties' => {
+              'redirects' => { 'available_on' => { 'class' => [] } }
+            }
+          }
+        end
+
+        it 'errors that the property must be available on at least one work or collection class' do
+          validator.validate!
+          expect(errors).to include(/work or collection class/)
+        end
+      end
+
+      context 'and the m3 profile has `redirects` with available_on entirely missing' do
+        let(:profile) do
+          {
+            'classes' => { 'GenericWork' => {} },
+            'properties' => {
+              'redirects' => { 'cardinality' => { 'minimum' => 0 } }
+            }
+          }
+        end
+
+        it 'errors that the property must be available on at least one work or collection class' do
+          validator.validate!
+          expect(errors).to include(/work or collection class/)
         end
       end
     end

--- a/spec/validators/hyrax/redirect_validator_spec.rb
+++ b/spec/validators/hyrax/redirect_validator_spec.rb
@@ -91,7 +91,7 @@ RSpec.describe Hyrax::RedirectValidator do
             @target = target
           end
 
-          def __getobj__
+          def model
             @target
           end
 


### PR DESCRIPTION
### Fixes

Fixes various issues encountered while UI testing the redirects feature.
- fixes routing
- hide alias tab when object has no redirects property
- validate the redirects property correctly so m3 profile works
- strip trailing query from root path on redirects tab


