### PR TITLE
Redirects schema changes

### DIFF
--- a/.dassie/db/migrate/20260521003627_add_additional_redirect_info.hyrax.rb
+++ b/.dassie/db/migrate/20260521003627_add_additional_redirect_info.hyrax.rb
@@ -1,0 +1,32 @@
+class AddAdditionalRedirectInfo < ActiveRecord::Migration[5.2]
+  def up
+    drop_table :hyrax_redirect_paths if table_exists?(:hyrax_redirect_paths)
+
+    create_table :hyrax_redirect_paths do |t|
+      t.string  :from_path,      null: false
+      t.string  :to_path,        null: false
+      t.string  :permalink_path, null: false
+      t.string  :resource_id,    null: false
+      t.boolean :is_display_url, null: false, default: false
+
+      t.timestamps
+    end
+
+    add_index :hyrax_redirect_paths, :from_path, unique: true
+    add_index :hyrax_redirect_paths, :resource_id
+  end
+
+  def down
+    drop_table :hyrax_redirect_paths
+
+    create_table :hyrax_redirect_paths do |t|
+      t.string :path,        null: false
+      t.string :resource_id, null: false
+
+      t.timestamps
+    end
+
+    add_index :hyrax_redirect_paths, :path, unique: true
+    add_index :hyrax_redirect_paths, :resource_id
+  end
+end

--- a/.dassie/db/schema.rb
+++ b/.dassie/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2026_04_30_000001) do
+ActiveRecord::Schema.define(version: 2026_05_21_003627) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -309,11 +309,14 @@ ActiveRecord::Schema.define(version: 2026_04_30_000001) do
   end
 
   create_table "hyrax_redirect_paths", force: :cascade do |t|
-    t.string "path", null: false
+    t.string "from_path", null: false
+    t.string "to_path", null: false
+    t.string "permalink_path", null: false
     t.string "resource_id", null: false
+    t.boolean "is_display_url", default: false, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["path"], name: "index_hyrax_redirect_paths_on_path", unique: true
+    t.index ["from_path"], name: "index_hyrax_redirect_paths_on_from_path", unique: true
     t.index ["resource_id"], name: "index_hyrax_redirect_paths_on_resource_id"
   end
 

--- a/.koppie/db/migrate/20260521003627_add_additional_redirect_info.hyrax.rb
+++ b/.koppie/db/migrate/20260521003627_add_additional_redirect_info.hyrax.rb
@@ -1,0 +1,32 @@
+class AddAdditionalRedirectInfo < ActiveRecord::Migration[5.2]
+  def up
+    drop_table :hyrax_redirect_paths if table_exists?(:hyrax_redirect_paths)
+
+    create_table :hyrax_redirect_paths do |t|
+      t.string  :from_path,      null: false
+      t.string  :to_path,        null: false
+      t.string  :permalink_path, null: false
+      t.string  :resource_id,    null: false
+      t.boolean :is_display_url, null: false, default: false
+
+      t.timestamps
+    end
+
+    add_index :hyrax_redirect_paths, :from_path, unique: true
+    add_index :hyrax_redirect_paths, :resource_id
+  end
+
+  def down
+    drop_table :hyrax_redirect_paths
+
+    create_table :hyrax_redirect_paths do |t|
+      t.string :path,        null: false
+      t.string :resource_id, null: false
+
+      t.timestamps
+    end
+
+    add_index :hyrax_redirect_paths, :path, unique: true
+    add_index :hyrax_redirect_paths, :resource_id
+  end
+end

--- a/.koppie/db/schema.rb
+++ b/.koppie/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_04_30_000001) do
+ActiveRecord::Schema[7.2].define(version: 2026_05_21_003627) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "uuid-ossp"
@@ -300,11 +300,14 @@ ActiveRecord::Schema[7.2].define(version: 2026_04_30_000001) do
   end
 
   create_table "hyrax_redirect_paths", force: :cascade do |t|
-    t.string "path", null: false
+    t.string "from_path", null: false
+    t.string "to_path", null: false
+    t.string "permalink_path", null: false
     t.string "resource_id", null: false
+    t.boolean "is_display_url", default: false, null: false
     t.datetime "created_at", precision: nil, null: false
     t.datetime "updated_at", precision: nil, null: false
-    t.index ["path"], name: "index_hyrax_redirect_paths_on_path", unique: true
+    t.index ["from_path"], name: "index_hyrax_redirect_paths_on_from_path", unique: true
     t.index ["resource_id"], name: "index_hyrax_redirect_paths_on_resource_id"
   end
 

--- a/app/helpers/hyrax/permalink_helper.rb
+++ b/app/helpers/hyrax/permalink_helper.rb
@@ -4,14 +4,10 @@ module Hyrax
   # Helpers for the "Copy permalink" button on work and collection show pages.
   # See documentation/copy_permalink.md.
   module PermalinkHelper
-    # The canonical, UUID-based URL for the record represented by `presenter`.
-    # This is the URL the redirect resolver redirects *to*, so it is stable
-    # across alias changes and is safe to share or cite. Collections are
-    # routed by the Hyrax engine; works are routed by the host app's
-    # curation-concern resources.
+    # The UUID-based URL for the record represented by `presenter`, so
+    # it is stable across alias changes and is safe to share or cite.
     def permalink_for(presenter)
-      proxy = collection_presenter?(presenter) ? hyrax : main_app
-      strip_query_string(polymorphic_url([proxy, presenter]))
+      strip_query_string(request.base_url + Hyrax::PermalinkPath.call(presenter))
     end
 
     def copy_permalink_enabled?
@@ -19,10 +15,6 @@ module Hyrax
     end
 
     private
-
-    def collection_presenter?(presenter)
-      presenter.respond_to?(:collection?) && presenter.collection?
-    end
 
     # Removes the `?…` query string from a URL so the permalink is a clean
     # canonical reference. Rails URL helpers append `?locale=...` (and any

--- a/app/models/hyrax/redirect_path.rb
+++ b/app/models/hyrax/redirect_path.rb
@@ -5,8 +5,9 @@ module Hyrax
   #
   # Maintained by Hyrax::Transactions::Steps::SyncRedirectPaths and
   # Hyrax::Transactions::Steps::RemoveRedirectPaths; queried by
-  # Hyrax::RedirectsLookup. The unique index on `path` is the source of truth
-  # for "no two records share a redirect path"; this class just exposes it.
+  # Hyrax::RedirectsLookup. The unique index on `from_path` is the source
+  # of truth for "no two records share a redirect alias"; this class just
+  # exposes it.
   class RedirectPath < ActiveRecord::Base
     self.table_name = 'hyrax_redirect_paths'
   end

--- a/app/services/hyrax/permalink_path.rb
+++ b/app/services/hyrax/permalink_path.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module Hyrax
+  # Returns the canonical, UUID-based path for a Hyrax resource
+  # (e.g. '/concern/generic_works/<uuid>' or '/collections/<uuid>').
+  #
+  # Collections are routed by the Hyrax engine; works are routed by the
+  # host app's curation-concern resources, so the picker consults
+  # `resource.collection?` to choose the right route helper.
+  module PermalinkPath
+    module_function
+
+    # @param resource [#collection?] a Hyrax::Resource (work or collection)
+    # @return [String] the canonical path, e.g. '/concern/generic_works/<uuid>'
+    def call(resource)
+      helpers = collection_resource?(resource) ? Hyrax::Engine.routes.url_helpers : Rails.application.routes.url_helpers
+      helpers.polymorphic_path(resource)
+    end
+
+    def collection_resource?(resource)
+      resource.respond_to?(:collection?) && resource.collection?
+    end
+    private_class_method :collection_resource?
+  end
+end

--- a/app/services/hyrax/redirects_lookup.rb
+++ b/app/services/hyrax/redirects_lookup.rb
@@ -3,8 +3,8 @@
 module Hyrax
   # Single point of truth for "is this redirect path already taken?".
   # Backed by the `hyrax_redirect_paths` table, which has a unique index on
-  # `path` for both correctness (rejects duplicates at insert time) and
-  # lookup speed (B-tree equality on a small derived table).
+  # `from_path` for both correctness (rejects duplicates at insert time)
+  # and lookup speed.
   #
   # See documentation/redirects.md.
   class RedirectsLookup
@@ -19,7 +19,7 @@ module Hyrax
 
     def taken?
       return false if @path.blank?
-      scope = Hyrax::RedirectPath.where(path: @path)
+      scope = Hyrax::RedirectPath.where(from_path: @path)
       scope = scope.where.not(resource_id: @except_id) if @except_id.present?
       scope.exists?
     end

--- a/documentation/redirects.md
+++ b/documentation/redirects.md
@@ -199,12 +199,22 @@ The validator rejects any redirect path that equals one of these prefixes, or st
 
 ### Uniqueness lookup and the `hyrax_redirect_paths` table
 
-Global uniqueness is enforced by a Postgres table, `hyrax_redirect_paths`, which has a unique B-tree index on `path`. The table is a derived record of every redirect path currently in use, and the unique index gives the hard guarantee that no two records can share a path even under concurrent saves. A second non-unique index on `resource_id` supports the per-resource sync described below.
+Global uniqueness is enforced by a Postgres table, `hyrax_redirect_paths`, with columns:
 
-`Hyrax::RedirectsLookup` is the single point of truth for "is this path taken?". It queries the table:
+| Column           | Purpose                                                                                                              |
+| ---------------- | -------------------------------------------------------------------------------------------------------------------- |
+| `from_path`      | The alias path the visitor types. Unique B-tree indexed — the primary request-time lookup key.                       |
+| `to_path`        | Where the visitor should be sent. For now, the resource's canonical UUID path on every row.                          |
+| `permalink_path` | The resource's canonical UUID path (e.g. `/concern/generic_works/<uuid>` or `/collections/<uuid>`).                  |
+| `resource_id`    | The UUID of the work or collection. Indexed (non-unique) for the per-resource sync described below.                  |
+| `is_display_url` | Boolean. Defaults to `false`. Reserved for the display-URL feature.                                                  |
+
+The unique index on `from_path` gives the hard guarantee that no two records can share an alias even under concurrent saves.
+
+`Hyrax::RedirectsLookup` is the single point of truth for "is this alias taken?". It queries the table:
 
 ```sql
-SELECT 1 FROM hyrax_redirect_paths WHERE path = ? AND resource_id <> ? LIMIT 1;
+SELECT 1 FROM hyrax_redirect_paths WHERE from_path = ? AND resource_id <> ? LIMIT 1;
 ```
 
 The validator calls `Hyrax::RedirectsLookup.taken?(path, except_id: record.id)` to give the user friendly feedback at form-submit time. If two simultaneous requests both pass validation (because both checked the table before either committed), the unique index rejects the second one at insert time and the enclosing transaction returns `Failure`.

--- a/lib/generators/hyrax/templates/db/migrate/20260521003627_add_additional_redirect_info.rb.erb
+++ b/lib/generators/hyrax/templates/db/migrate/20260521003627_add_additional_redirect_info.rb.erb
@@ -1,0 +1,39 @@
+class AddAdditionalRedirectInfo < ActiveRecord::Migration<%= migration_version %>
+  def up
+    drop_table :hyrax_redirect_paths if table_exists?(:hyrax_redirect_paths)
+
+    create_table :hyrax_redirect_paths do |t|
+      t.string  :from_path,      null: false
+      t.string  :to_path,        null: false
+      t.string  :permalink_path, null: false
+      t.string  :resource_id,    null: false
+      t.boolean :is_display_url, null: false, default: false
+
+      t.timestamps
+    end
+
+    # Unique index on from_path enforces global uniqueness at the DB level
+    # (the hard guarantee under concurrent writes) and is the primary
+    # request-time lookup: the resolver finds rows by the visited alias.
+    add_index :hyrax_redirect_paths, :from_path, unique: true
+
+    # Non-unique index supports the per-resource sync performed by
+    # Hyrax::Transactions::Steps::SyncRedirectPaths and the per-resource
+    # cleanup performed by Hyrax::Transactions::Steps::RemoveRedirectPaths.
+    add_index :hyrax_redirect_paths, :resource_id
+  end
+
+  def down
+    drop_table :hyrax_redirect_paths
+
+    create_table :hyrax_redirect_paths do |t|
+      t.string :path,        null: false
+      t.string :resource_id, null: false
+
+      t.timestamps
+    end
+
+    add_index :hyrax_redirect_paths, :path, unique: true
+    add_index :hyrax_redirect_paths, :resource_id
+  end
+end

--- a/lib/hyrax/transactions/steps/remove_redirect_paths.rb
+++ b/lib/hyrax/transactions/steps/remove_redirect_paths.rb
@@ -18,7 +18,7 @@ module Hyrax
         def call(resource)
           return Success(resource) unless removable?(resource)
           scope = Hyrax::RedirectPath.where(resource_id: resource.id.to_s)
-          paths = scope.pluck(:path)
+          paths = scope.pluck(:from_path)
           scope.delete_all
           Hyrax::RedirectCacheBuster.call(paths) if paths.any?
           Success(resource)

--- a/lib/hyrax/transactions/steps/sync_redirect_paths.rb
+++ b/lib/hyrax/transactions/steps/sync_redirect_paths.rb
@@ -6,8 +6,8 @@ module Hyrax
     module Steps
       # A `dry-transaction` step that mirrors a saved resource's `redirects`
       # entries into the `hyrax_redirect_paths` redirects table. The unique
-      # index on `path` enforces global uniqueness at the DB level — if a
-      # concurrent save already claimed a path, the insert raises
+      # index on `from_path` enforces global uniqueness at the DB level — if
+      # a concurrent save already claimed a path, the insert raises
       # ActiveRecord::RecordNotUnique and this step returns Failure, which
       # short-circuits the enclosing transaction.
       #
@@ -40,27 +40,36 @@ module Hyrax
         end
 
         def build_rows(object)
-          # Valkyrie's JSONValueMapper symbolizes hash keys on read; accept either.
-          # Paths are normalized at write time by Hyrax::RedirectsNormalization.
-          paths = Array(object.redirects)
-                  .map { |entry| entry['path'] || entry[:path] }
-                  .reject(&:blank?)
-                  .uniq
+          permalink = Hyrax::PermalinkPath.call(object)
+          resource_id = object.id.to_s
           now = Time.current
-          paths.map { |path| { path: path, resource_id: object.id.to_s, created_at: now, updated_at: now } }
+          alias_paths_for(object).map do |alias_path|
+            { from_path: alias_path,
+              to_path: permalink,
+              permalink_path: permalink,
+              resource_id: resource_id,
+              is_display_url: false,
+              created_at: now, updated_at: now }
+          end
         end
 
-        # @return [Array<String>, nil] the union of old + new paths that need
-        #   cache invalidation, or nil when nothing changed.
+        # Valkyrie's JSONValueMapper symbolizes hash keys on read; accept either.
+        # Paths are normalized at write time by Hyrax::RedirectsNormalization.
+        def alias_paths_for(object)
+          Array(object.redirects).map { |entry| entry['path'] || entry[:path] }.reject(&:blank?).uniq
+        end
+
+        # @return [Array<String>, nil] the union of old + new from_paths that
+        #   need cache invalidation, or nil when nothing changed.
         def replace_rows(object, rows)
-          desired_paths = rows.map { |r| r[:path] }.sort
+          desired_paths = rows.map { |r| r[:from_path] }.sort
 
           Hyrax::RedirectPath.transaction do
-            existing_paths = Hyrax::RedirectPath.where(resource_id: object.id.to_s).pluck(:path).sort
+            existing_paths = Hyrax::RedirectPath.where(resource_id: object.id.to_s).pluck(:from_path).sort
             return nil if desired_paths == existing_paths
 
             Hyrax::RedirectPath.where(resource_id: object.id.to_s).delete_all
-            # rubocop:disable Rails/SkipsModelValidations -- the DB unique index on `path` is the validation we rely on; bulk insert is intentional
+            # rubocop:disable Rails/SkipsModelValidations -- the DB unique index on `from_path` is the validation we rely on; bulk insert is intentional
             Hyrax::RedirectPath.insert_all!(rows) if rows.any?
             # rubocop:enable Rails/SkipsModelValidations
 

--- a/spec/helpers/hyrax/permalink_helper_spec.rb
+++ b/spec/helpers/hyrax/permalink_helper_spec.rb
@@ -16,47 +16,30 @@ RSpec.describe Hyrax::PermalinkHelper, type: :helper do
   end
 
   describe '#permalink_for' do
-    let(:work_presenter) { double('WorkPresenter', collection?: false) }
-    let(:collection_presenter) { double('CollectionPresenter', collection?: true) }
-    let(:bare_presenter) { double('BarePresenter') }
+    let(:presenter) { double('Presenter') }
 
-    it 'routes works through main_app' do
-      expect(helper).to receive(:polymorphic_url).with([helper.main_app, work_presenter]).and_return('http://example.test/works/1')
-      expect(helper.permalink_for(work_presenter)).to eq('http://example.test/works/1')
+    before do
+      allow(helper.request).to receive(:base_url).and_return('http://example.test')
     end
 
-    it 'routes collections through the Hyrax engine' do
-      expect(helper).to receive(:polymorphic_url).with([helper.hyrax, collection_presenter]).and_return('http://example.test/collections/1')
-      expect(helper.permalink_for(collection_presenter)).to eq('http://example.test/collections/1')
-    end
-
-    it 'treats presenters without a collection? method as non-collections' do
-      expect(helper).to receive(:polymorphic_url).with([helper.main_app, bare_presenter]).and_return('http://example.test/x/1')
-      expect(helper.permalink_for(bare_presenter)).to eq('http://example.test/x/1')
+    it 'concatenates request.base_url with the canonical path from Hyrax::PermalinkPath' do
+      allow(Hyrax::PermalinkPath).to receive(:call).with(presenter).and_return('/concern/generic_works/abc-123')
+      expect(helper.permalink_for(presenter)).to eq('http://example.test/concern/generic_works/abc-123')
     end
 
     it 'strips a locale query string appended by Rails default_url_options' do
-      expect(helper).to receive(:polymorphic_url)
-        .with([helper.main_app, work_presenter])
-        .and_return('http://example.test/concern/generic_works/abc-123?locale=en')
-      expect(helper.permalink_for(work_presenter))
-        .to eq('http://example.test/concern/generic_works/abc-123')
+      allow(Hyrax::PermalinkPath).to receive(:call).with(presenter).and_return('/concern/generic_works/abc-123?locale=en')
+      expect(helper.permalink_for(presenter)).to eq('http://example.test/concern/generic_works/abc-123')
     end
 
     it 'strips any query string, not just locale' do
-      expect(helper).to receive(:polymorphic_url)
-        .with([helper.main_app, work_presenter])
-        .and_return('http://example.test/concern/generic_works/abc-123?foo=bar&baz=qux')
-      expect(helper.permalink_for(work_presenter))
-        .to eq('http://example.test/concern/generic_works/abc-123')
+      allow(Hyrax::PermalinkPath).to receive(:call).with(presenter).and_return('/concern/generic_works/abc-123?foo=bar&baz=qux')
+      expect(helper.permalink_for(presenter)).to eq('http://example.test/concern/generic_works/abc-123')
     end
 
     it 'strips a URL fragment as well' do
-      expect(helper).to receive(:polymorphic_url)
-        .with([helper.main_app, work_presenter])
-        .and_return('http://example.test/concern/generic_works/abc-123?locale=en#section')
-      expect(helper.permalink_for(work_presenter))
-        .to eq('http://example.test/concern/generic_works/abc-123')
+      allow(Hyrax::PermalinkPath).to receive(:call).with(presenter).and_return('/concern/generic_works/abc-123#section')
+      expect(helper.permalink_for(presenter)).to eq('http://example.test/concern/generic_works/abc-123')
     end
   end
 end

--- a/spec/lib/hyrax/transactions/steps/remove_redirect_paths_spec.rb
+++ b/spec/lib/hyrax/transactions/steps/remove_redirect_paths_spec.rb
@@ -15,8 +15,12 @@ RSpec.describe Hyrax::Transactions::Steps::RemoveRedirectPaths do
   describe '#call' do
     context 'when the resource has rows in the table' do
       before do
-        Hyrax::RedirectPath.create!(path: '/handle/1', resource_id: resource_id)
-        Hyrax::RedirectPath.create!(path: '/handle/2', resource_id: 'other-record')
+        Hyrax::RedirectPath.create!(from_path: '/handle/1', to_path: "/concern/generic_works/#{resource_id}",
+                                    permalink_path: "/concern/generic_works/#{resource_id}",
+                                    resource_id: resource_id, is_display_url: false)
+        Hyrax::RedirectPath.create!(from_path: '/handle/2', to_path: '/concern/generic_works/other-record',
+                                    permalink_path: '/concern/generic_works/other-record',
+                                    resource_id: 'other-record', is_display_url: false)
       end
 
       it 'deletes only the resource\'s rows and returns Success' do

--- a/spec/lib/hyrax/transactions/steps/sync_redirect_paths_spec.rb
+++ b/spec/lib/hyrax/transactions/steps/sync_redirect_paths_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe Hyrax::Transactions::Steps::SyncRedirectPaths do
   subject(:step) { described_class.new }
 
   let(:resource_id) { 'res-1' }
+  let(:permalink)   { "/concern/generic_works/#{resource_id}" }
   let(:resource_class) do
     Struct.new(:id, :redirects)
   end
@@ -12,21 +13,41 @@ RSpec.describe Hyrax::Transactions::Steps::SyncRedirectPaths do
 
   before do
     allow(Hyrax.config).to receive(:redirects_active?).and_return(true)
+    allow(Hyrax::PermalinkPath).to receive(:call).with(resource).and_return(permalink)
     Hyrax::RedirectPath.delete_all
+  end
+
+  def existing_row(from_path:, resource_id:, **attrs)
+    Hyrax::RedirectPath.create!(
+      { from_path: from_path,
+        to_path: "/concern/generic_works/#{resource_id}",
+        permalink_path: "/concern/generic_works/#{resource_id}",
+        resource_id: resource_id,
+        is_display_url: false }.merge(attrs)
+    )
   end
 
   describe '#call' do
     context 'when feature is fully enabled and resource has redirects' do
       it 'replaces existing rows for the resource with the current redirect set' do
-        Hyrax::RedirectPath.create!(path: '/old', resource_id: resource_id)
+        existing_row(from_path: '/old', resource_id: resource_id)
         result = step.call(resource)
         expect(result).to be_success
-        paths = Hyrax::RedirectPath.where(resource_id: resource_id).pluck(:path)
+        paths = Hyrax::RedirectPath.where(resource_id: resource_id).pluck(:from_path)
         expect(paths).to contain_exactly('/handle/1', '/handle/2')
       end
 
+      it 'populates to_path and permalink_path with the canonical UUID URL on every row' do
+        result = step.call(resource)
+        expect(result).to be_success
+        rows = Hyrax::RedirectPath.where(resource_id: resource_id)
+        expect(rows.pluck(:to_path)).to all(eq(permalink))
+        expect(rows.pluck(:permalink_path)).to all(eq(permalink))
+        expect(rows.pluck(:is_display_url)).to all(be(false))
+      end
+
       it 'busts the cache for both old and new paths' do
-        Hyrax::RedirectPath.create!(path: '/old', resource_id: resource_id)
+        existing_row(from_path: '/old', resource_id: resource_id)
         expect(Hyrax::RedirectCacheBuster).to receive(:call)
           .with(array_including('/old', '/handle/1', '/handle/2'))
         step.call(resource)
@@ -34,7 +55,7 @@ RSpec.describe Hyrax::Transactions::Steps::SyncRedirectPaths do
     end
 
     context 'when a path is already claimed by another resource' do
-      before { Hyrax::RedirectPath.create!(path: '/handle/1', resource_id: 'other-record') }
+      before { existing_row(from_path: '/handle/1', resource_id: 'other-record') }
 
       it 'returns Failure with a redirect_path_collision tag' do
         result = step.call(resource)
@@ -80,16 +101,16 @@ RSpec.describe Hyrax::Transactions::Steps::SyncRedirectPaths do
       let(:original_created_at) { 1.day.ago.change(usec: 0) }
 
       before do
-        Hyrax::RedirectPath.create!(path: '/handle/1', resource_id: resource_id, created_at: original_created_at, updated_at: original_created_at)
-        Hyrax::RedirectPath.create!(path: '/handle/2', resource_id: resource_id, created_at: original_created_at, updated_at: original_created_at)
+        existing_row(from_path: '/handle/1', resource_id: resource_id, created_at: original_created_at, updated_at: original_created_at)
+        existing_row(from_path: '/handle/2', resource_id: resource_id, created_at: original_created_at, updated_at: original_created_at)
       end
 
       it 'leaves existing rows untouched (preserves created_at)' do
         result = step.call(resource)
         expect(result).to be_success
 
-        rows = Hyrax::RedirectPath.where(resource_id: resource_id).order(:path)
-        expect(rows.pluck(:path)).to eq %w[/handle/1 /handle/2]
+        rows = Hyrax::RedirectPath.where(resource_id: resource_id).order(:from_path)
+        expect(rows.pluck(:from_path)).to eq %w[/handle/1 /handle/2]
         expect(rows.pluck(:created_at)).to all(eq(original_created_at))
       end
 
@@ -107,8 +128,8 @@ RSpec.describe Hyrax::Transactions::Steps::SyncRedirectPaths do
       end
 
       before do
-        Hyrax::RedirectPath.create!(path: '/handle/1', resource_id: resource_id, created_at: original_created_at, updated_at: original_created_at)
-        Hyrax::RedirectPath.create!(path: '/handle/2', resource_id: resource_id, created_at: original_created_at, updated_at: original_created_at)
+        existing_row(from_path: '/handle/1', resource_id: resource_id, created_at: original_created_at, updated_at: original_created_at)
+        existing_row(from_path: '/handle/2', resource_id: resource_id, created_at: original_created_at, updated_at: original_created_at)
       end
 
       it 'recognizes the set is unchanged and leaves rows untouched' do

--- a/spec/services/hyrax/permalink_path_spec.rb
+++ b/spec/services/hyrax/permalink_path_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+RSpec.describe Hyrax::PermalinkPath do
+  describe '.call' do
+    let(:work_path) { '/concern/generic_works/abc-123' }
+    let(:collection_path) { '/collections/abc-123' }
+
+    context 'with a work resource (collection? returns false)' do
+      let(:work) { Struct.new(:collection?).new(false) }
+
+      it 'uses the host app route helpers' do
+        expect(Rails.application.routes.url_helpers).to receive(:polymorphic_path).with(work).and_return(work_path)
+        expect(Hyrax::Engine.routes.url_helpers).not_to receive(:polymorphic_path)
+        expect(described_class.call(work)).to eq(work_path)
+      end
+    end
+
+    context 'with a collection resource (collection? returns true)' do
+      let(:collection) { Struct.new(:collection?).new(true) }
+
+      it 'uses the Hyrax engine route helpers' do
+        expect(Hyrax::Engine.routes.url_helpers).to receive(:polymorphic_path).with(collection).and_return(collection_path)
+        expect(Rails.application.routes.url_helpers).not_to receive(:polymorphic_path)
+        expect(described_class.call(collection)).to eq(collection_path)
+      end
+    end
+
+    context 'with an object that does not respond to collection?' do
+      let(:object) { Object.new }
+
+      it 'falls back to the host app route helpers' do
+        expect(Rails.application.routes.url_helpers).to receive(:polymorphic_path).with(object).and_return(work_path)
+        expect(described_class.call(object)).to eq(work_path)
+      end
+    end
+  end
+end

--- a/spec/services/hyrax/redirects_lookup_spec.rb
+++ b/spec/services/hyrax/redirects_lookup_spec.rb
@@ -3,6 +3,16 @@
 RSpec.describe Hyrax::RedirectsLookup do
   before { Hyrax::RedirectPath.delete_all }
 
+  def existing_row(from_path:, resource_id:)
+    Hyrax::RedirectPath.create!(
+      from_path: from_path,
+      to_path: "/concern/generic_works/#{resource_id}",
+      permalink_path: "/concern/generic_works/#{resource_id}",
+      resource_id: resource_id,
+      is_display_url: false
+    )
+  end
+
   describe '.taken?' do
     let(:path) { '/handle/12345/678' }
 
@@ -13,7 +23,7 @@ RSpec.describe Hyrax::RedirectsLookup do
     end
 
     context 'when a row exists for the path on a different resource' do
-      before { Hyrax::RedirectPath.create!(path: path, resource_id: 'other-record') }
+      before { existing_row(from_path: path, resource_id: 'other-record') }
 
       it 'is true' do
         expect(described_class.taken?(path)).to be true
@@ -21,7 +31,7 @@ RSpec.describe Hyrax::RedirectsLookup do
     end
 
     context 'with except_id matching the row that owns the path' do
-      before { Hyrax::RedirectPath.create!(path: path, resource_id: 'self-id') }
+      before { existing_row(from_path: path, resource_id: 'self-id') }
 
       it 'is false (the path is held by the record being edited)' do
         expect(described_class.taken?(path, except_id: 'self-id')).to be false
@@ -29,7 +39,7 @@ RSpec.describe Hyrax::RedirectsLookup do
     end
 
     context 'with except_id not matching the row that owns the path' do
-      before { Hyrax::RedirectPath.create!(path: path, resource_id: 'other-record') }
+      before { existing_row(from_path: path, resource_id: 'other-record') }
 
       it 'is true' do
         expect(described_class.taken?(path, except_id: 'self-id')).to be true


### PR DESCRIPTION
## Summary
Reshape the `hyrax_redirect_paths` table to add `to_path`, `permalink_path`, and `is_display_url`, and rename `path` to `from_path`. Existing alias behavior is unchanged for users.
Refs notch8/palni_palci_knapsack#653

## Details
- New migration drops and recreates the table with the new column shape. Drop & recreate:
  - allows skipping migrating data into the new columns that don't allow NULL
  - is acceptable because the feature is unreleased and behind both a config flag and a Flipflop.
- Remaining functionality is modified to work with the new table structure.
