### PR TITLE
Allow editor_only in m3 profile indexing enum

### DIFF
--- a/config/metadata_profiles/m3_json_schema.json
+++ b/config/metadata_profiles/m3_json_schema.json
@@ -277,11 +277,11 @@
                   "pattern": "^[a-z_]+_(tesi|tesim|teim|ssi|sim|ssm|bsi|isi|dts|dtsi|ti|si|ss|is|bs|dt|ssim)$"
                 },
                 {
-                  "enum": ["facetable", "admin_only", "stored_searchable"]
+                  "enum": ["facetable", "admin_only", "editor_only", "stored_searchable"]
                 }
               ]
             },
-            "description": "Solr index key to map to, or behavioral flag (facetable, admin_only)."
+            "description": "Solr index key to map to, or behavioral flag (facetable, admin_only, editor_only)."
           },
           "definition": {
             "type": "object",

--- a/documentation/redirects.md
+++ b/documentation/redirects.md
@@ -76,16 +76,21 @@ properties:
         - CollectionResource
     cardinality:
       minimum: 0
+    display_label:
+      default: Redirects
     type: hash
     multiple: true
     indexing:
       - editor_only
     predicate: http://samvera.org/ns/hyku/redirects
+    range: http://www.w3.org/2001/XMLSchema#string
     view:
       render_term: redirects_path
       render_as: redirects_label
       html_dl: true
 ```
+
+The `display_label` and `range` entries are required for profile validation. `display_label.default` controls the label that appears next to the redirects field on show pages.
 
 The `indexing: [editor_only]` entry and the `view:` block together opt the redirects field into the show-page display described below in [Displaying redirect aliases on show pages](#displaying-redirect-aliases-on-show-pages). Both are required for that display to appear with editor-or-admin visibility. Note the placement: `editor_only` is an entry in the `indexing:` array (read by `Hyrax::SchemaLoader::AttributeDefinition#editor_only?`); `render_term`, `render_as`, and `html_dl` are inside the `view:` block. Non-flexible mode structures `editor_only` differently — see [Schema details](#schema-details-flexible-false-mode) below.
 

--- a/spec/services/hyrax/flexible_schema_validator_service_spec.rb
+++ b/spec/services/hyrax/flexible_schema_validator_service_spec.rb
@@ -128,6 +128,17 @@ RSpec.describe Hyrax::FlexibleSchemaValidatorService, :clean_repo do
         )
       end
     end
+    context 'when a property declares editor_only in its indexing array' do
+      before do
+        profile['properties']['title']['indexing'] = ['title_sim', 'title_tesim', 'editor_only']
+        service.validate!
+      end
+
+      it 'is valid' do
+        expect(service.errors).to be_empty
+      end
+    end
+
     context 'when the repository already contains records of a class the profile removes' do
       before do
         allow(Hyrax.query_service).to receive(:count_all_of_model).and_return(0)


### PR DESCRIPTION
## Summary

The m3 JSON schema validator's `indexing` array enum now lists editor_only alongside facetable, admin_only, and stored_searchable. Without this entry, profiles that declare editor_only on a property fail validation with "Invalid value" even though the rest of Hyrax handles the flag correctly.

Gap from the editor_only visibility feature, which added the flag across the schema loaders, view helpers, and catalog gating but overlooked the JSON schema validator that gates profile uploads.

(Includes a side update of redirects documentation so it validates appropriately as well).
