### PR TITLE
Add copy permalink button to show pages

### DIFF
--- a/app/assets/javascripts/hyrax.js
+++ b/app/assets/javascripts/hyrax.js
@@ -44,6 +44,7 @@
 //= require hyrax/proxy_rights
 //= require hyrax/sorting
 //= require hyrax/single_use_links_manager
+//= require hyrax/copy_permalink_button
 //= require hyrax/dashboard_actions
 //= require hyrax/batch
 //= require hyrax/flot_stats

--- a/app/assets/javascripts/hyrax/copy_permalink_button.js
+++ b/app/assets/javascripts/hyrax/copy_permalink_button.js
@@ -1,0 +1,28 @@
+// Wires the "Copy permalink" button (on work and collection show pages) to
+// ClipboardJS. The button ships with the button label as its `title` so a
+// pre-init hover shows something sensible; we initialize a manual-trigger
+// Bootstrap tooltip so the browser's native title-attribute tooltip stops
+// appearing on hover. On a successful copy we swap the tooltip text to the
+// "Copied!" message, show it briefly, then restore the original label.
+Blacklight.onLoad(function () {
+  var $buttons = $('.copy-permalink-button');
+  if (!$buttons.length) { return; }
+
+  $buttons.tooltip({ trigger: 'manual' });
+
+  var clipboard = new Clipboard('.copy-permalink-button');
+
+  clipboard.on('success', function (e) {
+    var $btn = $(e.trigger);
+    var originalLabel = $btn.attr('data-original-title');
+    var successText = $btn.attr('data-success-text');
+
+    $btn.attr('data-original-title', successText).tooltip('show');
+
+    setTimeout(function () {
+      $btn.tooltip('hide').attr('data-original-title', originalLabel);
+    }, 1500);
+
+    e.clearSelection();
+  });
+});

--- a/app/helpers/hyrax/hyrax_helper_behavior.rb
+++ b/app/helpers/hyrax/hyrax_helper_behavior.rb
@@ -20,6 +20,7 @@ module Hyrax
     include Hyrax::WorkflowsHelper
     include Hyrax::FacetsHelper
     include Hyrax::AttributesHelper
+    include Hyrax::PermalinkHelper
     include Hyrax::WorksHelper
     include Hyrax::FileSetFormHelper
 

--- a/app/helpers/hyrax/permalink_helper.rb
+++ b/app/helpers/hyrax/permalink_helper.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module Hyrax
+  # Helpers for the "Copy permalink" button on work and collection show pages.
+  # See documentation/copy_permalink.md.
+  module PermalinkHelper
+    # The canonical, UUID-based URL for the record represented by `presenter`.
+    # This is the URL the redirect resolver redirects *to*, so it is stable
+    # across alias changes and is safe to share or cite. Collections are
+    # routed by the Hyrax engine; works are routed by the host app's
+    # curation-concern resources.
+    def permalink_for(presenter)
+      proxy = collection_presenter?(presenter) ? hyrax : main_app
+      polymorphic_url([proxy, presenter])
+    end
+
+    def copy_permalink_enabled?
+      Flipflop.enabled?(:copy_permalink_button)
+    end
+
+    private
+
+    def collection_presenter?(presenter)
+      presenter.respond_to?(:collection?) && presenter.collection?
+    end
+  end
+end

--- a/app/views/hyrax/base/_citations.html.erb
+++ b/app/views/hyrax/base/_citations.html.erb
@@ -1,4 +1,5 @@
 <div class="citations">
+    <%= render 'hyrax/shared/copy_permalink', presenter: presenter %>
     <% if Hyrax.config.citations? %>
       <%= link_to t(".citations"), hyrax.citations_work_path(presenter), id: 'citations', class: 'btn btn-secondary btn-sm mr-2' %>
     <% end %>

--- a/app/views/hyrax/base/show.html.erb
+++ b/app/views/hyrax/base/show.html.erb
@@ -1,4 +1,7 @@
 <% provide :page_title, @presenter.page_title %>
+<% content_for :canonical_url do %>
+  <link rel="canonical" href="<%= permalink_for(@presenter) %>" />
+<% end %>
 
 <%= render 'shared/citations' %>
 

--- a/app/views/hyrax/collections/show.html.erb
+++ b/app/views/hyrax/collections/show.html.erb
@@ -1,4 +1,7 @@
 <% provide :page_title, construct_page_title(@presenter.title) %>
+<% content_for :canonical_url do %>
+  <link rel="canonical" href="<%= permalink_for(@presenter) %>" />
+<% end %>
 <div class="hyc-container" itemscope itemtype="http://schema.org/CollectionPage">
   <div class="row hyc-header">
     <div class="col-md-12">
@@ -13,6 +16,7 @@
         <h1><%= @presenter.title.first %></h1>
         <%= @presenter.collection_type_badge %>
         <%= @presenter.permission_badge %>
+        <%= render 'hyrax/shared/copy_permalink', presenter: @presenter %>
       </div>
 
       <% unless @presenter.logo_record.blank? %>

--- a/app/views/hyrax/shared/_copy_permalink.html.erb
+++ b/app/views/hyrax/shared/_copy_permalink.html.erb
@@ -1,0 +1,10 @@
+<% if copy_permalink_enabled? %>
+  <% label = t('hyrax.copy_permalink.button') %>
+  <button type="button"
+          class="btn btn-secondary btn-sm copy-permalink-button"
+          data-clipboard-text="<%= permalink_for(presenter) %>"
+          data-success-text="<%= t('hyrax.copy_permalink.success') %>"
+          title="<%= label %>">
+    <%= label %>
+  </button>
+<% end %>

--- a/app/views/layouts/_head_tag_content.html.erb
+++ b/app/views/layouts/_head_tag_content.html.erb
@@ -15,6 +15,9 @@ signed in %>
 <%= yield :twitter_meta %>
 <!-- Google Scholar metadata -->
 <%= yield :gscholar_meta %>
+<!-- Canonical URL (set by show pages so search engines treat the
+     UUID-based URL as the authoritative one when redirect aliases exist) -->
+<%= yield :canonical_url %>
 
 <title><%= content_for?(:page_title) ? yield(:page_title) : default_page_title %></title>
 

--- a/config/features.rb
+++ b/config/features.rb
@@ -66,13 +66,17 @@ Flipflop.configure do
             description: "Depositors may transfer their works to another user"
   end
 
-  # See documentation/redirects.md for the redirects feature.
-  if Hyrax.config.redirects_enabled?
-    group :experimental_features do
+  group :experimental_features do
+    # See documentation/redirects.md for the redirects feature.
+    if Hyrax.config.redirects_enabled?
       feature :redirects,
               default: false,
               description: "Enable per-record URL redirects from legacy paths to the canonical Hyku URL."
     end
+
+    feature :copy_permalink_button,
+            default: false,
+            description: "Show a 'Copy permalink' button on work and collection show pages that copies the record's canonical UUID-based URL to the clipboard."
   end
 
 rescue Flipflop::StrategyError, Flipflop::FeatureError => err

--- a/config/locales/hyrax.de.yml
+++ b/config/locales/hyrax.de.yml
@@ -886,6 +886,9 @@ de:
       contact: Kontakt
       help: Hilfe
       home: Startseite
+    copy_permalink:
+      button: Permalink kopieren
+      success: Kopiert!
     dashboard:
       additional_notifications: Alle Benachrichtigungen
       admin_sets:

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -887,6 +887,9 @@ en:
       contact: Contact
       help: Help
       home: Home
+    copy_permalink:
+      button: Copy permalink
+      success: Copied!
     dashboard:
       additional_notifications: See all notifications
       admin_sets:

--- a/config/locales/hyrax.es.yml
+++ b/config/locales/hyrax.es.yml
@@ -892,6 +892,9 @@ es:
       contact: Contacto
       help: Ayuda
       home: Inicio
+    copy_permalink:
+      button: Copiar enlace permanente
+      success: ¡Copiado!
     dashboard:
       additional_notifications: ver todas las notificaciones
       admin_sets:

--- a/config/locales/hyrax.fr.yml
+++ b/config/locales/hyrax.fr.yml
@@ -893,6 +893,9 @@ fr:
       contact: Contact
       help: Aidez-moi
       home: Accueil
+    copy_permalink:
+      button: Copier le lien permanent
+      success: Copié !
     dashboard:
       additional_notifications: Voir toutes les notifications
       admin_sets:

--- a/config/locales/hyrax.it.yml
+++ b/config/locales/hyrax.it.yml
@@ -892,6 +892,9 @@ it:
       contact: contatto
       help: Aiuto
       home: Casa
+    copy_permalink:
+      button: Copia permalink
+      success: Copiato!
     dashboard:
       additional_notifications: Vedere tutte le notifiche
       admin_sets:

--- a/config/locales/hyrax.pt-BR.yml
+++ b/config/locales/hyrax.pt-BR.yml
@@ -885,6 +885,9 @@ pt-BR:
       contact: Contato
       help: Ajuda
       home: Página Principal
+    copy_permalink:
+      button: Copiar link permanente
+      success: Copiado!
     dashboard:
       additional_notifications: Ver todas as notificações
       admin_sets:

--- a/config/locales/hyrax.zh.yml
+++ b/config/locales/hyrax.zh.yml
@@ -890,6 +890,9 @@ zh:
       contact: 联系
       help: 帮助
       home: 首页
+    copy_permalink:
+      button: 复制永久链接
+      success: 已复制!
     dashboard:
       additional_notifications: 见所有通知
       admin_sets:

--- a/documentation/copy_permalink.md
+++ b/documentation/copy_permalink.md
@@ -1,0 +1,29 @@
+# Copy permalink button
+
+A "Copy permalink" button on the show pages for works and collections lets a viewer copy the record's canonical, UUID-based URL to their clipboard. The canonical URL is the form `…/concern/<work_type>/<uuid>` (for works) or `…/collections/<uuid>` (for collections) — the stable URL the redirect resolver redirects *to*, regardless of any aliases registered for the record.
+
+## Why
+
+When the redirects feature is in use, an alias like `/handle/12345/678` resolves to the canonical record URL. The browser address bar then shows the alias. A user who copies that URL is copying the alias, which could later be edited or removed. The permalink button gives one-click access to the canonical URL so the copied link will keep working as long as the record itself exists.
+
+The button has value even without redirects enabled, because the canonical URL is the long-term stable form of the address.
+
+## Feature flag
+
+The button is gated by a Flipflop feature, `copy_permalink_button`, defaulting to **off**. Enable it per environment (via the YAML strategy) or per tenant (via the database strategy) like any other Flipflop feature. When the feature is off, no button is rendered.
+
+The feature is independent of the `redirects` feature flag — the permalink button can be enabled standalone.
+
+## What appears
+
+On a work show page, the button appears in the citations block in the left-hand column. On a collection show page, it appears in the title header next to the collection-type and permission badges. In both cases the button is visible to all users, including anonymous visitors.
+
+The button uses ClipboardJS (already a Hyrax dependency) and shows a brief Bootstrap tooltip on successful copy.
+
+## Canonical URL in the page head
+
+The work and collection show pages also emit a `<link rel="canonical" href="...">` tag in the `<head>` regardless of the feature flag. This helps search engines treat the UUID-based URL as authoritative when the same record is reachable via multiple alias paths, avoiding duplicate-content penalties.
+
+## Related
+
+- [`documentation/redirects.md`](redirects.md) — the redirect aliases feature that motivates the canonical/alias distinction.

--- a/documentation/flexible_metadata.md
+++ b/documentation/flexible_metadata.md
@@ -47,6 +47,7 @@ See the official [Flexible Metadata Documentation](https://samvera.atlassian.net
 ## Related features
 
 - **URL Redirects** (`HYRAX_REDIRECTS_ENABLED`): when enabled, the redirects feature requires a `redirects` property in the m3 profile (when also Flipflop-enabled per tenant). See [`documentation/redirects.md`](redirects.md) for the full schema and gating model.
+- **Copy permalink button** (Flipflop `copy_permalink_button`): a show-page button that copies the record's canonical UUID-based URL. See [`documentation/copy_permalink.md`](copy_permalink.md).
 
 ## Flexible TODOs
 * add the schema loader

--- a/spec/helpers/hyrax/permalink_helper_spec.rb
+++ b/spec/helpers/hyrax/permalink_helper_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Hyrax::PermalinkHelper, type: :helper do
+  describe '#copy_permalink_enabled?' do
+    context 'when the Flipflop feature is enabled' do
+      before { allow(Flipflop).to receive(:enabled?).with(:copy_permalink_button).and_return(true) }
+      it { expect(helper.copy_permalink_enabled?).to be true }
+    end
+
+    context 'when the Flipflop feature is disabled' do
+      before { allow(Flipflop).to receive(:enabled?).with(:copy_permalink_button).and_return(false) }
+      it { expect(helper.copy_permalink_enabled?).to be false }
+    end
+  end
+
+  describe '#permalink_for' do
+    let(:work_presenter) { double('WorkPresenter', collection?: false) }
+    let(:collection_presenter) { double('CollectionPresenter', collection?: true) }
+    let(:bare_presenter) { double('BarePresenter') }
+
+    it 'routes works through main_app' do
+      expect(helper).to receive(:polymorphic_url).with([helper.main_app, work_presenter]).and_return('http://example.test/works/1')
+      expect(helper.permalink_for(work_presenter)).to eq('http://example.test/works/1')
+    end
+
+    it 'routes collections through the Hyrax engine' do
+      expect(helper).to receive(:polymorphic_url).with([helper.hyrax, collection_presenter]).and_return('http://example.test/collections/1')
+      expect(helper.permalink_for(collection_presenter)).to eq('http://example.test/collections/1')
+    end
+
+    it 'treats presenters without a collection? method as non-collections' do
+      expect(helper).to receive(:polymorphic_url).with([helper.main_app, bare_presenter]).and_return('http://example.test/x/1')
+      expect(helper.permalink_for(bare_presenter)).to eq('http://example.test/x/1')
+    end
+  end
+end

--- a/spec/views/hyrax/base/show.html.erb_spec.rb
+++ b/spec/views/hyrax/base/show.html.erb_spec.rb
@@ -59,6 +59,8 @@ RSpec.describe 'hyrax/base/show.html.erb', type: :view do
     allow(view).to receive(:blacklight_config).and_return(Blacklight::Configuration.new)
     allow(view).to receive(:signed_in?)
     allow(view).to receive(:on_the_dashboard?).and_return(false)
+    # Stub route because view specs don't handle engine/main_app polymorphic routes
+    allow(view).to receive(:permalink_for).with(presenter).and_return("http://example.test/concern/generic_works/#{presenter.id}")
     stub_template 'hyrax/base/_metadata.html.erb' => ''
     stub_template 'hyrax/base/_relationships.html.erb' => ''
     stub_template 'hyrax/base/_show_actions.html.erb' => ''

--- a/spec/views/hyrax/collections/show.html.erb_spec.rb
+++ b/spec/views/hyrax/collections/show.html.erb_spec.rb
@@ -27,8 +27,9 @@ RSpec.describe 'hyrax/collections/show.html.erb', type: :view do
     allow(ability).to receive(:current_user).and_return(build(:user, id: nil, email: ""))
     assign(:presenter, presenter)
 
-    # Stub route because view specs don't handle engine routes
+    # Stub routes because view specs don't handle engine routes
     allow(view).to receive(:collection_path).and_return("/collection/123")
+    allow(view).to receive(:permalink_for).with(presenter).and_return("http://example.test/collection/123")
 
     stub_template '_search_form.html.erb' => 'search form'
     stub_template 'hyrax/collections/_sort_and_per_page.html.erb' => 'sort and per page'

--- a/spec/views/hyrax/shared/_copy_permalink.html.erb_spec.rb
+++ b/spec/views/hyrax/shared/_copy_permalink.html.erb_spec.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'hyrax/shared/_copy_permalink.html.erb', type: :view do
+  let(:presenter) { double('Presenter') }
+
+  before do
+    allow(view).to receive(:permalink_for).with(presenter).and_return('http://example.test/concern/generic_works/abc-123')
+  end
+
+  context 'when the copy_permalink_button feature is enabled' do
+    before { allow(view).to receive(:copy_permalink_enabled?).and_return(true) }
+
+    it 'renders a button with the canonical URL as data-clipboard-text' do
+      render partial: 'hyrax/shared/copy_permalink', locals: { presenter: presenter }
+      expect(rendered).to have_css(
+        'button.copy-permalink-button[data-clipboard-text="http://example.test/concern/generic_works/abc-123"]'
+      )
+    end
+
+    it 'renders the button label from the locale' do
+      render partial: 'hyrax/shared/copy_permalink', locals: { presenter: presenter }
+      expect(rendered).to include(I18n.t('hyrax.copy_permalink.button'))
+    end
+
+    # The button's initial `title` is the button label, not the success text.
+    # Before the Bootstrap tooltip is initialized (or if JS doesn't run), the
+    # browser falls back to the native title-attribute tooltip on hover. If we
+    # left "Copied!" in the title, a pre-click hover would misleadingly suggest
+    # the copy already happened. The success text lives in a separate
+    # data-success-text attribute that the JS swaps in only after a copy.
+    it 'uses the button label (not the success text) as the initial title' do
+      render partial: 'hyrax/shared/copy_permalink', locals: { presenter: presenter }
+      expect(rendered).to have_css(
+        "button.copy-permalink-button[title=\"#{I18n.t('hyrax.copy_permalink.button')}\"]"
+      )
+    end
+
+    it 'carries the success text in a data-success-text attribute' do
+      render partial: 'hyrax/shared/copy_permalink', locals: { presenter: presenter }
+      expect(rendered).to have_css(
+        "button.copy-permalink-button[data-success-text=\"#{I18n.t('hyrax.copy_permalink.success')}\"]"
+      )
+    end
+  end
+
+  context 'when the copy_permalink_button feature is disabled' do
+    before { allow(view).to receive(:copy_permalink_enabled?).and_return(false) }
+
+    it 'renders nothing' do
+      render partial: 'hyrax/shared/copy_permalink', locals: { presenter: presenter }
+      expect(rendered.strip).to be_empty
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Adds a "Copy permalink" button to work and collection show pages (behind a feature flipper) that copies the record's canonical UUID-based URL to the clipboard, so users have a stable link to share or cite when the browser address bar shows an alias path.
- Refs notch8/palni_palci_knapsack#651
