### PR TITLE
Add editor_only visibility flag and use it for redirects display

### DIFF
--- a/app/controllers/concerns/hyrax/flexible_catalog_behavior.rb
+++ b/app/controllers/concerns/hyrax/flexible_catalog_behavior.rb
@@ -23,7 +23,7 @@ module Hyrax
           # to prevent them from being exposed in catalog search results.
           # They remain available on show pages, based on visibility.
           if restricted_field?(indexing)
-            blacklight_config.facet_fields.delete("#{itemprop}_sim")
+            remove_from_blacklight_config!(itemprop)
             next
           end
 
@@ -139,16 +139,22 @@ module Hyrax
 
       def remove_old_properties!(previous_properties, current_properties)
         props = previous_properties - current_properties
-        return if props.empty?
+        props.each { |prop| remove_from_blacklight_config!(prop) }
+      end
 
-        props.each do |prop|
-          # remove from facet field
-          blacklight_config.facet_fields.delete("#{prop}_sim")
-          # remove from index field
-          blacklight_config.index_fields.delete("#{prop}_tesim")
-          # remove from qf
-          blacklight_config.search_fields['all_fields'].solr_parameters[:qf].slice!("#{prop}_tesim")
-        end
+      # Evict every Blacklight registration for `itemprop`.
+      def remove_from_blacklight_config!(itemprop)
+        blacklight_config.facet_fields.delete("#{itemprop}_sim")
+
+        name = blacklight_config.index_fields.keys.detect { |key| key.start_with?(itemprop) }
+        name ||= "#{itemprop}_tesim"
+        blacklight_config.index_fields.delete(name)
+
+        qf = blacklight_config.search_fields['all_fields']&.solr_parameters&.dig(:qf)
+        return if qf.nil?
+
+        qf.slice!(" #{name}")
+        qf.slice!(name)
       end
     end
 

--- a/app/controllers/concerns/hyrax/flexible_catalog_behavior.rb
+++ b/app/controllers/concerns/hyrax/flexible_catalog_behavior.rb
@@ -19,12 +19,16 @@ module Hyrax
           indexing = prop['indexing']
           next if indexing.nil?
 
+          # prevents all restricted fields from being added to blacklight config
+          # to prevent them from being exposed in catalog search results.
+          # They remain available on show pages, based on visibility.
+          if restricted_field?(indexing)
+            blacklight_config.facet_fields.delete("#{itemprop}_sim")
+            next
+          end
+
           if stored_searchable?(indexing, itemprop)
             index_args = { itemprop:, label: }
-
-            if admin_only?(indexing)
-              index_args[:if] = lambda { |context, _field_config, _document| context.try(:current_user)&.admin? }
-            end
 
             if facetable?(indexing, itemprop)
               index_args[:link_to_facet] = "#{itemprop}_sim"
@@ -75,11 +79,7 @@ module Hyrax
           if facetable?(indexing, itemprop)
             name = "#{itemprop}_sim"
             unless blacklight_config.facet_fields[name].present?
-              facet_args = { label: }
-              if indexing.include?("admin_only")
-                facet_args[:if] = lambda { |context, _field_config, _document| context.try(:current_user)&.admin? }
-              end
-              blacklight_config.add_facet_field(name, **facet_args)
+              blacklight_config.add_facet_field(name, label: label)
             end
           else
             # if the property does not have facetable in the indexing section of the metadata profile, remove the facet field from the blacklight config
@@ -124,8 +124,13 @@ module Hyrax
         indexing.include?('stored_searchable') || indexing.include?("#{itemprop}_tesim")
       end
 
-      def admin_only?(indexing)
-        indexing.include?("admin_only")
+      # True when the property declares `admin_only` or `editor_only` in its
+      # indexing array. Restricted fields are never exposed through the
+      # Blacklight catalog (no index column, no facet, no free-text match);
+      # visibility is enforced on show pages by the `field_visible?` view
+      # helper.
+      def restricted_field?(indexing)
+        indexing.include?("admin_only") || indexing.include?("editor_only")
       end
 
       def facetable?(indexing, itemprop)

--- a/app/controllers/concerns/hyrax/flexible_catalog_behavior.rb
+++ b/app/controllers/concerns/hyrax/flexible_catalog_behavior.rb
@@ -145,7 +145,7 @@ module Hyrax
           # remove from facet field
           blacklight_config.facet_fields.delete("#{prop}_sim")
           # remove from index field
-          blacklight_config.facet_fields.delete("#{prop}_tesim")
+          blacklight_config.index_fields.delete("#{prop}_tesim")
           # remove from qf
           blacklight_config.search_fields['all_fields'].solr_parameters[:qf].slice!("#{prop}_tesim")
         end

--- a/app/controllers/concerns/hyrax/flexible_catalog_behavior.rb
+++ b/app/controllers/concerns/hyrax/flexible_catalog_behavior.rb
@@ -144,17 +144,20 @@ module Hyrax
 
       # Evict every Blacklight registration for `itemprop`.
       def remove_from_blacklight_config!(itemprop)
-        blacklight_config.facet_fields.delete("#{itemprop}_sim")
+        blacklight_config.facet_fields.each do |field|
+          blacklight_config.facet_fields.delete(field) if field.start_with?(item prop)  
+        end
 
-        name = blacklight_config.index_fields.keys.detect { |key| key.start_with?(itemprop) }
-        name ||= "#{itemprop}_tesim"
-        blacklight_config.index_fields.delete(name)
-
+        names = blacklight_config.index_fields.keys.select do |field|
+          blacklight_config.index_fields.delete(field) if field.start_with?(item_prop)
+        end
+        
         qf = blacklight_config.search_fields['all_fields']&.solr_parameters&.dig(:qf)
         return if qf.nil?
-
-        qf.slice!(" #{name}")
-        qf.slice!(name)
+        names.each do |name|
+          qf.slice!(" #{name}")
+          qf.slice!(name)
+        end
       end
     end
 

--- a/app/controllers/concerns/hyrax/flexible_catalog_behavior.rb
+++ b/app/controllers/concerns/hyrax/flexible_catalog_behavior.rb
@@ -10,7 +10,7 @@ module Hyrax
         return if previous_profile.blank? && current_profile.blank?
 
         current_profile = previous_profile if current_profile.nil?
-        remove_old_properties!(previous_profile['properties'].keys, current_profile['properties'].keys) if current_profile != previous_profile
+        remove_old_properties!(previous_profile['properties'], current_profile['properties'].keys) if current_profile != previous_profile
         properties_hash = current_profile['properties']
         properties_hash.each do |itemprop, prop|
           label = display_label_for(itemprop, prop)
@@ -23,7 +23,7 @@ module Hyrax
           # to prevent them from being exposed in catalog search results.
           # They remain available on show pages, based on visibility.
           if restricted_field?(indexing)
-            remove_from_blacklight_config!(itemprop)
+            remove_from_blacklight_config!(itemprop, indexing)
             next
           end
 
@@ -137,27 +137,47 @@ module Hyrax
         indexing.include?('facetable')
       end
 
-      def remove_old_properties!(previous_properties, current_properties)
-        props = previous_properties - current_properties
-        props.each { |prop| remove_from_blacklight_config!(prop) }
+      def remove_old_properties!(previous_profile_properties, current_property_keys)
+        props = previous_profile_properties.keys - current_property_keys
+        props.each do |prop|
+          indexing = previous_profile_properties.dig(prop, 'indexing')
+          remove_from_blacklight_config!(prop, indexing)
+        end
       end
 
-      # Evict every Blacklight registration for `itemprop`.
-      def remove_from_blacklight_config!(itemprop)
-        blacklight_config.facet_fields.each do |field|
-          blacklight_config.facet_fields.delete(field) if field.start_with?(item prop)  
+      # Evict every Blacklight registration for `itemprop`. Collects the set of
+      # Solr field names to remove from three sources:
+      # - "<itemprop>_tesim" — the default Solr field name used as the
+      #   index field for this property,
+      # - "<itemprop>_sim"   — the default Solr field name used as the
+      #   facet field for this property,
+      # - any additional Solr-field names explicitly declared in `indexing:`
+      #   (filtering out the directive flags `stored_searchable`, `facetable`,
+      #   `admin_only`, and `editor_only`).
+      # Then removes those exact names from `facet_fields`, `index_fields`, and
+      # the all_fields qf. Exact-name matching avoids prefix collisions where
+      # e.g. `title` would otherwise match `title_alternative_*`.
+      INDEXING_DIRECTIVES = %w[stored_searchable facetable admin_only editor_only].freeze
+
+      def remove_from_blacklight_config!(itemprop, indexing = nil)
+        names = solr_field_names_for(itemprop, indexing)
+        names.each do |name|
+          blacklight_config.facet_fields.delete(name)
+          blacklight_config.index_fields.delete(name)
         end
 
-        names = blacklight_config.index_fields.keys.select do |field|
-          blacklight_config.index_fields.delete(field) if field.start_with?(item_prop)
-        end
-        
         qf = blacklight_config.search_fields['all_fields']&.solr_parameters&.dig(:qf)
         return if qf.nil?
         names.each do |name|
           qf.slice!(" #{name}")
           qf.slice!(name)
         end
+      end
+
+      def solr_field_names_for(itemprop, indexing)
+        default_fields = ["#{itemprop}_tesim", "#{itemprop}_sim"]
+        declared_fields = (indexing || []) - INDEXING_DIRECTIVES
+        (default_fields + declared_fields).uniq
       end
     end
 

--- a/app/helpers/hyrax/attributes_helper.rb
+++ b/app/helpers/hyrax/attributes_helper.rb
@@ -90,5 +90,14 @@ module Hyrax
       view_options[:base_url] = request.base_url if respond_to?(:request) && request.respond_to?(:base_url)
       view_options
     end
+
+    # Returns true when the field should render for the current user.
+    # Honors `admin_only` and `editor_only` view options with OR semantics:
+    # when both are set, the field is visible to admins *or* editors.
+    def field_visible?(view_options, presenter)
+      return false if view_options[:admin_only] && !current_user&.admin?
+      return false if view_options[:editor_only] && !presenter.try(:editor?)
+      true
+    end
   end
 end

--- a/app/presenters/hyrax/collection_presenter.rb
+++ b/app/presenters/hyrax/collection_presenter.rb
@@ -129,6 +129,10 @@ module Hyrax
       current_ability.can?(:deposit, solr_document)
     end
 
+    def editor?
+      current_ability.can?(:edit, self)
+    end
+
     def user_can_create_new_nest_collection?
       current_ability.can?(:create_collection_of_type, collection_type)
     end

--- a/app/services/hyrax/m3_schema_loader.rb
+++ b/app/services/hyrax/m3_schema_loader.rb
@@ -11,9 +11,10 @@ module Hyrax
     def view_definitions_for(schema:, version: 1, contexts: nil)
       definitions(schema, version, contexts).each_with_object({}) do |definition, hash|
         view_options = definition.view_options
-        # display_label and admin_only keys are always added to the view_options hash
-        # if there are no other view options, skip this field
-        next if view_options.without(:display_label, :admin_only).empty?
+        # display_label, admin_only, and editor_only keys are always added to
+        # the view_options hash. If there are no other view options, skip this
+        # field.
+        next if view_options.without(:display_label, :admin_only, :editor_only).empty?
 
         hash[definition.name] = definition.view_options
       end

--- a/app/services/hyrax/schema_loader.rb
+++ b/app/services/hyrax/schema_loader.rb
@@ -76,7 +76,7 @@ module Hyrax
       ##
       # @return [Enumerable<Symbol>]
       def index_keys
-        (config.fetch('indexing', nil) || config.fetch('index_keys', []))&.reject { |k| ['facetable', 'stored_searchable', 'admin_only'].include?(k) }&.map(&:to_sym) || []
+        (config.fetch('indexing', nil) || config.fetch('index_keys', []))&.reject { |k| ['facetable', 'stored_searchable', 'admin_only', 'editor_only'].include?(k) }&.map(&:to_sym) || []
       end
 
       ##
@@ -88,6 +88,7 @@ module Hyrax
         @view_options.delete(:label)
         @view_options[:display_label] = display_label
         @view_options[:admin_only] = admin_only?
+        @view_options[:editor_only] = editor_only?
         @view_options
       end
 
@@ -100,6 +101,10 @@ module Hyrax
 
       def admin_only?
         @admin_only ||= config.fetch('admin_only', false) || config['indexing']&.include?('admin_only')
+      end
+
+      def editor_only?
+        @editor_only ||= config.fetch('editor_only', false) || config['indexing']&.include?('editor_only')
       end
 
       ##

--- a/app/views/hyrax/base/_attribute_rows.html.erb
+++ b/app/views/hyrax/base/_attribute_rows.html.erb
@@ -1,4 +1,4 @@
 <% view_options_for(presenter).each do |field, options| %>
   <% view_options = conform_options(field, options) %>
-  <%= presenter.attribute_to_html(conform_field(field, options), view_options) unless view_options[:admin_only] && !current_user.admin?  %>
+  <%= presenter.attribute_to_html(conform_field(field, options), view_options) if field_visible?(view_options, presenter) %>
 <% end %>

--- a/app/views/hyrax/file_sets/_metadata.html.erb
+++ b/app/views/hyrax/file_sets/_metadata.html.erb
@@ -2,11 +2,10 @@
 <dl class="file-show-term file-show-details">
   <% if @presenter.try(:flexible?) %>
     <% view_options_for(@presenter).each do |field, options| %>
-      <% next if options["admin_only"] && !current_user&.admin? %>
-      <% next if field == :admin_note && !@presenter.editor? %>
+      <% view_options = conform_options(field, options) %>
+      <% next unless field_visible?(view_options, @presenter) %>
       <% values = Array(@presenter.try(field)).reject(&:blank?) %>
       <% next if values.empty? %>
-      <% view_options = conform_options(field, options) %>
       <% label = view_options["label"] %>
       <div class="row">
         <dt class="col-5"><%= label %></dt>

--- a/config/metadata/redirects.yaml
+++ b/config/metadata/redirects.yaml
@@ -6,7 +6,7 @@ attributes:
     form:
       display: false
     view:
-      admin_only: true
+      editor_only: true
       render_term: redirects_path
       render_as: redirects_label
       html_dl: true

--- a/documentation/flexible_metadata.md
+++ b/documentation/flexible_metadata.md
@@ -44,6 +44,54 @@ For comprehensive information about flexible metadata, including:
 
 See the official [Flexible Metadata Documentation](https://samvera.atlassian.net/wiki/spaces/hyraxdocs/pages/3382542341/Flexible+Metadata) on the Samvera Confluence.
 
+## Property visibility flags
+
+A property declaration can mark a field as restricted so it is hidden from public visitors. Two flags are supported, each enforcing an independent restriction:
+
+- **`admin_only`** — the field renders on show pages only when the current user has the admin role.
+- **`editor_only`** — the field renders on show pages only when the current user has CanCan `:edit` ability on the record being viewed. Admins satisfy this by virtue of edit permission on everything, so an `editor_only` field is visible to admins as well as to per-record editors.
+
+Each flag is an independent restrictor. When both are set on the same field, both must pass: the field renders only for users who are admin *and* an editor of the record.
+
+### Catalog behavior
+
+Restricted fields (declared with either `admin_only` or `editor_only`) are **not exposed through the Blacklight catalog at all** — no search-results column, no facet, and not added to free-text search. Hiding occurs at field registration time, not at render time, so a restricted field's data does not appear in catalog responses for any user.
+
+Visibility for restricted fields is enforced on show pages by the `field_visible?` view helper.
+
+### Declaring the flags
+
+In a YAML schema (HYRAX_FLEXIBLE=false), declare the flag at the top level of the property:
+
+```yaml
+admin_note:
+  type: string
+  multiple: false
+  predicate: http://schema.org/positiveNotes
+  editor_only: true
+  view:
+    html_dl: true
+```
+
+In an m3 profile (HYRAX_FLEXIBLE=true), declare the flag as a string entry in the property's `indexing:` array, alongside index keys and the standard `stored_searchable` / `facetable` flags:
+
+```yaml
+admin_note:
+  available_on:
+    class:
+      - GenericWork
+  display_label:
+    default: Admin Note
+  indexing:
+    - admin_note_tesim
+    - stored_searchable
+    - editor_only
+  property_uri: http://schema.org/positiveNotes
+  range: http://www.w3.org/2001/XMLSchema#string
+```
+
+Use `admin_only` in place of `editor_only` to restrict visibility to admins only.
+
 ## Related features
 
 - **URL Redirects** (`HYRAX_REDIRECTS_ENABLED`): when enabled, the redirects feature requires a `redirects` property in the m3 profile (when also Flipflop-enabled per tenant). See [`documentation/redirects.md`](redirects.md) for the full schema and gating model.

--- a/documentation/redirects.md
+++ b/documentation/redirects.md
@@ -79,7 +79,7 @@ properties:
     type: hash
     multiple: true
     indexing:
-      - admin_only
+      - editor_only
     predicate: http://samvera.org/ns/hyku/redirects
     view:
       render_term: redirects_path
@@ -87,7 +87,7 @@ properties:
       html_dl: true
 ```
 
-The `indexing: [admin_only]` entry and the `view:` block together opt the redirects field into the show-page display described below in [Displaying redirect aliases on show pages](#displaying-redirect-aliases-on-show-pages). Both are required for that display to appear with admin-only visibility. Note the placement: `admin_only` is an entry in the `indexing:` array (read by `Hyrax::SchemaLoader::AttributeDefinition#admin_only?`); `render_term`, `render_as`, and `html_dl` are inside the `view:` block. Non-flexible mode structures `admin_only` differently — see [Schema details](#schema-details-flexible-false-mode) below.
+The `indexing: [editor_only]` entry and the `view:` block together opt the redirects field into the show-page display described below in [Displaying redirect aliases on show pages](#displaying-redirect-aliases-on-show-pages). Both are required for that display to appear with editor-or-admin visibility. Note the placement: `editor_only` is an entry in the `indexing:` array (read by `Hyrax::SchemaLoader::AttributeDefinition#editor_only?`); `render_term`, `render_as`, and `html_dl` are inside the `view:` block. Non-flexible mode structures `editor_only` differently — see [Schema details](#schema-details-flexible-false-mode) below.
 
 Each redirect entry is a plain hash with `path`, `canonical`, and `sequence` keys, persisted as JSONB on the parent resource. The `type: hash` token resolves to `Dry::Types['hash']`, which round-trips entries through Postgres without the sub-field stripping a nested `Valkyrie::Resource` would suffer. `available_on.class` must include at least one work or collection class declared in this profile's top-level `classes:` block; substitute the class names your profile declares (`Image`, `Etd`, `Oer`, etc.) as appropriate.
 
@@ -116,7 +116,7 @@ attributes:
     form:
       display: false
     view:
-      admin_only: true
+      editor_only: true
       render_term: redirects_path
       render_as: redirects_label
       html_dl: true
@@ -125,7 +125,7 @@ attributes:
       simple_dc_pmh: ~
 ```
 
-The `view:` block opts the redirects field into the show-page display described below in [Displaying redirect aliases on show pages](#displaying-redirect-aliases-on-show-pages). In non-flexible mode, all view options live inside the `view:` block — that's where `Hyrax::SimpleSchemaLoader#view_definitions_for` reads them from. (Flex-true uses a different structure for `admin_only`; see the [m3 profile requirements](#m3-profile-requirements-flexible-true-mode) section.)
+The `view:` block opts the redirects field into the show-page display described below in [Displaying redirect aliases on show pages](#displaying-redirect-aliases-on-show-pages). In non-flexible mode, all view options live inside the `view:` block — that's where `Hyrax::SimpleSchemaLoader#view_definitions_for` reads them from. (Flex-true uses a different structure for `editor_only`; see the [m3 profile requirements](#m3-profile-requirements-flexible-true-mode) section.)
 
 When the config is on, this schema is loaded and `Hyrax::Work` / `Hyrax::PcdmCollection` include it via `Hyrax::Schema(:redirects)`. The schema loader produces:
 
@@ -266,15 +266,17 @@ bundle exec rails hyrax:solr:reindex_everything
 
 ## Displaying redirect aliases on show pages
 
-When the redirects feature is enabled, the registered aliases for a work or collection appear on its show page as a list of clickable links. The display is gated by `admin_only: true` — only signed-in admins see it. Public visitors and non-admin users see no trace of the redirects on the show page.
+When the redirects feature is enabled, the registered aliases for a work or collection appear on its show page as a list of clickable links. The display is gated by `editor_only: true` — visible to signed-in users with edit ability for the record (which includes site admins, who can edit everything). Public visitors and signed-in users without edit ability see no trace of the redirects on the show page.
 
-The display is driven by two pieces on the redirects schema: an `admin_only` flag that gates visibility, and a `render_as: redirects_label` instruction that selects the renderer. **The two flex modes structure these differently** because their schema loaders read view options from different places.
+The `editor_only` flag (and its sibling `admin_only`) are general flexible-metadata property visibility flags. For the full reference — including the combination rule when both flags are set and the catalog-exclusion behavior — see [Property visibility flags](flexible_metadata.md#property-visibility-flags) in the flexible metadata documentation.
+
+The display is driven by two pieces on the redirects schema: an `editor_only` flag that gates visibility, and a `render_as: redirects_label` instruction that selects the renderer. **The two flex modes structure these differently** because their schema loaders read view options from different places.
 
 **Non-flexible mode (`HYRAX_FLEXIBLE=false`)** — all view options live inside the `view:` block in `config/metadata/redirects.yaml`:
 
 ```yaml
 view:
-  admin_only: true
+  editor_only: true
   render_term: redirects_path
   render_as: redirects_label
   html_dl: true
@@ -282,18 +284,18 @@ view:
 
 `Hyrax::SimpleSchemaLoader#view_definitions_for` reads `property.meta['view']` and passes the block through verbatim to the show-page rendering.
 
-**Flexible mode (`HYRAX_FLEXIBLE=true`)** — `admin_only` is an entry in the property's `indexing:` array; the rest live inside the `view:` block:
+**Flexible mode (`HYRAX_FLEXIBLE=true`)** — `editor_only` is an entry in the property's `indexing:` array; the rest live inside the `view:` block:
 
 ```yaml
 indexing:
-  - admin_only
+  - editor_only
 view:
   render_term: redirects_path
   render_as: redirects_label
   html_dl: true
 ```
 
-`Hyrax::M3SchemaLoader#view_definitions_for` calls `definition.view_options`, which reads `admin_only?` (via `Hyrax::SchemaLoader::AttributeDefinition#admin_only?`, which honors both top-level `admin_only: true` and `indexing: [admin_only]`) and injects it into the view options hash. The `view:` block contents are passed through alongside.
+`Hyrax::M3SchemaLoader#view_definitions_for` calls `definition.view_options`, which reads `editor_only?` (via `Hyrax::SchemaLoader::AttributeDefinition#editor_only?`, which honors both top-level `editor_only: true` and `indexing: [editor_only]`) and injects it into the view options hash. The `view:` block contents are passed through alongside.
 
 Full snippets for each mode are shown in the [m3 profile requirements](#m3-profile-requirements-flexible-true-mode) and [Schema details](#schema-details-flexible-false-mode) sections above.
 
@@ -305,7 +307,7 @@ Full snippets for each mode are shown in the [m3 profile requirements](#m3-profi
 - The `render_term: redirects_path` view option tells the show-page partial to call `presenter.redirects_path` instead of `presenter.redirects`. The bare `redirects` attribute returns the persisted array of hashes and isn't useful for direct rendering.
 - The `render_as: redirects_label` view option tells Hyrax to use the `Hyrax::Renderers::RedirectsLabelAttributeRenderer` class to render the field. Each path becomes a clickable link whose text is the full absolute URL (host + path) and whose `href` is the path alone (the browser resolves it against the current host).
 - The `html_dl: true` view option matches the show page's description-list layout — the renderer emits `<dt>/<dd>` rather than the table-row `<tr>/<td>` it would default to.
-- The `admin_only: true` view option makes the existing attribute-rows partial skip rendering the field entirely when the current user is not an admin. No section heading, no empty list — just nothing.
+- The `editor_only: true` view option makes the existing attribute-rows partial skip rendering the field entirely when the current user cannot edit the record. No section heading, no empty list — just nothing.
 
 ### Adopter customization
 

--- a/spec/controllers/concerns/hyrax/flexible_catalog_behavior_spec.rb
+++ b/spec/controllers/concerns/hyrax/flexible_catalog_behavior_spec.rb
@@ -443,5 +443,68 @@ RSpec.describe Hyrax::FlexibleCatalogBehavior, type: :controller do
         end
       end
     end
+
+    describe 'multi-name cleanup driven by the indexing: array' do
+      # When a property declares additional Solr field variants in its
+      # indexing: array (e.g. a `_label_tesim` variant alongside the
+      # canonical `_tesim`), the helper removes all of them — not just the
+      # canonical pair synthesized from the itemprop. Directive flags like
+      # `stored_searchable`/`facetable`/`admin_only`/`editor_only` are
+      # filtered out and not treated as Solr field names.
+      # Uses an itemprop unlikely to collide with the host app's default
+      # CatalogController registrations; blacklight_config is a class-level
+      # singleton shared across examples in this file.
+      before do
+        blacklight_config.add_index_field('memo_tesim', label: 'Memo') unless blacklight_config.index_fields.key?('memo_tesim')
+        blacklight_config.add_index_field('memo_label_tesim', label: 'Memo Label') unless blacklight_config.index_fields.key?('memo_label_tesim')
+        blacklight_config.add_facet_field('memo_sim', label: 'Memo') unless blacklight_config.facet_fields.key?('memo_sim')
+        blacklight_config.add_facet_field('memo_label_sim', label: 'Memo Label') unless blacklight_config.facet_fields.key?('memo_label_sim')
+        blacklight_config.search_fields['all_fields'].solr_parameters[:qf] =
+          String.new('title_tesim memo_tesim memo_label_tesim')
+      end
+
+      let(:indexing) do
+        ['memo_tesim', 'memo_sim', 'memo_label_tesim', 'memo_label_sim',
+         'stored_searchable', 'facetable', 'editor_only']
+      end
+
+      it 'removes the canonical pair and all variants declared in indexing:' do
+        controller.class.send(:remove_from_blacklight_config!, 'memo', indexing)
+
+        expect(blacklight_config.index_fields).not_to have_key('memo_tesim')
+        expect(blacklight_config.index_fields).not_to have_key('memo_label_tesim')
+        expect(blacklight_config.facet_fields).not_to have_key('memo_sim')
+        expect(blacklight_config.facet_fields).not_to have_key('memo_label_sim')
+
+        qf = blacklight_config.search_fields['all_fields'].solr_parameters[:qf]
+        expect(qf).to eq('title_tesim')
+      end
+    end
+
+    describe 'prefix collision safety' do
+      # A potential failure mode of prefix-based matching: `notes` cleanup
+      # accidentally evicting unrelated `notes_internal_*` registrations.
+      # The helper matches on *exact* Solr field names (canonical pair plus
+      # explicit indexing: entries), so unrelated properties whose names
+      # happen to start with the itemprop are untouched.
+      #
+      # Uses field names that are unlikely to collide with the host app's
+      # CatalogController defaults; `blacklight_config` is a class-level
+      # singleton shared across examples in this file, and re-registering a
+      # field that already exists raises.
+      before do
+        blacklight_config.add_index_field('notes_tesim', label: 'Notes') unless blacklight_config.index_fields.key?('notes_tesim')
+        blacklight_config.add_index_field('notes_internal_tesim', label: 'Internal Notes') unless blacklight_config.index_fields.key?('notes_internal_tesim')
+        blacklight_config.add_facet_field('notes_internal_sim', label: 'Internal Notes') unless blacklight_config.facet_fields.key?('notes_internal_sim')
+      end
+
+      it 'does not remove a different property whose name starts with the same prefix' do
+        controller.class.send(:remove_from_blacklight_config!, 'notes')
+
+        expect(blacklight_config.index_fields).not_to have_key('notes_tesim')
+        expect(blacklight_config.index_fields).to have_key('notes_internal_tesim')
+        expect(blacklight_config.facet_fields).to have_key('notes_internal_sim')
+      end
+    end
   end
 end

--- a/spec/controllers/concerns/hyrax/flexible_catalog_behavior_spec.rb
+++ b/spec/controllers/concerns/hyrax/flexible_catalog_behavior_spec.rb
@@ -395,4 +395,53 @@ RSpec.describe Hyrax::FlexibleCatalogBehavior, type: :controller do
       expect(qf).not_to include('secret_note_tesim')
     end
   end
+
+  describe '.remove_from_blacklight_config!' do
+    let(:blacklight_config) { controller.class.blacklight_config }
+
+    before { routes.draw { get 'index' => 'anonymous#index' } }
+
+    describe 'all_fields qf cleanup' do
+      # Registration appends fields as " #{name}", so by the time
+      # remove_from_blacklight_config! runs, the field may be anywhere in the
+      # qf string. The two slice! calls in the helper exist to cover all three
+      # positions: middle (covered by the leading-space slice), first (no
+      # leading space — covered by the bare slice), and only term (also no
+      # leading space).
+      before do
+        controller.class.blacklight_config.search_fields['all_fields']
+                  .solr_parameters[:qf] = qf_initial
+      end
+
+      let(:qf) { controller.class.blacklight_config.search_fields['all_fields'].solr_parameters[:qf] }
+
+      context 'when the field is a middle term in qf' do
+        let(:qf_initial) { String.new('title_tesim creator_tesim subject_tesim') }
+
+        it 'removes the field and its preceding space' do
+          controller.class.send(:remove_from_blacklight_config!, 'creator')
+          expect(qf).to eq('title_tesim subject_tesim')
+        end
+      end
+
+      context 'when the field is the first term in qf with no leading space' do
+        let(:qf_initial) { String.new('creator_tesim title_tesim') }
+
+        it 'removes the field even though there is no leading space to match' do
+          controller.class.send(:remove_from_blacklight_config!, 'creator')
+          expect(qf).not_to include('creator_tesim')
+          expect(qf).to include('title_tesim')
+        end
+      end
+
+      context 'when the field is the only term in qf' do
+        let(:qf_initial) { String.new('creator_tesim') }
+
+        it 'removes the field, leaving an empty qf' do
+          controller.class.send(:remove_from_blacklight_config!, 'creator')
+          expect(qf).to eq('')
+        end
+      end
+    end
+  end
 end

--- a/spec/controllers/concerns/hyrax/flexible_catalog_behavior_spec.rb
+++ b/spec/controllers/concerns/hyrax/flexible_catalog_behavior_spec.rb
@@ -285,18 +285,6 @@ RSpec.describe Hyrax::FlexibleCatalogBehavior, type: :controller do
     end
   end
 
-  describe '.admin_only?' do
-    it 'returns true when indexing includes admin_only' do
-      result = controller.class.send(:admin_only?, ['admin_only', 'stored_searchable'])
-      expect(result).to be true
-    end
-
-    it 'returns false when indexing does not include admin_only' do
-      result = controller.class.send(:admin_only?, ['stored_searchable'])
-      expect(result).to be false
-    end
-  end
-
   describe '.require_view_helper_method?' do
     it 'returns true for external_link render_as' do
       result = controller.class.send(:require_view_helper_method?, { 'render_as' => 'external_link' })
@@ -338,6 +326,73 @@ RSpec.describe Hyrax::FlexibleCatalogBehavior, type: :controller do
     it 'returns :rights_statement_links for rights_statement' do
       result = controller.class.send(:view_option_for_helper_method, { 'render_as' => 'rights_statement' })
       expect(result).to eq(:rights_statement_links)
+    end
+  end
+
+  describe '.restricted_field?' do
+    it 'is true when admin_only is in the indexing array' do
+      expect(controller.class.send(:restricted_field?, ['title_tesim', 'stored_searchable', 'admin_only'])).to be true
+    end
+
+    it 'is true when editor_only is in the indexing array' do
+      expect(controller.class.send(:restricted_field?, ['title_tesim', 'stored_searchable', 'editor_only'])).to be true
+    end
+
+    it 'is false when neither flag is present' do
+      expect(controller.class.send(:restricted_field?, ['title_tesim', 'stored_searchable'])).to be false
+    end
+  end
+
+  describe 'catalog registration of restricted fields' do
+    let(:restricted_properties) do
+      YAML.safe_load(<<-YAML)
+        properties:
+          secret_note:
+            available_on:
+              class:
+                - GenericWork
+                - Monograph
+            display_label:
+              default: Secret Note
+            indexing:
+              - secret_note_tesim
+              - secret_note_sim
+              - stored_searchable
+              - facetable
+              - editor_only
+            property_uri: http://example.org/secret_note
+            range: http://www.w3.org/2001/XMLSchema#string
+      YAML
+    end
+
+    before do
+      allow(Hyrax.config).to receive(:flexible?).and_return(true)
+      routes.draw { get 'index' => 'anonymous#index' }
+
+      mock_schema = double('FlexibleSchema',
+        profile: base_profile.deep_merge(restricted_properties))
+
+      allow(Hyrax::FlexibleSchema)
+        .to receive_message_chain(:order, :last)
+        .with("created_at asc")
+        .with(2)
+        .and_return([mock_schema])
+
+      controller.class.load_flexible_schema
+      get :index
+    end
+
+    it 'does not add the field as an index column' do
+      expect(controller.blacklight_config.index_fields).not_to have_key('secret_note_tesim')
+    end
+
+    it 'does not add the field as a facet' do
+      expect(controller.blacklight_config.facet_fields).not_to have_key('secret_note_sim')
+    end
+
+    it 'does not add the field to the all_fields qf' do
+      qf = controller.blacklight_config.search_fields['all_fields'].solr_parameters[:qf]
+      expect(qf).not_to include('secret_note_tesim')
     end
   end
 end

--- a/spec/helpers/hyrax/attributes_helper_spec.rb
+++ b/spec/helpers/hyrax/attributes_helper_spec.rb
@@ -1,0 +1,131 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Hyrax::AttributesHelper, type: :helper do
+  describe '#conform_field' do
+    it 'returns the field name when no render_term is set' do
+      expect(helper.conform_field(:title, {})).to eq(:title)
+    end
+
+    it 'returns the render_term when set' do
+      expect(helper.conform_field(:based_near, 'render_term' => :based_near_label)).to eq(:based_near_label)
+    end
+
+    it 'handles nil options' do
+      expect(helper.conform_field(:title, nil)).to eq(:title)
+    end
+  end
+
+  describe '#conform_options' do
+    around do |example|
+      original = I18n.locale
+      example.run
+      I18n.locale = original
+    end
+
+    it 'resolves :display_label to a :label using the current locale' do
+      view_options = { display_label: { 'en' => 'Title', 'es' => 'Título' } }.with_indifferent_access
+      I18n.locale = :es
+      result = helper.conform_options(:title, view_options)
+      expect(result[:label]).to eq('Título')
+    end
+
+    it 'falls back to :default when the current locale is missing' do
+      view_options = { display_label: { 'default' => 'Title' } }.with_indifferent_access
+      I18n.locale = :fr
+      result = helper.conform_options(:title, view_options)
+      expect(result[:label]).to eq('Title')
+    end
+
+    it 'derives a label from the field name when display_label is empty' do
+      result = helper.conform_options(:date_created, {}.with_indifferent_access)
+      expect(result[:label]).to eq('Date created')
+    end
+  end
+
+  describe '#schema' do
+    it 'returns nil for a nil model' do
+      expect(helper.schema(nil)).to be_nil
+    end
+
+    it 'returns nil for a model without a schema method' do
+      expect(helper.schema(Object.new)).to be_nil
+    end
+
+    it 'returns the schema when the model responds to :schema' do
+      model = double('Model', schema: :a_schema)
+      expect(helper.schema(model)).to eq(:a_schema)
+    end
+  end
+
+  describe '#field_visible?' do
+    let(:admin_user) { instance_double(User, admin?: true) }
+    let(:non_admin_user) { instance_double(User, admin?: false) }
+    let(:editor_presenter) { double('Presenter', editor?: true) }
+    let(:non_editor_presenter) { double('Presenter', editor?: false) }
+
+    context 'when no visibility flags are set' do
+      it 'is true regardless of user' do
+        allow(helper).to receive(:current_user).and_return(nil)
+        expect(helper.field_visible?({}, non_editor_presenter)).to be true
+      end
+    end
+
+    context 'when admin_only is set' do
+      let(:view_options) { { admin_only: true } }
+
+      it 'is true for admins' do
+        allow(helper).to receive(:current_user).and_return(admin_user)
+        expect(helper.field_visible?(view_options, non_editor_presenter)).to be true
+      end
+
+      it 'is false for non-admins' do
+        allow(helper).to receive(:current_user).and_return(non_admin_user)
+        expect(helper.field_visible?(view_options, non_editor_presenter)).to be false
+      end
+
+      it 'is false when there is no current_user' do
+        allow(helper).to receive(:current_user).and_return(nil)
+        expect(helper.field_visible?(view_options, non_editor_presenter)).to be false
+      end
+    end
+
+    context 'when editor_only is set' do
+      let(:view_options) { { editor_only: true } }
+
+      before { allow(helper).to receive(:current_user).and_return(non_admin_user) }
+
+      it 'is true when the presenter reports the user as an editor' do
+        expect(helper.field_visible?(view_options, editor_presenter)).to be true
+      end
+
+      it 'is false when the presenter reports the user is not an editor' do
+        expect(helper.field_visible?(view_options, non_editor_presenter)).to be false
+      end
+
+      it 'is false when the presenter does not respond to editor?' do
+        expect(helper.field_visible?(view_options, Object.new)).to be false
+      end
+    end
+
+    context 'when both admin_only and editor_only are set' do
+      let(:view_options) { { admin_only: true, editor_only: true } }
+
+      it 'requires both: passes only when user is admin and presenter reports editor' do
+        allow(helper).to receive(:current_user).and_return(admin_user)
+        expect(helper.field_visible?(view_options, editor_presenter)).to be true
+      end
+
+      it 'is false when user is admin but not an editor of the record' do
+        allow(helper).to receive(:current_user).and_return(admin_user)
+        expect(helper.field_visible?(view_options, non_editor_presenter)).to be false
+      end
+
+      it 'is false when user is an editor of the record but not an admin' do
+        allow(helper).to receive(:current_user).and_return(non_admin_user)
+        expect(helper.field_visible?(view_options, editor_presenter)).to be false
+      end
+    end
+  end
+end

--- a/spec/presenters/hyrax/collection_presenter_spec.rb
+++ b/spec/presenters/hyrax/collection_presenter_spec.rb
@@ -159,6 +159,18 @@ RSpec.describe Hyrax::CollectionPresenter do
     it { is_expected.to eq "/dashboard/collections/#{solr_doc.id}?locale=en" }
   end
 
+  describe '#editor?' do
+    it 'returns true when current_ability can edit the presenter' do
+      allow(ability).to receive(:can?).with(:edit, presenter).and_return(true)
+      expect(presenter.editor?).to be true
+    end
+
+    it 'returns false when current_ability cannot edit the presenter' do
+      allow(ability).to receive(:can?).with(:edit, presenter).and_return(false)
+      expect(presenter.editor?).to be false
+    end
+  end
+
   describe "banner_file" do
     let(:solr_doc) { SolrDocument.new(id: '123') }
 

--- a/spec/services/hyrax/m3_schema_loader_spec.rb
+++ b/spec/services/hyrax/m3_schema_loader_spec.rb
@@ -140,6 +140,25 @@ RSpec.describe Hyrax::M3SchemaLoader do
       end
     end
 
+    context 'when a property declares editor_only via the indexing array' do
+      let(:profile_with_editor_only) do
+        modified_profile = profile.dup
+        modified_profile['properties']['abstract']['available_on']['class'] << 'Monograph'
+        modified_profile['properties']['abstract']['indexing'] = ['abstract_tesim', 'stored_searchable', 'editor_only']
+        modified_profile
+      end
+      let(:schema_with_editor_only) do
+        Hyrax::FlexibleSchema.create(profile: profile_with_editor_only)
+      end
+
+      before { allow(Hyrax::FlexibleSchema).to receive(:find_by).and_return(schema_with_editor_only) }
+
+      it 'includes the field with editor_only true in view options' do
+        result = schema_loader.view_definitions_for(schema: Monograph.to_s)
+        expect(result[:abstract]).to include("editor_only" => true)
+      end
+    end
+
     context 'when work type properties have display_label, admin_only, and additional view options' do
       let(:profile_with_view) do
         modified_profile = profile.dup
@@ -178,16 +197,16 @@ RSpec.describe Hyrax::M3SchemaLoader do
       it 'returns only properties with additional view options' do
         expect(schema_loader.view_definitions_for(schema: GenericWork.to_s))
           .to eq({
-                   creator: { "html_dl" => true, "display_label" => { "default" => "Creator" }, "admin_only" => false },
-                   keyword: { "render_as" => "linked", "html_dl" => true, "display_label" => { "default" => "Keyword" }, "admin_only" => false },
-                   abstract: { "html_dl" => true, "display_label" => { "default" => "Abstract" }, "admin_only" => false }
+                   creator: { "html_dl" => true, "display_label" => { "default" => "Creator" }, "admin_only" => false, "editor_only" => false },
+                   keyword: { "render_as" => "linked", "html_dl" => true, "display_label" => { "default" => "Keyword" }, "admin_only" => false, "editor_only" => false },
+                   abstract: { "html_dl" => true, "display_label" => { "default" => "Abstract" }, "admin_only" => false, "editor_only" => false }
                  })
       end
 
       it 'excludes deprecated view.label from properties' do
         expect(schema_loader.view_definitions_for(schema: Monograph.to_s)[:creator])
           .to eq({
-                   "display_label" => { "default" => "Creator" }, "admin_only" => false, "html_dl" => true
+                   "display_label" => { "default" => "Creator" }, "admin_only" => false, "editor_only" => false, "html_dl" => true
                  })
       end
     end
@@ -219,7 +238,7 @@ RSpec.describe Hyrax::M3SchemaLoader do
           result = schema_loader.view_definitions_for(schema: Monograph.to_s, contexts: nil)
           expect(result)
             .to eq(
-              abstract: { "html_dl" => true, "display_label" => { "default" => "Abstract" }, "admin_only" => false }
+              abstract: { "html_dl" => true, "display_label" => { "default" => "Abstract" }, "admin_only" => false, "editor_only" => false }
             )
           expect(result).not_to have_key(:context)
         end
@@ -229,8 +248,8 @@ RSpec.describe Hyrax::M3SchemaLoader do
         it 'includes fields matching the context' do
           expect(schema_loader.view_definitions_for(schema: Monograph.to_s, contexts: 'flexible_context'))
             .to eq(
-              keyword: { "render_as" => "linked", "html_dl" => true, "display_label" => { "default" => "Keyword" }, "admin_only" => false },
-              abstract: { "html_dl" => true, "display_label" => { "default" => "Abstract" }, "admin_only" => false }
+              keyword: { "render_as" => "linked", "html_dl" => true, "display_label" => { "default" => "Keyword" }, "admin_only" => false, "editor_only" => false },
+              abstract: { "html_dl" => true, "display_label" => { "default" => "Abstract" }, "admin_only" => false, "editor_only" => false }
             )
         end
       end
@@ -240,7 +259,7 @@ RSpec.describe Hyrax::M3SchemaLoader do
           result = schema_loader.view_definitions_for(schema: Monograph.to_s, contexts: 'other_context')
           expect(result)
             .to eq(
-              abstract: { "html_dl" => true, "display_label" => { "default" => "Abstract" }, "admin_only" => false }
+              abstract: { "html_dl" => true, "display_label" => { "default" => "Abstract" }, "admin_only" => false, "editor_only" => false }
             )
           expect(result).not_to have_key(:context)
         end

--- a/spec/services/hyrax/schema_loader_spec.rb
+++ b/spec/services/hyrax/schema_loader_spec.rb
@@ -53,6 +53,58 @@ RSpec.describe Hyrax::SchemaLoader::AttributeDefinition do
     end
   end
 
+  describe '#admin_only?' do
+    context 'when set as a top-level key' do
+      let(:config) { { 'type' => 'string', 'admin_only' => true } }
+      it { expect(attribute_definition.admin_only?).to be true }
+    end
+
+    context 'when set in the indexing array' do
+      let(:config) { { 'type' => 'string', 'indexing' => ['stored_searchable', 'admin_only'] } }
+      it { expect(attribute_definition.admin_only?).to be true }
+    end
+
+    context 'when neither is set' do
+      it { expect(attribute_definition.admin_only?).to be_falsey }
+    end
+  end
+
+  describe '#editor_only?' do
+    context 'when set as a top-level key' do
+      let(:config) { { 'type' => 'string', 'editor_only' => true } }
+      it { expect(attribute_definition.editor_only?).to be true }
+    end
+
+    context 'when set in the indexing array' do
+      let(:config) { { 'type' => 'string', 'indexing' => ['stored_searchable', 'editor_only'] } }
+      it { expect(attribute_definition.editor_only?).to be true }
+    end
+
+    context 'when neither is set' do
+      it { expect(attribute_definition.editor_only?).to be_falsey }
+    end
+  end
+
+  describe '#index_keys' do
+    context 'when indexing array contains visibility flags' do
+      let(:config) { { 'type' => 'string', 'indexing' => ['title_tesim', 'stored_searchable', 'facetable', 'admin_only', 'editor_only'] } }
+
+      it 'filters out facetable, stored_searchable, admin_only, and editor_only' do
+        expect(attribute_definition.index_keys).to eq([:title_tesim])
+      end
+    end
+  end
+
+  describe '#view_options' do
+    let(:config) { { 'type' => 'string', 'admin_only' => true, 'editor_only' => true, 'view' => { 'html_dl' => true } } }
+
+    it 'includes admin_only and editor_only flags' do
+      expect(attribute_definition.view_options[:admin_only]).to be true
+      expect(attribute_definition.view_options[:editor_only]).to be true
+      expect(attribute_definition.view_options[:html_dl]).to be true
+    end
+  end
+
   describe '#type' do
     context 'when multiple is true' do
       it 'returns a Valkyrie array type' do

--- a/spec/services/hyrax/simple_schema_loader_spec.rb
+++ b/spec/services/hyrax/simple_schema_loader_spec.rb
@@ -175,11 +175,11 @@ RSpec.describe Hyrax::SimpleSchemaLoader do
       it "exposes the redirects schema's view options for use under flex-false" do
         # Under flex-false, all view options live inside the view: block;
         # SimpleSchemaLoader#view_definitions_for passes the block through
-        # verbatim. Flex-true structures admin_only differently (via the
-        # indexing: array or top-level admin_only: true), handled by
+        # verbatim. Flex-true structures editor_only differently (via the
+        # indexing: array or top-level editor_only: true), handled by
         # M3SchemaLoader.
         view = {
-          'admin_only' => true,
+          'editor_only' => true,
           'render_term' => 'redirects_path',
           'render_as' => 'redirects_label',
           'html_dl' => true
@@ -187,7 +187,7 @@ RSpec.describe Hyrax::SimpleSchemaLoader do
         mock_property = double('Property', name: :redirects, meta: { 'view' => view })
         result = schema_loader.view_definitions_for(schema: [mock_property])
         expect(result['redirects']).to include(
-          'admin_only' => true,
+          'editor_only' => true,
           'render_term' => 'redirects_path',
           'render_as' => 'redirects_label',
           'html_dl' => true


### PR DESCRIPTION
## Summary
- Adds an `editor_only` flexible-metadata visibility flag so schemas can hide selected properties on show pages from users without edit ability for the record, and switches the redirects show-page display to use it (broadening visibility from admins-only to anyone with edit ability).
- Refs samvera/hyrax#656, notch8/palni_palci_knapsack#657

## Details

A property can now declare `editor_only: true` (alongside the existing `admin_only`) to restrict its show-page visibility. Editor visibility uses CanCan's `:edit` ability against the specific record being viewed, so admins (who have edit ability on everything) see editor-only fields, and per-record editors see them on records they can edit.

Each flag is an independent restrictor. When both are set on the same property, both must pass — the field renders only for a user who is admin *and* an editor of the record. The same semantics apply uniformly across the work, collection, and file_set show pages.

Restricted properties (with either flag) are excluded from Blacklight catalog registration entirely — no column header, no facet, not added to free-text search. This is a stronger guarantee than per-row gating: the data is not present in catalog responses for any user, including anonymous visitors.

A new `field_visible?` view helper centralizes the show-page gate, replacing duplicated inline checks. A previously hardcoded `admin_note` check in the FileSet metadata partial is removed; the helper now does the gating, and the field's schema can declare `editor_only: true` to opt in. (FileSet schemas don't currently declare `admin_note`, so no Hyrax-side schema change is needed; downstream apps that add `admin_note` to their own profiles can adopt the flag at their own pace.)

The redirects display (added in #7442) is switched from `admin_only` to `editor_only`, so per-record editors — not just site admins — can audit registered aliases on the show pages of works and collections they can edit.

While tightening the catalog-exclusion path, a pre-existing bug in `remove_old_properties!` was uncovered and fixed in its own commit: `_tesim` was being deleted from `facet_fields` instead of `index_fields`, so the intended cleanup was silently dropped. The fix and the new restricted-field eviction now share a single `remove_from_blacklight_config!` helper that covers all three Blacklight surfaces (facet, index, and the all_fields qf), with spec coverage demonstrating the qf cleanup across middle, first, and only-term positions.

Documentation for the visibility flags was previously missing entirely; this PR adds a "Property visibility flags" section to `documentation/flexible_metadata.md` covering both `admin_only` and `editor_only`, including the YAML and m3 declaration patterns and the catalog-exclusion behavior. `documentation/redirects.md` is updated to reference the new flag, with a cross-link to the general visibility-flags reference.

## Testing
- Confirm a logged-out visitor on a work, collection, or file_set show page does not see any property declared `editor_only: true`.
- Confirm an editor (non-admin user with edit ability for the record) sees the property on records they can edit, and does not see it on records they cannot edit.
- Confirm an admin sees properties declared `editor_only: true` everywhere, and also sees properties declared `admin_only: true`.
- Confirm a property declared with both `admin_only: true` and `editor_only: true` renders only when the user is both an admin and an editor of the record.
- With the redirects feature enabled, register an alias on a work, then visit the work's show page as a non-admin user with edit ability — confirm the registered aliases appear. Repeat as a logged-out visitor and confirm nothing appears. Repeat for a collection.
- Visit `/catalog` as an anonymous user and confirm that no property declared `admin_only` or `editor_only` appears as a column, facet, or search suggestion. Repeat as an admin and confirm the same — restricted fields stay out of catalog regardless of who is signed in.
- Verify the same behavior under both `HYRAX_FLEXIBLE=false` (top-level `editor_only:` key in the YAML schema) and `HYRAX_FLEXIBLE=true` (`editor_only` entry in the m3 profile property's `indexing:` array).