### PR TITLE
Do not require transcript IDS for file sets

### DIFF
--- a/app/indexers/hyrax/indexers/file_set_indexer.rb
+++ b/app/indexers/hyrax/indexers/file_set_indexer.rb
@@ -24,7 +24,7 @@ module Hyrax
           solr_doc['extracted_text_id_ssi']        = resource.extracted_text_id.to_s
           solr_doc['hasRelatedMediaFragment_ssim'] = resource.representative_id.to_s
           solr_doc['hasRelatedImage_ssim']         = resource.thumbnail_id.to_s
-          solr_doc['transcript_ids_ssim']          = resource.transcript_ids&.map(&:to_s)
+          solr_doc['transcript_ids_ssim']          = resource.transcript_ids&.map(&:to_s) if resource.respond_to?(:transcript_ids)
 
           index_lease(solr_doc)
           index_embargo(solr_doc)

--- a/spec/indexers/hyrax/indexers/file_set_indexer_spec.rb
+++ b/spec/indexers/hyrax/indexers/file_set_indexer_spec.rb
@@ -243,6 +243,23 @@ RSpec.describe Hyrax::Indexers::FileSetIndexer, :frozen_time, if: Hyrax.config.u
       end
     end
 
+    context "when the FileSet does not carry the file_set_metadata schema" do
+      # Adopters running flexible mode with HYRAX_DISABLE_INCLUDE_METADATA=true
+      # don't include Hyrax::Schema(:file_set_metadata) on Hyrax::FileSet, so
+      # transcript_ids (and other schema attributes) aren't defined. Simulate
+      # this by making transcript_ids raise NoMethodError when the indexer
+      # tries to read it.
+      before do
+        allow(file_set).to receive(:respond_to?).and_call_original
+        allow(file_set).to receive(:respond_to?).with(:transcript_ids).and_return(false)
+        allow(file_set).to receive(:transcript_ids).and_raise(NoMethodError)
+      end
+
+      it "skips the transcript_ids field instead of raising" do
+        expect { subject }.not_to raise_error
+      end
+    end
+
     context 'with a valid embargo' do
       let!(:embargo) { FactoryBot.create(:hyrax_embargo) }
 


### PR DESCRIPTION
### Fixes

Refs https://github.com/samvera/hyrax/pull/7418

Makes transcript_ids optional for file sets.

File set metadata yaml file was updated to include transcript_ids, but this only gets included when including metadata... for flexible metadata, file sets failed when it wasn't present in the m3 file.

