### PR TITLE
Show redirect aliases on show pages for admins

### DIFF
--- a/app/helpers/hyrax/attributes_helper.rb
+++ b/app/helpers/hyrax/attributes_helper.rb
@@ -87,6 +87,7 @@ module Hyrax
           field.to_s.humanize
         )
       end
+      view_options[:base_url] = request.base_url if respond_to?(:request) && request.respond_to?(:base_url)
       view_options
     end
   end

--- a/app/indexers/hyrax/indexers/redirects_indexer.rb
+++ b/app/indexers/hyrax/indexers/redirects_indexer.rb
@@ -3,9 +3,10 @@
 module Hyrax
   module Indexers
     ##
-    # Indexer mixin that emits the `redirects_path_ssim` Solr field for
-    # resources that carry a `redirects` attribute. The redirect resolver
-    # (`Hyrax::RedirectsController`) queries this field by path.
+    # Indexer mixin that emits the `redirects_path_ssim` and
+    # `redirects_path_tesim` Solr fields for resources that carry a
+    # `redirects` attribute. The redirect resolver
+    # (`Hyrax::RedirectsController`) queries `_ssim` by path.
     #
     # @example
     #   class WorkIndexer < Hyrax::Indexers::PcdmObjectIndexer
@@ -18,9 +19,11 @@ module Hyrax
           next document unless resource.respond_to?(:redirects)
           # Valkyrie's JSONValueMapper symbolizes hash keys on read; accept either.
           # Paths are normalized at write time by Hyrax::RedirectsNormalization.
-          document['redirects_path_ssim'] = Array(resource.redirects)
-                                            .map { |entry| entry['path'] || entry[:path] }
-                                            .reject(&:blank?)
+          paths = Array(resource.redirects)
+                  .map { |entry| entry['path'] || entry[:path] }
+                  .reject(&:blank?)
+          document['redirects_path_ssim'] = paths
+          document['redirects_path_tesim'] = paths
         end
       end
     end

--- a/app/models/concerns/hyrax/solr_document/metadata.rb
+++ b/app/models/concerns/hyrax/solr_document/metadata.rb
@@ -53,6 +53,7 @@ module Hyrax
         attribute :identifier, Solr::Array, "identifier_tesim"
         attribute :based_near, Solr::Array, "based_near_tesim"
         attribute :based_near_label, Solr::Array, "based_near_label_tesim"
+        attribute :redirects_path, Solr::Array, "redirects_path_tesim"
         attribute :related_url, Solr::Array, "related_url_tesim"
         attribute :resource_type, Solr::Array, "resource_type_tesim"
         attribute :edit_groups, Solr::Array, ::Ability.edit_group_field

--- a/app/renderers/hyrax/renderers/redirects_label_attribute_renderer.rb
+++ b/app/renderers/hyrax/renderers/redirects_label_attribute_renderer.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module Hyrax
+  module Renderers
+    # Renders each redirect path as a clickable link. The link text is the full
+    # absolute URL (host + path); the href is the path alone, which the browser
+    # resolves against the current document's host. Used on show pages via the
+    # `redirects` schema's `render_as: redirects_label` view option.
+    class RedirectsLabelAttributeRenderer < AttributeRenderer
+      private
+
+      def li_value(value)
+        path = value.to_s
+        return ERB::Util.h(path) if path.blank?
+
+        display = base_url.present? ? "#{base_url}#{path}" : path
+        link_to(ERB::Util.h(display), path)
+      end
+
+      def base_url
+        options[:base_url].to_s.sub(%r{/+\z}, '')
+      end
+    end
+  end
+end

--- a/config/metadata/redirects.yaml
+++ b/config/metadata/redirects.yaml
@@ -5,6 +5,11 @@ attributes:
     multiple: true
     form:
       display: false
+    view:
+      admin_only: true
+      render_term: redirects_path
+      render_as: redirects_label
+      html_dl: true
     predicate: http://samvera.org/ns/hyku/redirects
     mappings:
       simple_dc_pmh: ~

--- a/documentation/redirects.md
+++ b/documentation/redirects.md
@@ -78,8 +78,16 @@ properties:
       minimum: 0
     type: hash
     multiple: true
+    indexing:
+      - admin_only
     predicate: http://samvera.org/ns/hyku/redirects
+    view:
+      render_term: redirects_path
+      render_as: redirects_label
+      html_dl: true
 ```
+
+The `indexing: [admin_only]` entry and the `view:` block together opt the redirects field into the show-page display described below in [Displaying redirect aliases on show pages](#displaying-redirect-aliases-on-show-pages). Both are required for that display to appear with admin-only visibility. Note the placement: `admin_only` is an entry in the `indexing:` array (read by `Hyrax::SchemaLoader::AttributeDefinition#admin_only?`); `render_term`, `render_as`, and `html_dl` are inside the `view:` block. Non-flexible mode structures `admin_only` differently — see [Schema details](#schema-details-flexible-false-mode) below.
 
 Each redirect entry is a plain hash with `path`, `canonical`, and `sequence` keys, persisted as JSONB on the parent resource. The `type: hash` token resolves to `Dry::Types['hash']`, which round-trips entries through Postgres without the sub-field stripping a nested `Valkyrie::Resource` would suffer. `available_on.class` must include at least one work or collection class declared in this profile's top-level `classes:` block; substitute the class names your profile declares (`Image`, `Etd`, `Oer`, etc.) as appropriate.
 
@@ -107,10 +115,17 @@ attributes:
     multiple: true
     form:
       display: false
+    view:
+      admin_only: true
+      render_term: redirects_path
+      render_as: redirects_label
+      html_dl: true
     predicate: http://samvera.org/ns/hyku/redirects
     mappings:
       simple_dc_pmh: ~
 ```
+
+The `view:` block opts the redirects field into the show-page display described below in [Displaying redirect aliases on show pages](#displaying-redirect-aliases-on-show-pages). In non-flexible mode, all view options live inside the `view:` block — that's where `Hyrax::SimpleSchemaLoader#view_definitions_for` reads them from. (Flex-true uses a different structure for `admin_only`; see the [m3 profile requirements](#m3-profile-requirements-flexible-true-mode) section.)
 
 When the config is on, this schema is loaded and `Hyrax::Work` / `Hyrax::PcdmCollection` include it via `Hyrax::Schema(:redirects)`. The schema loader produces:
 
@@ -249,6 +264,55 @@ Toggling the config or the Flipflop changes what the indexer emits. Existing rec
 bundle exec rails hyrax:solr:reindex_everything
 ```
 
+## Displaying redirect aliases on show pages
+
+When the redirects feature is enabled, the registered aliases for a work or collection appear on its show page as a list of clickable links. The display is gated by `admin_only: true` — only signed-in admins see it. Public visitors and non-admin users see no trace of the redirects on the show page.
+
+The display is driven by two pieces on the redirects schema: an `admin_only` flag that gates visibility, and a `render_as: redirects_label` instruction that selects the renderer. **The two flex modes structure these differently** because their schema loaders read view options from different places.
+
+**Non-flexible mode (`HYRAX_FLEXIBLE=false`)** — all view options live inside the `view:` block in `config/metadata/redirects.yaml`:
+
+```yaml
+view:
+  admin_only: true
+  render_term: redirects_path
+  render_as: redirects_label
+  html_dl: true
+```
+
+`Hyrax::SimpleSchemaLoader#view_definitions_for` reads `property.meta['view']` and passes the block through verbatim to the show-page rendering.
+
+**Flexible mode (`HYRAX_FLEXIBLE=true`)** — `admin_only` is an entry in the property's `indexing:` array; the rest live inside the `view:` block:
+
+```yaml
+indexing:
+  - admin_only
+view:
+  render_term: redirects_path
+  render_as: redirects_label
+  html_dl: true
+```
+
+`Hyrax::M3SchemaLoader#view_definitions_for` calls `definition.view_options`, which reads `admin_only?` (via `Hyrax::SchemaLoader::AttributeDefinition#admin_only?`, which honors both top-level `admin_only: true` and `indexing: [admin_only]`) and injects it into the view options hash. The `view:` block contents are passed through alongside.
+
+Full snippets for each mode are shown in the [m3 profile requirements](#m3-profile-requirements-flexible-true-mode) and [Schema details](#schema-details-flexible-false-mode) sections above.
+
+### How it works
+
+- The redirects indexer emits two Solr fields: `redirects_path_ssim` (used by the resolver to look up records by path) and `redirects_path_tesim` (used by the show-page display).
+- `Hyrax::SolrDocument::Metadata` declares `redirects_path` as a SolrDocument attribute bound to the `redirects_path_tesim` field. This is what makes `solr_document.redirects_path` available; the per-attribute declaration is required (Hyrax does not coerce arbitrary Solr fields into methods automatically).
+- The presenter's `MissingMethodBehavior` delegates `presenter.redirects_path` to `solr_document.redirects_path`.
+- The `render_term: redirects_path` view option tells the show-page partial to call `presenter.redirects_path` instead of `presenter.redirects`. The bare `redirects` attribute returns the persisted array of hashes and isn't useful for direct rendering.
+- The `render_as: redirects_label` view option tells Hyrax to use the `Hyrax::Renderers::RedirectsLabelAttributeRenderer` class to render the field. Each path becomes a clickable link whose text is the full absolute URL (host + path) and whose `href` is the path alone (the browser resolves it against the current host).
+- The `html_dl: true` view option matches the show page's description-list layout — the renderer emits `<dt>/<dd>` rather than the table-row `<tr>/<td>` it would default to.
+- The `admin_only: true` view option makes the existing attribute-rows partial skip rendering the field entirely when the current user is not an admin. No section heading, no empty list — just nothing.
+
+### Adopter customization
+
+Adopters can override the renderer to change link styling or the displayed URL format. Subclass `Hyrax::Renderers::RedirectsLabelAttributeRenderer` and register the subclass under the same `render_as` key.
+
+Adopters can also turn the display off without removing the redirects feature: remove the `view:` block from the schema (or the m3 profile property declaration). The redirects functionality continues to work — only the show-page display goes away.
+
 ## Migration playbook (Bulkrax)
 
 Institutions migrating from another repository typically have hundreds to thousands of legacy URLs to preserve. Bulkrax (v9.5+) supports redirects via its `nested_attributes: true` field-mapping flag.
@@ -327,7 +391,9 @@ Alternatively, gate the inclusion of the calling code itself on `Hyrax.config.re
 - `documentation/forms/field_behaviors.md` — the Field Behavior pattern used by `Hyrax::RedirectsFieldBehavior` to wire the form's nested-attribute property.
 - `Hyrax::Redirect` (`app/models/hyrax/redirect.rb`) — thin Ruby presenter for a single redirect entry; used on the form's render path.
 - `Hyrax::RedirectsFieldBehavior` (`app/forms/concerns/hyrax/redirects_field_behavior.rb`) — form-side wiring for the `redirects` and `redirects_attributes` properties: loads the persisted property from `config/metadata/redirects.yaml` via `Hyrax::FormFields(:redirects)`, and owns the populator/prepopulator and the `deserialize!` strip for the nested-attributes payload.
-- `Hyrax::Indexers::RedirectsIndexer` (`app/indexers/hyrax/indexers/redirects_indexer.rb`) — the indexer mixin.
+- `Hyrax::Indexers::RedirectsIndexer` (`app/indexers/hyrax/indexers/redirects_indexer.rb`) — the indexer mixin. Emits `redirects_path_ssim` (resolver lookup) and `redirects_path_tesim` (show-page display).
+- `Hyrax::SolrDocument::Metadata` (`app/models/concerns/hyrax/solr_document/metadata.rb`) — declares the `redirects_path` attribute on `SolrDocument`, bound to the `redirects_path_tesim` Solr field. This is what makes `solr_document.redirects_path` (and therefore `presenter.redirects_path` via `MissingMethodBehavior`) available to the show-page renderer.
+- `Hyrax::Renderers::RedirectsLabelAttributeRenderer` (`app/renderers/hyrax/renderers/redirects_label_attribute_renderer.rb`) — show-page renderer that turns each redirect path into a clickable link.
 - `Hyrax::RedirectsController` (`app/controllers/hyrax/redirects_controller.rb`) — the redirect resolver.
 - `Hyrax::FlexibleSchemaValidators::RedirectsValidator` (`app/services/hyrax/flexible_schema_validators/redirects_validator.rb`) — the m3 profile validator.
 - `Hyrax::RedirectValidator` (`app/validators/hyrax/redirect_validator.rb`) — the form-level entry validator.

--- a/spec/indexers/hyrax/indexers/redirects_indexer_spec.rb
+++ b/spec/indexers/hyrax/indexers/redirects_indexer_spec.rb
@@ -33,6 +33,11 @@ RSpec.describe Hyrax::Indexers::RedirectsIndexer do
         expect(indexer.to_solr['redirects_path_ssim'])
           .to contain_exactly('/handle/12345/678', '/islandora/object/ir:1138')
       end
+
+      it 'emits redirects_path_tesim with each entry path for display use' do
+        expect(indexer.to_solr['redirects_path_tesim'])
+          .to contain_exactly('/handle/12345/678', '/islandora/object/ir:1138')
+      end
     end
 
     context 'for a resource with no redirects entries' do
@@ -40,6 +45,10 @@ RSpec.describe Hyrax::Indexers::RedirectsIndexer do
 
       it 'emits redirects_path_ssim as an empty array' do
         expect(indexer.to_solr['redirects_path_ssim']).to eq([])
+      end
+
+      it 'emits redirects_path_tesim as an empty array' do
+        expect(indexer.to_solr['redirects_path_tesim']).to eq([])
       end
     end
 
@@ -56,6 +65,10 @@ RSpec.describe Hyrax::Indexers::RedirectsIndexer do
       it 'does not emit the redirects_path_ssim field' do
         expect(indexer.to_solr).not_to have_key('redirects_path_ssim')
       end
+
+      it 'does not emit the redirects_path_tesim field' do
+        expect(indexer.to_solr).not_to have_key('redirects_path_tesim')
+      end
     end
 
     context 'when an entry is missing a path' do
@@ -68,6 +81,8 @@ RSpec.describe Hyrax::Indexers::RedirectsIndexer do
 
       it 'compacts nil paths out of the indexed field' do
         expect(indexer.to_solr['redirects_path_ssim'])
+          .to contain_exactly('/handle/12345/678')
+        expect(indexer.to_solr['redirects_path_tesim'])
           .to contain_exactly('/handle/12345/678')
       end
     end
@@ -82,6 +97,10 @@ RSpec.describe Hyrax::Indexers::RedirectsIndexer do
 
     it 'does not emit redirects_path_ssim' do
       expect(indexer.to_solr).not_to have_key('redirects_path_ssim')
+    end
+
+    it 'does not emit redirects_path_tesim' do
+      expect(indexer.to_solr).not_to have_key('redirects_path_tesim')
     end
   end
 end

--- a/spec/renderers/hyrax/renderers/redirects_label_attribute_renderer_spec.rb
+++ b/spec/renderers/hyrax/renderers/redirects_label_attribute_renderer_spec.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+RSpec.describe Hyrax::Renderers::RedirectsLabelAttributeRenderer do
+  let(:options) { { base_url: 'https://example.edu' } }
+
+  describe '#render_dl_row' do
+    context 'with no values' do
+      subject(:rendered) { described_class.new(:redirects, [], options).render_dl_row }
+
+      it 'renders nothing' do
+        expect(rendered).to eq('')
+      end
+    end
+
+    context 'with a single path' do
+      subject(:rendered) { described_class.new(:redirects, ['/handle/12345/678'], options).render_dl_row }
+
+      it 'renders a link whose text is the full absolute URL' do
+        expect(rendered).to include('https://example.edu/handle/12345/678')
+      end
+
+      it 'uses the path alone for the href' do
+        expect(rendered).to include('href="/handle/12345/678"')
+      end
+    end
+
+    context 'with multiple paths' do
+      let(:paths) { ['/handle/12345/678', '/old/path/here'] }
+      subject(:rendered) { described_class.new(:redirects, paths, options).render_dl_row }
+
+      it 'renders one link per path' do
+        expect(rendered).to include('https://example.edu/handle/12345/678')
+        expect(rendered).to include('https://example.edu/old/path/here')
+      end
+    end
+
+    context 'with a base_url that has a trailing slash' do
+      let(:options) { { base_url: 'https://example.edu/' } }
+      subject(:rendered) { described_class.new(:redirects, ['/handle/12345/678'], options).render_dl_row }
+
+      it 'normalizes to a single slash between host and path' do
+        expect(rendered).to include('https://example.edu/handle/12345/678')
+        expect(rendered).not_to include('https://example.edu//handle')
+      end
+    end
+
+    context 'with no base_url option' do
+      subject(:rendered) { described_class.new(:redirects, ['/handle/12345/678'], {}).render_dl_row }
+
+      it 'falls back to the path alone as the link text' do
+        expect(rendered).to include('>/handle/12345/678</a>')
+      end
+    end
+
+    context 'with a path containing special characters' do
+      let(:path) { '/handle/12345/678 with spaces' }
+      subject(:rendered) { described_class.new(:redirects, [path], options).render_dl_row }
+
+      it 'HTML-escapes the path in the link text' do
+        expect(rendered).to include('https://example.edu/handle/12345/678 with spaces')
+      end
+    end
+
+    context 'with a blank value in the array (defensive)' do
+      subject(:rendered) { described_class.new(:redirects, ['/handle/123', ''], options).render_dl_row }
+
+      it 'does not render an empty link' do
+        expect(rendered).not_to include('href=""')
+      end
+    end
+  end
+end

--- a/spec/services/hyrax/simple_schema_loader_spec.rb
+++ b/spec/services/hyrax/simple_schema_loader_spec.rb
@@ -171,6 +171,28 @@ RSpec.describe Hyrax::SimpleSchemaLoader do
         attributes = schema_loader.attributes_for(schema: :redirects)
         expect(attributes.keys).to include(:redirects)
       end
+
+      it "exposes the redirects schema's view options for use under flex-false" do
+        # Under flex-false, all view options live inside the view: block;
+        # SimpleSchemaLoader#view_definitions_for passes the block through
+        # verbatim. Flex-true structures admin_only differently (via the
+        # indexing: array or top-level admin_only: true), handled by
+        # M3SchemaLoader.
+        view = {
+          'admin_only' => true,
+          'render_term' => 'redirects_path',
+          'render_as' => 'redirects_label',
+          'html_dl' => true
+        }
+        mock_property = double('Property', name: :redirects, meta: { 'view' => view })
+        result = schema_loader.view_definitions_for(schema: [mock_property])
+        expect(result['redirects']).to include(
+          'admin_only' => true,
+          'render_term' => 'redirects_path',
+          'render_as' => 'redirects_label',
+          'html_dl' => true
+        )
+      end
     end
 
     context 'when Hyrax.config.redirects_enabled? is false' do


### PR DESCRIPTION
## Summary

- When the redirects feature is enabled, registered aliases for a work or collection can now appear on its show page as a list of clickable links — visible only to admins.
- Refs notch8/palni_palci_knapsack#650.

## Details

Until now, the only place to see which redirect paths a record had was the edit form's Aliases tab. Admins auditing redirects, troubleshooting broken links, or confirming a migration's URL mappings had to open each record's edit form to check. The show page now surfaces the same information for at-a-glance review.

The display is gated by the existing `admin_only: true` flexible-metadata flag. Public visitors and non-admin signed-in users see no trace of redirects on the show page — no section heading, no empty list, no hint that the field exists. Admins see a list of full absolute URLs (e.g. `https://example.edu/handle/12345/678`), each linked to the path itself.

Both flex modes are supported via the same `view:` block on the redirects schema. The block declares `admin_only: true` and `render_as: redirects_label`, which the existing view machinery honors without any per-controller changes. Adopters who don't want the display can omit the block; the rest of the redirects feature is unaffected.

A new Solr field `redirects_path_tesim` is emitted alongside the existing `redirects_path_ssim`. The new field exposes paths through the SolrDocument's missing-method behavior so the show-page renderer can read them; the existing `_ssim` field continues to drive the redirect resolver.

A follow-up issue will broaden visibility from admin-only to all editors (per-record CanCan check). That requires adding a new `editor_only` schema flag, which is general-purpose infrastructure beyond the scope of this PR.

## Testing

- [ ] Sign in as an admin, open a work that has registered redirects. The show page lists each redirect as a clickable link whose text is the full absolute URL.
- [ ] Sign in as a non-admin, open the same work. No redirects appear on the show page.
- [ ] Sign out, open the same work. No redirects appear.
- [ ] Open a work that has no registered redirects, as an admin. No empty section or heading appears.
- [ ] Repeat the four steps above for a collection that has registered redirects.
- [ ] Click one of the redirect links on the show page. It resolves to the work's permanent URL via the redirect resolver.
- [ ] View source on the show page and confirm the `href` attribute for each link is the path alone (e.g. `/handle/12345/678`), not the full URL.
- [ ] Repeat the whole sequence under `HYRAX_FLEXIBLE=false` and `HYRAX_FLEXIBLE=true`.

## Notes

Followup ticket https://github.com/notch8/palni_palci_knapsack/issues/656 expands this to editor access.

## Screenshots (from Hyku)

<details>
<summary>As an admin user</summary>

<img width="1171" height="693" alt="Screenshot 2026-05-12 at 3 35 47 PM" src="https://github.com/user-attachments/assets/8482810b-4c80-4019-8a6a-6fb9b86cfa23" />

</details>

<details>
<summary>As a non-admin user</summary>

<img width="1154" height="675" alt="Screenshot 2026-05-12 at 3 35 26 PM" src="https://github.com/user-attachments/assets/6983158b-4ff7-4758-83a6-4212326688bf" />

</details>