### PR TITLE
Add display_url column for redirect aliases

### DIFF
--- a/.dassie/db/migrate/20260518000001_add_display_url_to_hyrax_redirect_paths.hyrax.rb
+++ b/.dassie/db/migrate/20260518000001_add_display_url_to_hyrax_redirect_paths.hyrax.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+class AddDisplayUrlToHyraxRedirectPaths < ActiveRecord::Migration[5.2]
+  def change
+    add_column :hyrax_redirect_paths, :display_url, :boolean, default: false, null: false
+  end
+end

--- a/.dassie/db/schema.rb
+++ b/.dassie/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2026_04_30_000001) do
+ActiveRecord::Schema.define(version: 2026_05_18_000001) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -313,6 +313,7 @@ ActiveRecord::Schema.define(version: 2026_04_30_000001) do
     t.string "resource_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "display_url", default: false, null: false
     t.index ["path"], name: "index_hyrax_redirect_paths_on_path", unique: true
     t.index ["resource_id"], name: "index_hyrax_redirect_paths_on_resource_id"
   end

--- a/.koppie/db/migrate/20260518000001_add_display_url_to_hyrax_redirect_paths.hyrax.rb
+++ b/.koppie/db/migrate/20260518000001_add_display_url_to_hyrax_redirect_paths.hyrax.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+class AddDisplayUrlToHyraxRedirectPaths < ActiveRecord::Migration[5.2]
+  def change
+    add_column :hyrax_redirect_paths, :display_url, :boolean, default: false, null: false
+  end
+end

--- a/.koppie/db/schema.rb
+++ b/.koppie/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_04_30_000001) do
+ActiveRecord::Schema[7.2].define(version: 2026_05_18_000001) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "uuid-ossp"
@@ -304,6 +304,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_04_30_000001) do
     t.string "resource_id", null: false
     t.datetime "created_at", precision: nil, null: false
     t.datetime "updated_at", precision: nil, null: false
+    t.boolean "display_url", default: false, null: false
     t.index ["path"], name: "index_hyrax_redirect_paths_on_path", unique: true
     t.index ["resource_id"], name: "index_hyrax_redirect_paths_on_resource_id"
   end

--- a/app/forms/concerns/hyrax/redirects_field_behavior.rb
+++ b/app/forms/concerns/hyrax/redirects_field_behavior.rb
@@ -7,8 +7,8 @@ module Hyrax
   # turned into plain hashes (the persisted shape — see
   # `config/metadata/redirects.yaml`, `type: hash`) by the populator.
   # On render, the prepopulator wraps each persisted hash in a
-  # `Hyrax::Redirect` value object so the view can call `.path` /
-  # `.canonical` / `.sequence`.
+  # `Hyrax::Redirect` value object so the view can call `.path` and
+  # `.display_url`.
   #
   # The `deserialize!` override removes the renamed `redirects` key
   # before Reform's `from_hash` runs, so the form's `redirects`
@@ -54,17 +54,15 @@ module Hyrax
     # Builds plain hashes (the persisted shape) from the submitted
     # `redirects_attributes` payload. Drops rows marked for destruction
     # or with a blank path. Normalizes paths up-front so the validator
-    # sees canonical form (so DSpace-style pasted URLs validate cleanly).
-    # or with a blank path.
+    # sees normalized form (so DSpace-style pasted URLs validate cleanly).
     def redirects_attributes_populator(fragment:, **_options)
       return unless respond_to?(:redirects)
       return unless Hyrax.config.redirects_active?
       entries = Array(fragment&.values)
                 .reject { |row| row['_destroy'].to_s == 'true' || row['path'].to_s.strip.empty? }
-                .each_with_index.map do |row, i|
+                .map do |row|
         { 'path' => Hyrax::RedirectPathNormalizer.call(row['path']),
-          'canonical' => row['canonical'].to_s == 'true',
-          'sequence' => row['sequence'].presence&.to_i || i }
+          'display_url' => row['display_url'].to_s == 'true' }
       end
       self.redirects = entries
     end

--- a/app/forms/hyrax/forms/resource_form.rb
+++ b/app/forms/hyrax/forms/resource_form.rb
@@ -28,6 +28,7 @@ module Hyrax
 
       include BasedNearFieldBehavior
       include RedirectsFieldBehavior
+      include Hyrax::FormFields(:redirects) if Hyrax.config.redirects_enabled? && !Hyrax.config.flexible?
       class_attribute :model_class
 
       property :human_readable_type, writable: false
@@ -89,7 +90,6 @@ module Hyrax
               to_remove = singleton_class.definitions.select { |k, v| !deprecated_resource.respond_to?(k) && v.instance_variable_get("@options")[:display] }
               to_remove.keys.each { |removed_field| singleton_class.definitions.delete(removed_field) }
             end
-            install_redirects_property_if_supported(deprecated_resource)
             super(deprecated_resource)
           else
             super()
@@ -108,21 +108,10 @@ module Hyrax
             end
           end
 
-          install_redirects_property_if_supported(resource)
           super(resource)
         end
       end
-
-      # Install the `redirects` form property on the singleton class when
-      # the resource actually has it. Runs after any flexible-mode resource
-      # reconstruction so we check the resource Reform will see — not the
-      # pre-reconstruction copy whose schema version may be stale.
-      def install_redirects_property_if_supported(resource_for_form)
-        return unless Hyrax.config.redirects_enabled?
-        return unless resource_for_form&.respond_to?(:redirects)
-        return if singleton_class.definitions.key?(:redirects)
-        singleton_class.include Hyrax::FormFields(:redirects)
-      end # rubocop:enable Metrics/MethodLength, Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+      # rubocop:enable Metrics/MethodLength, Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
 
       class << self
         def inherited(subclass)

--- a/app/forms/hyrax/forms/resource_form.rb
+++ b/app/forms/hyrax/forms/resource_form.rb
@@ -28,7 +28,7 @@ module Hyrax
 
       include BasedNearFieldBehavior
       include RedirectsFieldBehavior
-      include Hyrax::FormFields(:redirects) if Hyrax.config.redirects_enabled? && !Hyrax.config.flexible?
+      include Hyrax::FormFields(:redirects) if Hyrax.config.redirects_enabled? && Hyrax.config.work_include_metadata?
       class_attribute :model_class
 
       property :human_readable_type, writable: false

--- a/app/models/hyrax/redirect.rb
+++ b/app/models/hyrax/redirect.rb
@@ -2,9 +2,8 @@
 
 module Hyrax
   ##
-  # Wraps a single redirect entry for use in form views, providing
-  # `.path`, `.canonical`, and `.sequence` readers over the underlying
-  # persisted hash.
+  # Wraps a single redirect entry for use in form views, providing `.path`
+  # and `.display_url` readers over the underlying persisted hash.
   #
   # Redirects are persisted as plain hashes on the parent work or
   # collection. Form-render code calls `Hyrax::Redirect.wrap(entry)` to
@@ -12,17 +11,16 @@ module Hyrax
   # validator, indexer, sync step) reads the persisted hash directly.
   #
   # @example
-  #   Hyrax::Redirect.new(path: '/handle/12345/678', canonical: false)
-  #   Hyrax::Redirect.wrap('path' => '/foo', 'canonical' => true)
+  #   Hyrax::Redirect.new(path: '/handle/12345/678', display_url: false)
+  #   Hyrax::Redirect.wrap('path' => '/foo', 'display_url' => true)
   class Redirect
-    attr_reader :path, :canonical, :sequence
+    attr_reader :path, :display_url
 
     ##
     # Accept nil values so the view can build an empty trailing row.
-    def initialize(path: nil, canonical: false, sequence: nil)
+    def initialize(path: nil, display_url: false)
       @path = path
-      @canonical = canonical
-      @sequence = sequence
+      @display_url = display_url
     end
 
     ##
@@ -37,13 +35,13 @@ module Hyrax
       raise ArgumentError, "cannot wrap #{input.class} as Hyrax::Redirect" unless input.respond_to?(:to_h)
 
       h = input.to_h.transform_keys(&:to_s)
-      new(path: h['path'], canonical: h.fetch('canonical', false), sequence: h['sequence'])
+      new(path: h['path'], display_url: h.fetch('display_url', false))
     end
 
     ##
     # @return [Hash{String => Object}] string-keyed hash matching the persisted shape.
     def to_h
-      { 'path' => path, 'canonical' => canonical, 'sequence' => sequence }
+      { 'path' => path, 'display_url' => display_url }
     end
 
     def as_json(*)
@@ -55,13 +53,12 @@ module Hyrax
     def ==(other)
       other.is_a?(Hyrax::Redirect) &&
         other.path == path &&
-        other.canonical == canonical &&
-        other.sequence == sequence
+        other.display_url == display_url
     end
     alias eql? ==
 
     def hash
-      [path, canonical, sequence].hash
+      [path, display_url].hash
     end
   end
 end

--- a/app/services/hyrax/schema_loader.rb
+++ b/app/services/hyrax/schema_loader.rb
@@ -163,9 +163,9 @@ module Hyrax
       # Recognized values:
       #   - `id`, `uri`, `date_time` — Valkyrie type shortcuts.
       #   - `hash` — for attributes whose entries carry multiple sub-fields
-      #     (e.g. redirects, with path / canonical / sequence). Use this
-      #     instead of nesting a Valkyrie::Resource. See
-      #     `documentation/redirects.md` for a worked example.
+      #     (e.g. redirects, with path / display_url). Use this instead of
+      #     nesting a Valkyrie::Resource. See `documentation/redirects.md`
+      #     for a worked example.
       #   - Any primitive Valkyrie type, looked up under `Valkyrie::Types::*`
       #     by classified name (e.g. `string` → `Valkyrie::Types::String`).
       #

--- a/app/validators/hyrax/redirect_validator.rb
+++ b/app/validators/hyrax/redirect_validator.rb
@@ -29,7 +29,7 @@ module Hyrax
       validate_each_entry(record, attribute, entries)
       validate_intra_record_uniqueness(record, attribute, entries)
       validate_global_uniqueness(record, attribute, entries)
-      validate_at_most_one_canonical(record, attribute, entries)
+      validate_at_most_one_display_url(record, attribute, entries)
     end
 
     private
@@ -42,9 +42,9 @@ module Hyrax
       nil
     end
 
-    def canonical_for(entry)
-      return entry.canonical if entry.respond_to?(:canonical)
-      return entry.key?('canonical') ? entry['canonical'] : entry[:canonical] if entry.respond_to?(:[])
+    def display_url_for(entry)
+      return entry.display_url if entry.respond_to?(:display_url)
+      return entry.key?('display_url') ? entry['display_url'] : entry[:display_url] if entry.respond_to?(:[])
       nil
     end
 
@@ -96,10 +96,10 @@ module Hyrax
       Hyrax::RedirectPathNormalizer.call(path)
     end
 
-    def validate_at_most_one_canonical(record, attribute, entries)
-      canonical_count = entries.count { |entry| canonical_for(entry) }
-      return if canonical_count <= 1
-      record.errors.add(attribute, message_for(:multiple_canonical))
+    def validate_at_most_one_display_url(record, attribute, entries)
+      display_url_count = entries.count { |entry| display_url_for(entry) }
+      return if display_url_count <= 1
+      record.errors.add(attribute, message_for(:multiple_display_url))
     end
 
     def message_for(key, **interpolations)

--- a/app/views/hyrax/base/_form_redirects.html.erb
+++ b/app/views/hyrax/base/_form_redirects.html.erb
@@ -14,10 +14,10 @@
   </thead>
   <tbody>
     <%# Wrap each row through Hyrax::Redirect.wrap so the view can rely on
-        the presenter API (.path, .canonical, .sequence). On initial render
-        the prepopulator already wrapped them; on a re-render after a
-        failed save, f.object.redirects holds the populator's plain hashes,
-        and we wrap them here. %>
+        the presenter API (.path, .display_url). On initial render the
+        prepopulator already wrapped them; on a re-render after a failed
+        save, f.object.redirects holds the populator's plain hashes, and
+        we wrap them here. %>
     <% rows = Array(f.object.redirects).map { |e| Hyrax::Redirect.wrap(e) } + [Hyrax::Redirect.new(path: nil)] %>
     <% rows.each_with_index do |entry, index| %>
       <% input_id = "#{f.object_name}_redirects_attributes_#{index}_path" %>

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -43,7 +43,7 @@ en:
         blank: A redirect path can't be blank.
         intra_record_duplicate: '"%{path}" is listed more than once on this record.'
         invalid_format: '"%{path}" is not a valid path. Paths must start with "/" and contain no spaces, "?", or "#".'
-        multiple_canonical: At most one redirect entry may be marked canonical.
+        multiple_display_url: At most one redirect entry may be marked as the display URL.
         reserved_prefix: '"%{path}" can''t be used. The path is reserved by the application and may not be used as an alias.'
   helpers:
     action:

--- a/documentation/forms/field_behaviors.md
+++ b/documentation/forms/field_behaviors.md
@@ -10,8 +10,8 @@ Use a Field Behavior when you have a property that:
 
 Two reference exemplars ship with Hyrax:
 
-- `Hyrax::BasedNearFieldBehavior` — single-string-per-entry (URI), hydrated to a `ControlledVocabularies::Location` for the view.
-- `Hyrax::RedirectsFieldBehavior` — multi-field-per-entry (path / canonical / sequence), hydrated to a `Hyrax::Redirect` presenter for the view.
+- `Hyrax::BasedNearFieldBehavior` — single-string-per-entry (URI), wrapped in a `ControlledVocabularies::Location` for the view.
+- `Hyrax::RedirectsFieldBehavior` — multi-field-per-entry (path / display_url), wrapped in a `Hyrax::Redirect` presenter for the view.
 
 This document covers the contract a Field Behavior must satisfy, the decision points for a new behavior, and the worked examples.
 
@@ -68,7 +68,7 @@ A Field Behavior is a module that:
 
    Drop empty rows and rows marked `_destroy` here. Normalize values here too — the persisted shape should be canonical so non-form callers (importers, console, validators) don't have to re-normalize.
 
-4. **Provides a prepopulator** that hydrates the persisted value into a render-friendly object.
+4. **Provides a prepopulator** that wraps each persisted entry in a render-friendly object.
 
    ```ruby
    def <name>_attributes_prepopulator
@@ -126,7 +126,7 @@ When adding a Field Behavior, work through these:
 ### 1. What does each entry look like?
 
 - **Single value per entry** (URI string, scalar): see `BasedNearFieldBehavior`.
-- **Multiple sub-fields per entry** (path + canonical + sequence; or label + value + lang): see `RedirectsFieldBehavior`.
+- **Multiple sub-fields per entry** (path + display_url; or label + value + lang): see `RedirectsFieldBehavior`.
 
 ### 2. Persisted as what?
 
@@ -223,10 +223,9 @@ module Hyrax
       return unless Hyrax.config.redirects_active?
       entries = Array(fragment&.values)
                 .reject { |row| row['_destroy'].to_s == 'true' || row['path'].to_s.strip.empty? }
-                .each_with_index.map do |row, i|
+                .map do |row|
         { 'path' => Hyrax::RedirectPathNormalizer.call(row['path']),
-          'canonical' => row['canonical'].to_s == 'true',
-          'sequence' => row['sequence'].presence&.to_i || i }
+          'display_url' => row['display_url'].to_s == 'true' }
       end
       self.redirects = entries
     end
@@ -240,9 +239,9 @@ module Hyrax
 end
 ```
 
-- **Persisted shape:** array of plain hashes (`'path'`, `'canonical'`, `'sequence'`). Declared with `type: hash, multiple: true` in `config/metadata/redirects.yaml` and loaded onto the form via `Hyrax::FormFields(:redirects)` in `self.included`.
-- **View-side shape:** array of `Hyrax::Redirect` presenters, exposing `.path` / `.canonical` / `.sequence`.
-- **Diff from BasedNear:** entries carry multiple sub-fields, so the persisted shape is a hash rather than a string. The populator normalizes paths up front (canonical form lives in storage). The behavior is feature-gated — every callback consults `Hyrax.config.redirects_active?`. The behavior also loads the persisted `redirects` property from YAML in `self.included`, since `Hyrax::Schema(:redirects)` puts the attribute on the model but the form needs the property registered separately for the partial's `f.object.redirects` call to work.
+- **Persisted shape:** array of plain hashes (`'path'`, `'display_url'`). Declared with `type: hash, multiple: true` in `config/metadata/redirects.yaml` and loaded onto the form via `Hyrax::FormFields(:redirects)`.
+- **View-side shape:** array of `Hyrax::Redirect` presenters, exposing `.path` and `.display_url`.
+- **Diff from BasedNear:** entries carry multiple sub-fields, so the persisted shape is a hash rather than a string. The populator normalizes paths up front (canonical form lives in storage). The behavior is feature-gated — every callback consults `Hyrax.config.redirects_active?`.
 
 ## Wiring on `ResourceForm`
 
@@ -277,12 +276,11 @@ Example for `RedirectsFieldBehavior`:
 
 ```ruby
 # In the host app's Bulkrax field-mapping configuration
-'path'      => { from: ['redirect_path'],      object: 'redirects', nested_attributes: true },
-'canonical' => { from: ['redirect_canonical'], object: 'redirects', nested_attributes: true },
-'sequence'  => { from: ['redirect_sequence'],  object: 'redirects', nested_attributes: true },
+'path'        => { from: ['redirect_path'],        object: 'redirects', nested_attributes: true },
+'display_url' => { from: ['redirect_display_url'], object: 'redirects', nested_attributes: true }
 ```
 
-CSV columns are `redirect_path_1`, `redirect_canonical_1`, `redirect_sequence_1`, `redirect_path_2`, …
+CSV columns are `redirect_path_1`, `redirect_display_url_1`, `redirect_path_2`, `redirect_display_url_2`, …
 
 Conventions:
 

--- a/documentation/redirects.md
+++ b/documentation/redirects.md
@@ -80,6 +80,8 @@ properties:
       default: Redirects
     type: hash
     multiple: true
+    form:
+      display: false
     indexing:
       - editor_only
     predicate: http://samvera.org/ns/hyku/redirects
@@ -89,6 +91,8 @@ properties:
       render_as: redirects_label
       html_dl: true
 ```
+
+The `form:` block is required in m3. Without it, the m3 form-definition loader skips the property (its filter drops attributes with empty `form_options`), and the Aliases tab errors when the partial reads `f.object.redirects`. The Aliases UI is rendered by `_form_redirects.html.erb`, not by the auto-generated form, so `display: false` is the right value here.
 
 The `display_label` and `range` entries are required for profile validation. `display_label.default` controls the label that appears next to the redirects field on show pages.
 

--- a/documentation/redirects.md
+++ b/documentation/redirects.md
@@ -98,7 +98,7 @@ The `display_label` and `range` entries are required for profile validation. `di
 
 The `indexing: [editor_only]` entry and the `view:` block together opt the redirects field into the show-page display described below in [Displaying redirect aliases on show pages](#displaying-redirect-aliases-on-show-pages). Both are required for that display to appear with editor-or-admin visibility. Note the placement: `editor_only` is an entry in the `indexing:` array (read by `Hyrax::SchemaLoader::AttributeDefinition#editor_only?`); `render_term`, `render_as`, and `html_dl` are inside the `view:` block. Non-flexible mode structures `editor_only` differently — see [Schema details](#schema-details-flexible-false-mode) below.
 
-Each redirect entry is a plain hash with `path`, `canonical`, and `sequence` keys, persisted as JSONB on the parent resource. The `type: hash` token resolves to `Dry::Types['hash']`, which round-trips entries through Postgres without the sub-field stripping a nested `Valkyrie::Resource` would suffer. `available_on.class` must include at least one work or collection class declared in this profile's top-level `classes:` block; substitute the class names your profile declares (`Image`, `Etd`, `Oer`, etc.) as appropriate.
+Each redirect entry is a plain hash with `path` and `display_url` keys, persisted as JSONB on the parent resource. The `type: hash` token resolves to `Dry::Types['hash']`, which round-trips entries through Postgres without the sub-field stripping a nested `Valkyrie::Resource` would suffer. `available_on.class` must include at least one work or collection class declared in this profile's top-level `classes:` block; substitute the class names your profile declares (`Image`, `Etd`, `Oer`, etc.) as appropriate.
 
 Validation matrix on profile save (with the config on):
 
@@ -142,7 +142,7 @@ When the config is on, this schema is loaded and `Hyrax::Work` / `Hyrax::PcdmCol
 attribute :redirects, Valkyrie::Types::Array.of(Dry::Types['hash'])
 ```
 
-Each entry is a plain hash with `path`, `canonical`, and `sequence` keys. Entries persist as JSONB on the parent resource, so sub-fields round-trip cleanly without an intermediate nested-resource schema mangling them. `Hyrax::Redirect` is retained as a thin Ruby presenter the form view consumes; non-form code (validator, indexer, sync step) reads the persisted hash directly.
+Each entry is a plain hash with `path` and `display_url` keys. Entries persist as JSONB on the parent resource, so sub-fields round-trip cleanly without an intermediate nested-resource schema mangling them. `Hyrax::Redirect` is retained as a thin Ruby presenter the form view consumes; non-form code (validator, indexer, sync step) reads the persisted hash directly.
 
 When the config is off, the loader filters `redirects.yaml` out of the schema set entirely. The file is on disk but invisible to `permissive_schema_for_valkrie_adapter`, `Hyrax::Schema(:redirects)`, and any other consumer of the simple schema loader.
 
@@ -180,7 +180,7 @@ The validator enforces six rules on the `redirects` attribute:
 | Reserved prefix | path equals or starts with one of `Hyrax.config.reserved_redirect_prefixes` (defaults to the routes Hyrax itself reserves) | the path is reserved by the application and may not be used as an alias |
 | Intra-record uniqueness | the same path appears more than once on a single record | `is listed more than once on this record` |
 | Global uniqueness | the path is already in use on a different record (excluding the current record's own id) | `is already in use by another record` |
-| At most one canonical | more than one entry has `canonical: true` | `at most one redirect entry may be marked canonical` |
+| At most one display URL | more than one entry has `display_url: true` | `at most one redirect entry may be marked as the display URL` |
 
 ### Reserved-prefix list
 
@@ -330,23 +330,22 @@ Institutions migrating from another repository typically have hundreds to thousa
 
 ### CSV column format
 
-Each redirect entry maps to three numbered columns: `redirect_path_<n>`, `redirect_canonical_<n>`, `redirect_sequence_<n>`. A row with two redirects, one canonical:
+Each redirect entry maps to two numbered columns: `redirect_path_<n>` and `redirect_display_url_<n>`. A row with two redirects, one marked as the display URL:
 
 ```csv
-source_identifier,title,redirect_path_1,redirect_canonical_1,redirect_sequence_1,redirect_path_2,redirect_canonical_2,redirect_sequence_2
-work-001,My Work,/handle/12345/678,true,0,/old/path/678,false,1
+source_identifier,title,redirect_path_1,redirect_display_url_1,redirect_path_2,redirect_display_url_2
+work-001,My Work,/handle/12345/678,true,/old/path/678,false
 ```
 
-`canonical` accepts the literal string `true` or `false` (boolean strings, not `1`/`0`). At most one entry per record may be canonical. `sequence` is an integer that orders the entries; if omitted, Bulkrax uses the column position.
+`display_url` accepts the literal string `true` or `false` (boolean strings, not `1`/`0`). At most one entry per record may be marked as the display URL.
 
 ### Field-mapping configuration
 
 Add to the host app's Bulkrax field-mapping configuration (usually `config/initializers/default_bulkrax_mappings.rb` or a per-tenant override):
 
 ```ruby
-'path'      => { from: ['redirect_path'],      object: 'redirects', nested_attributes: true },
-'canonical' => { from: ['redirect_canonical'], object: 'redirects', nested_attributes: true },
-'sequence'  => { from: ['redirect_sequence'],  object: 'redirects', nested_attributes: true },
+'path'        => { from: ['redirect_path'],        object: 'redirects', nested_attributes: true },
+'display_url' => { from: ['redirect_display_url'], object: 'redirects', nested_attributes: true }
 ```
 
 See [field_behaviors.md](forms/field_behaviors.md#wiring-up-bulkrax-imports) for the conventions around the `nested_attributes: true` flag.
@@ -365,7 +364,7 @@ If the redirects feature was just enabled (config + Flipflop turned on) and exis
 
 - **"is reserved by the application and may not be used as an alias"** — the path matches a reserved prefix. Choose a different path or extend `Hyrax.config.reserved_redirect_prefixes` if the conflict is intentional.
 - **"is already in use by another record"** — the path is registered as a redirect on a different work or collection. Paths are globally unique.
-- **"at most one redirect entry may be marked canonical"** — multiple rows in the same CSV record have `redirect_canonical_<n>=true`. Only one entry per record may be canonical.
+- **"at most one redirect entry may be marked as the display URL"** — multiple rows in the same CSV record have `redirect_display_url_<n>=true`. Only one entry per record may be marked as the display URL.
 - **m3 profile validation: "redirects property is required"** (flexible mode) — the Flipflop is on but the m3 profile doesn't declare the `redirects` property. Add it per the section above.
 - **m3 profile validation: "the property will be ignored"** (flexible mode, config off) — a stale `redirects` property is declared but the config is off. Either remove the property from the profile or re-enable the config.
 

--- a/lib/generators/hyrax/templates/db/migrate/20260518000001_add_display_url_to_hyrax_redirect_paths.rb.erb
+++ b/lib/generators/hyrax/templates/db/migrate/20260518000001_add_display_url_to_hyrax_redirect_paths.rb.erb
@@ -1,0 +1,5 @@
+class AddDisplayUrlToHyraxRedirectPaths < ActiveRecord::Migration<%= migration_version %>
+  def change
+    add_column :hyrax_redirect_paths, :display_url, :boolean, default: false, null: false
+  end
+end

--- a/lib/hyrax/transactions/steps/sync_redirect_paths.rb
+++ b/lib/hyrax/transactions/steps/sync_redirect_paths.rb
@@ -42,29 +42,34 @@ module Hyrax
         def build_rows(object)
           # Valkyrie's JSONValueMapper symbolizes hash keys on read; accept either.
           # Paths are normalized at write time by Hyrax::RedirectsNormalization.
-          paths = Array(object.redirects)
-                  .map { |entry| entry['path'] || entry[:path] }
-                  .reject(&:blank?)
-                  .uniq
+          seen = Set.new
           now = Time.current
-          paths.map { |path| { path: path, resource_id: object.id.to_s, created_at: now, updated_at: now } }
+          Array(object.redirects).each_with_object([]) do |entry, rows|
+            path = entry['path'] || entry[:path]
+            next if path.blank? || seen.include?(path)
+            seen << path
+
+            display_url = entry['display_url'] || entry[:display_url]
+            rows << { path: path, resource_id: object.id.to_s, display_url: display_url ? true : false,
+                      created_at: now, updated_at: now }
+          end
         end
 
         # @return [Array<String>, nil] the union of old + new paths that need
         #   cache invalidation, or nil when nothing changed.
         def replace_rows(object, rows)
-          desired_paths = rows.map { |r| r[:path] }.sort
+          desired = rows.map { |r| [r[:path], r[:display_url]] }.sort
 
           Hyrax::RedirectPath.transaction do
-            existing_paths = Hyrax::RedirectPath.where(resource_id: object.id.to_s).pluck(:path).sort
-            return nil if desired_paths == existing_paths
+            existing_rows = Hyrax::RedirectPath.where(resource_id: object.id.to_s).pluck(:path, :display_url)
+            return nil if desired == existing_rows.sort
 
             Hyrax::RedirectPath.where(resource_id: object.id.to_s).delete_all
             # rubocop:disable Rails/SkipsModelValidations -- the DB unique index on `path` is the validation we rely on; bulk insert is intentional
             Hyrax::RedirectPath.insert_all!(rows) if rows.any?
             # rubocop:enable Rails/SkipsModelValidations
 
-            (existing_paths | desired_paths)
+            (existing_rows.map(&:first) | rows.map { |r| r[:path] })
           end
         end
       end

--- a/spec/forms/concerns/hyrax/redirects_field_behavior_spec.rb
+++ b/spec/forms/concerns/hyrax/redirects_field_behavior_spec.rb
@@ -72,21 +72,21 @@ RSpec.describe Hyrax::RedirectsFieldBehavior do
   describe '#redirects_attributes_populator' do
     it 'normalizes paths and produces the persisted hash shape' do
       fragment = {
-        '0' => { 'path' => '  /foo/  ', 'canonical' => 'true' },
-        '1' => { 'path' => '/bar', 'canonical' => 'false', 'sequence' => '5' }
+        '0' => { 'path' => '  /foo/  ', 'display_url' => 'true' },
+        '1' => { 'path' => '/bar', 'display_url' => 'false' }
       }
       form.send(:redirects_attributes_populator, fragment: fragment)
 
       expect(form.redirects).to eq([
-                                     { 'path' => '/foo', 'canonical' => true, 'sequence' => 0 },
-                                     { 'path' => '/bar', 'canonical' => false, 'sequence' => 5 }
+                                     { 'path' => '/foo', 'display_url' => true },
+                                     { 'path' => '/bar', 'display_url' => false }
                                    ])
     end
 
     it 'drops rows marked for destruction' do
       fragment = {
-        '0' => { 'path' => '/keep', 'canonical' => 'false' },
-        '1' => { 'path' => '/drop', 'canonical' => 'false', '_destroy' => 'true' }
+        '0' => { 'path' => '/keep', 'display_url' => 'false' },
+        '1' => { 'path' => '/drop', 'display_url' => 'false', '_destroy' => 'true' }
       }
       form.send(:redirects_attributes_populator, fragment: fragment)
 
@@ -95,8 +95,8 @@ RSpec.describe Hyrax::RedirectsFieldBehavior do
 
     it 'drops rows with a blank path' do
       fragment = {
-        '0' => { 'path' => '/keep', 'canonical' => 'false' },
-        '1' => { 'path' => '   ', 'canonical' => 'false' }
+        '0' => { 'path' => '/keep', 'display_url' => 'false' },
+        '1' => { 'path' => '   ', 'display_url' => 'false' }
       }
       form.send(:redirects_attributes_populator, fragment: fragment)
 
@@ -114,12 +114,12 @@ RSpec.describe Hyrax::RedirectsFieldBehavior do
 
   describe '#redirects_attributes_prepopulator' do
     it 'wraps each persisted hash entry in a Hyrax::Redirect presenter' do
-      form.redirects = [{ 'path' => '/foo', 'canonical' => true, 'sequence' => 0 }]
+      form.redirects = [{ 'path' => '/foo', 'display_url' => true }]
       form.send(:redirects_attributes_prepopulator)
 
       expect(form.redirects.first).to be_a(Hyrax::Redirect)
       expect(form.redirects.first.path).to eq('/foo')
-      expect(form.redirects.first.canonical).to be(true)
+      expect(form.redirects.first.display_url).to be(true)
     end
 
     it 'is a no-op when the feature is inactive' do

--- a/spec/forms/hyrax/forms/resource_form_spec.rb
+++ b/spec/forms/hyrax/forms/resource_form_spec.rb
@@ -261,16 +261,6 @@ RSpec.describe Hyrax::Forms::ResourceForm do
   end
 
   describe '#redirects' do
-    # The view partial `_form_redirects.html.erb` calls `f.object.redirects`
-    # directly. The bare `redirects` property is installed per-resource at
-    # form init time when the resource has the attribute; the
-    # `redirects_attributes` virtual property is installed by
-    # `RedirectsFieldBehavior`.
-    #
-    # The engine test suite boots with `redirects_enabled?` off, so the
-    # app's models and forms don't carry the redirects properties. Build
-    # a synthetic resource and form with the gate stubbed open, mirroring
-    # an installation that has the feature on.
     subject(:form) { form_class.new(resource_class.new) }
 
     before do
@@ -296,68 +286,21 @@ RSpec.describe Hyrax::Forms::ResourceForm do
     end
   end
 
-  # Per-resource install of the `redirects` property. The form declares
-  # `redirects` only when the concrete resource has it as an attribute —
-  # this single check handles all combinations of base-class metadata
-  # gates and per-class flexibility.
-  describe 'redirects per-resource installation' do
-    let(:no_redirects_resource) do
-      klass = Class.new(Hyrax::Resource) do
-        def self.name
-          'NoRedirectsTestResource'
-        end
-      end
-      stub_const('NoRedirectsTestResource', klass)
-      klass.new
-    end
-
-    let(:with_redirects_resource) do
-      klass = Class.new(Hyrax::Resource) do
-        attribute :redirects, Valkyrie::Types::Array.of(Dry::Types['hash'])
-        def self.name
-          'WithRedirectsTestResource'
-        end
-      end
-      stub_const('WithRedirectsTestResource', klass)
-      klass.new
-    end
-
-    let(:redirects_form_class) do
+  # Class-level `include Hyrax::FormFields(:redirects)` is what makes
+  # Reform's `sync` step write the populator's assignment to the model.
+  # Without it, the form responds to `:redirects` via method-missing
+  # delegation but Reform drops the assigned value during sync. Validate
+  # that including FormFields(:redirects) on a form actually registers
+  # the property in Reform's `definitions` registry.
+  describe 'FormFields(:redirects) registers a Reform property' do
+    let(:synthetic_form_class) do
       Class.new(Hyrax::Forms::ResourceForm) do
-        include Hyrax::RedirectsFieldBehavior
+        include Hyrax::FormFields(:redirects)
       end
     end
 
-    before do
-      allow(Hyrax.config).to receive(:redirects_enabled?).and_return(true)
-    end
-
-    context 'when the resource has the redirects attribute' do
-      it 'installs the redirects property on the form' do
-        form = redirects_form_class.new(with_redirects_resource)
-        expect(form).to respond_to(:redirects)
-      end
-
-      it 'installs the redirects_attributes virtual property too' do
-        form = redirects_form_class.new(with_redirects_resource)
-        expect(form).to respond_to(:redirects_attributes)
-      end
-    end
-
-    context 'when the resource lacks the redirects attribute' do
-      it 'does not crash on form initialization' do
-        expect { redirects_form_class.new(no_redirects_resource) }.not_to raise_error
-      end
-
-      it 'does not install the redirects property' do
-        form = redirects_form_class.new(no_redirects_resource)
-        expect(form).not_to respond_to(:redirects)
-      end
-
-      it 'still installs the redirects_attributes virtual property (it does not read from the model)' do
-        form = redirects_form_class.new(no_redirects_resource)
-        expect(form).to respond_to(:redirects_attributes)
-      end
+    it 'registers `redirects` in the form class definitions' do
+      expect(synthetic_form_class.definitions.key?('redirects')).to be true
     end
   end
 

--- a/spec/forms/hyrax/forms/resource_form_spec.rb
+++ b/spec/forms/hyrax/forms/resource_form_spec.rb
@@ -270,9 +270,12 @@ RSpec.describe Hyrax::Forms::ResourceForm do
 
     let(:resource_class) { RedirectsTestResource }
 
+    # Re-include redirects here so the property is
+    # registered regardless of boot-time env.
     let(:form_class) do
       resource = resource_class
       Class.new(Hyrax::Forms::ResourceForm(resource)) do
+        include Hyrax::FormFields(:redirects)
         include Hyrax::RedirectsFieldBehavior
       end
     end
@@ -293,6 +296,8 @@ RSpec.describe Hyrax::Forms::ResourceForm do
   # that including FormFields(:redirects) on a form actually registers
   # the property in Reform's `definitions` registry.
   describe 'FormFields(:redirects) registers a Reform property' do
+    before { allow(Hyrax.config).to receive(:redirects_enabled?).and_return(true) }
+
     let(:synthetic_form_class) do
       Class.new(Hyrax::Forms::ResourceForm) do
         include Hyrax::FormFields(:redirects)

--- a/spec/helpers/hyrax/redirects_tab_helper_spec.rb
+++ b/spec/helpers/hyrax/redirects_tab_helper_spec.rb
@@ -69,7 +69,10 @@ RSpec.describe Hyrax::RedirectsTabHelper, type: :helper do
 
   describe '#redirects_supported_form?' do
     it 'returns true for a Hyrax::Forms::ResourceForm instance' do
-      form = Hyrax::Forms::ResourceForm.new(Hyrax::Resource.new)
+      # Use allocate to skip ResourceForm#initialize
+      # The helper under test is a plain is_a? check, so we don't need an
+      # initialized form instance.
+      form = Hyrax::Forms::ResourceForm.allocate
       expect(helper.redirects_supported_form?(form)).to be(true)
     end
 

--- a/spec/lib/hyrax/transactions/steps/sync_redirect_paths_spec.rb
+++ b/spec/lib/hyrax/transactions/steps/sync_redirect_paths_spec.rb
@@ -25,11 +25,32 @@ RSpec.describe Hyrax::Transactions::Steps::SyncRedirectPaths do
         expect(paths).to contain_exactly('/handle/1', '/handle/2')
       end
 
+      it 'defaults every row display_url to false when no entry is flagged' do
+        step.call(resource)
+        flags = Hyrax::RedirectPath.where(resource_id: resource_id).pluck(:display_url)
+        expect(flags).to all(be false)
+      end
+
       it 'busts the cache for both old and new paths' do
         Hyrax::RedirectPath.create!(path: '/old', resource_id: resource_id)
         expect(Hyrax::RedirectCacheBuster).to receive(:call)
           .with(array_including('/old', '/handle/1', '/handle/2'))
         step.call(resource)
+      end
+    end
+
+    context 'when one entry is marked as the display URL' do
+      let(:redirects) do
+        [
+          { 'path' => '/handle/1', 'display_url' => true },
+          { 'path' => '/handle/2' }
+        ]
+      end
+
+      it 'marks only the display entry display_url=true' do
+        step.call(resource)
+        rows = Hyrax::RedirectPath.where(resource_id: resource_id).order(:path).pluck(:path, :display_url)
+        expect(rows).to eq([['/handle/1', true], ['/handle/2', false]])
       end
     end
 

--- a/spec/models/concerns/hyrax/redirects_normalization_spec.rb
+++ b/spec/models/concerns/hyrax/redirects_normalization_spec.rb
@@ -32,11 +32,10 @@ RSpec.describe Hyrax::RedirectsNormalization do
     end
 
     it 'preserves non-path keys on the entry' do
-      resource.redirects = [{ 'path' => '/foo/', 'canonical' => true, 'sequence' => 0 }]
+      resource.redirects = [{ 'path' => '/foo/', 'display_url' => true }]
       entry = resource.redirects.first
       expect(entry['path']).to eq('/foo')
-      expect(entry['canonical']).to be true
-      expect(entry['sequence']).to eq(0)
+      expect(entry['display_url']).to be true
     end
 
     it 'normalizes every entry in a multi-entry array' do

--- a/spec/models/hyrax/redirect_spec.rb
+++ b/spec/models/hyrax/redirect_spec.rb
@@ -2,22 +2,20 @@
 
 RSpec.describe Hyrax::Redirect do
   describe '#initialize' do
-    it 'accepts a path, canonical flag, and sequence' do
-      r = described_class.new(path: '/handle/12345/678', canonical: true, sequence: 0)
+    it 'accepts a path and display_url flag' do
+      r = described_class.new(path: '/handle/12345/678', display_url: true)
       expect(r.path).to eq('/handle/12345/678')
-      expect(r.canonical).to be true
-      expect(r.sequence).to eq(0)
+      expect(r.display_url).to be true
     end
 
-    it 'defaults canonical to false' do
+    it 'defaults display_url to false' do
       r = described_class.new(path: '/foo')
-      expect(r.canonical).to be false
+      expect(r.display_url).to be false
     end
 
-    it 'allows path and sequence to be nil (e.g. for the trailing blank row in the form view)' do
+    it 'allows path to be nil (e.g. for the trailing blank row in the form view)' do
       r = described_class.new(path: nil)
       expect(r.path).to be_nil
-      expect(r.sequence).to be_nil
     end
   end
 
@@ -32,18 +30,18 @@ RSpec.describe Hyrax::Redirect do
     end
 
     it 'builds a presenter from a string-keyed hash (JSONB shape)' do
-      r = described_class.wrap('path' => '/foo', 'canonical' => true, 'sequence' => 2)
-      expect(r).to have_attributes(path: '/foo', canonical: true, sequence: 2)
+      r = described_class.wrap('path' => '/foo', 'display_url' => true)
+      expect(r).to have_attributes(path: '/foo', display_url: true)
     end
 
     it 'builds a presenter from a symbol-keyed hash' do
-      r = described_class.wrap(path: '/foo', canonical: true, sequence: 2)
-      expect(r).to have_attributes(path: '/foo', canonical: true, sequence: 2)
+      r = described_class.wrap(path: '/foo', display_url: true)
+      expect(r).to have_attributes(path: '/foo', display_url: true)
     end
 
-    it 'defaults canonical to false when omitted' do
+    it 'defaults display_url to false when omitted' do
       r = described_class.wrap('path' => '/foo')
-      expect(r.canonical).to be false
+      expect(r.display_url).to be false
     end
 
     it 'raises ArgumentError when input cannot be coerced to a hash' do
@@ -53,8 +51,8 @@ RSpec.describe Hyrax::Redirect do
 
   describe '#to_h and #as_json' do
     it 'returns a string-keyed hash matching the persisted shape' do
-      r = described_class.new(path: '/foo', canonical: true, sequence: 1)
-      expected = { 'path' => '/foo', 'canonical' => true, 'sequence' => 1 }
+      r = described_class.new(path: '/foo', display_url: true)
+      expected = { 'path' => '/foo', 'display_url' => true }
       expect(r.to_h).to eq(expected)
       expect(r.as_json).to eq(expected)
     end
@@ -62,8 +60,8 @@ RSpec.describe Hyrax::Redirect do
 
   describe '#==' do
     it 'compares equal on attribute values' do
-      a = described_class.new(path: '/x', canonical: true, sequence: 0)
-      b = described_class.new(path: '/x', canonical: true, sequence: 0)
+      a = described_class.new(path: '/x', display_url: true)
+      b = described_class.new(path: '/x', display_url: true)
       expect(a).to eq(b)
     end
 
@@ -74,8 +72,8 @@ RSpec.describe Hyrax::Redirect do
     end
 
     it 'is not equal to a Hash with the same shape (presenters and hashes are distinct types)' do
-      r = described_class.new(path: '/x', canonical: false, sequence: nil)
-      expect(r).not_to eq('path' => '/x', 'canonical' => false, 'sequence' => nil)
+      r = described_class.new(path: '/x', display_url: false)
+      expect(r).not_to eq('path' => '/x', 'display_url' => false)
     end
   end
 end

--- a/spec/services/hyrax/schema_loader_spec.rb
+++ b/spec/services/hyrax/schema_loader_spec.rb
@@ -170,8 +170,8 @@ RSpec.describe Hyrax::SchemaLoader::AttributeDefinition do
     context 'when type is hash' do
       # The `hash` shortcut lets a YAML schema declare a nested-attribute
       # property whose entries are plain hashes (e.g. `redirects` with
-      # `path`, `canonical`, `sequence` sub-fields). Persisted as JSONB
-      # without a nested Valkyrie::Resource schema in between, so round-trips
+      # `path` and `display_url` sub-fields). Persisted as JSONB without
+      # a nested Valkyrie::Resource schema in between, so round-trips
       # don't strip sub-fields. See documentation/redirects.md.
       let(:config) { { 'type' => 'hash', 'multiple' => true } }
 
@@ -179,7 +179,7 @@ RSpec.describe Hyrax::SchemaLoader::AttributeDefinition do
         expect(attribute_definition.type).to be_a(Dry::Types::Constructor)
         expect(attribute_definition.type.to_s).to include('Array')
         # End-to-end: an array of hashes coerces to itself, preserving sub-keys.
-        input = [{ 'path' => '/foo', 'canonical' => true, 'sequence' => 0 }]
+        input = [{ 'path' => '/foo', 'display_url' => true }]
         expect(attribute_definition.type.call(input)).to eq(input)
       end
     end
@@ -190,7 +190,7 @@ RSpec.describe Hyrax::SchemaLoader::AttributeDefinition do
       it 'returns a constructor wrapping Dry::Types["hash"] that passes hashes through' do
         expect(attribute_definition.type).to be_a(Dry::Types::Constructor)
         expect(attribute_definition.type.type).to eq(Dry::Types['hash'])
-        input = { 'path' => '/foo', 'canonical' => true }
+        input = { 'path' => '/foo', 'display_url' => true }
         expect(attribute_definition.type.call(input)).to eq(input)
       end
     end

--- a/spec/validators/hyrax/redirect_validator_spec.rb
+++ b/spec/validators/hyrax/redirect_validator_spec.rb
@@ -16,8 +16,8 @@ RSpec.describe Hyrax::RedirectValidator do
       r.redirects = entries
     end
   end
-  def entry(path:, canonical: false)
-    { 'path' => path, 'canonical' => canonical }
+  def entry(path:, display_url: false)
+    { 'path' => path, 'display_url' => display_url }
   end
   let(:entries) { [] }
 
@@ -28,7 +28,7 @@ RSpec.describe Hyrax::RedirectValidator do
 
   describe '#validate_each' do
     context 'when the redirects feature is active' do
-      let(:entries) { [entry(path: '/handle/12345/678', canonical: true)] }
+      let(:entries) { [entry(path: '/handle/12345/678', display_url: true)] }
 
       it 'is valid' do
         record.valid?
@@ -38,7 +38,7 @@ RSpec.describe Hyrax::RedirectValidator do
 
     context 'when the redirects feature is inactive' do
       before { allow(Hyrax.config).to receive(:redirects_active?).and_return(false) }
-      let(:entries) { [entry(path: 'no-leading-slash', canonical: false)] }
+      let(:entries) { [entry(path: 'no-leading-slash', display_url: false)] }
 
       it 'short-circuits without recording errors' do
         record.valid?
@@ -107,7 +107,7 @@ RSpec.describe Hyrax::RedirectValidator do
     end
 
     context 'with a blank path' do
-      let(:entries) { [entry(path: '', canonical: false)] }
+      let(:entries) { [entry(path: '', display_url: false)] }
 
       it 'records a blank-path error' do
         record.valid?
@@ -116,7 +116,7 @@ RSpec.describe Hyrax::RedirectValidator do
     end
 
     context 'with a path missing a leading slash' do
-      let(:entries) { [entry(path: 'handle/12345/678', canonical: false)] }
+      let(:entries) { [entry(path: 'handle/12345/678', display_url: false)] }
 
       it 'records a format error' do
         record.valid?
@@ -125,7 +125,7 @@ RSpec.describe Hyrax::RedirectValidator do
     end
 
     context 'with whitespace in the path' do
-      let(:entries) { [entry(path: '/has space', canonical: false)] }
+      let(:entries) { [entry(path: '/has space', display_url: false)] }
 
       it 'records a format error' do
         record.valid?
@@ -134,7 +134,7 @@ RSpec.describe Hyrax::RedirectValidator do
     end
 
     context 'with a query string in the path' do
-      let(:entries) { [entry(path: '/foo?bar=baz', canonical: false)] }
+      let(:entries) { [entry(path: '/foo?bar=baz', display_url: false)] }
 
       it 'records a format error' do
         record.valid?
@@ -143,7 +143,7 @@ RSpec.describe Hyrax::RedirectValidator do
     end
 
     context 'with a path under a reserved Hyrax prefix' do
-      let(:entries) { [entry(path: '/concern/generic_works/abc', canonical: false)] }
+      let(:entries) { [entry(path: '/concern/generic_works/abc', display_url: false)] }
 
       it 'records a reserved-prefix error' do
         record.valid?
@@ -152,7 +152,7 @@ RSpec.describe Hyrax::RedirectValidator do
     end
 
     context 'with a path that exactly matches a reserved prefix' do
-      let(:entries) { [entry(path: '/dashboard', canonical: false)] }
+      let(:entries) { [entry(path: '/dashboard', display_url: false)] }
 
       it 'records a reserved-prefix error' do
         record.valid?
@@ -163,8 +163,8 @@ RSpec.describe Hyrax::RedirectValidator do
     context 'with two entries sharing the same path on the same record' do
       let(:entries) do
         [
-          entry(path: '/handle/1', canonical: false),
-          entry(path: '/handle/1', canonical: false)
+          entry(path: '/handle/1', display_url: false),
+          entry(path: '/handle/1', display_url: false)
         ]
       end
 
@@ -174,11 +174,11 @@ RSpec.describe Hyrax::RedirectValidator do
       end
     end
 
-    context 'with two entries that normalize to the same canonical path' do
+    context 'with two entries that normalize to the same path' do
       let(:entries) do
         [
-          entry(path: '/handle/1', canonical: false),
-          entry(path: '/handle/1/', canonical: false)
+          entry(path: '/handle/1', display_url: false),
+          entry(path: '/handle/1/', display_url: false)
         ]
       end
 
@@ -189,7 +189,7 @@ RSpec.describe Hyrax::RedirectValidator do
     end
 
     context 'with a reserved prefix typed with a trailing slash' do
-      let(:entries) { [entry(path: '/dashboard/', canonical: false)] }
+      let(:entries) { [entry(path: '/dashboard/', display_url: false)] }
 
       it 'records a reserved-prefix error' do
         record.valid?
@@ -198,7 +198,7 @@ RSpec.describe Hyrax::RedirectValidator do
     end
 
     context 'when the path is taken on another record' do
-      let(:entries) { [entry(path: '/handle/12345/678', canonical: false)] }
+      let(:entries) { [entry(path: '/handle/12345/678', display_url: false)] }
 
       before do
         allow(Hyrax::RedirectsLookup)
@@ -213,8 +213,8 @@ RSpec.describe Hyrax::RedirectValidator do
       end
     end
 
-    context 'when a non-canonical form of the path is taken on another record' do
-      let(:entries) { [entry(path: '/handle/12345/678/', canonical: false)] }
+    context 'when an unnormalized form of the path is taken on another record' do
+      let(:entries) { [entry(path: '/handle/12345/678/', display_url: false)] }
 
       before do
         allow(Hyrax::RedirectsLookup)
@@ -223,53 +223,53 @@ RSpec.describe Hyrax::RedirectValidator do
           .and_return(true)
       end
 
-      it 'records a global-uniqueness error against the canonical path' do
+      it 'records a global-uniqueness error against the normalized path' do
         record.valid?
         expect(record.errors[:redirects]).to include(t(:already_taken, path: '/handle/12345/678/'))
       end
     end
 
-    context 'when more than one entry is marked canonical' do
+    context 'when more than one entry is marked as the display URL' do
       let(:entries) do
         [
-          entry(path: '/a', canonical: true),
-          entry(path: '/b', canonical: true)
+          entry(path: '/a', display_url: true),
+          entry(path: '/b', display_url: true)
         ]
       end
 
-      it 'records an at-most-one-canonical error' do
+      it 'records an at-most-one-display-url error' do
         record.valid?
-        expect(record.errors[:redirects]).to include(t(:multiple_canonical))
+        expect(record.errors[:redirects]).to include(t(:multiple_display_url))
       end
     end
 
-    context 'when zero entries are marked canonical' do
+    context 'when zero entries are marked as the display URL' do
       let(:entries) do
         [
-          entry(path: '/a', canonical: false),
-          entry(path: '/b', canonical: false)
+          entry(path: '/a', display_url: false),
+          entry(path: '/b', display_url: false)
         ]
       end
 
-      it 'is valid (canonical is optional)' do
+      it 'is valid (display_url is optional)' do
         record.valid?
         expect(record.errors[:redirects]).to be_empty
       end
     end
   end
 
-  describe '#canonical_for' do
+  describe '#display_url_for' do
     it 'returns the stored false flag rather than nil' do
-      expect(validator.send(:canonical_for, 'canonical' => false)).to be(false)
-      expect(validator.send(:canonical_for, canonical: false)).to be(false)
+      expect(validator.send(:display_url_for, 'display_url' => false)).to be(false)
+      expect(validator.send(:display_url_for, display_url: false)).to be(false)
     end
 
     it 'returns true when the flag is set' do
-      expect(validator.send(:canonical_for, 'canonical' => true)).to be(true)
+      expect(validator.send(:display_url_for, 'display_url' => true)).to be(true)
     end
 
     it 'returns nil when the flag is absent' do
-      expect(validator.send(:canonical_for, 'path' => '/x')).to be_nil
+      expect(validator.send(:display_url_for, 'path' => '/x')).to be_nil
     end
   end
 end


### PR DESCRIPTION
## Summary
Adds a `display_url` boolean column to `hyrax_redirect_paths` and renames the per-entry 'canonical`/`sequence` fields to a single `display_url`. Subsequent PRs will add the form UI (radio column) and the resolver wiring that uses the flag.
- Refs Pitt #653.

## Details

Note: we are changing some behavior in ways that are not backward compatible. Since the feature is new and in active development, I did not worry about backward compatibility in the changes. This was intentional. 

Changes in this PR:
- Schema-only foundation. The column is added and the persistence layer carries it, but nothing in this PR can set the flag — the form UI and any import path land in follow-up PRs. Every row this code writes today persists `display_url: false`.
- One alias per record will eventually be flagged as the institution's preferred display URL; the rest are plain redirects with no ordering semantics. This PR replaces the prior `canonical`/`sequence` shape with that simpler model.

## Note

I have been weighing whether to add a suggested source_path / target_path pair, or drop target_path and have the controller compute where to send a visitor at request time.

That schema mixes a per-row fact ("what alias points to what resource") with a per-resource fact ("which alias is the institution's preferred URL"). It forces a rewrite of every alias row on the record whenever the display flag moves, and produces self-referential rows where source_path == target_path on the display alias itself — which causes an infinite redirect loop unless the controller special-cases it.

It is my opinion that having to rewrite every row whenever the display flag moves, plus the special-case the controller needs for self-referential rows outweighs the savings of a single-query lookup.