### PR TITLE
Add Display URL radio column to redirects form

### DIFF
--- a/app/assets/javascripts/hyrax.js
+++ b/app/assets/javascripts/hyrax.js
@@ -89,6 +89,7 @@
 //= require hyrax/turbolinks_events
 //= require hyrax/i18n_helper
 //= require hyrax/collapse
+//= require hyrax/redirects
 //= require hyrax/skip_to_content
 //= require hyrax/reports-buttons
 //= require hydra-editor/field_manager

--- a/app/assets/javascripts/hyrax/redirects.js
+++ b/app/assets/javascripts/hyrax/redirects.js
@@ -1,8 +1,13 @@
 // Behavior for the Aliases form (see app/views/hyrax/base/_form_redirects.html.erb).
 // Event-delegated handlers on document so dynamically-added rows work
-// without rebinding. Registered once at script load — re-binding inside
-// Blacklight.onLoad would stack a new listener on every Turbolinks visit.
+// without rebinding. A sentinel on document guards against the IIFE
+// running twice (Turbolinks evaluates module scripts again on some
+// navigation paths in development), which would otherwise stack
+// duplicate listeners and fire each handler N times per click.
 (function() {
+    if (document.hyraxRedirectsBound) return;
+    document.hyraxRedirectsBound = true;
+
     document.addEventListener('input', function(event) {
         var pathInput = event.target.closest('[data-redirects-path-input]');
         if (!pathInput) return;
@@ -25,8 +30,16 @@
         var table = document.querySelector('[data-redirects-table]');
         if (!template || !table) return;
         var tbody = table.querySelector('tbody');
-        var nextIndex = tbody.querySelectorAll('[data-redirects-row]').length;
+        if (!tbody) return;
+        // Monotonic counter on the table; never recycle an index after a
+        // row is removed. Fallback to row count when the attribute is
+        // missing (older adopter override of the partial).
+        var nextIndex = parseInt(table.dataset.nextIndex, 10);
+        if (isNaN(nextIndex)) {
+            nextIndex = tbody.querySelectorAll('[data-redirects-row]').length;
+        }
         var html = template.innerHTML.replace(/__INDEX__/g, nextIndex);
         tbody.insertAdjacentHTML('beforeend', html);
+        table.dataset.nextIndex = String(nextIndex + 1);
     });
 })();

--- a/app/assets/javascripts/hyrax/redirects.js
+++ b/app/assets/javascripts/hyrax/redirects.js
@@ -1,0 +1,32 @@
+// Behavior for the Aliases form (see app/views/hyrax/base/_form_redirects.html.erb).
+// Event-delegated handlers on document so dynamically-added rows work
+// without rebinding. Registered once at script load — re-binding inside
+// Blacklight.onLoad would stack a new listener on every Turbolinks visit.
+(function() {
+    document.addEventListener('input', function(event) {
+        var pathInput = event.target.closest('[data-redirects-path-input]');
+        if (!pathInput) return;
+        var radioId = pathInput.getAttribute('data-redirects-display-radio');
+        var radio = document.getElementById(radioId);
+        if (radio) radio.disabled = (pathInput.value.trim() === '');
+    });
+
+    document.addEventListener('click', function(event) {
+        var removeButton = event.target.closest('[data-redirects-remove-row]');
+        if (removeButton) {
+            var row = removeButton.closest('tr');
+            if (row) row.parentNode.removeChild(row);
+            return;
+        }
+
+        var addButton = event.target.closest('[data-redirects-add-row]');
+        if (!addButton) return;
+        var template = document.querySelector('[data-redirects-row-template]');
+        var table = document.querySelector('[data-redirects-table]');
+        if (!template || !table) return;
+        var tbody = table.querySelector('tbody');
+        var nextIndex = tbody.querySelectorAll('[data-redirects-row]').length;
+        var html = template.innerHTML.replace(/__INDEX__/g, nextIndex);
+        tbody.insertAdjacentHTML('beforeend', html);
+    });
+})();

--- a/app/forms/concerns/hyrax/redirects_field_behavior.rb
+++ b/app/forms/concerns/hyrax/redirects_field_behavior.rb
@@ -30,6 +30,10 @@ module Hyrax
   module RedirectsFieldBehavior
     def self.included(descendant)
       return unless Hyrax.config.redirects_enabled?
+      # Declare the radio-group scalar before redirects_attributes so Reform
+      # deserializes it first; the populator reads its value while building
+      # per-row entries.
+      descendant.property :redirects_display_url_index, virtual: true
       descendant.property :redirects_attributes,
                           virtual: true,
                           populator: :redirects_attributes_populator,
@@ -55,16 +59,38 @@ module Hyrax
     # `redirects_attributes` payload. Drops rows marked for destruction
     # or with a blank path. Normalizes paths up-front so the validator
     # sees normalized form (so DSpace-style pasted URLs validate cleanly).
+    #
+    # When `redirects_display_url_index` is set (form-driven radio
+    # group), the matching original-index row gets `display_url: true`
+    # and all other rows get false. When absent (Bulkrax import path),
+    # the row's own `display_url` value is honored.
     def redirects_attributes_populator(fragment:, **_options)
       return unless respond_to?(:redirects)
       return unless Hyrax.config.redirects_active?
-      entries = Array(fragment&.values)
-                .reject { |row| row['_destroy'].to_s == 'true' || row['path'].to_s.strip.empty? }
-                .map do |row|
-        { 'path' => Hyrax::RedirectPathNormalizer.call(row['path']),
-          'display_url' => row['display_url'].to_s == 'true' }
+      pairs = redirects_fragment_pairs(fragment)
+      self.redirects = pairs.sort_by { |k, _row| k.to_i }
+                            .map { |k, row| redirects_entry_from(k, row) }
+                            .compact
+    end
+
+    def redirects_fragment_pairs(fragment)
+      return {} if fragment.nil?
+      fragment.respond_to?(:to_unsafe_h) ? fragment.to_unsafe_h : fragment.to_h
+    end
+
+    def redirects_entry_from(key, row)
+      row = row.respond_to?(:to_unsafe_h) ? row.to_unsafe_h : row
+      return nil if row['_destroy'].to_s == 'true' || row['path'].to_s.strip.empty?
+      { 'path' => Hyrax::RedirectPathNormalizer.call(row['path']),
+        'display_url' => redirects_display_url_flag_for(key, row) }
+    end
+
+    def redirects_display_url_flag_for(key, row)
+      if redirects_display_url_index.nil?
+        row['display_url'].to_s == 'true'
+      else
+        key.to_s == redirects_display_url_index.to_s
       end
-      self.redirects = entries
     end
 
     # Wraps each persisted hash in a `Hyrax::Redirect` value object for

--- a/app/forms/concerns/hyrax/redirects_field_behavior.rb
+++ b/app/forms/concerns/hyrax/redirects_field_behavior.rb
@@ -6,8 +6,8 @@ module Hyrax
   # Submitted form payloads arrive under `redirects_attributes` and are
   # turned into plain hashes (the persisted shape — see
   # `config/metadata/redirects.yaml`, `type: hash`) by the populator.
-  # On render, the prepopulator wraps each persisted hash in a
-  # `Hyrax::Redirect` value object so the view can call `.path` and
+  # The form partial wraps each persisted hash in a `Hyrax::Redirect`
+  # value object at render time so the view can call `.path` and
   # `.display_url`.
   #
   # The `deserialize!` override removes the renamed `redirects` key
@@ -36,8 +36,7 @@ module Hyrax
       descendant.property :redirects_display_url_index, virtual: true
       descendant.property :redirects_attributes,
                           virtual: true,
-                          populator: :redirects_attributes_populator,
-                          prepopulator: :redirects_attributes_prepopulator
+                          populator: :redirects_attributes_populator
     end
 
     # Reform's FormBuilderMethods rewrites `redirects_attributes` →
@@ -91,15 +90,6 @@ module Hyrax
       else
         key.to_s == redirects_display_url_index.to_s
       end
-    end
-
-    # Wraps each persisted hash in a `Hyrax::Redirect` value object for
-    # the form view. Mirrors how `BasedNearFieldBehavior` hydrates URI
-    # strings into `ControlledVocabularies::Location` instances.
-    def redirects_attributes_prepopulator
-      return unless respond_to?(:redirects)
-      return unless Hyrax.config.redirects_active?
-      self.redirects = Array(redirects).map { |entry| Hyrax::Redirect.wrap(entry) }
     end
   end
 end

--- a/app/views/hyrax/base/_form_redirects.html.erb
+++ b/app/views/hyrax/base/_form_redirects.html.erb
@@ -13,7 +13,7 @@
     display_url flags. %>
 <% radio_name = "#{f.object_name}[redirects_display_url_index]" %>
 
-<table class="table table-striped" data-redirects-table>
+<table class="table table-striped" data-redirects-table data-next-index="<%= rows.length %>">
   <caption class="sr-only"><%= t('hyrax.works.form.redirects.caption') %></caption>
   <thead>
     <tr>
@@ -107,6 +107,13 @@
                            disabled: true,
                            'aria-label': t('hyrax.works.form.redirects.display_url.row_label', path: t('hyrax.works.form.redirects.new_path_label')) %>
     </td>
-    <td class="text-right" style="width: 1%;"></td>
+    <td class="text-right" style="width: 1%;">
+      <button type="button"
+              class="btn close"
+              aria-label="<%= t('hyrax.works.form.redirects.remove_label') %>"
+              data-redirects-remove-row="true">
+        <span aria-hidden="true">&times;</span>
+      </button>
+    </td>
   </tr>
 </template>

--- a/app/views/hyrax/base/_form_redirects.html.erb
+++ b/app/views/hyrax/base/_form_redirects.html.erb
@@ -13,6 +13,12 @@
     display_url flags. %>
 <% radio_name = "#{f.object_name}[redirects_display_url_index]" %>
 
+<%# Always-submitted hidden marker so the populator runs even when the
+    user has removed every row from the DOM. The populator drops rows
+    with blank paths, so the marker contributes nothing to the saved
+    set. %>
+<%= hidden_field_tag "#{f.object_name}[redirects_attributes][_marker][path]", '' %>
+
 <table class="table table-striped" data-redirects-table data-next-index="<%= rows.length %>">
   <caption class="sr-only"><%= t('hyrax.works.form.redirects.caption') %></caption>
   <thead>

--- a/app/views/hyrax/base/_form_redirects.html.erb
+++ b/app/views/hyrax/base/_form_redirects.html.erb
@@ -4,25 +4,39 @@
 
 <p><%= sanitize t('hyrax.works.form.redirects.help_html'), tags: %w[code] %></p>
 
-<table class="table table-striped">
+<p><%= sanitize t('hyrax.works.form.redirects.display_url.help_html'), tags: %w[em] %></p>
+
+<% rows = Array(f.object.redirects).map { |e| Hyrax::Redirect.wrap(e) } %>
+<% selected_idx = rows.index(&:display_url) %>
+<%# All radios share one name so HTML treats them as one group; value is
+    the row's index. The populator folds the selected index onto per-row
+    display_url flags. %>
+<% radio_name = "#{f.object_name}[redirects_display_url_index]" %>
+
+<table class="table table-striped" data-redirects-table>
   <caption class="sr-only"><%= t('hyrax.works.form.redirects.caption') %></caption>
   <thead>
     <tr>
       <th scope="col"><%= t('hyrax.works.form.redirects.header.path') %></th>
+      <th scope="col"><%= t('hyrax.works.form.redirects.header.display_url') %></th>
       <th scope="col" class="sr-only"><%= t('hyrax.works.form.redirects.header.actions') %></th>
     </tr>
   </thead>
   <tbody>
-    <%# Wrap each row through Hyrax::Redirect.wrap so the view can rely on
-        the presenter API (.path, .display_url). On initial render the
-        prepopulator already wrapped them; on a re-render after a failed
-        save, f.object.redirects holds the populator's plain hashes, and
-        we wrap them here. %>
-    <% rows = Array(f.object.redirects).map { |e| Hyrax::Redirect.wrap(e) } + [Hyrax::Redirect.new(path: nil)] %>
+    <tr>
+      <td colspan="2">
+        <label>
+          <%= radio_button_tag radio_name, '', selected_idx.nil? %>
+          <%= t('hyrax.works.form.redirects.display_url.none_label') %>
+        </label>
+      </td>
+      <td></td>
+    </tr>
     <% rows.each_with_index do |entry, index| %>
       <% input_id = "#{f.object_name}_redirects_attributes_#{index}_path" %>
       <% label_text = entry.path.present? ? t('hyrax.works.form.redirects.path_label') : t('hyrax.works.form.redirects.new_path_label') %>
-      <tr>
+      <% radio_id = "#{f.object_name}_redirects_display_url_index_#{index}" %>
+      <tr data-redirects-row>
         <td>
           <%= label_tag input_id, label_text, class: 'sr-only' %>
           <div class="input-group">
@@ -33,15 +47,24 @@
                                entry.path,
                                id: input_id,
                                class: 'form-control',
-                               placeholder: t('hyrax.works.form.redirects.placeholder.path') %>
+                               placeholder: t('hyrax.works.form.redirects.placeholder.path'),
+                               data: { 'redirects-path-input': true, 'redirects-display-radio': radio_id } %>
           </div>
+        </td>
+        <td>
+          <%= radio_button_tag radio_name,
+                               index.to_s,
+                               index == selected_idx,
+                               id: radio_id,
+                               disabled: entry.path.blank?,
+                               'aria-label': t('hyrax.works.form.redirects.display_url.row_label', path: entry.path.presence || (index + 1)) %>
         </td>
         <td class="text-right" style="width: 1%;">
           <% if entry.path.present? %>
             <button type="button"
                     class="btn close"
                     aria-label="<%= t('hyrax.works.form.redirects.remove_with_path_label', path: entry.path) %>"
-                    onclick="this.closest('tr').remove()">
+                    data-redirects-remove-row="true">
               <span aria-hidden="true">&times;</span>
             </button>
           <% end %>
@@ -50,3 +73,40 @@
     <% end %>
   </tbody>
 </table>
+
+<p>
+  <button type="button" class="btn btn-secondary" data-redirects-add-row>
+    <%= t('hyrax.works.form.redirects.add_label') %>
+  </button>
+</p>
+
+<%# Template used by the Add button. JS clones this. %>
+<template data-redirects-row-template>
+  <% template_input_id = "#{f.object_name}_redirects_attributes___INDEX___path" %>
+  <% template_radio_id = "#{f.object_name}_redirects_display_url_index___INDEX__" %>
+  <tr data-redirects-row>
+    <td>
+      <%= label_tag template_input_id, t('hyrax.works.form.redirects.new_path_label'), class: 'sr-only' %>
+      <div class="input-group">
+        <div class="input-group-prepend">
+          <span class="input-group-text"><%= request.base_url %></span>
+        </div>
+        <%= text_field_tag "#{f.object_name}[redirects_attributes][__INDEX__][path]",
+                           nil,
+                           id: template_input_id,
+                           class: 'form-control',
+                           placeholder: t('hyrax.works.form.redirects.placeholder.path'),
+                           data: { 'redirects-path-input': true, 'redirects-display-radio': template_radio_id } %>
+      </div>
+    </td>
+    <td>
+      <%= radio_button_tag radio_name,
+                           '__INDEX__',
+                           false,
+                           id: template_radio_id,
+                           disabled: true,
+                           'aria-label': t('hyrax.works.form.redirects.display_url.row_label', path: t('hyrax.works.form.redirects.new_path_label')) %>
+    </td>
+    <td class="text-right" style="width: 1%;"></td>
+  </tr>
+</template>

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -1817,10 +1817,16 @@ en:
         in_other_works: This Work in Other Works
         in_this_work: Other Works in this Work
         redirects:
+          add_label: Add another alias
           caption: List of URL aliases for this resource
+          display_url:
+            help_html: Optionally mark one alias as the <em>display URL</em>. When set, the record's permanent UUID URL redirects to the chosen alias. Leave as "None" to keep the UUID URL as the destination.
+            none_label: None (use the record's UUID URL)
+            row_label: 'Use "%{path}" as the display URL'
           errors_heading: Please correct the following alias errors
           header:
             actions: Actions
+            display_url: Display URL
             path: Path
           heading: URL Aliases
           help_html: 'Register legacy URL paths that should redirect to this record. Each path will resolve from this site''s root. Reserved Hyrax routes (e.g. <code>/concern</code>, <code>/dashboard</code>) cannot be used.'

--- a/documentation/forms/field_behaviors.md
+++ b/documentation/forms/field_behaviors.md
@@ -201,11 +201,10 @@ module Hyrax
     def self.included(descendant)
       return unless Hyrax.config.redirects_enabled?
       descendant.include Hyrax::FormFields(:redirects)
+      descendant.property :redirects_display_url_index, virtual: true
       descendant.property :redirects_attributes,
                           virtual: true,
-                          populator: :redirects_attributes_populator,
-                          prepopulator: :redirects_attributes_prepopulator
-      descendant.property :redirects_display_url_index, virtual: true
+                          populator: :redirects_attributes_populator
     end
 
     def deserialize!(params)
@@ -232,18 +231,12 @@ module Hyrax
       end.compact
       self.redirects = entries
     end
-
-    def redirects_attributes_prepopulator
-      return unless respond_to?(:redirects)
-      return unless Hyrax.config.redirects_active?
-      self.redirects = Array(redirects).map { |entry| Hyrax::Redirect.wrap(entry) }
-    end
   end
 end
 ```
 
 - **Persisted shape:** array of plain hashes (`'path'`, `'display_url'`). Declared with `type: hash, multiple: true` in `config/metadata/redirects.yaml` and loaded onto the form via `Hyrax::FormFields(:redirects)`.
-- **View-side shape:** array of `Hyrax::Redirect` presenters, exposing `.path` and `.display_url`.
+- **View-side shape:** the form partial calls `Hyrax::Redirect.wrap(entry)` inline at render time, so the view can rely on the `.path` and `.display_url` presenter API without the form having to maintain a wrapped copy. No prepopulator is needed.
 - **Diff from BasedNear:** entries carry multiple sub-fields, so the persisted shape is a hash rather than a string. The populator normalizes paths up front (canonical form lives in storage). The behavior is feature-gated — every callback consults `Hyrax.config.redirects_active?`.
 - **Form-side radio fold:** the second virtual property `redirects_display_url_index` carries the form's radio-group selection (the row index, or `''` for "none"). The populator reads it and folds it onto per-row `display_url` flags. When absent (Bulkrax-style imports send per-row flags directly), the row's own `display_url` value is honored instead.
 

--- a/documentation/forms/field_behaviors.md
+++ b/documentation/forms/field_behaviors.md
@@ -205,6 +205,7 @@ module Hyrax
                           virtual: true,
                           populator: :redirects_attributes_populator,
                           prepopulator: :redirects_attributes_prepopulator
+      descendant.property :redirects_display_url_index, virtual: true
     end
 
     def deserialize!(params)
@@ -221,12 +222,14 @@ module Hyrax
     def redirects_attributes_populator(fragment:, **_options)
       return unless respond_to?(:redirects)
       return unless Hyrax.config.redirects_active?
-      entries = Array(fragment&.values)
-                .reject { |row| row['_destroy'].to_s == 'true' || row['path'].to_s.strip.empty? }
-                .map do |row|
+      use_index_fold = !redirects_display_url_index.nil?
+      selected_index = redirects_display_url_index.to_s
+      entries = Array(fragment).sort_by { |k, _row| k.to_i }.map do |k, row|
+        next if row['_destroy'].to_s == 'true' || row['path'].to_s.strip.empty?
+        flag = use_index_fold ? (k.to_s == selected_index) : (row['display_url'].to_s == 'true')
         { 'path' => Hyrax::RedirectPathNormalizer.call(row['path']),
-          'display_url' => row['display_url'].to_s == 'true' }
-      end
+          'display_url' => flag }
+      end.compact
       self.redirects = entries
     end
 
@@ -242,6 +245,7 @@ end
 - **Persisted shape:** array of plain hashes (`'path'`, `'display_url'`). Declared with `type: hash, multiple: true` in `config/metadata/redirects.yaml` and loaded onto the form via `Hyrax::FormFields(:redirects)`.
 - **View-side shape:** array of `Hyrax::Redirect` presenters, exposing `.path` and `.display_url`.
 - **Diff from BasedNear:** entries carry multiple sub-fields, so the persisted shape is a hash rather than a string. The populator normalizes paths up front (canonical form lives in storage). The behavior is feature-gated — every callback consults `Hyrax.config.redirects_active?`.
+- **Form-side radio fold:** the second virtual property `redirects_display_url_index` carries the form's radio-group selection (the row index, or `''` for "none"). The populator reads it and folds it onto per-row `display_url` flags. When absent (Bulkrax-style imports send per-row flags directly), the row's own `display_url` value is honored instead.
 
 ## Wiring on `ResourceForm`
 

--- a/documentation/redirects.md
+++ b/documentation/redirects.md
@@ -209,6 +209,14 @@ SELECT 1 FROM hyrax_redirect_paths WHERE path = ? AND resource_id <> ? LIMIT 1;
 
 The validator calls `Hyrax::RedirectsLookup.taken?(path, except_id: record.id)` to give the user friendly feedback at form-submit time. If two simultaneous requests both pass validation (because both checked the table before either committed), the unique index rejects the second one at insert time and the enclosing transaction returns `Failure`.
 
+## Selecting the display URL
+
+The Aliases form column "Display URL" lets a user mark one alias per record as the display URL — the path the resolver treats as the institution's preferred public URL for that record. The form persists the flag onto the `display_url` column of `hyrax_redirect_paths` via the sync transaction step.
+
+Implementation note: the form renders the column as a single radio group whose `name` is `<form>[redirects_display_url_index]` and whose values are the row indices. `Hyrax::RedirectsFieldBehavior#redirects_attributes_populator` reads that scalar and folds it onto per-row entries — the selected row gets `display_url: true`, every other row gets `display_url: false`. When the scalar is absent (the Bulkrax CSV import path), the per-row `display_url` value on each entry is honored instead, so CSV imports with explicit per-row `redirect_display_url_<n>` columns work unchanged.
+
+The "None" radio option is the default selection and persists every row as `display_url: false`. The validator continues to enforce at-most-one display URL per record.
+
 ### Sync between `redirects` attribute and the redirects table
 
 The redirects table is kept in sync by two `dry-transaction` steps composed into the create/update/destroy transactions:

--- a/spec/forms/concerns/hyrax/redirects_field_behavior_spec.rb
+++ b/spec/forms/concerns/hyrax/redirects_field_behavior_spec.rb
@@ -3,7 +3,7 @@
 RSpec.describe Hyrax::RedirectsFieldBehavior do
   let(:form_class) do
     Class.new do
-      attr_accessor :redirects
+      attr_accessor :redirects, :redirects_display_url_index
 
       def self.property(*); end
 
@@ -47,6 +47,7 @@ RSpec.describe Hyrax::RedirectsFieldBehavior do
         populator: :redirects_attributes_populator,
         prepopulator: :redirects_attributes_prepopulator
       )
+      expect(property_target).to receive(:property).with(:redirects_display_url_index, virtual: true)
       property_target.include(described_class)
     end
 
@@ -109,6 +110,78 @@ RSpec.describe Hyrax::RedirectsFieldBehavior do
       form.send(:redirects_attributes_populator, fragment: { '0' => { 'path' => '/foo' } })
 
       expect(form.redirects).to eq('untouched')
+    end
+
+    context 'with redirects_display_url_index set (form radio group)' do
+      let(:fragment) do
+        {
+          '0' => { 'path' => '/foo' },
+          '1' => { 'path' => '/bar' },
+          '2' => { 'path' => '/baz' }
+        }
+      end
+
+      it 'marks only the selected row as display_url' do
+        form.redirects_display_url_index = '1'
+        form.send(:redirects_attributes_populator, fragment: fragment)
+
+        flags = form.redirects.map { |e| [e['path'], e['display_url']] }
+        expect(flags).to eq([['/foo', false], ['/bar', true], ['/baz', false]])
+      end
+
+      it 'leaves every row as display_url=false when the index is blank' do
+        form.redirects_display_url_index = ''
+        form.send(:redirects_attributes_populator, fragment: fragment)
+
+        expect(form.redirects.map { |e| e['display_url'] }).to all(be false)
+      end
+
+      it 'silently ignores a selected index pointing at a row dropped for blank path' do
+        form.redirects_display_url_index = '1'
+        fragment_with_blank = { '0' => { 'path' => '/foo' }, '1' => { 'path' => '   ' } }
+        form.send(:redirects_attributes_populator, fragment: fragment_with_blank)
+
+        expect(form.redirects.map { |e| [e['path'], e['display_url']] }).to eq([['/foo', false]])
+      end
+
+      it 'silently ignores a selected index past the end of the fragment' do
+        form.redirects_display_url_index = '99'
+        form.send(:redirects_attributes_populator, fragment: fragment)
+
+        expect(form.redirects.map { |e| e['display_url'] }).to all(be false)
+      end
+    end
+
+    context 'with redirects_display_url_index nil (Bulkrax-style import path)' do
+      it 'falls back to per-row display_url values' do
+        form.redirects_display_url_index = nil
+        fragment = {
+          '0' => { 'path' => '/foo', 'display_url' => 'true' },
+          '1' => { 'path' => '/bar', 'display_url' => 'false' }
+        }
+        form.send(:redirects_attributes_populator, fragment: fragment)
+
+        expect(form.redirects).to eq([
+                                       { 'path' => '/foo', 'display_url' => true },
+                                       { 'path' => '/bar', 'display_url' => false }
+                                     ])
+      end
+    end
+
+    context 'when fragment is ActionController::Parameters (real form submit)' do
+      it 'unwraps the params object and folds the index' do
+        form.redirects_display_url_index = '1'
+        params = ActionController::Parameters.new(
+          '0' => { 'path' => '/foo' },
+          '1' => { 'path' => '/bar' }
+        )
+        form.send(:redirects_attributes_populator, fragment: params)
+
+        expect(form.redirects).to eq([
+                                       { 'path' => '/foo', 'display_url' => false },
+                                       { 'path' => '/bar', 'display_url' => true }
+                                     ])
+      end
     end
   end
 

--- a/spec/forms/concerns/hyrax/redirects_field_behavior_spec.rb
+++ b/spec/forms/concerns/hyrax/redirects_field_behavior_spec.rb
@@ -44,8 +44,7 @@ RSpec.describe Hyrax::RedirectsFieldBehavior do
       expect(property_target).to receive(:property).with(
         :redirects_attributes,
         virtual: true,
-        populator: :redirects_attributes_populator,
-        prepopulator: :redirects_attributes_prepopulator
+        populator: :redirects_attributes_populator
       )
       expect(property_target).to receive(:property).with(:redirects_display_url_index, virtual: true)
       property_target.include(described_class)
@@ -182,26 +181,6 @@ RSpec.describe Hyrax::RedirectsFieldBehavior do
                                        { 'path' => '/bar', 'display_url' => true }
                                      ])
       end
-    end
-  end
-
-  describe '#redirects_attributes_prepopulator' do
-    it 'wraps each persisted hash entry in a Hyrax::Redirect presenter' do
-      form.redirects = [{ 'path' => '/foo', 'display_url' => true }]
-      form.send(:redirects_attributes_prepopulator)
-
-      expect(form.redirects.first).to be_a(Hyrax::Redirect)
-      expect(form.redirects.first.path).to eq('/foo')
-      expect(form.redirects.first.display_url).to be(true)
-    end
-
-    it 'is a no-op when the feature is inactive' do
-      allow(Hyrax.config).to receive(:redirects_active?).and_return(false)
-      original = [{ 'path' => '/foo' }]
-      form.redirects = original
-      form.send(:redirects_attributes_prepopulator)
-
-      expect(form.redirects).to be(original)
     end
   end
 end

--- a/spec/views/hyrax/base/_form_redirects.html.erb_spec.rb
+++ b/spec/views/hyrax/base/_form_redirects.html.erb_spec.rb
@@ -37,6 +37,10 @@ RSpec.describe 'hyrax/base/_form_redirects.html.erb', type: :view do
     it 'renders a row template element' do
       expect(page).to have_css('template[data-redirects-row-template]', visible: :all)
     end
+
+    it 'sets data-next-index to 0 so JS-added rows start at index 0' do
+      expect(page).to have_css('table[data-redirects-table][data-next-index="0"]')
+    end
   end
 
   context 'when the resource has one redirect with display_url false' do
@@ -66,6 +70,10 @@ RSpec.describe 'hyrax/base/_form_redirects.html.erb', type: :view do
       group_radios = page.all("input[type=radio][name='#{form_object_name}[redirects_display_url_index]']")
       # None radio + 2 row radios (template content isn't in the live DOM)
       expect(group_radios.size).to eq(3)
+    end
+
+    it 'sets data-next-index past the highest existing row index' do
+      expect(page).to have_css('table[data-redirects-table][data-next-index="2"]')
     end
   end
 

--- a/spec/views/hyrax/base/_form_redirects.html.erb_spec.rb
+++ b/spec/views/hyrax/base/_form_redirects.html.erb_spec.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+RSpec.describe 'hyrax/base/_form_redirects.html.erb', type: :view do
+  let(:form_object_name) { 'generic_work' }
+  let(:form) { double('form', object_name: form_object_name, object: form_object) }
+  let(:form_object) { double('resource', redirects: redirects) }
+  let(:redirects) { [] }
+
+  before do
+    allow(view).to receive(:redirects_tab?).and_return(true)
+    allow(view).to receive(:request).and_return(double(base_url: 'http://example.test'))
+  end
+
+  let(:page) do
+    render partial: 'hyrax/base/form_redirects', locals: { f: form }
+    Capybara::Node::Simple.new(rendered)
+  end
+
+  def radio_for_index(value)
+    page.find("input[type=radio][name='#{form_object_name}[redirects_display_url_index]'][value='#{value}']")
+  end
+
+  context 'when the resource has no redirects' do
+    let(:redirects) { [] }
+
+    it 'renders the "None" radio as the only checked option' do
+      expect(radio_for_index('')).to be_checked
+    end
+
+    it 'renders no row radios' do
+      expect(page).not_to have_css("input[type=radio][name='#{form_object_name}[redirects_display_url_index]'][value='0']")
+    end
+
+    it 'renders the Add another alias button' do
+      expect(page).to have_button('Add another alias')
+    end
+
+    it 'renders a row template element' do
+      expect(page).to have_css('template[data-redirects-row-template]', visible: :all)
+    end
+  end
+
+  context 'when the resource has one redirect with display_url false' do
+    let(:redirects) { [Hyrax::Redirect.new(path: '/handle/1', display_url: false)] }
+
+    it 'checks the "None" radio and leaves per-row radios unchecked' do
+      expect(radio_for_index('')).to be_checked
+      expect(radio_for_index('0')).not_to be_checked
+    end
+  end
+
+  context 'when one entry is flagged as display_url' do
+    let(:redirects) do
+      [
+        Hyrax::Redirect.new(path: '/handle/1', display_url: false),
+        Hyrax::Redirect.new(path: '/handle/2', display_url: true)
+      ]
+    end
+
+    it 'checks only the matching row radio' do
+      expect(radio_for_index('')).not_to be_checked
+      expect(radio_for_index('0')).not_to be_checked
+      expect(radio_for_index('1')).to be_checked
+    end
+
+    it 'shares one radio group name across all rows' do
+      group_radios = page.all("input[type=radio][name='#{form_object_name}[redirects_display_url_index]']")
+      # None radio + 2 row radios (template content isn't in the live DOM)
+      expect(group_radios.size).to eq(3)
+    end
+  end
+
+  context 'when redirects holds plain hashes (re-render after validation failure)' do
+    let(:redirects) do
+      [
+        { 'path' => '/handle/1', 'display_url' => true }
+      ]
+    end
+
+    it 'still wraps and renders the display_url radio as checked' do
+      expect(radio_for_index('0')).to be_checked
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Adds a Display URL radio column to the Aliases form with a "None" option, plus an "Add another alias" button so users can enter multiple aliases before saving.
- Refs samvera/hyrax#7451 (replaces the prior approach), Pitt #653.

## Details
- Stacks on top of the schema-rename PR. The `display_url` column added there now has a UI.
- Enforces "at most one per record" rule server-side by the existing redirect validator, so Bulkrax imports and direct console writes follow the same constraint.
- The redirects resolver is unchanged in this PR — visiting any alias still 301s to the record's UUID URL. 
- Existing inline and new javascript moved to `app/assets/javascripts/hyrax/redirects.js`.
