### PR TITLE
Render the based_near widget without crashing on form re-render

### DIFF
--- a/app/inputs/controlled_vocabulary_input.rb
+++ b/app/inputs/controlled_vocabulary_input.rb
@@ -44,7 +44,13 @@ class ControlledVocabularyInput < MultiValueInput
   def hidden_id_field(value, index)
     name = name_for(attribute_name, index, 'id')
     id = id_for(attribute_name, index, 'id')
-    hidden_value = value.try(:node?) || value.is_a?(ActionController::Parameters) ? '' : value.rdf_subject
+    hidden_value = if value.try(:node?) || value.is_a?(ActionController::Parameters)
+                     ''
+                   elsif value.respond_to?(:rdf_subject)
+                     value.rdf_subject
+                   else
+                     value.to_s
+                   end
     @builder.hidden_field(attribute_name, name: name, id: id, value: hidden_value, data: { id: 'remote' })
   end
 

--- a/spec/inputs/controlled_vocabulary_input_spec.rb
+++ b/spec/inputs/controlled_vocabulary_input_spec.rb
@@ -44,6 +44,18 @@ RSpec.describe 'ControlledVocabularyInput', type: :input do
         expect(subject).to have_selector('input[name="generic_work[based_near_attributes][0][_destroy]"][value=""][data-destroy]', visible: false)
       end
     end
+
+    context 'for a bare URI string (form re-render after a validation failure)' do
+      let(:value) { 'http://sws.geonames.org/5391959/' }
+
+      it 'renders without raising and uses the string as the hidden id value' do
+        expect { subject }.not_to raise_error
+        expect(subject).to have_selector(
+          'input[name="generic_work[based_near_attributes][0][id]"][value="http://sws.geonames.org/5391959/"]',
+          visible: false
+        )
+      end
+    end
   end
 
   describe "#build_options" do


### PR DESCRIPTION
## Summary

Fixes a crash where the based_near widget raised `NoMethodError: undefined method 'rdf_subject' for an instance of String` when re-rendering an edit form after a validation failure. The crash masked the underlying validation error with a 500, leaving users with no inline feedback to act on.

When a form first loads, the prepopulator wraps each `based_near` value in a `Hyrax::ControlledVocabularies::Location`. On a re-render after validation failure, the values arrive as the bare URI strings the user submitted — the wrapping step doesn't run a second time. The widget's hidden-id field assumed every value carried an `rdf_subject` accessor and crashed on the String.

This patch makes `hidden_id_field` accept any value that doesn't carry an `rdf_subject` by falling back to its string form. The submitted URI round-trips through the form so the user can correct the validation error and resubmit.

## References

Ref notch8/palni_palci_knapsack#647
