### PR TITLE
Hide attribute rows when all values are blank

### DIFF
--- a/app/renderers/hyrax/renderers/attribute_renderer.rb
+++ b/app/renderers/hyrax/renderers/attribute_renderer.rb
@@ -109,7 +109,6 @@ module Hyrax
       end
 
       def blank_values?
-        return true if values.blank?
         Array(values).all?(&:blank?)
       end
     end

--- a/app/renderers/hyrax/renderers/attribute_renderer.rb
+++ b/app/renderers/hyrax/renderers/attribute_renderer.rb
@@ -27,7 +27,7 @@ module Hyrax
 
       # Draw the table row for the attribute
       def render
-        return '' if values.blank? && !options[:include_empty]
+        return '' if blank_values? && !options[:include_empty]
 
         markup = %(<tr><th>#{label}</th>\n<td><ul class='tabular'>)
 
@@ -47,7 +47,7 @@ module Hyrax
 
       # Draw the dl row for the attribute
       def render_dl_row
-        return '' if values.blank? && !options[:include_empty]
+        return '' if blank_values? && !options[:include_empty]
 
         markup = %(<dt>#{label}</dt>\n<dd><ul class='tabular'>)
 
@@ -106,6 +106,11 @@ module Hyrax
 
       def work_type_label_key
         options[:work_type] ? options[:work_type].underscore : nil
+      end
+
+      def blank_values?
+        return true if values.blank?
+        Array(values).all?(&:blank?)
       end
     end
   end

--- a/app/services/hyrax/schema_loader.rb
+++ b/app/services/hyrax/schema_loader.rb
@@ -147,13 +147,11 @@ module Hyrax
       # @example
       #   Identity.of(Valkyrie::Types::String) # => Valkyrie::Types::String with blank-string → nil coercion
       class Identity
-        CoerceSingular = lambda do |value|
-          return nil if value.equal?(Dry::Types::Undefined)
-          value.is_a?(String) ? value.presence : value
-        end
-
         def self.of(type)
-          type.constructor(&CoerceSingular)
+          type.constructor do |value|
+            next nil if value.equal?(Dry::Types::Undefined)
+            value.is_a?(String) ? value.presence : value
+          end
         end
       end
 

--- a/app/services/hyrax/schema_loader.rb
+++ b/app/services/hyrax/schema_loader.rb
@@ -135,19 +135,20 @@ module Hyrax
       ##
       # @api private
       #
-      # No-op wrapper for single-value attributes. Lets `#type` build its
-      # output the same way regardless of whether the attribute holds one
-      # value or many: `wrapper.of(member_type)` either wraps it (Array)
-      # or hands it back unchanged (Identity).
+      # Single-value wrapper that matches the multi-value branch's cleanup:
+      # strips the dry-types Undefined placeholder and coerces blank strings to nil.
+      # Booleans, numbers, and other types pass through unchanged.
       #
       # @example
-      #   Identity.of(Valkyrie::Types::String) # => Valkyrie::Types::String
+      #   Identity.of(Valkyrie::Types::String) # => Valkyrie::Types::String with blank-string → nil coercion
       class Identity
-        ##
-        # @param [Dry::Types::Type]
-        # @return [Dry::Types::Type] the type passed in
+        CoerceSingular = lambda do |value|
+          return nil if value.equal?(Dry::Types::Undefined)
+          value.is_a?(String) ? value.presence : value
+        end
+
         def self.of(type)
-          type
+          type.constructor(&CoerceSingular)
         end
       end
 

--- a/spec/renderers/hyrax/renderers/attribute_renderer_spec.rb
+++ b/spec/renderers/hyrax/renderers/attribute_renderer_spec.rb
@@ -59,6 +59,27 @@ RSpec.describe Hyrax::Renderers::AttributeRenderer do
       it { expect(subject).to be_equivalent_to(expected) }
     end
 
+    context 'with an array whose entries are all blank' do
+      # A common Valkyrie persistence pattern: a single-value attribute
+      # round-trips as a one-element array containing an empty string,
+      # and a multi-value attribute can hold a mix of blank strings and
+      # nils. Neither should render any markup.
+      let(:renderer) { described_class.new(field, ['', '   ', nil]) }
+
+      it 'renders nothing when include_empty is not set' do
+        expect(renderer.render).to eq('')
+      end
+
+      context 'with include_empty: true' do
+        let(:renderer) { described_class.new(field, ['', '   ', nil], include_empty: true) }
+
+        it 'renders the row even when every value is blank' do
+          expect(renderer.render).not_to eq('')
+          expect(renderer.render).to include('<tr>')
+        end
+      end
+    end
+
     context 'with links and < characters' do
       let(:field) { :description }
       let(:renderer) { described_class.new(field, ['Foo < Bar http://www.example.com. & More Text']) }
@@ -91,6 +112,23 @@ RSpec.describe Hyrax::Renderers::AttributeRenderer do
 
     it { expect(renderer).not_to be_microdata(field) }
     it { expect(subject).to be_equivalent_to(expected) }
+
+    context 'with an array whose entries are all blank' do
+      let(:renderer) { described_class.new(field, ['', '   ', nil]) }
+
+      it 'renders nothing when include_empty is not set' do
+        expect(renderer.render_dl_row).to eq('')
+      end
+
+      context 'with include_empty: true' do
+        let(:renderer) { described_class.new(field, ['', '   ', nil], include_empty: true) }
+
+        it 'renders the row even when every value is blank' do
+          expect(renderer.render_dl_row).not_to eq('')
+          expect(renderer.render_dl_row).to include('<dt>')
+        end
+      end
+    end
   end
 
   describe "#label" do

--- a/spec/services/hyrax/schema_loader_spec.rb
+++ b/spec/services/hyrax/schema_loader_spec.rb
@@ -65,32 +65,53 @@ RSpec.describe Hyrax::SchemaLoader::AttributeDefinition do
     context 'when multiple is false' do
       let(:config) { { 'type' => 'string', 'multiple' => false } }
 
-      it 'returns a Valkyrie string type' do
-        expect(attribute_definition.type).to eq(Valkyrie::Types::String)
+      it 'returns a string-typed constructor that coerces blanks to nil' do
+        expect(attribute_definition.type).to be_a(Dry::Types::Constructor)
+        # Real strings pass through.
+        expect(attribute_definition.type.call('hello')).to eq('hello')
+        # Blank strings become nil, matching the multi-value branch's blank cleanup.
+        expect(attribute_definition.type.call('')).to be_nil
+        expect(attribute_definition.type.call('   ')).to be_nil
+        # The dry-types Undefined placeholder is dropped.
+        expect(attribute_definition.type.call(Dry::Types::Undefined)).to be_nil
+      end
+    end
+
+    context 'when multiple is false and the underlying type is non-string' do
+      let(:config) { { 'type' => 'date_time', 'multiple' => false } }
+
+      it 'wraps the type but lets non-string values pass through unchanged' do
+        expect(attribute_definition.type).to be_a(Dry::Types::Constructor)
+        time = DateTime.new(2026, 1, 1)
+        expect(attribute_definition.type.call(time)).to eq(time)
       end
     end
 
     context 'when type is id' do
       let(:config) { { 'type' => 'id' } }
 
-      it 'returns a Valkyrie ID type' do
-        expect(attribute_definition.type).to eq(Valkyrie::Types::ID)
+      it 'returns a constructor that coerces input to a Valkyrie::ID' do
+        expect(attribute_definition.type).to be_a(Dry::Types::Constructor)
+        expect(attribute_definition.type.call('abc')).to eq(Valkyrie::ID.new('abc'))
       end
     end
 
     context 'when type is uri' do
       let(:config) { { 'type' => 'uri' } }
 
-      it 'returns a Valkyrie URI type' do
-        expect(attribute_definition.type).to eq(Valkyrie::Types::URI)
+      it 'returns a constructor that coerces input to an RDF::URI' do
+        expect(attribute_definition.type).to be_a(Dry::Types::Constructor)
+        expect(attribute_definition.type.call('http://example.com')).to eq(RDF::URI('http://example.com'))
       end
     end
 
     context 'when type is date_time' do
       let(:config) { { 'type' => 'date_time' } }
 
-      it 'returns a Valkyrie DateTime type' do
-        expect(attribute_definition.type).to eq(Valkyrie::Types::DateTime)
+      it 'returns a constructor wrapping the Valkyrie DateTime type' do
+        expect(attribute_definition.type).to be_a(Dry::Types::Constructor)
+        time = DateTime.new(2026, 1, 1)
+        expect(attribute_definition.type.call(time)).to eq(time)
       end
     end
 
@@ -114,8 +135,11 @@ RSpec.describe Hyrax::SchemaLoader::AttributeDefinition do
     context 'when type is hash with multiple: false' do
       let(:config) { { 'type' => 'hash', 'multiple' => false } }
 
-      it 'returns a bare Dry::Types["hash"]' do
-        expect(attribute_definition.type).to eq(Dry::Types['hash'])
+      it 'returns a constructor wrapping Dry::Types["hash"] that passes hashes through' do
+        expect(attribute_definition.type).to be_a(Dry::Types::Constructor)
+        expect(attribute_definition.type.type).to eq(Dry::Types['hash'])
+        input = { 'path' => '/foo', 'canonical' => true }
+        expect(attribute_definition.type.call(input)).to eq(input)
       end
     end
 


### PR DESCRIPTION
## Summary
- Attribute rows on show pages no longer render an empty row when every value is blank.
- Single-value flexible-schema attributes now coerce blank strings to `nil`, matching multi-value behavior.

## Details
- `Hyrax::Renderers::AttributeRenderer#render` / `#render_dl_row` previously short-circuited only when `values` was Ruby-blank. An array of all-blank strings rendered empty `<dt>`/`<dd>` (or `<tr>`/`<td>`) rows. A new `blank_values?` predicate treats an all-blank array the same as an empty one.
- The schema loader's single-value branch (`Identity.of`) was a no-op, so blank strings survived round-trips. It now applies a `CoerceSingular` constructor that strips the dry-types `Undefined` placeholder and coerces blank strings to `nil`. Booleans, numbers, and other non-string types are unchanged.
- Single-value and multi-value attributes now apply equivalent blank-cleanup at the type boundary.