### PR TITLE
Make BasedNearFieldBehavior compose via super

### DIFF
--- a/app/forms/concerns/hyrax/based_near_field_behavior.rb
+++ b/app/forms/concerns/hyrax/based_near_field_behavior.rb
@@ -1,18 +1,46 @@
 # frozen_string_literal: true
 module Hyrax
+  # Form-side handling for the `based_near` (location) controlled vocabulary
+  # field. The form expects a `ControlledVocabularies::Location` object as
+  # input and produces a hash like those used with `accepts_nested_attributes_for`.
+  #
+  # The `deserialize!` override below is the canonical Field Behavior pattern
+  # for nested-attribute properties: a module prepended onto every
+  # `ResourceForm` subclass that strips its own key from the rewritten params
+  # so Reform's `from_hash` doesn't write the raw `_attributes` payload to a
+  # same-named property. Calling `super` first lets the chain compose — every
+  # Field Behavior runs its own delete, then control falls through to Reform's
+  # base `deserialize!` (the `<name>_attributes` rename pass).
   module BasedNearFieldBehavior
-    # Provides compatibility with the behavior of the based_near (location) controlled vocabulary form field.
-    # The form expects a ControlledVocabularies::Location object as input and produces a hash like those
-    # used with accepts_nested_attributes_for.
     def self.included(descendant)
       descendant.property :based_near_attributes, virtual: true, populator: :based_near_attributes_populator, prepopulator: :based_near_attributes_prepopulator
     end
 
-    # there is a race condition during validation that leaves the based_near field in an inconsistent state.
-    # we skip the unedited based_near for validation and only handle it during attribute population
-    def deserialize(params)
-      params = deserialize!(params)
-      deserializer.new(self).from_hash(params.except('based_near'))
+    # Skipping based_near in deserialize avoids a race condition where it
+    # would otherwise end up in an inconsistent state during validation; the
+    # field is handled exclusively by the populator on
+    # `based_near_attributes`.
+    #
+    # Override `deserialize!` (not `deserialize`) so the strip runs *after*
+    # Reform's `FormBuilderMethods#deserialize!` has renamed
+    # `based_near_attributes` to `based_near`, but *before* `from_hash`
+    # reads property values from the params. Stripping in `deserialize`
+    # would happen before the rename, and the rename would put the key
+    # back; `from_hash` would then write raw fragment hashes onto the
+    # form's `based_near` field, breaking the populator's contract.
+    #
+    # Mutate `params` in place — never replace it. Reform's `validate(params)`
+    # exposes the same hash via `form.input_params`, and downstream callers
+    # (`WorksControllerBehavior#update_valkyrie_work` reading
+    # `form.input_params["permissions"]`) read from that exact reference
+    # *after* the rename.
+    def deserialize!(params)
+      result = super
+      if result.respond_to?(:delete)
+        result.delete('based_near')
+        result.delete(:based_near)
+      end
+      result
     end
 
     private

--- a/app/forms/hyrax/forms/resource_form.rb
+++ b/app/forms/hyrax/forms/resource_form.rb
@@ -43,7 +43,23 @@ module Hyrax
       # @see https://github.com/samvera/valkyrie/wiki/Optimistic-Locking
       property :version, virtual: true, prepopulator: LockKeyPrepopulator
 
-      validates_with Hyrax::RedirectValidator, attributes: [:redirects] if Hyrax.config.redirects_enabled?
+      # Wire validators with `attributes:` through `validation { ... }` rather
+      # than the bare `validates_with`. Reform's `validates_with` shim closes
+      # over the args array, so the options hash (`{attributes: [:foo]}`) is
+      # shared across heritage replays. ActiveModel mutates that hash on each
+      # call (`options[:class] = self`, then `options.delete(:attributes)`
+      # inside `EachValidator#initialize`). The first replay leaves the hash
+      # without `:attributes`; the second replay raises
+      # `:attributes cannot be blank` and the subclass crashes at load time.
+      # Wrapping in `validation(name: :default, inherit: true) { ... }` rebuilds
+      # the literal options hash on every replay so each subclass gets its own
+      # clean copy. This pattern applies to *any* `validates_with` that takes
+      # an `attributes:` keyword.
+      if Hyrax.config.redirects_enabled?
+        validation(name: :default, inherit: true) do
+          validates_with Hyrax::RedirectValidator, attributes: [:redirects]
+        end
+      end
 
       ##
       # @api public


### PR DESCRIPTION
# Summary

A minor refactor to based near with no behavior changes. Makes BasedNearFieldBehavior more composable with other Field Behaviors, and fixes a bug in validates_with.

Preparation for adding redirects.

# Details

Two related form-layer fixes:

1. BasedNearFieldBehavior used to handle its own deserialize step end-to-end. That made it impossible for a second Field Behavior on the same form to take part in deserialization. The module now lets Reform handle the standard rename pass first, removes its own key, and passes control along. Multiple Field Behaviors can now coexist on one form without conflict.
2. ResourceForm declared its redirects validator with `validates_with` and a list of attributes. Reform and ActiveModel together end up sharing one options hash across every form subclass at load time. ActiveModel empties that hash the first time through, so the second subclass to load crashed with "attributes cannot be blank." Wiring the same validator through a `validation { ... }` block instead gives each subclass its own copy of the options.

# Tested behavor

Verified ability to add or remove based_near while adding or editing both works and collections.
Verified CRUD with and without based_near.