### PR TITLE
Strip query string and fragment from permalink URL

### DIFF
--- a/app/helpers/hyrax/permalink_helper.rb
+++ b/app/helpers/hyrax/permalink_helper.rb
@@ -11,7 +11,7 @@ module Hyrax
     # curation-concern resources.
     def permalink_for(presenter)
       proxy = collection_presenter?(presenter) ? hyrax : main_app
-      polymorphic_url([proxy, presenter])
+      strip_query_string(polymorphic_url([proxy, presenter]))
     end
 
     def copy_permalink_enabled?
@@ -22,6 +22,17 @@ module Hyrax
 
     def collection_presenter?(presenter)
       presenter.respond_to?(:collection?) && presenter.collection?
+    end
+
+    # Removes the `?…` query string from a URL so the permalink is a clean
+    # canonical reference. Rails URL helpers append `?locale=...` (and any
+    # other registered `default_url_options`) by default; for a stable
+    # citable URL we want the bare host + path.
+    def strip_query_string(url)
+      parsed = URI.parse(url)
+      parsed.query = nil
+      parsed.fragment = nil
+      parsed.to_s
     end
   end
 end

--- a/spec/helpers/hyrax/permalink_helper_spec.rb
+++ b/spec/helpers/hyrax/permalink_helper_spec.rb
@@ -34,5 +34,29 @@ RSpec.describe Hyrax::PermalinkHelper, type: :helper do
       expect(helper).to receive(:polymorphic_url).with([helper.main_app, bare_presenter]).and_return('http://example.test/x/1')
       expect(helper.permalink_for(bare_presenter)).to eq('http://example.test/x/1')
     end
+
+    it 'strips a locale query string appended by Rails default_url_options' do
+      expect(helper).to receive(:polymorphic_url)
+        .with([helper.main_app, work_presenter])
+        .and_return('http://example.test/concern/generic_works/abc-123?locale=en')
+      expect(helper.permalink_for(work_presenter))
+        .to eq('http://example.test/concern/generic_works/abc-123')
+    end
+
+    it 'strips any query string, not just locale' do
+      expect(helper).to receive(:polymorphic_url)
+        .with([helper.main_app, work_presenter])
+        .and_return('http://example.test/concern/generic_works/abc-123?foo=bar&baz=qux')
+      expect(helper.permalink_for(work_presenter))
+        .to eq('http://example.test/concern/generic_works/abc-123')
+    end
+
+    it 'strips a URL fragment as well' do
+      expect(helper).to receive(:polymorphic_url)
+        .with([helper.main_app, work_presenter])
+        .and_return('http://example.test/concern/generic_works/abc-123?locale=en#section')
+      expect(helper.permalink_for(work_presenter))
+        .to eq('http://example.test/concern/generic_works/abc-123')
+    end
   end
 end


### PR DESCRIPTION
## Summary

The "Copy permalink" button (and the rel=canonical link in the show-page head) now produces a clean URL without the appended ?locale=... or other query parameters Rails attaches via default_url_options. The URL is the bare host + path, suitable for citing or sharing.