### PR TITLE
Redirects rob style

### DIFF
--- a/.dassie/db/migrate/20260520215624_add_additional_redirect_info.hyrax.rb
+++ b/.dassie/db/migrate/20260520215624_add_additional_redirect_info.hyrax.rb
@@ -1,0 +1,23 @@
+class AddAdditionalRedirectInfo < ActiveRecord::Migration[6.1]
+  def change
+    remove_index :hyrax_redirect_paths, :path
+    remove_index :hyrax_redirect_paths, :resource_id
+    drop_table :hyrax_redirect_paths do |t|
+      t.string :path, null: false
+      t.string :resource_id, null: false
+
+      t.timestamps
+    end
+
+    create_table :hyrax_redirect_paths do |t|
+      t.string :from_path, null: false, index: true
+      t.string :to_path, null: false, index: true
+      t.string :permalink_path, null: false
+      t.string :resource_id, null: false, index: true
+      t.boolean :is_display_url, null: false, default: false
+
+      t.timestamps
+    end
+
+  end
+end

--- a/.dassie/db/schema.rb
+++ b/.dassie/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2026_04_30_000001) do
+ActiveRecord::Schema.define(version: 2026_05_20_215624) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -309,12 +309,16 @@ ActiveRecord::Schema.define(version: 2026_04_30_000001) do
   end
 
   create_table "hyrax_redirect_paths", force: :cascade do |t|
-    t.string "path", null: false
+    t.string "from_path", null: false
+    t.string "to_path", null: false
+    t.string "permalink_path", null: false
     t.string "resource_id", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["path"], name: "index_hyrax_redirect_paths_on_path", unique: true
+    t.boolean "is_display_url", default: false, null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["from_path"], name: "index_hyrax_redirect_paths_on_from_path"
     t.index ["resource_id"], name: "index_hyrax_redirect_paths_on_resource_id"
+    t.index ["to_path"], name: "index_hyrax_redirect_paths_on_to_path"
   end
 
   create_table "job_io_wrappers", force: :cascade do |t|

--- a/.koppie/db/migrate/20260520215624_add_additional_redirect_info.hyrax.rb
+++ b/.koppie/db/migrate/20260520215624_add_additional_redirect_info.hyrax.rb
@@ -1,0 +1,23 @@
+class AddAdditionalRedirectInfo < ActiveRecord::Migration[6.1]
+  def change
+    remove_index :hyrax_redirect_paths, :path
+    remove_index :hyrax_redirect_paths, :resource_id
+    drop_table :hyrax_redirect_paths do |t|
+      t.string :path, null: false
+      t.string :resource_id, null: false
+
+      t.timestamps
+    end
+
+    create_table :hyrax_redirect_paths do |t|
+      t.string :from_path, null: false, index: true
+      t.string :to_path, null: false, index: true
+      t.string :permalink_path, null: false
+      t.string :resource_id, null: false, index: true
+      t.boolean :is_display_url, null: false, default: false
+
+      t.timestamps
+    end
+
+  end
+end

--- a/.koppie/db/schema.rb
+++ b/.koppie/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_04_30_000001) do
+ActiveRecord::Schema[7.2].define(version: 2026_05_20_215624) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "uuid-ossp"
@@ -300,12 +300,16 @@ ActiveRecord::Schema[7.2].define(version: 2026_04_30_000001) do
   end
 
   create_table "hyrax_redirect_paths", force: :cascade do |t|
-    t.string "path", null: false
+    t.string "from_path", null: false
+    t.string "to_path", null: false
+    t.string "permalink_path", null: false
     t.string "resource_id", null: false
-    t.datetime "created_at", precision: nil, null: false
-    t.datetime "updated_at", precision: nil, null: false
-    t.index ["path"], name: "index_hyrax_redirect_paths_on_path", unique: true
+    t.boolean "is_display_url", default: false, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["from_path"], name: "index_hyrax_redirect_paths_on_from_path"
     t.index ["resource_id"], name: "index_hyrax_redirect_paths_on_resource_id"
+    t.index ["to_path"], name: "index_hyrax_redirect_paths_on_to_path"
   end
 
   create_table "job_io_wrappers", force: :cascade do |t|

--- a/app/controllers/concerns/hyrax/collections_controller_behavior.rb
+++ b/app/controllers/concerns/hyrax/collections_controller_behavior.rb
@@ -34,6 +34,12 @@ module Hyrax
     end
 
     def show
+      unless params[:is_redirect]
+        normal_path = Hyrax::RedirectPathNormalizer.call(request.path)
+        redirect_path = Hyrax::RedirectPath.find_by(from_path: normal_path)
+        redirect_to redirect_path&.to_path if redirect_path.present? && redirect_path.to_path != normal_path
+      end
+
       @curation_concern = @collection # we must populate curation_concern
       presenter
       query_collection_members

--- a/app/controllers/concerns/hyrax/works_controller_behavior.rb
+++ b/app/controllers/concerns/hyrax/works_controller_behavior.rb
@@ -81,6 +81,12 @@ module Hyrax
     # @raise CanCan::AccessDenied if the document is not found or the user doesn't have access to it.
     # rubocop:disable Metrics/AbcSize
     def show
+      unless params[:is_redirect]
+        normal_path = Hyrax::RedirectPathNormalizer.call(request.path)
+        redirect_path = Hyrax::RedirectPath.find_by(from_path: normal_path)
+        redirect_to redirect_path&.to_path if redirect_path.present? && redirect_path.to_path != normal_path
+      end
+
       @user_collections = user_collections
 
       respond_to do |wants|

--- a/app/controllers/hyrax/redirects_controller.rb
+++ b/app/controllers/hyrax/redirects_controller.rb
@@ -3,48 +3,23 @@
 module Hyrax
   # See documentation/redirects.md for the redirects feature.
   class RedirectsController < ApplicationController
-    CACHE_TTL = 60.seconds
-
     def show
       path = Hyrax::RedirectPathNormalizer.call(params[:alias_path])
-      doc = lookup(path)
-      raise ActionController::RoutingError, 'Not Found' if doc.blank?
+      redirect_path = Hyrax::RedirectPath.find_by(from_path: path)
+      raise ActionController::RoutingError, 'Not Found' if redirect_path.blank?
 
-      redirect_to permanent_url_for(::SolrDocument.new(doc)), status: :moved_permanently
-    end
-
-    private
-
-    # Collections are routed by the Hyrax engine; works are routed by
-    # the host app's curation-concern resources. `polymorphic_path`
-    # consults a routes proxy, so we pick the right one per type.
-    def permanent_url_for(document)
-      proxy = collection_document?(document) ? hyrax : main_app
-      polymorphic_path([proxy, document])
-    end
-
-    def collection_document?(document)
-      model = document.hydra_model
-      Hyrax::ModelRegistry.collection_classes.any? { |klass| model <= klass }
-    rescue StandardError
-      false
-    end
-
-    def lookup(path)
-      Rails.cache.fetch(cache_key_for(path), expires_in: CACHE_TTL) do
-        response = Hyrax::SolrService.get(%(redirects_path_ssim:"#{path}"), rows: 1)
-        response.dig('response', 'docs')&.first
+      if redirect_path.is_display_url?
+        begin
+          info = Rails.application.routes.recognize_path(redirect_path.permalink_path)
+          controller = "#{info[:controller].camelize}Controller".constantize
+          request.path_parameters = info.merge(is_redirect: true)
+          controller.dispatch(info[:action], request, response)
+          # rescue StandardError => e
+          # raise ActionController::RoutingError, e.message
+        end
+      else
+        redirect_to redirect_path.to_path, status: :moved_permanently
       end
-    rescue RSolr::Error::Http => e
-      Hyrax.logger.warn "Redirect lookup failed for #{path.inspect}: #{e.message}"
-      nil
-    end
-
-    # Delegate to RedirectCacheBuster so the key format lives in one place.
-    # Override RedirectCacheBuster.cache_key_for in a downstream app to
-    # encode tenancy.
-    def cache_key_for(path)
-      Hyrax::RedirectCacheBuster.cache_key_for(path)
     end
   end
 end

--- a/lib/generators/hyrax/templates/db/migrate/20260520214939_add_additional_redirect_info.rb.erb
+++ b/lib/generators/hyrax/templates/db/migrate/20260520214939_add_additional_redirect_info.rb.erb
@@ -1,0 +1,22 @@
+class AddAdditionalRedirectInfo < ActiveRecord::Migration<%= migration_version %>
+  def change
+    remove_index :hyrax_redirect_paths, :path
+    remove_index :hyrax_redirect_paths, :resource_id
+    drop_table :hyrax_redirect_paths do |t|
+        t.string :path, null: false
+        t.string :resource_id, null: false
+
+        t.timestamps
+    end
+
+    create_table :hyrax_redirect_paths do |t|
+        t.string :from_path, null: false, index: true
+        t.string :to_path, null: false, index: true
+        t.string :permalink_path, null: false
+        t.string :resource_id, null: false, index: true
+        t.boolean :is_display_url, null: false, default: false
+
+        t.timestamps
+    end
+  end
+end


### PR DESCRIPTION
Work with id jd472w44j and a display URL
```ruby
Hyrax::RedirectPath.create(from_path: '/concern/generic_works/jd472w44j', to_path: '/hang-in-there', permalink_path: '/concern/generic_works/jd472w44j', resource_id: 'jd472w44j')
Hyrax::RedirectPath.create(from_path: '/old-url/handinthere', to_path: '/hang-in-there', permalink_path: '/concern/generic_works/jd472w44j', resource_id: 'jd472w44j')
Hyrax::RedirectPath.create(from_path: '/hang-in-there', to_path: '/hang-in-there', permalink_path: '/concern/generic_works/jd472w44j', resource_id: 'jd472w44j', is_display_url: true)
```

Collection with id xg94hp52v
```ruby
Hyrax::RedirectPath.create(from_path: '/collections/xg94hp52v', to_path: '/test-slug', permalink_path: '/collections/xg94hp52v', resource_id: 'xg94hp52v')
Hyrax::RedirectPath.create(from_path: '/old-url/test-slug', to_path: '/test-slug', permalink_path: '/collections/xg94hp52v', resource_id: 'xg94hp52v')
Hyrax::RedirectPath.create(from_path: '/test-slug', to_path: '/test-slug', permalink_path: '/collections/xg94hp52v', resource_id: 'xg94hp52v', is_display_url: true)
```

Work with id jd472w44j without display URL

```ruby
Hyrax::RedirectPath.create(from_path: '/concern/generic_works/jd472w44j', to_path: '/concern/generic_works/jd472w44j', permalink_path: '/concern/generic_works/jd472w44j', resource_id: 'jd472w44j')
Hyrax::RedirectPath.create(from_path: '/old-url/handinthere', to_path: '/concern/generic_works/jd472w44j', permalink_path: '/concern/generic_works/jd472w44j', resource_id: 'jd472w44j')
```