### PR TITLE
Support libvips use in hydra-derivatives

### DIFF
--- a/hyrax.gemspec
+++ b/hyrax.gemspec
@@ -57,7 +57,7 @@ SUMMARY
   spec.add_dependency 'flot-rails', '~> 0.0.6'
   spec.add_dependency 'font-awesome-rails', '~> 4.2'
   spec.add_dependency 'google-analytics-data', '~> 0.6'
-  spec.add_dependency 'hydra-derivatives', '~> 4.0'
+  spec.add_dependency 'hydra-derivatives', '~> 4.1'
   spec.add_dependency 'hydra-editor', '~> 7.0'
   spec.add_dependency 'hydra-file_characterization', '~> 1.1'
   spec.add_dependency 'hydra-head', '~> 13.0'


### PR DESCRIPTION
libvips support[1] was added in hydra-derivatives 4.1.0 and we would like to be able to use it to address some performance issues we're having generating image derivatives for large images.

I'm not sure what else needs to be addressed to potentially make this branch suitable for review/merge so starting with just the gemspec/version bump for consideration. Thank you!

1. https://github.com/samvera/hydra-derivatives/commit/c8effd03ca180709c522b92bdc3d4c8ecb1b3eef

@samvera/hyrax-code-reviewers
