### PR TITLE
Hide m3 property from catalog via view flag

### DIFF
--- a/app/controllers/concerns/hyrax/flexible_catalog_behavior.rb
+++ b/app/controllers/concerns/hyrax/flexible_catalog_behavior.rb
@@ -27,7 +27,12 @@ module Hyrax
             next
           end
 
-          if stored_searchable?(indexing, itemprop)
+          # `view.search_results: false` in the m3 profile hides this property from catalog
+          # search-result columns. Only gates the dynamic add_index_field path below;
+          # properties already declared in CatalogController are left untouched, and
+          # the `qf` (query-field relevance) list is unaffected. Facet registration below
+          # is intentionally not gated — a hidden property can still be facetable.
+          if catalog_indexable?(view_options) && stored_searchable?(indexing, itemprop)
             index_args = { itemprop:, label: }
 
             if facetable?(indexing, itemprop)
@@ -131,6 +136,13 @@ module Hyrax
       # helper.
       def restricted_field?(indexing)
         indexing.include?("admin_only") || indexing.include?("editor_only")
+      end
+
+      # Returns false only when the m3 profile sets `view.search_results: false`
+      # for the property; absent or `true` keeps existing catalog-display behavior.
+      def catalog_indexable?(view_options)
+        return true unless view_options.is_a?(Hash)
+        view_options['search_results'] != false
       end
 
       def facetable?(indexing, itemprop)

--- a/spec/controllers/concerns/hyrax/flexible_catalog_behavior_spec.rb
+++ b/spec/controllers/concerns/hyrax/flexible_catalog_behavior_spec.rb
@@ -67,6 +67,20 @@ RSpec.describe Hyrax::FlexibleCatalogBehavior, type: :controller do
           view:
             render_as: linked
             html_dl: true
+        internal_note:
+          available_on:
+            class:
+              - GenericWork
+          display_label:
+            default: Internal Note
+          indexing:
+            - stored_searchable
+            - facetable
+          property_uri: http://example.org/internal_note
+          range: http://www.w3.org/2001/XMLSchema#string
+          view:
+            html_dl: true
+            search_results: false
     YAML
   end
 
@@ -178,6 +192,21 @@ RSpec.describe Hyrax::FlexibleCatalogBehavior, type: :controller do
       end
     end
 
+    context 'properties hidden from catalog search results' do
+      it 'does not register an index field when view.search_results is false' do
+        expect(blacklight_config.index_fields).not_to have_key('internal_note_tesim')
+      end
+
+      it 'does not add the property to the all_fields qf list' do
+        qf = blacklight_config.search_fields['all_fields'].solr_parameters[:qf]
+        expect(qf).not_to include('internal_note_tesim')
+      end
+
+      it 'still registers the facet field when indexing includes facetable' do
+        expect(blacklight_config.facet_fields).to have_key('internal_note_sim')
+      end
+    end
+
     context 'properties with sidebar faceting' do
       it 'have a facet field added to the blacklight config' do
         # if the  property has facetable in the indexing section of the metadata profile, ensure the _sim field is added to the blacklight config
@@ -270,6 +299,28 @@ RSpec.describe Hyrax::FlexibleCatalogBehavior, type: :controller do
     it 'returns false when neither condition is met' do
       result = controller.class.send(:stored_searchable?, ['facetable'], 'test_field')
       expect(result).to be false
+    end
+  end
+
+  describe '.catalog_indexable?' do
+    it 'returns false when view.search_results is false' do
+      result = controller.class.send(:catalog_indexable?, { 'search_results' => false })
+      expect(result).to be false
+    end
+
+    it 'returns true when view.search_results is true' do
+      result = controller.class.send(:catalog_indexable?, { 'search_results' => true })
+      expect(result).to be true
+    end
+
+    it 'returns true when view options do not include search_results' do
+      result = controller.class.send(:catalog_indexable?, { 'html_dl' => true })
+      expect(result).to be true
+    end
+
+    it 'returns true when view options are nil' do
+      result = controller.class.send(:catalog_indexable?, nil)
+      expect(result).to be true
     end
   end
 


### PR DESCRIPTION
## Summary
- New `view.search_results: false` flag in the M3 metadata profile hides a property from the catalog search-results columns.

## Details
Under flexible metadata, a property's `view:` block already controls show-page rendering (`html_dl: true`). Until now, the only way to suppress a property from the **catalog search-results** columns was the runtime `render_optionally?` hook, which Hyku layers on top via a per-account "Hidden index fields" admin setting — there was no first-class M3-profile control.

This change adds an opt-out flag. Set `view.search_results: false` on a property and `Hyrax::FlexibleCatalogBehavior` will skip registering it as a Blacklight index field (and won't add it to the `qf` query-field list for that property). Default behavior is unchanged: a property without the flag, or with `search_results: true`, continues to register as it does today.

Intentional scope boundaries — what this flag does **not** change:

- Properties already declared inside `Hyrax::CatalogController` stay declared; the flag only gates the dynamic add path. Removing pre-declared fields was considered and rejected as too broad for a profile-driven flag.
- The facet sidebar is untouched — facet visibility is still governed by `indexing: facetable`.
- The per-request `render_optionally?` hook is preserved, so Hyku's account-level "Hidden index fields" override keeps working unchanged.
- Effective only under `HYRAX_FLEXIBLE=true`. With the flag off, `FlexibleCatalogBehavior.load_flexible_schema` short-circuits and the M3 profile isn't consulted.

Example M3 profile usage:

```yaml
internal_note:
  display_label:
    default: Internal Note
  indexing:
    - stored_searchable
  view:
    html_dl: true
    search_results: false   # hide from catalog search results
```
