### PR TITLE
Only run one workflow at a time per PR

### DIFF
--- a/.github/workflows/lint-build-test.yml
+++ b/.github/workflows/lint-build-test.yml
@@ -15,6 +15,10 @@ on:
         required: false
         default: false
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}-dev


### PR DESCRIPTION
Adds concurrency group and cancel-in-progress to the CI workflow. The intent is if a PR or branch is updated with new commits then any specs running will be cancelled.