### PR TITLE
Bust redirect cache on save and destroy

### DIFF
--- a/app/controllers/hyrax/redirects_controller.rb
+++ b/app/controllers/hyrax/redirects_controller.rb
@@ -30,7 +30,6 @@ module Hyrax
       false
     end
 
-    # TODO: bust the cache key on redirect save/destroy (Phase 1 follow-up).
     def lookup(path)
       Rails.cache.fetch(cache_key_for(path), expires_in: CACHE_TTL) do
         response = Hyrax::SolrService.get(%(redirects_path_ssim:"#{path}"), rows: 1)
@@ -41,9 +40,11 @@ module Hyrax
       nil
     end
 
-    # Override in a downstream app to encode tenancy.
+    # Delegate to RedirectCacheBuster so the key format lives in one place.
+    # Override RedirectCacheBuster.cache_key_for in a downstream app to
+    # encode tenancy.
     def cache_key_for(path)
-      ['hyrax', 'redirects', Digest::SHA1.hexdigest(path)].join('/')
+      Hyrax::RedirectCacheBuster.cache_key_for(path)
     end
   end
 end

--- a/app/services/hyrax/redirect_cache_buster.rb
+++ b/app/services/hyrax/redirect_cache_buster.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module Hyrax
+  # Invalidates the redirect-resolution cache entries for a set of paths.
+  #
+  # The RedirectsController caches Solr lookups under a key derived from
+  # the normalized path. This service deletes those keys so that saves and
+  # destroys take effect immediately instead of waiting for the 60s TTL.
+  #
+  # See documentation/redirects.md.
+  class RedirectCacheBuster
+    # @param paths [Array<String>] unnormalized or normalized redirect paths
+    def self.call(paths)
+      Array(paths).each do |path|
+        normalized = Hyrax::RedirectPathNormalizer.call(path)
+        Rails.cache.delete(cache_key_for(normalized))
+      end
+    end
+
+    # The cache key format used by RedirectsController#lookup. Kept here as
+    # the single source of truth; the controller delegates to this method.
+    #
+    # @param normalized_path [String] a path already run through RedirectPathNormalizer
+    # @return [String]
+    def self.cache_key_for(normalized_path)
+      ['hyrax', 'redirects', Digest::SHA1.hexdigest(normalized_path)].join('/')
+    end
+  end
+end

--- a/app/services/hyrax/redirect_cache_buster.rb
+++ b/app/services/hyrax/redirect_cache_buster.rb
@@ -13,6 +13,7 @@ module Hyrax
     def self.call(paths)
       Array(paths).each do |path|
         normalized = Hyrax::RedirectPathNormalizer.call(path)
+        next if normalized.blank?
         Rails.cache.delete(cache_key_for(normalized))
       end
     end

--- a/lib/hyrax/transactions/steps/remove_redirect_paths.rb
+++ b/lib/hyrax/transactions/steps/remove_redirect_paths.rb
@@ -17,7 +17,10 @@ module Hyrax
         # @return [Dry::Monads::Result]
         def call(resource)
           return Success(resource) unless removable?(resource)
-          Hyrax::RedirectPath.where(resource_id: resource.id.to_s).delete_all
+          scope = Hyrax::RedirectPath.where(resource_id: resource.id.to_s)
+          paths = scope.pluck(:path)
+          scope.delete_all
+          Hyrax::RedirectCacheBuster.call(paths) if paths.any?
           Success(resource)
         rescue ActiveRecord::StatementInvalid => e
           Hyrax.logger.error("[redirects] remove_redirect_paths failed: #{e.message}")

--- a/lib/hyrax/transactions/steps/sync_redirect_paths.rb
+++ b/lib/hyrax/transactions/steps/sync_redirect_paths.rb
@@ -54,17 +54,18 @@ module Hyrax
         #   cache invalidation, or nil when nothing changed.
         def replace_rows(object, rows)
           desired_paths = rows.map { |r| r[:path] }.sort
-          existing_paths = Hyrax::RedirectPath.where(resource_id: object.id.to_s).pluck(:path).sort
-          return nil if desired_paths == existing_paths
 
           Hyrax::RedirectPath.transaction do
+            existing_paths = Hyrax::RedirectPath.where(resource_id: object.id.to_s).pluck(:path).sort
+            return nil if desired_paths == existing_paths
+
             Hyrax::RedirectPath.where(resource_id: object.id.to_s).delete_all
             # rubocop:disable Rails/SkipsModelValidations -- the DB unique index on `path` is the validation we rely on; bulk insert is intentional
             Hyrax::RedirectPath.insert_all!(rows) if rows.any?
             # rubocop:enable Rails/SkipsModelValidations
-          end
 
-          (existing_paths | desired_paths)
+            (existing_paths | desired_paths)
+          end
         end
       end
     end

--- a/lib/hyrax/transactions/steps/sync_redirect_paths.rb
+++ b/lib/hyrax/transactions/steps/sync_redirect_paths.rb
@@ -22,7 +22,8 @@ module Hyrax
         # @return [Dry::Monads::Result]
         def call(object)
           return Success(object) unless syncable?(object)
-          replace_rows(object, build_rows(object))
+          changed_paths = replace_rows(object, build_rows(object))
+          Hyrax::RedirectCacheBuster.call(changed_paths) if changed_paths
           Success(object)
         rescue ActiveRecord::RecordNotUnique => e
           Failure([:redirect_path_collision, e.message])
@@ -49,10 +50,12 @@ module Hyrax
           paths.map { |path| { path: path, resource_id: object.id.to_s, created_at: now, updated_at: now } }
         end
 
+        # @return [Array<String>, nil] the union of old + new paths that need
+        #   cache invalidation, or nil when nothing changed.
         def replace_rows(object, rows)
           desired_paths = rows.map { |r| r[:path] }.sort
           existing_paths = Hyrax::RedirectPath.where(resource_id: object.id.to_s).pluck(:path).sort
-          return if desired_paths == existing_paths
+          return nil if desired_paths == existing_paths
 
           Hyrax::RedirectPath.transaction do
             Hyrax::RedirectPath.where(resource_id: object.id.to_s).delete_all
@@ -60,6 +63,8 @@ module Hyrax
             Hyrax::RedirectPath.insert_all!(rows) if rows.any?
             # rubocop:enable Rails/SkipsModelValidations
           end
+
+          (existing_paths | desired_paths)
         end
       end
     end

--- a/spec/lib/hyrax/transactions/steps/remove_redirect_paths_spec.rb
+++ b/spec/lib/hyrax/transactions/steps/remove_redirect_paths_spec.rb
@@ -25,6 +25,11 @@ RSpec.describe Hyrax::Transactions::Steps::RemoveRedirectPaths do
         expect(Hyrax::RedirectPath.where(resource_id: resource_id)).to be_empty
         expect(Hyrax::RedirectPath.where(resource_id: 'other-record').count).to eq(1)
       end
+
+      it 'busts the cache for the removed paths' do
+        expect(Hyrax::RedirectCacheBuster).to receive(:call).with(['/handle/1'])
+        step.call(resource)
+      end
     end
 
     context 'when the config is off' do

--- a/spec/lib/hyrax/transactions/steps/sync_redirect_paths_spec.rb
+++ b/spec/lib/hyrax/transactions/steps/sync_redirect_paths_spec.rb
@@ -24,6 +24,13 @@ RSpec.describe Hyrax::Transactions::Steps::SyncRedirectPaths do
         paths = Hyrax::RedirectPath.where(resource_id: resource_id).pluck(:path)
         expect(paths).to contain_exactly('/handle/1', '/handle/2')
       end
+
+      it 'busts the cache for both old and new paths' do
+        Hyrax::RedirectPath.create!(path: '/old', resource_id: resource_id)
+        expect(Hyrax::RedirectCacheBuster).to receive(:call)
+          .with(array_including('/old', '/handle/1', '/handle/2'))
+        step.call(resource)
+      end
     end
 
     context 'when a path is already claimed by another resource' do
@@ -84,6 +91,11 @@ RSpec.describe Hyrax::Transactions::Steps::SyncRedirectPaths do
         rows = Hyrax::RedirectPath.where(resource_id: resource_id).order(:path)
         expect(rows.pluck(:path)).to eq %w[/handle/1 /handle/2]
         expect(rows.pluck(:created_at)).to all(eq(original_created_at))
+      end
+
+      it 'does not bust the cache' do
+        expect(Hyrax::RedirectCacheBuster).not_to receive(:call)
+        step.call(resource)
       end
     end
 

--- a/spec/services/hyrax/redirect_cache_buster_spec.rb
+++ b/spec/services/hyrax/redirect_cache_buster_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+RSpec.describe Hyrax::RedirectCacheBuster do
+  before { Rails.cache.clear }
+
+  describe '.cache_key_for' do
+    it 'returns the same key format the controller uses for lookups' do
+      key = described_class.cache_key_for('/handle/123')
+      expect(key).to eq("hyrax/redirects/#{Digest::SHA1.hexdigest('/handle/123')}")
+    end
+  end
+
+  describe '.call' do
+    it 'deletes the cache entry for each given path' do
+      key1 = described_class.cache_key_for('/handle/1')
+      key2 = described_class.cache_key_for('/handle/2')
+      Rails.cache.write(key1, { 'id' => 'work-1' })
+      Rails.cache.write(key2, { 'id' => 'work-2' })
+
+      described_class.call(['/handle/1', '/handle/2'])
+
+      expect(Rails.cache.read(key1)).to be_nil
+      expect(Rails.cache.read(key2)).to be_nil
+    end
+
+    it 'normalizes paths before computing the cache key' do
+      # RedirectPathNormalizer prepends "/" if missing
+      key = described_class.cache_key_for('/no-leading-slash')
+      Rails.cache.write(key, { 'id' => 'work-1' })
+
+      described_class.call(['no-leading-slash'])
+
+      expect(Rails.cache.read(key)).to be_nil
+    end
+
+    it 'accepts a single path (not wrapped in an array)' do
+      key = described_class.cache_key_for('/solo')
+      Rails.cache.write(key, { 'id' => 'work-1' })
+
+      described_class.call('/solo')
+
+      expect(Rails.cache.read(key)).to be_nil
+    end
+
+    it 'is a no-op for an empty array' do
+      expect { described_class.call([]) }.not_to raise_error
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Extracts the redirect cache key format into a new `Hyrax::RedirectCacheBuster` service, giving the transaction steps a way to invalidate cache entries without duplicating the key logic from the controller
- `SyncRedirectPaths` now busts the cache for the union of old and new paths after a replace, so renames and edits take effect immediately
- `RemoveRedirectPaths` busts the cache for all paths belonging to the destroyed resource
- No-op path (redirects unchanged) still skips both the DB write and the cache bust

Resolves notch8/palni_palci_knapsack#628

## Test plan

- [ ] Save a work with a new redirect path, curl it immediately — should 301 (no 60s wait)
- [ ] Edit a work to change its redirect path, curl the old path immediately — should 404
- [ ] Delete a work with redirects, curl its path immediately — should 404
- [ ] Save a work without changing redirects — verify no unnecessary cache deletes (check logs or add a breakpoint)
- [ ] Run redirect-related specs: `bundle exec rspec spec/services/hyrax/redirect_cache_buster_spec.rb spec/lib/hyrax/transactions/steps/sync_redirect_paths_spec.rb spec/lib/hyrax/transactions/steps/remove_redirect_paths_spec.rb spec/controllers/hyrax/redirects_controller_spec.rb`