### PR TITLE
Stabilize flaky Fedora-versioned spec timing on sirenia

### DIFF
--- a/spec/presenters/hyrax/version_list_presenter_spec.rb
+++ b/spec/presenters/hyrax/version_list_presenter_spec.rb
@@ -114,6 +114,10 @@ RSpec.describe Hyrax::VersionListPresenter do
       let(:another_file) { fixture_file_upload('/hyrax_generic_stub.txt') }
       let(:new_version) { storage_adapter.upload_version(id: uploaded.id, file: another_file) }
       before do
+        # Fedora 6 auto-versions on PUT using a UTC-second timestamp, so an
+        # initial upload and a follow-up upload_version landing within the
+        # same second produce an extra version. Sleep across the boundary.
+        sleep 1
         new_version
       end
 

--- a/spec/services/hyrax/versioning_service_spec.rb
+++ b/spec/services/hyrax/versioning_service_spec.rb
@@ -139,6 +139,10 @@ RSpec.describe Hyrax::VersioningService do
         let(:another_file) { fixture_file_upload('/hyrax_generic_stub.txt') }
         let(:new_version) { storage_adapter.upload_version(id: uploaded.id, file: another_file) }
         before do
+          # Fedora 6 auto-versions on PUT using a UTC-second timestamp, so an
+          # initial upload and a follow-up upload_version landing within the
+          # same second produce an extra version. Sleep across the boundary.
+          sleep 1
           new_version
         end
         it {
@@ -176,6 +180,10 @@ RSpec.describe Hyrax::VersioningService do
         let(:another_file) { fixture_file_upload('/hyrax_generic_stub.txt') }
         let(:new_version) { storage_adapter.upload_version(id: uploaded.id, file: another_file) }
         before do
+          # Fedora 6 auto-versions on PUT using a UTC-second timestamp, so an
+          # initial upload and a follow-up upload_version landing within the
+          # same second produce an extra version. Sleep across the boundary.
+          sleep 1
           new_version
         end
         it { is_expected.to eq new_version.version_id }
@@ -193,6 +201,10 @@ RSpec.describe Hyrax::VersioningService do
         let(:another_file) { fixture_file_upload('/hyrax_generic_stub.txt') }
         let(:new_version) { storage_adapter.upload_version(id: uploaded.id, file: another_file) }
         before do
+          # Fedora 6 auto-versions on PUT using a UTC-second timestamp, so an
+          # initial upload and a follow-up upload_version landing within the
+          # same second produce an extra version. Sleep across the boundary.
+          sleep 1
           new_version
         end
         it { is_expected.to eq new_version.version_id }


### PR DESCRIPTION
## Summary
- Stabilizes flaky version-count specs on the sirenia stack.

## Details
On the sirenia stack (Valkyrie + Fedora storage), Fedora 6 auto-versions every PUT and labels the resulting version with a UTC-second timestamp. When the factory's initial file upload and the spec's follow-up `upload_version` call landed inside the same second, the version listing came back with three entries instead of two, and the count assertions failed intermittently. Sleeping one second between the initial upload and the explicit `upload_version` lets the timestamps separate, which restores deterministic behavior. The underlying upstream-gem quirk is unchanged; this is a spec-side stabilization. Affects `Hyrax::VersionListPresenter` and `Hyrax::VersioningService` "with two versions" contexts. No production code paths change.