### PR TITLE
Introduce composable Field Behavior pattern

### DIFF
--- a/app/forms/concerns/hyrax/based_near_field_behavior.rb
+++ b/app/forms/concerns/hyrax/based_near_field_behavior.rb
@@ -1,18 +1,27 @@
 # frozen_string_literal: true
 module Hyrax
+  # Field Behavior for the `based_near` (location) controlled vocabulary form
+  # field. The form expects a ControlledVocabularies::Location object as input
+  # and produces a hash like those used with accepts_nested_attributes_for.
+  #
+  # See documentation/forms/field_behaviors.md for the pattern this module
+  # follows (why `deserialize` strips and calls `super`, why it's prepended
+  # in `inherited`, etc).
   module BasedNearFieldBehavior
-    # Provides compatibility with the behavior of the based_near (location) controlled vocabulary form field.
-    # The form expects a ControlledVocabularies::Location object as input and produces a hash like those
-    # used with accepts_nested_attributes_for.
     def self.included(descendant)
       descendant.property :based_near_attributes, virtual: true, populator: :based_near_attributes_populator, prepopulator: :based_near_attributes_prepopulator
     end
 
-    # there is a race condition during validation that leaves the based_near field in an inconsistent state.
-    # we skip the unedited based_near for validation and only handle it during attribute population
+    # Skipping based_near in deserialize avoids a race condition where it
+    # would otherwise end up in an inconsistent state during validation; the
+    # field is handled exclusively by the populator on
+    # `based_near_attributes`.
     def deserialize(params)
-      params = deserialize!(params)
-      deserializer.new(self).from_hash(params.except('based_near'))
+      if params.respond_to?(:delete)
+        params.delete('based_near')
+        params.delete(:based_near)
+      end
+      super
     end
 
     private

--- a/app/forms/concerns/hyrax/redirects_field_behavior.rb
+++ b/app/forms/concerns/hyrax/redirects_field_behavior.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+module Hyrax
+  # Field Behavior for the `redirects` nested-attribute property. The Aliases
+  # tab posts under `redirects_attributes`; the populator translates that
+  # index-keyed payload into clean `Hyrax::Redirect` entries on the form's
+  # `redirects` property and normalizes paths.
+  #
+  # See documentation/forms/field_behaviors.md for the pattern this module
+  # follows (why `deserialize` strips and calls `super`, why it's prepended
+  # in `inherited`, etc).
+  module RedirectsFieldBehavior
+    def self.included(descendant)
+      return unless Hyrax.config.redirects_enabled?
+      descendant.property :redirects_attributes, virtual: true, populator: :redirects_populator
+    end
+
+    def deserialize(params)
+      if Hyrax.config.redirects_enabled? && params.respond_to?(:delete)
+        params.delete('redirects')
+        params.delete(:redirects)
+      end
+      super
+    end
+
+    private
+
+    def redirects_populator(fragment:, **_options)
+      return unless respond_to?(:redirects)
+      return unless Flipflop.redirects?
+      entries = Array(fragment&.values)
+                .reject { |row| row['_destroy'].to_s == 'true' || row['path'].to_s.strip.empty? }
+                .map do |row|
+                  { path: Hyrax::RedirectPathNormalizer.call(row['path']),
+                    canonical: row['canonical'].to_s == 'true' }
+                end
+      self.redirects = entries
+    end
+  end
+end

--- a/app/forms/hyrax/forms/resource_form.rb
+++ b/app/forms/hyrax/forms/resource_form.rb
@@ -27,6 +27,7 @@ module Hyrax
       end
 
       include BasedNearFieldBehavior
+      include RedirectsFieldBehavior
       class_attribute :model_class
 
       property :human_readable_type, writable: false
@@ -43,8 +44,19 @@ module Hyrax
       # @see https://github.com/samvera/valkyrie/wiki/Optimistic-Locking
       property :version, virtual: true, prepopulator: LockKeyPrepopulator
 
-      validates_with Hyrax::RedirectValidator, attributes: [:redirects] if Hyrax.config.redirects_enabled?
-      property :redirects_attributes, virtual: true, populator: :redirects_populator if Hyrax.config.redirects_enabled?
+      # Wired through `validation { ... }` rather than Reform's `validates_with`
+      # shim. The shim closes over the args array, so the options hash is
+      # shared across heritage replays — AM mutates that hash on each call
+      # (`options[:class] = self`, then `options.delete(:attributes)` inside
+      # EachValidator#initialize), and the second replay raises
+      # `:attributes cannot be blank`. Using `validation { ... }` re-evaluates
+      # the literal options hash on every replay, so each subclass gets its
+      # own clean copy.
+      if Hyrax.config.redirects_enabled?
+        validation(name: :default, inherit: true) do
+          validates_with Hyrax::RedirectValidator, attributes: [:redirects]
+        end
+      end
 
       ##
       # @api public
@@ -97,9 +109,13 @@ module Hyrax
 
       class << self
         def inherited(subclass)
-          # this is a noop if based near is not defined on a given model
-          # we need these to be before and included properties
+          # Field Behaviors must be prepended onto every subclass so their
+          # `deserialize` overrides land above Reform's base method on the
+          # ancestor chain. Each behavior is a no-op when the property it
+          # owns isn't on the subclass's model. See
+          # documentation/forms/field_behaviors.md.
           subclass.prepend(BasedNearFieldBehavior)
+          subclass.prepend(RedirectsFieldBehavior) if Hyrax.config.redirects_enabled?
           super
         end
 
@@ -196,24 +212,6 @@ module Hyrax
       def redirects=(values)
         return super unless Hyrax.config.redirects_enabled?
         super(Array(values).map { |entry| normalize_redirect_entry(entry) })
-      end
-
-      # Populator for the nested-attributes payload posted by the Aliases
-      # tab. Each form submission rebuilds the `redirects` list from the
-      # visible rows; rows marked `_destroy` are dropped, blank rows are
-      # ignored. The `redirects=` setter then normalizes paths and the
-      # validator runs against the result.
-      #
-      # No-ops when the Flipflop is off so a stale or out-of-band post of
-      # redirects_attributes can't mutate (or clear) existing redirects on
-      # a resource while the runtime feature is disabled. Existing entries
-      # on the resource are preserved untouched.
-      def redirects_populator(fragment:, **_options)
-        return unless Flipflop.redirects?
-        entries = Array(fragment&.values)
-                  .reject { |row| row['_destroy'].to_s == 'true' || row['path'].to_s.strip.empty? }
-                  .map { |row| { path: row['path'], canonical: row['canonical'].to_s == 'true' } }
-        self.redirects = entries
       end
 
       ##

--- a/documentation/forms/field_behaviors.md
+++ b/documentation/forms/field_behaviors.md
@@ -1,0 +1,192 @@
+# Form Field Behaviors
+
+A **Field Behavior** is a Ruby module that owns the form-side handling for one nested-attribute property on `Hyrax::Forms::ResourceForm` (and its subclasses). When a Hyrax adopter's form posts a nested-attribute payload like `redirects_attributes` or `based_near_attributes`, a Field Behavior is what turns that payload into clean values on the underlying resource.
+
+This document describes the contract every Field Behavior must follow, why the contract is shaped this way, and how to add a new one.
+
+## When you need a Field Behavior
+
+You need a Field Behavior when **all three** of these are true:
+
+1. The property holds a list of nested entries — e.g., a list of redirect rows, a list of `ControlledVocabularies::Location` URIs.
+2. The form posts under `<name>_attributes` (the Rails nested-attributes convention) and the populator needs to convert that index-keyed payload into clean entries.
+3. A property by `<name>` is also declared on the form (e.g., from a Valkyrie schema include or an m3 metadata profile). Without #3, a virtual property + populator is enough; a Field Behavior is overkill.
+
+The third condition is the one that makes a Field Behavior necessary. When `<name>` is a real form property, some preprocessing between the controller and the form copies `<name>_attributes` to `<name>` alongside in the params hash. Reform's `from_hash` then writes `params['<name>']` directly into `@fields["<name>"]` via Disposable's internal `field_write`, **bypassing both** the public `<name>=` setter and the virtual `<name>_attributes` populator. The form ends up with a raw `ActionController::Parameters` value where it expected a list of entries, and validation crashes.
+
+The Field Behavior's job is to **strip the duplicate `<name>` key from incoming params** before Reform's `from_hash` runs. The populator on `<name>_attributes` then becomes the single entry point for form-driven writes.
+
+## The contract
+
+Every Field Behavior must:
+
+### 1. Declare the virtual `_attributes` property in `self.included(descendant)`
+
+```ruby
+def self.included(descendant)
+  descendant.property :foo_attributes, virtual: true, populator: :foo_attributes_populator
+end
+```
+
+Optional: pass `prepopulator:` if the values stored on the model aren't directly renderable by the form widget and need to be wrapped first. For example, `based_near` is stored as plain URI strings on the model, but the location widget expects `Hyrax::ControlledVocabularies::Location` instances; the prepopulator wraps the strings into those objects before render. `BasedNearFieldBehavior` does this; `RedirectsFieldBehavior` does not (a `Hyrax::Redirect` is already what the redirects widget renders directly).
+
+### 2. Override `deserialize(params)` to strip the duplicate key in place, **then call `super`**
+
+```ruby
+def deserialize(params)
+  if params.respond_to?(:delete)
+    params.delete('foo')
+    params.delete(:foo)
+  end
+  super
+end
+```
+
+**Mutate `params` in place; do not replace it.** Reform's `validate(params)` saves the incoming hash as `@input_params` and exposes it via `form.input_params`. Downstream code (e.g., `WorksControllerBehavior` reading `form.input_params["permissions"]`) reads from that same hash *after* Reform's `FormBuilderMethods#deserialize!` mutates it in place to translate `<name>_attributes` keys to `<name>`. If your Field Behavior reassigns `params = params.except(...)`, the rename happens on a local copy and the controller sees an unrenamed `@input_params`, silently breaking permissions and other nested-attribute reads.
+
+Delete both the string and symbol form. `ActionController::Parameters#delete` is key-form-agnostic, but a plain `Hash` with symbol keys is not — deleting both keeps unit tests that pass a symbol-keyed hash and production controllers that pass string-keyed `Parameters` symmetric.
+
+**Always call `super`.** Reform's base `Reform::Form::Validate#deserialize` is the natural terminus — it runs `deserialize!` (the `<name>_attributes` rename) and `deserializer.new(self).from_hash(params)` after every Field Behavior in the prepend chain has deleted its key. Calling `from_hash` directly inside your override would short-circuit other Field Behaviors that should have run first.
+
+The `respond_to?(:delete)` guard is defensive — `params` is usually `ActionController::Parameters` or `Hash`, both of which respond to `delete`, but a hand-rolled deserializer test might pass something else.
+
+### 3. Implement the populator as a private instance method
+
+The populator's name matches the symbol you passed to `populator:` in step 1.
+
+```ruby
+private
+
+def foo_attributes_populator(fragment:, **_options)
+  return unless respond_to?(:foo)  # form's underlying resource must have :foo
+  entries = Array(fragment&.values)
+            .reject { |row| row['_destroy'].to_s == 'true' }
+            .map    { |row| build_foo_entry(row) }
+  self.foo = entries
+end
+```
+
+The `respond_to?(:foo)` guard is important — adopters may inherit from `ResourceForm` for resources that don't have the property (e.g., a deployment's custom work class that doesn't include the redirects schema). Without the guard, the populator crashes when invoked on those forms.
+
+### 4. Wire it onto `ResourceForm` in two places
+
+```ruby
+# app/forms/hyrax/forms/resource_form.rb
+
+class ResourceForm < Hyrax::ChangeSet
+  include FooFieldBehavior  # so self.included fires and declares the virtual property
+
+  class << self
+    def inherited(subclass)
+      subclass.prepend(BasedNearFieldBehavior)
+      subclass.prepend(FooFieldBehavior)  # so deserialize override lands on every subclass
+      super
+    end
+  end
+end
+```
+
+Both wirings are required. `include` makes the `_attributes` virtual property available; `prepend` (inside `inherited`) makes the `deserialize` override take precedence over Reform's base method.
+
+## Why `super` matters: the chain composes
+
+Each prepended Field Behavior sits above the form class in the ancestor chain, in declaration order. When the controller calls `form.validate(params)`:
+
+1. The outermost Field Behavior's `deserialize(params)` runs first.
+2. It strips its key and calls `super`.
+3. The next Field Behavior down the chain runs, strips *its* key, calls `super`.
+4. Eventually Reform's base `deserialize` runs with all keys stripped, calls `from_hash` once, and writes only the surviving (clean, non-duplicated) keys to the form.
+
+This means **adding a new Field Behavior is purely additive**. Write the module, include it on `ResourceForm`, prepend it in `inherited`. You don't need to know about prior Field Behaviors. The chain takes care of itself.
+
+If a Field Behavior breaks the chain by *not* calling `super`, every Field Behavior below it stops working. Always call `super`.
+
+## Worked examples
+
+### `BasedNearFieldBehavior`
+
+```ruby
+# app/forms/concerns/hyrax/based_near_field_behavior.rb
+module Hyrax
+  module BasedNearFieldBehavior
+    def self.included(descendant)
+      descendant.property :based_near_attributes,
+                          virtual: true,
+                          populator: :based_near_attributes_populator,
+                          prepopulator: :based_near_attributes_prepopulator
+    end
+
+    def deserialize(params)
+      if params.respond_to?(:delete)
+        params.delete('based_near')
+        params.delete(:based_near)
+      end
+      super
+    end
+
+    private
+
+    def based_near_attributes_populator(fragment:, **_options)
+      return unless respond_to?(:based_near)
+      adds = []
+      deletes = []
+      fragment.each do |_, h|
+        uri = RDF::URI.parse(h["id"]).to_s
+        h["_destroy"] == "true" ? deletes << uri : adds << uri
+      end
+      self.based_near = ((model.based_near + adds) - deletes).uniq
+    end
+
+    def based_near_attributes_prepopulator
+      # Hydrate URIs into widget-friendly Location objects on form render.
+      # ...
+    end
+  end
+end
+```
+
+### `RedirectsFieldBehavior`
+
+```ruby
+# app/forms/concerns/hyrax/redirects_field_behavior.rb
+module Hyrax
+  module RedirectsFieldBehavior
+    def self.included(descendant)
+      return unless Hyrax.config.redirects_enabled?
+      descendant.property :redirects_attributes, virtual: true, populator: :redirects_populator
+    end
+
+    def deserialize(params)
+      if Hyrax.config.redirects_enabled? && params.respond_to?(:delete)
+        params.delete('redirects')
+        params.delete(:redirects)
+      end
+      super
+    end
+
+    private
+
+    def redirects_populator(fragment:, **_options)
+      return unless respond_to?(:redirects)
+      return unless Flipflop.redirects?
+      entries = Array(fragment&.values)
+                .reject { |row| row['_destroy'].to_s == 'true' || row['path'].to_s.strip.empty? }
+                .map    { |row| { path: row['path'], canonical: row['canonical'].to_s == 'true' } }
+      self.redirects = entries
+    end
+  end
+end
+```
+
+The two modules differ only in feature-gating (`Hyrax.config.redirects_enabled?` / `Flipflop.redirects?`) and in whether they have a prepopulator. The shape is otherwise identical.
+
+## Checklist for adding a new Field Behavior
+
+1. [ ] Module defines `self.included(descendant)` declaring the `<name>_attributes` virtual property.
+2. [ ] Module defines `deserialize(params)` that strips `<name>` and calls `super`.
+3. [ ] Module defines a private populator named after the property's `populator:` symbol.
+4. [ ] Populator guards `respond_to?(:<name>)` for forms whose model lacks the property.
+5. [ ] Populator handles the `_destroy` flag for row removal.
+6. [ ] If feature-gated, the gate appears in `self.included`, `deserialize`, AND the populator.
+7. [ ] `ResourceForm` does both `include FooFieldBehavior` AND `subclass.prepend(FooFieldBehavior)` inside `inherited`.
+8. [ ] Optional: `prepopulator:` if the values stored on the model need to be wrapped into a different shape before the form widget can render them.

--- a/spec/forms/hyrax/forms/resource_form_spec.rb
+++ b/spec/forms/hyrax/forms/resource_form_spec.rb
@@ -260,6 +260,80 @@ RSpec.describe Hyrax::Forms::ResourceForm do
     end
   end
 
+  describe '#redirects' do
+    subject(:form) { form_class.new(resource: work) }
+
+    let(:work) { resource_class.new }
+
+    let(:resource_class) do
+      Class.new(Valkyrie::Resource) do
+        attribute :redirects, Valkyrie::Types::Array.of(Hyrax::Redirect).optional
+
+        def self.name
+          'TestRedirectsResource'
+        end
+
+        def flexible?
+          false
+        end
+      end
+    end
+
+    let(:form_class) do
+      rc = resource_class
+      Class.new(Hyrax::Forms::ResourceForm) do
+        self.model_class = rc
+        property :redirects, default: []
+        prepend Hyrax::RedirectsFieldBehavior
+      end
+    end
+
+    before do
+      allow(Hyrax.config).to receive(:redirects_enabled?).and_return(true)
+      allow(Flipflop).to receive(:redirects?).and_return(true)
+      # Ensure the behavior's `self.included` declares the virtual property
+      # under the test's gating, since the module was loaded with the gate off.
+      form_class.property :redirects_attributes, virtual: true, populator: :redirects_populator unless form_class.definitions.key?('redirects_attributes')
+    end
+
+    it 'runs the redirects populator on submitted nested-attributes payload' do
+      form.validate(redirects_attributes: { "0" => { "path" => "/old/url", "canonical" => "false" } })
+      expect(form.redirects).to contain_exactly(hash_including(path: '/old/url', canonical: false))
+    end
+
+    it 'normalizes paths in the populator before assigning to redirects' do
+      form.validate(redirects_attributes: { "0" => { "path" => "/foo/" } })
+      expect(form.redirects.first[:path]).to eq('/foo')
+    end
+
+    it 'strips the duplicate `redirects` key so `_attributes` wins' do
+      form.validate(
+        redirects: { "0" => { "path" => "/raw" } },
+        redirects_attributes: { "0" => { "path" => "/from-attributes" } }
+      )
+      expect(form.redirects).to contain_exactly(hash_including(path: '/from-attributes'))
+    end
+
+    it 'rejects rows marked _destroy or with blank path' do
+      form.validate(redirects_attributes: {
+                      "0" => { "path" => "/keep" },
+                      "1" => { "path" => "/gone", "_destroy" => "true" },
+                      "2" => { "path" => "  " }
+                    })
+      expect(form.redirects).to contain_exactly(hash_including(path: '/keep'))
+    end
+
+    context 'when the Flipflop is off' do
+      before { allow(Flipflop).to receive(:redirects?).and_return(false) }
+
+      it 'does not mutate redirects from a submitted payload' do
+        work.redirects = []
+        form.validate(redirects_attributes: { "0" => { "path" => "/blocked" } })
+        expect(form.redirects).to eq([])
+      end
+    end
+  end
+
   describe '#embargo_release_date' do
     context 'without an embargo' do
       it 'is nil' do


### PR DESCRIPTION
# Summary

Introduces a new documented pattern for Field Behaviors that compose via super, and uses it to add a new Hyrax::RedirectsFieldBehavior providing support for the Aliases tab in the UI. This is gated behind the HYRAX_REDIRECTS_ENABLED flip, so the new behavior is a no-op when the flip is off and doesn't affect existing ResourceForms.

Rewires Hyrax::BasedNearFieldBehavior along with Hyrax::RedirectsFieldBehavior so the two compose via super.

Also fixes a prior bug where any subclass of ResourceForm crashed at load time once HYRAX_REDIRECTS_ENABLED=true. Reform's validates_with helper accidentally shares one options hash ({attributes: [:redirects]}) across every form that inherits from ResourceForm. The first time it runs, ActiveModel's validator empties that hash by deleting :attributes. The second time it runs — on a subclass — the hash is already empty, so the validator crashes with :attributes cannot be blank. The fix sidesteps the helper so a fresh hash is built each time, and the sharing problem goes away.
