### PR TITLE
Enhance the UI to prepare for Display URL support

### DIFF
--- a/app/assets/javascripts/hyrax.js
+++ b/app/assets/javascripts/hyrax.js
@@ -45,6 +45,7 @@
 //= require hyrax/sorting
 //= require hyrax/single_use_links_manager
 //= require hyrax/copy_permalink_button
+//= require hyrax/redirects
 //= require hyrax/dashboard_actions
 //= require hyrax/batch
 //= require hyrax/flot_stats

--- a/app/assets/javascripts/hyrax/redirects.js
+++ b/app/assets/javascripts/hyrax/redirects.js
@@ -1,0 +1,45 @@
+// Behavior for the Aliases form (see app/views/hyrax/base/_form_redirects.html.erb).
+// Event-delegated handlers on document so dynamically-added rows work
+// without rebinding. A sentinel on document guards against the IIFE
+// running twice (Turbolinks evaluates module scripts again on some
+// navigation paths in development), which would otherwise stack
+// duplicate listeners and fire each handler N times per click.
+(function() {
+    if (document.hyraxRedirectsBound) return;
+    document.hyraxRedirectsBound = true;
+
+    document.addEventListener('input', function(event) {
+        var pathInput = event.target.closest('[data-redirects-path-input]');
+        if (!pathInput) return;
+        var radioId = pathInput.getAttribute('data-redirects-display-radio');
+        var radio = document.getElementById(radioId);
+        if (radio) radio.disabled = (pathInput.value.trim() === '');
+    });
+
+    document.addEventListener('click', function(event) {
+        var removeButton = event.target.closest('[data-redirects-remove-row]');
+        if (removeButton) {
+            var row = removeButton.closest('tr');
+            if (row) row.parentNode.removeChild(row);
+            return;
+        }
+
+        var addButton = event.target.closest('[data-redirects-add-row]');
+        if (!addButton) return;
+        var template = document.querySelector('[data-redirects-row-template]');
+        var table = document.querySelector('[data-redirects-table]');
+        if (!template || !table) return;
+        var tbody = table.querySelector('tbody');
+        if (!tbody) return;
+        // Monotonic counter on the table; never recycle an index after a
+        // row is removed. Fallback to row count when the attribute is
+        // missing.
+        var nextIndex = parseInt(table.dataset.nextIndex, 10);
+        if (isNaN(nextIndex)) {
+            nextIndex = tbody.querySelectorAll('[data-redirects-row]').length;
+        }
+        var html = template.innerHTML.replace(/__INDEX__/g, nextIndex);
+        tbody.insertAdjacentHTML('beforeend', html);
+        table.dataset.nextIndex = String(nextIndex + 1);
+    });
+})();

--- a/app/forms/concerns/hyrax/redirects_field_behavior.rb
+++ b/app/forms/concerns/hyrax/redirects_field_behavior.rb
@@ -6,9 +6,9 @@ module Hyrax
   # Submitted form payloads arrive under `redirects_attributes` and are
   # turned into plain hashes (the persisted shape — see
   # `config/metadata/redirects.yaml`, `type: hash`) by the populator.
-  # On render, the prepopulator wraps each persisted hash in a
-  # `Hyrax::Redirect` value object so the view can call `.path` /
-  # `.canonical` / `.sequence`.
+  # The form partial wraps each persisted hash in a `Hyrax::Redirect`
+  # value object at render time so the view can call `.path` and
+  # `.is_display_url`.
   #
   # The `deserialize!` override removes the renamed `redirects` key
   # before Reform's `from_hash` runs, so the form's `redirects`
@@ -22,18 +22,21 @@ module Hyrax
   # check isn't meaningful here because the form class is being
   # defined, not handling a request.
   #
-  # All runtime-side methods (`deserialize!`, populator, prepopulator)
-  # delegate to `Hyrax.config.redirects_active?`, the two-gate
-  # combinator (`redirects_enabled? && Flipflop.redirects?`). Calling
+  # All runtime-side methods (`deserialize!`, populator) delegate to
+  # `Hyrax.config.redirects_active?`, the two-gate combinator
+  # (`redirects_enabled? && Flipflop.redirects?`). Calling
   # `Flipflop.redirects?` directly is unsafe when the config is off
   # because the feature isn't registered in that case.
   module RedirectsFieldBehavior
     def self.included(descendant)
       return unless Hyrax.config.redirects_enabled?
+      # Declare the radio-group scalar before redirects_attributes so Reform
+      # deserializes it first; the populator reads its value while building
+      # per-row entries.
+      descendant.property :redirects_display_url_index, virtual: true
       descendant.property :redirects_attributes,
                           virtual: true,
-                          populator: :redirects_attributes_populator,
-                          prepopulator: :redirects_attributes_prepopulator
+                          populator: :redirects_attributes_populator
     end
 
     # Reform's FormBuilderMethods rewrites `redirects_attributes` →
@@ -54,28 +57,39 @@ module Hyrax
     # Builds plain hashes (the persisted shape) from the submitted
     # `redirects_attributes` payload. Drops rows marked for destruction
     # or with a blank path. Normalizes paths up-front so the validator
-    # sees canonical form (so DSpace-style pasted URLs validate cleanly).
-    # or with a blank path.
+    # sees normalized form (so DSpace-style pasted URLs validate cleanly).
+    #
+    # When `redirects_display_url_index` is set (form-driven radio
+    # group), the matching original-index row gets `is_display_url: true`
+    # and all other rows get false. When absent (Bulkrax import path),
+    # the row's own `is_display_url` value is honored.
     def redirects_attributes_populator(fragment:, **_options)
       return unless respond_to?(:redirects)
       return unless Hyrax.config.redirects_active?
-      entries = Array(fragment&.values)
-                .reject { |row| row['_destroy'].to_s == 'true' || row['path'].to_s.strip.empty? }
-                .each_with_index.map do |row, i|
-        { 'path' => Hyrax::RedirectPathNormalizer.call(row['path']),
-          'canonical' => row['canonical'].to_s == 'true',
-          'sequence' => row['sequence'].presence&.to_i || i }
-      end
-      self.redirects = entries
+      pairs = redirects_fragment_pairs(fragment)
+      self.redirects = pairs.sort_by { |k, _row| k.to_i }
+                            .map { |k, row| redirects_entry_from(k, row) }
+                            .compact
     end
 
-    # Wraps each persisted hash in a `Hyrax::Redirect` value object for
-    # the form view. Mirrors how `BasedNearFieldBehavior` hydrates URI
-    # strings into `ControlledVocabularies::Location` instances.
-    def redirects_attributes_prepopulator
-      return unless respond_to?(:redirects)
-      return unless Hyrax.config.redirects_active?
-      self.redirects = Array(redirects).map { |entry| Hyrax::Redirect.wrap(entry) }
+    def redirects_fragment_pairs(fragment)
+      return {} if fragment.nil?
+      fragment.respond_to?(:to_unsafe_h) ? fragment.to_unsafe_h : fragment.to_h
+    end
+
+    def redirects_entry_from(key, row)
+      row = row.respond_to?(:to_unsafe_h) ? row.to_unsafe_h : row
+      return nil if row['_destroy'].to_s == 'true' || row['path'].to_s.strip.empty?
+      { 'path' => Hyrax::RedirectPathNormalizer.call(row['path']),
+        'is_display_url' => redirects_is_display_url_flag_for(key, row) }
+    end
+
+    def redirects_is_display_url_flag_for(key, row)
+      if redirects_display_url_index.nil?
+        row['is_display_url'].to_s == 'true'
+      else
+        key.to_s == redirects_display_url_index.to_s
+      end
     end
   end
 end

--- a/app/models/hyrax/redirect.rb
+++ b/app/models/hyrax/redirect.rb
@@ -2,9 +2,8 @@
 
 module Hyrax
   ##
-  # Wraps a single redirect entry for use in form views, providing
-  # `.path`, `.canonical`, and `.sequence` readers over the underlying
-  # persisted hash.
+  # Wraps a single redirect entry for use in form views, providing `.path`
+  # and `.is_display_url` readers over the underlying persisted hash.
   #
   # Redirects are persisted as plain hashes on the parent work or
   # collection. Form-render code calls `Hyrax::Redirect.wrap(entry)` to
@@ -12,17 +11,16 @@ module Hyrax
   # validator, indexer, sync step) reads the persisted hash directly.
   #
   # @example
-  #   Hyrax::Redirect.new(path: '/handle/12345/678', canonical: false)
-  #   Hyrax::Redirect.wrap('path' => '/foo', 'canonical' => true)
+  #   Hyrax::Redirect.new(path: '/handle/12345/678', is_display_url: false)
+  #   Hyrax::Redirect.wrap('path' => '/foo', 'is_display_url' => true)
   class Redirect
-    attr_reader :path, :canonical, :sequence
+    attr_reader :path, :is_display_url
 
     ##
     # Accept nil values so the view can build an empty trailing row.
-    def initialize(path: nil, canonical: false, sequence: nil)
+    def initialize(path: nil, is_display_url: false)
       @path = path
-      @canonical = canonical
-      @sequence = sequence
+      @is_display_url = is_display_url
     end
 
     ##
@@ -37,13 +35,13 @@ module Hyrax
       raise ArgumentError, "cannot wrap #{input.class} as Hyrax::Redirect" unless input.respond_to?(:to_h)
 
       h = input.to_h.transform_keys(&:to_s)
-      new(path: h['path'], canonical: h.fetch('canonical', false), sequence: h['sequence'])
+      new(path: h['path'], is_display_url: h.fetch('is_display_url', false))
     end
 
     ##
     # @return [Hash{String => Object}] string-keyed hash matching the persisted shape.
     def to_h
-      { 'path' => path, 'canonical' => canonical, 'sequence' => sequence }
+      { 'path' => path, 'is_display_url' => is_display_url }
     end
 
     def as_json(*)
@@ -55,13 +53,12 @@ module Hyrax
     def ==(other)
       other.is_a?(Hyrax::Redirect) &&
         other.path == path &&
-        other.canonical == canonical &&
-        other.sequence == sequence
+        other.is_display_url == is_display_url
     end
     alias eql? ==
 
     def hash
-      [path, canonical, sequence].hash
+      [path, is_display_url].hash
     end
   end
 end

--- a/app/services/hyrax/flexible_schema_validators/redirects_validator.rb
+++ b/app/services/hyrax/flexible_schema_validators/redirects_validator.rb
@@ -49,26 +49,26 @@ module Hyrax
 
       def validate_when_config_off
         return if redirects_property.blank?
-        warn_dead_property('Hyrax.config.redirects_enabled? is false')
+        @warnings << I18n.t('hyrax.flexible_schema_validators.redirects_validator.warnings.config_disabled')
       end
 
       def validate_when_flipflop_off
         return if redirects_property.blank?
-        warn_dead_property('the :redirects feature flag is off for this tenant')
+        @warnings << I18n.t('hyrax.flexible_schema_validators.redirects_validator.warnings.flipflop_disabled')
       end
 
       def validate_when_enabled
         if redirects_property.blank?
-          @errors << 'm3 profile must declare a `redirects` property when the redirects feature is enabled'
+          @errors << I18n.t('hyrax.flexible_schema_validators.redirects_validator.errors.property_required')
           return
         end
 
-        @errors << "m3 profile `redirects` property must declare `type: hash` (got `#{redirects_property['type'].inspect}`)" unless redirects_property['type'].to_s == 'hash'
+        @errors << I18n.t('hyrax.flexible_schema_validators.redirects_validator.errors.invalid_type', actual_type: redirects_property['type'].inspect) unless redirects_property['type'].to_s == 'hash'
 
         available_on = clean(Array(redirects_property.dig('available_on', 'class')))
         return if (available_on & profile_work_or_collection_classes).any?
 
-        @errors << 'm3 profile `redirects` property must be available on at least one work or collection class declared in this profile'
+        @errors << I18n.t('hyrax.flexible_schema_validators.redirects_validator.errors.invalid_available_on')
       end
 
       # Class names declared in this m3 profile's top-level `classes:` block,
@@ -110,11 +110,6 @@ module Hyrax
 
       def clean(names)
         names.map { |name| name.to_s.delete_prefix('::') }
-      end
-
-      def warn_dead_property(reason)
-        @warnings << "m3 profile declares a `redirects` property but #{reason}; " \
-                     'the property will be ignored'
       end
     end
   end

--- a/app/validators/hyrax/redirect_validator.rb
+++ b/app/validators/hyrax/redirect_validator.rb
@@ -42,9 +42,13 @@ module Hyrax
       nil
     end
 
+    # Returns nil when the flag is absent, otherwise a real boolean.
     def display_url_for(entry)
-      return entry.is_display_url if entry.respond_to?(:is_display_url)
-      return entry.key?('is_display_url') ? entry['is_display_url'] : entry[:is_display_url] if entry.respond_to?(:[])
+      return ActiveModel::Type::Boolean.new.cast(entry.is_display_url) if entry.respond_to?(:is_display_url)
+      if entry.respond_to?(:[])
+        return ActiveModel::Type::Boolean.new.cast(entry['is_display_url']) if entry.key?('is_display_url')
+        return ActiveModel::Type::Boolean.new.cast(entry[:is_display_url]) if entry.key?(:is_display_url)
+      end
       nil
     end
 

--- a/app/validators/hyrax/redirect_validator.rb
+++ b/app/validators/hyrax/redirect_validator.rb
@@ -6,7 +6,12 @@ module Hyrax
   #
   # See documentation/redirects.md for the validation rules.
   class RedirectValidator < ActiveModel::EachValidator
-    PATH_FORMAT = %r{\A/[^?\s#]+\z}.freeze
+    # Allow-list per RFC 3986 path chars: unreserved + sub-delims + ":" + "@" + "/"
+    # plus pct-encoded "%XX". Rejects quotes, backslashes, angle brackets, pipes,
+    # braces, control chars, whitespace, "?", and "#" — anything Rails routing
+    # would refuse or that would be unsafe to round-trip through a URL.
+    PATH_CHAR = %r{[A-Za-z0-9\-._~!$&'()*+,;=:@/]|%[0-9A-Fa-f]{2}}.freeze
+    PATH_FORMAT = %r{\A/(?:#{PATH_CHAR})+\z}.freeze
 
     # Override `validate` so we can short-circuit before ActiveModel calls
     # `record.read_attribute_for_validation`, which would crash on records

--- a/app/validators/hyrax/redirect_validator.rb
+++ b/app/validators/hyrax/redirect_validator.rb
@@ -29,7 +29,7 @@ module Hyrax
       validate_each_entry(record, attribute, entries)
       validate_intra_record_uniqueness(record, attribute, entries)
       validate_global_uniqueness(record, attribute, entries)
-      validate_at_most_one_canonical(record, attribute, entries)
+      validate_at_most_one_display_url(record, attribute, entries)
     end
 
     private
@@ -42,9 +42,9 @@ module Hyrax
       nil
     end
 
-    def canonical_for(entry)
-      return entry.canonical if entry.respond_to?(:canonical)
-      return entry.key?('canonical') ? entry['canonical'] : entry[:canonical] if entry.respond_to?(:[])
+    def display_url_for(entry)
+      return entry.is_display_url if entry.respond_to?(:is_display_url)
+      return entry.key?('is_display_url') ? entry['is_display_url'] : entry[:is_display_url] if entry.respond_to?(:[])
       nil
     end
 
@@ -96,10 +96,10 @@ module Hyrax
       Hyrax::RedirectPathNormalizer.call(path)
     end
 
-    def validate_at_most_one_canonical(record, attribute, entries)
-      canonical_count = entries.count { |entry| canonical_for(entry) }
-      return if canonical_count <= 1
-      record.errors.add(attribute, message_for(:multiple_canonical))
+    def validate_at_most_one_display_url(record, attribute, entries)
+      display_url_count = entries.count { |entry| display_url_for(entry) }
+      return if display_url_count <= 1
+      record.errors.add(attribute, message_for(:multiple_display_url))
     end
 
     def message_for(key, **interpolations)

--- a/app/views/hyrax/base/_form_redirects.html.erb
+++ b/app/views/hyrax/base/_form_redirects.html.erb
@@ -4,25 +4,45 @@
 
 <p><%= sanitize t('hyrax.works.form.redirects.help_html'), tags: %w[code] %></p>
 
-<table class="table table-striped">
+<p><%= sanitize t('hyrax.works.form.redirects.display_url.help_html'), tags: %w[em] %></p>
+
+<% rows = Array(f.object.redirects).map { |e| Hyrax::Redirect.wrap(e) } %>
+<% selected_idx = rows.index(&:is_display_url) %>
+<%# All radios share one name so HTML treats them as one group; value is
+    the row's index. The populator folds the selected index onto per-row
+    is_display_url flags. %>
+<% radio_name = "#{f.object_name}[redirects_display_url_index]" %>
+
+<%# Always-submitted hidden marker so the populator runs even when the
+    user has removed every row from the DOM. The populator drops rows
+    with blank paths, so the marker contributes nothing to the saved
+    set. %>
+<%= hidden_field_tag "#{f.object_name}[redirects_attributes][_marker][path]", '' %>
+
+<table class="table table-striped" data-redirects-table data-next-index="<%= rows.length %>">
   <caption class="sr-only"><%= t('hyrax.works.form.redirects.caption') %></caption>
   <thead>
     <tr>
       <th scope="col"><%= t('hyrax.works.form.redirects.header.path') %></th>
+      <th scope="col"><%= t('hyrax.works.form.redirects.header.display_url') %></th>
       <th scope="col" class="sr-only"><%= t('hyrax.works.form.redirects.header.actions') %></th>
     </tr>
   </thead>
   <tbody>
-    <%# Wrap each row through Hyrax::Redirect.wrap so the view can rely on
-        the presenter API (.path, .canonical, .sequence). On initial render
-        the prepopulator already wrapped them; on a re-render after a
-        failed save, f.object.redirects holds the populator's plain hashes,
-        and we wrap them here. %>
-    <% rows = Array(f.object.redirects).map { |e| Hyrax::Redirect.wrap(e) } + [Hyrax::Redirect.new(path: nil)] %>
+    <tr>
+      <td colspan="2">
+        <label>
+          <%= radio_button_tag radio_name, '', selected_idx.nil? %>
+          <%= t('hyrax.works.form.redirects.display_url.none_label') %>
+        </label>
+      </td>
+      <td></td>
+    </tr>
     <% rows.each_with_index do |entry, index| %>
       <% input_id = "#{f.object_name}_redirects_attributes_#{index}_path" %>
       <% label_text = entry.path.present? ? t('hyrax.works.form.redirects.path_label') : t('hyrax.works.form.redirects.new_path_label') %>
-      <tr>
+      <% radio_id = "#{f.object_name}_redirects_display_url_index_#{index}" %>
+      <tr data-redirects-row>
         <td>
           <%= label_tag input_id, label_text, class: 'sr-only' %>
           <div class="input-group">
@@ -33,15 +53,24 @@
                                entry.path,
                                id: input_id,
                                class: 'form-control',
-                               placeholder: t('hyrax.works.form.redirects.placeholder.path') %>
+                               placeholder: t('hyrax.works.form.redirects.placeholder.path'),
+                               data: { 'redirects-path-input': true, 'redirects-display-radio': radio_id } %>
           </div>
+        </td>
+        <td>
+          <%= radio_button_tag radio_name,
+                               index.to_s,
+                               index == selected_idx,
+                               id: radio_id,
+                               disabled: entry.path.blank?,
+                               'aria-label': t('hyrax.works.form.redirects.display_url.row_label', path: entry.path.presence || (index + 1)) %>
         </td>
         <td class="text-right" style="width: 1%;">
           <% if entry.path.present? %>
             <button type="button"
                     class="btn close"
                     aria-label="<%= t('hyrax.works.form.redirects.remove_with_path_label', path: entry.path) %>"
-                    onclick="this.closest('tr').remove()">
+                    data-redirects-remove-row="true">
               <span aria-hidden="true">&times;</span>
             </button>
           <% end %>
@@ -50,3 +79,47 @@
     <% end %>
   </tbody>
 </table>
+
+<p>
+  <button type="button" class="btn btn-secondary" data-redirects-add-row>
+    <%= t('hyrax.works.form.redirects.add_label') %>
+  </button>
+</p>
+
+<%# Template used by the Add button. JS clones this. %>
+<template data-redirects-row-template>
+  <% template_input_id = "#{f.object_name}_redirects_attributes___INDEX___path" %>
+  <% template_radio_id = "#{f.object_name}_redirects_display_url_index___INDEX__" %>
+  <tr data-redirects-row>
+    <td>
+      <%= label_tag template_input_id, t('hyrax.works.form.redirects.new_path_label'), class: 'sr-only' %>
+      <div class="input-group">
+        <div class="input-group-prepend">
+          <span class="input-group-text"><%= request.base_url %></span>
+        </div>
+        <%= text_field_tag "#{f.object_name}[redirects_attributes][__INDEX__][path]",
+                           nil,
+                           id: template_input_id,
+                           class: 'form-control',
+                           placeholder: t('hyrax.works.form.redirects.placeholder.path'),
+                           data: { 'redirects-path-input': true, 'redirects-display-radio': template_radio_id } %>
+      </div>
+    </td>
+    <td>
+      <%= radio_button_tag radio_name,
+                           '__INDEX__',
+                           false,
+                           id: template_radio_id,
+                           disabled: true,
+                           'aria-label': t('hyrax.works.form.redirects.display_url.row_label', path: t('hyrax.works.form.redirects.new_path_label')) %>
+    </td>
+    <td class="text-right" style="width: 1%;">
+      <button type="button"
+              class="btn close"
+              aria-label="<%= t('hyrax.works.form.redirects.remove_label') %>"
+              data-redirects-remove-row="true">
+        <span aria-hidden="true">&times;</span>
+      </button>
+    </td>
+  </tr>
+</template>

--- a/config/locales/hyrax.de.yml
+++ b/config/locales/hyrax.de.yml
@@ -1396,6 +1396,14 @@ de:
         save_your_note: Sie müssen auf "Revision speichern" klicken. um eine frühere Version dieser Datei wiederherzustellen
         upload: Neue Version hochladen
     flexible_schema_validators:
+      redirects_validator:
+        errors:
+          invalid_available_on: "die Eigenschaft `redirects` des m3-Profils muss in mindestens einer im Profil deklarierten Werk- oder Sammlungsklasse verfügbar sein"
+          invalid_type: "die Eigenschaft `redirects` des m3-Profils muss `type: hash` deklarieren (erhalten: `%{actual_type}`)"
+          property_required: "das m3-Profil muss eine `redirects`-Eigenschaft deklarieren, wenn die Weiterleitungsfunktion aktiviert ist"
+        warnings:
+          config_disabled: "das m3-Profil deklariert eine `redirects`-Eigenschaft, aber Hyrax.config.redirects_enabled? ist false; die Eigenschaft wird ignoriert"
+          flipflop_disabled: "das m3-Profil deklariert eine `redirects`-Eigenschaft, aber das Feature-Flag :redirects ist deaktiviert; die Eigenschaft wird ignoriert"
       sort_properties_validator:
         warnings:
           message: "%{property} muss auf %{classes} definiert sein, um die Sortierung nach dieser Eigenschaft zu unterstützen, es sei denn, Sie haben %{property}_ssi auf einem anderen Feld indiziert."

--- a/config/locales/hyrax.de.yml
+++ b/config/locales/hyrax.de.yml
@@ -41,6 +41,13 @@ de:
       carrierwave_processing_error: Bild kann nicht verkleinernt werden.
       extension_blacklist_error: "Sie dürfen keine %{extension}-Dateien hochladen, nicht erlaubt sind: %{prohibited_types}"
       extension_whitelist_error: "Sie dürfen keine %{extension}-Dateien hochladen, erlaubt sind: %{allowed_types}"
+      redirect:
+        already_taken: '"%{path}" wird bereits von einer anderen Arbeit oder Sammlung verwendet.'
+        blank: Ein Weiterleitungspfad darf nicht leer sein.
+        intra_record_duplicate: '"%{path}" ist in diesem Datensatz mehrfach aufgeführt.'
+        invalid_format: '"%{path}" ist kein gültiger Pfad. Pfade müssen mit "/" beginnen und dürfen keine Leerzeichen, "?" oder "#" enthalten.'
+        multiple_display_url: Höchstens ein Weiterleitungseintrag darf als Anzeige-URL markiert sein.
+        reserved_prefix: '"%{path}" kann nicht verwendet werden. Der Pfad ist von der Anwendung reserviert und darf nicht als Alias verwendet werden.'
   helpers:
     action:
       accept: Akzeptieren
@@ -1816,6 +1823,26 @@ de:
         in_collections: Sammlungen
         in_other_works: Diese Arbeit in anderen Arbeiten
         in_this_work: Andere Arbeiten in dieser Arbeit
+        redirects:
+          add_label: Weiteren Alias hinzufügen
+          caption: Liste der URL-Aliase für diese Ressource
+          display_url:
+            help_html: Optional einen Alias als <em>Anzeige-URL</em> markieren. Wenn gesetzt, leitet die permanente UUID-URL des Datensatzes auf den gewählten Alias um. Auf "Keiner" lassen, um die UUID-URL als Ziel zu behalten.
+            none_label: Keiner (UUID-URL des Datensatzes verwenden)
+            row_label: '"%{path}" als Anzeige-URL verwenden'
+          errors_heading: Bitte korrigieren Sie die folgenden Alias-Fehler
+          header:
+            actions: Aktionen
+            display_url: Anzeige-URL
+            path: Pfad
+          heading: URL-Aliase
+          help_html: 'Registrieren Sie ältere URL-Pfade, die auf diesen Datensatz weiterleiten sollen. Jeder Pfad wird vom Stammverzeichnis dieser Website aus aufgelöst. Reservierte Hyrax-Routen (z. B. <code>/concern</code>, <code>/dashboard</code>) können nicht verwendet werden.'
+          new_path_label: Neuer Alias-Pfad
+          path_label: Alias-Pfad
+          placeholder:
+            path: Geben Sie einen alten Pfad ein...
+          remove_label: Entfernen
+          remove_with_path_label: '%{path} entfernen'
         tab:
           files: Dateien
           metadata: Metadaten

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -1390,6 +1390,14 @@ en:
         save_your_note: You must click "Save Revision" to revert a previous version of this file
         upload: Upload New Version
     flexible_schema_validators:
+      redirects_validator:
+        errors:
+          invalid_available_on: "m3 profile `redirects` property must be available on at least one work or collection class declared in this profile"
+          invalid_type: "m3 profile `redirects` property must declare `type: hash` (got `%{actual_type}`)"
+          property_required: "m3 profile must declare a `redirects` property when the redirects feature is enabled"
+        warnings:
+          config_disabled: "m3 profile declares a `redirects` property but Hyrax.config.redirects_enabled? is false; the property will be ignored"
+          flipflop_disabled: "m3 profile declares a `redirects` property but the :redirects feature flag is off; the property will be ignored"
       sort_properties_validator:
         warnings:
           message: "%{property} must be defined on %{classes} to support sorting on that property, unless you have indexed %{property}_ssi on some other field."

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -43,7 +43,7 @@ en:
         blank: A redirect path can't be blank.
         intra_record_duplicate: '"%{path}" is listed more than once on this record.'
         invalid_format: '"%{path}" is not a valid path. Paths must start with "/" and contain no spaces, "?", or "#".'
-        multiple_canonical: At most one redirect entry may be marked canonical.
+        multiple_display_url: At most one redirect entry may be marked as the display URL.
         reserved_prefix: '"%{path}" can''t be used. The path is reserved by the application and may not be used as an alias.'
   helpers:
     action:
@@ -1817,17 +1817,23 @@ en:
         in_other_works: This Work in Other Works
         in_this_work: Other Works in this Work
         redirects:
+          add_label: Add another alias
           caption: List of URL aliases for this resource
+          display_url:
+            help_html: Optionally mark one alias as the <em>display URL</em>. When set, the record's permanent UUID URL redirects to the chosen alias. Leave as "None" to keep the UUID URL as the destination.
+            none_label: None (use the record's UUID URL)
+            row_label: 'Use "%{path}" as the display URL'
           errors_heading: Please correct the following alias errors
           header:
             actions: Actions
+            display_url: Display URL
             path: Path
           heading: URL Aliases
           help_html: 'Register legacy URL paths that should redirect to this record. Each path will resolve from this site''s root. Reserved Hyrax routes (e.g. <code>/concern</code>, <code>/dashboard</code>) cannot be used.'
           new_path_label: New alias path
           path_label: Alias path
           placeholder:
-            path: Enter a legacy path...
+            path: Enter a path...
           remove_label: Remove
           remove_with_path_label: 'Remove %{path}'
         tab:

--- a/config/locales/hyrax.es.yml
+++ b/config/locales/hyrax.es.yml
@@ -41,6 +41,13 @@ es:
       carrierwave_processing_error: No se puede cambiar el tamaño de la imagen.
       extension_blacklist_error: "La subida de archivos %{extension} no está permitida, tipos prohibidos: %{prohibited_types}"
       extension_whitelist_error: "La subida de archivos %{extension} no está permitida, tipos permitidos: %{allowed_types}"
+      redirect:
+        already_taken: '"%{path}" ya está siendo usado por otro trabajo o colección.'
+        blank: Una ruta de redirección no puede estar en blanco.
+        intra_record_duplicate: '"%{path}" aparece más de una vez en este registro.'
+        invalid_format: '"%{path}" no es una ruta válida. Las rutas deben comenzar con "/" y no contener espacios, "?" ni "#".'
+        multiple_display_url: A lo sumo una entrada de redirección puede marcarse como la URL de visualización.
+        reserved_prefix: '"%{path}" no se puede usar. La ruta está reservada por la aplicación y no puede usarse como alias.'
   helpers:
     action:
       accept: Aceptar
@@ -1825,6 +1832,26 @@ es:
         in_collections: Colecciones
         in_other_works: Este Trabajo en otros Trabajos
         in_this_work: Otros Trabaos en este Trabajo
+        redirects:
+          add_label: Agregar otro alias
+          caption: Lista de alias de URL para este recurso
+          display_url:
+            help_html: Opcionalmente, marque un alias como la <em>URL de visualización</em>. Cuando se establece, la URL UUID permanente del registro redirige al alias elegido. Deje en "Ninguno" para mantener la URL UUID como destino.
+            none_label: Ninguno (usar la URL UUID del registro)
+            row_label: 'Usar "%{path}" como URL de visualización'
+          errors_heading: Por favor corrija los siguientes errores de alias
+          header:
+            actions: Acciones
+            display_url: URL de visualización
+            path: Ruta
+          heading: Alias de URL
+          help_html: 'Registre rutas de URL antiguas que deberían redirigir a este registro. Cada ruta se resolverá desde la raíz de este sitio. Las rutas reservadas de Hyrax (por ejemplo, <code>/concern</code>, <code>/dashboard</code>) no pueden utilizarse.'
+          new_path_label: Nueva ruta de alias
+          path_label: Ruta de alias
+          placeholder:
+            path: Ingrese una ruta antigua...
+          remove_label: Eliminar
+          remove_with_path_label: 'Eliminar %{path}'
         tab:
           files: Archivos
           metadata: Descripciones

--- a/config/locales/hyrax.es.yml
+++ b/config/locales/hyrax.es.yml
@@ -1405,6 +1405,14 @@ es:
         save_your_note: Debe hacer clic en "Guardar revisión" para revertir una versión anterior de este archivo
         upload: Subir nueva versión
     flexible_schema_validators:
+      redirects_validator:
+        errors:
+          invalid_available_on: "la propiedad `redirects` del perfil m3 debe estar disponible en al menos una clase de obra o colección declarada en este perfil"
+          invalid_type: "la propiedad `redirects` del perfil m3 debe declarar `type: hash` (se recibió `%{actual_type}`)"
+          property_required: "el perfil m3 debe declarar una propiedad `redirects` cuando la función de redirecciones está habilitada"
+        warnings:
+          config_disabled: "el perfil m3 declara una propiedad `redirects` pero Hyrax.config.redirects_enabled? es false; la propiedad será ignorada"
+          flipflop_disabled: "el perfil m3 declara una propiedad `redirects` pero la bandera de característica :redirects está desactivada; la propiedad será ignorada"
       sort_properties_validator:
         warnings:
           message: "%{property} debe estar definido en %{classes} para permitir la ordenación por esa propiedad, a menos que haya indexado %{property}_ssi en algún otro campo."

--- a/config/locales/hyrax.fr.yml
+++ b/config/locales/hyrax.fr.yml
@@ -41,6 +41,13 @@ fr:
       carrierwave_processing_error: Impossible de redimensionner l'image.
       extension_blacklist_error: "Vous n'êtes pas autorisé à télécharger des fichiers %{extension}, types interdits: %{prohibited_types}"
       extension_whitelist_error: "Vous n'êtes pas autorisé à télécharger des fichiers %{extension}, types autorisés: %{allowed_types}"
+      redirect:
+        already_taken: '"%{path}" est déjà utilisé par un autre travail ou une autre collection.'
+        blank: Un chemin de redirection ne peut pas être vide.
+        intra_record_duplicate: '"%{path}" est listé plusieurs fois dans cet enregistrement.'
+        invalid_format: '"%{path}" n''est pas un chemin valide. Les chemins doivent commencer par "/" et ne pas contenir d''espaces, "?" ou "#".'
+        multiple_display_url: Au plus une entrée de redirection peut être marquée comme URL d'affichage.
+        reserved_prefix: '"%{path}" ne peut pas être utilisé. Le chemin est réservé par l''application et ne peut pas être utilisé comme alias.'
   helpers:
     action:
       accept: Acceptez
@@ -1823,6 +1830,26 @@ fr:
         in_collections: Collections
         in_other_works: Ce travail dans d'autres ouvrages
         in_this_work: Autres travaux dans ce travail
+        redirects:
+          add_label: Ajouter un autre alias
+          caption: Liste des alias d'URL pour cette ressource
+          display_url:
+            help_html: Marquer éventuellement un alias comme <em>URL d'affichage</em>. Lorsqu'il est défini, l'URL UUID permanente de l'enregistrement redirige vers l'alias choisi. Laisser "Aucun" pour conserver l'URL UUID comme destination.
+            none_label: Aucun (utiliser l'URL UUID de l'enregistrement)
+            row_label: 'Utiliser "%{path}" comme URL d''affichage'
+          errors_heading: Veuillez corriger les erreurs d'alias suivantes
+          header:
+            actions: Actions
+            display_url: URL d'affichage
+            path: Chemin
+          heading: Alias d'URL
+          help_html: 'Enregistrez les anciens chemins d''URL qui devraient rediriger vers cet enregistrement. Chaque chemin sera résolu depuis la racine de ce site. Les routes Hyrax réservées (par exemple, <code>/concern</code>, <code>/dashboard</code>) ne peuvent pas être utilisées.'
+          new_path_label: Nouveau chemin d'alias
+          path_label: Chemin d'alias
+          placeholder:
+            path: Entrez un ancien chemin...
+          remove_label: Supprimer
+          remove_with_path_label: 'Supprimer %{path}'
         tab:
           files: Des dossiers
           metadata: Descriptions

--- a/config/locales/hyrax.fr.yml
+++ b/config/locales/hyrax.fr.yml
@@ -1403,6 +1403,14 @@ fr:
         save_your_note: Vous devez cliquer sur "Enregistrer la révision". pour revenir à une version précédente de ce fichier
         upload: Télécharger une nouvelle version
     flexible_schema_validators:
+      redirects_validator:
+        errors:
+          invalid_available_on: "la propriété `redirects` du profil m3 doit être disponible sur au moins une classe d'œuvre ou de collection déclarée dans ce profil"
+          invalid_type: "la propriété `redirects` du profil m3 doit déclarer `type: hash` (reçu `%{actual_type}`)"
+          property_required: "le profil m3 doit déclarer une propriété `redirects` lorsque la fonctionnalité de redirections est activée"
+        warnings:
+          config_disabled: "le profil m3 déclare une propriété `redirects` mais Hyrax.config.redirects_enabled? est false ; la propriété sera ignorée"
+          flipflop_disabled: "le profil m3 déclare une propriété `redirects` mais l'indicateur de fonctionnalité :redirects est désactivé ; la propriété sera ignorée"
       sort_properties_validator:
         warnings:
           message: "%{property} doit être défini sur %{classes} pour permettre le tri sur cette propriété, à moins que vous n'ayez indexé %{property}_ssi sur un autre champ."

--- a/config/locales/hyrax.it.yml
+++ b/config/locales/hyrax.it.yml
@@ -1402,6 +1402,14 @@ it:
         save_your_note: Devi fare clic su "Salva revisione" per ripristinare una versione precedente di questo file
         upload: Carica nuova versione
     flexible_schema_validators:
+      redirects_validator:
+        errors:
+          invalid_available_on: "la proprietà `redirects` del profilo m3 deve essere disponibile su almeno una classe di opera o raccolta dichiarata in questo profilo"
+          invalid_type: "la proprietà `redirects` del profilo m3 deve dichiarare `type: hash` (ricevuto `%{actual_type}`)"
+          property_required: "il profilo m3 deve dichiarare una proprietà `redirects` quando la funzionalità dei reindirizzamenti è abilitata"
+        warnings:
+          config_disabled: "il profilo m3 dichiara una proprietà `redirects` ma Hyrax.config.redirects_enabled? è false; la proprietà verrà ignorata"
+          flipflop_disabled: "il profilo m3 dichiara una proprietà `redirects` ma il feature flag :redirects è disattivato; la proprietà verrà ignorata"
       sort_properties_validator:
         warnings:
           message: "%{property} deve essere definito su %{classes} per supportare l'ordinamento su tale proprietà, a meno che non sia stato indicizzato %{property}_ssi su un altro campo."

--- a/config/locales/hyrax.it.yml
+++ b/config/locales/hyrax.it.yml
@@ -41,6 +41,13 @@ it:
       carrierwave_processing_error: Impossibile ridimensionare l'immagine.
       extension_blacklist_error: "Non è consentito caricare file %{extension}, tipi proibiti: %{prohibited_types}"
       extension_whitelist_error: "Non è consentito caricare i file %{extension}, i tipi consentiti: %{allowed_types}"
+      redirect:
+        already_taken: '"%{path}" è già utilizzato da un''altra opera o collezione.'
+        blank: Un percorso di reindirizzamento non può essere vuoto.
+        intra_record_duplicate: '"%{path}" è elencato più di una volta in questo record.'
+        invalid_format: '"%{path}" non è un percorso valido. I percorsi devono iniziare con "/" e non contenere spazi, "?" o "#".'
+        multiple_display_url: Al massimo una voce di reindirizzamento può essere contrassegnata come URL di visualizzazione.
+        reserved_prefix: '"%{path}" non può essere utilizzato. Il percorso è riservato dall''applicazione e non può essere usato come alias.'
   helpers:
     action:
       accept: Accettare
@@ -1822,6 +1829,26 @@ it:
         in_collections: Collezioni
         in_other_works: Questo lavoro in altre opere
         in_this_work: Altri lavori in questo lavoro
+        redirects:
+          add_label: Aggiungi un altro alias
+          caption: Elenco degli alias URL per questa risorsa
+          display_url:
+            help_html: Facoltativamente, contrassegna un alias come <em>URL di visualizzazione</em>. Quando impostato, l'URL UUID permanente del record reindirizza all'alias scelto. Lascia "Nessuno" per mantenere l'URL UUID come destinazione.
+            none_label: Nessuno (usa l'URL UUID del record)
+            row_label: 'Usa "%{path}" come URL di visualizzazione'
+          errors_heading: Si prega di correggere i seguenti errori di alias
+          header:
+            actions: Azioni
+            display_url: URL di visualizzazione
+            path: Percorso
+          heading: Alias URL
+          help_html: 'Registra i vecchi percorsi URL che dovrebbero reindirizzare a questo record. Ogni percorso sarà risolto dalla radice di questo sito. I percorsi Hyrax riservati (ad esempio, <code>/concern</code>, <code>/dashboard</code>) non possono essere utilizzati.'
+          new_path_label: Nuovo percorso alias
+          path_label: Percorso alias
+          placeholder:
+            path: Inserisci un vecchio percorso...
+          remove_label: Rimuovi
+          remove_with_path_label: 'Rimuovi %{path}'
         tab:
           files: File
           metadata: descrizioni

--- a/config/locales/hyrax.pt-BR.yml
+++ b/config/locales/hyrax.pt-BR.yml
@@ -1395,6 +1395,14 @@ pt-BR:
         save_your_note: Você deve clicar em "Salvar revisão". reverter uma versão anterior deste arquivo
         upload: Carregar nova versão
     flexible_schema_validators:
+      redirects_validator:
+        errors:
+          invalid_available_on: "a propriedade `redirects` do perfil m3 deve estar disponível em pelo menos uma classe de obra ou coleção declarada neste perfil"
+          invalid_type: "a propriedade `redirects` do perfil m3 deve declarar `type: hash` (recebido `%{actual_type}`)"
+          property_required: "o perfil m3 deve declarar uma propriedade `redirects` quando o recurso de redirecionamentos está habilitado"
+        warnings:
+          config_disabled: "o perfil m3 declara uma propriedade `redirects`, mas Hyrax.config.redirects_enabled? é false; a propriedade será ignorada"
+          flipflop_disabled: "o perfil m3 declara uma propriedade `redirects`, mas o sinalizador de recurso :redirects está desativado; a propriedade será ignorada"
       sort_properties_validator:
         warnings:
           message: "%{property} deve ser definido em %{classes} para oferecer suporte à ordenação por essa propriedade, a menos que você tenha indexado %{property}_ssi em algum outro campo."

--- a/config/locales/hyrax.pt-BR.yml
+++ b/config/locales/hyrax.pt-BR.yml
@@ -41,6 +41,13 @@ pt-BR:
       carrierwave_processing_error: Não é possível redimensionar a imagem.
       extension_blacklist_error: "Você não tem permissão para carregar arquivos %{extension}; tipos proibidos: %{prohibited_types}"
       extension_whitelist_error: "Você não tem permissão para carregar arquivos %{extension}; tipos permitidos: %{allowed_types}"
+      redirect:
+        already_taken: '"%{path}" já está sendo usado por outra obra ou coleção.'
+        blank: Um caminho de redirecionamento não pode estar em branco.
+        intra_record_duplicate: '"%{path}" está listado mais de uma vez neste registro.'
+        invalid_format: '"%{path}" não é um caminho válido. Os caminhos devem começar com "/" e não conter espaços, "?" ou "#".'
+        multiple_display_url: No máximo uma entrada de redirecionamento pode ser marcada como URL de exibição.
+        reserved_prefix: '"%{path}" não pode ser usado. O caminho é reservado pela aplicação e não pode ser usado como alias.'
   helpers:
     action:
       accept: Aceitar
@@ -1815,6 +1822,26 @@ pt-BR:
         in_collections: Coleções
         in_other_works: Esta obra em outras obras
         in_this_work: Outras obras nesta obra
+        redirects:
+          add_label: Adicionar outro alias
+          caption: Lista de aliases de URL para este recurso
+          display_url:
+            help_html: Opcionalmente, marque um alias como a <em>URL de exibição</em>. Quando definido, o URL UUID permanente do registro redireciona para o alias escolhido. Deixe como "Nenhum" para manter o URL UUID como destino.
+            none_label: Nenhum (usar o URL UUID do registro)
+            row_label: 'Usar "%{path}" como URL de exibição'
+          errors_heading: Por favor, corrija os seguintes erros de alias
+          header:
+            actions: Ações
+            display_url: URL de exibição
+            path: Caminho
+          heading: Aliases de URL
+          help_html: 'Registre caminhos de URL legados que devem redirecionar para este registro. Cada caminho será resolvido a partir da raiz deste site. Rotas reservadas do Hyrax (por exemplo, <code>/concern</code>, <code>/dashboard</code>) não podem ser usadas.'
+          new_path_label: Novo caminho de alias
+          path_label: Caminho do alias
+          placeholder:
+            path: Insira um caminho legado...
+          remove_label: Remover
+          remove_with_path_label: 'Remover %{path}'
         tab:
           files: Arquivos
           metadata: Descrições

--- a/config/locales/hyrax.zh.yml
+++ b/config/locales/hyrax.zh.yml
@@ -1400,6 +1400,14 @@ zh:
         save_your_note: 您必须点击“保存修订版”还原此文件的先前版本
         upload: 上传新版本
     flexible_schema_validators:
+      redirects_validator:
+        errors:
+          invalid_available_on: "m3 配置文件的 `redirects` 属性必须在此配置文件中声明的至少一个作品或收藏类上可用"
+          invalid_type: "m3 配置文件的 `redirects` 属性必须声明 `type: hash`（实际为 `%{actual_type}`）"
+          property_required: "启用重定向功能时，m3 配置文件必须声明 `redirects` 属性"
+        warnings:
+          config_disabled: "m3 配置文件声明了 `redirects` 属性，但 Hyrax.config.redirects_enabled? 为 false；该属性将被忽略"
+          flipflop_disabled: "m3 配置文件声明了 `redirects` 属性，但 :redirects 功能标志已关闭；该属性将被忽略"
       sort_properties_validator:
         warnings:
           message: "%{property} 必须在 %{classes} 上定义才能支持该属性的排序，除非您已在其他字段上索引了 %{property}_ssi。"

--- a/config/locales/hyrax.zh.yml
+++ b/config/locales/hyrax.zh.yml
@@ -41,6 +41,13 @@ zh:
       carrierwave_processing_error: 图片大小不能调整。
       extension_blacklist_error: "%{extension} 的文件不能上传, 限制上传的扩展类型: %{prohibited_types}"
       extension_whitelist_error: "%{extension} 的文件不能上传, 可上传的扩展类型: %{allowed_types}"
+      redirect:
+        already_taken: '"%{path}" 已被另一个作品或集合使用。'
+        blank: 重定向路径不能为空。
+        intra_record_duplicate: '"%{path}" 在此记录中列出多次。'
+        invalid_format: '"%{path}" 不是有效路径。路径必须以 "/" 开头，且不能包含空格、"?" 或 "#"。'
+        multiple_display_url: 每条记录最多只能将一个重定向条目标记为显示 URL。
+        reserved_prefix: '"%{path}" 不能使用。该路径已被应用程序保留，不能用作别名。'
   helpers:
     action:
       accept: 接受
@@ -1820,6 +1827,26 @@ zh:
         in_collections: 集合
         in_other_works: 在其它作品中包括的这件作品
         in_this_work: 这件作品包括的其它作品
+        redirects:
+          add_label: 添加另一个别名
+          caption: 此资源的 URL 别名列表
+          display_url:
+            help_html: 可以选择将一个别名标记为<em>显示 URL</em>。设置后，记录的永久 UUID URL 将重定向到所选别名。保留为"无"以将 UUID URL 作为目标。
+            none_label: 无（使用记录的 UUID URL）
+            row_label: '使用 "%{path}" 作为显示 URL'
+          errors_heading: 请更正以下别名错误
+          header:
+            actions: 操作
+            display_url: 显示 URL
+            path: 路径
+          heading: URL 别名
+          help_html: '注册应重定向到此记录的旧 URL 路径。每个路径将从本站点的根目录解析。保留的 Hyrax 路由（例如 <code>/concern</code>、<code>/dashboard</code>）不能使用。'
+          new_path_label: 新别名路径
+          path_label: 别名路径
+          placeholder:
+            path: 输入旧路径...
+          remove_label: 删除
+          remove_with_path_label: '删除 %{path}'
         tab:
           files: 文件
           metadata: 描述

--- a/documentation/forms/field_behaviors.md
+++ b/documentation/forms/field_behaviors.md
@@ -1,6 +1,6 @@
 # Field Behaviors
 
-A **Field Behavior** is a Ruby module mixed into `Hyrax::Forms::ResourceForm` (and its subclasses) that wires up a single property whose persisted shape and submitted-form shape differ. It owns the populator, prepopulator, and `deserialize!` strip for that property.
+A **Field Behavior** is a Ruby module mixed into `Hyrax::Forms::ResourceForm` (and its subclasses) that wires up a single property whose persisted shape and submitted-form shape differ. It owns the populator and the `deserialize!` strip for that property, and may optionally provide a prepopulator if the view needs a presenter wrapping each entry.
 
 Use a Field Behavior when you have a property that:
 
@@ -8,10 +8,10 @@ Use a Field Behavior when you have a property that:
 - Persists in a shape the view can't render directly (a hash of sub-fields, a URI string the view wants as a `ControlledVocabulary` instance, a triple of values, etc.).
 - Needs the same wiring on every form subclass.
 
-Two reference exemplars ship with Hyrax:
+Two examples ship with Hyrax:
 
-- `Hyrax::BasedNearFieldBehavior` — single-string-per-entry (URI), hydrated to a `ControlledVocabularies::Location` for the view.
-- `Hyrax::RedirectsFieldBehavior` — multi-field-per-entry (path / canonical / sequence), hydrated to a `Hyrax::Redirect` presenter for the view.
+- `Hyrax::BasedNearFieldBehavior` — single-string-per-entry (URI), wrapped in a `ControlledVocabularies::Location` for the view.
+- `Hyrax::RedirectsFieldBehavior` — multi-field-per-entry (path / is_display_url), wrapped in a `Hyrax::Redirect` presenter for the view.
 
 This document covers the contract a Field Behavior must satisfy, the decision points for a new behavior, and the worked examples.
 
@@ -25,19 +25,18 @@ Reform's `FormBuilderMethods#deserialize!` rewrites the submitted `<name>_attrib
 
 A Field Behavior is a module that:
 
-1. **Registers a virtual `<name>_attributes` property** in `self.included`, with a populator and prepopulator. If the persisted `<name>` property is not already on the form via some other include path, also load it from the corresponding YAML schema in `self.included` so the form partial can read `f.object.<name>` directly.
+1. **Registers a virtual `<name>_attributes` property** in `self.included`, with a populator. Add a prepopulator if the view needs a presenter wrapping each persisted entry; otherwise the form partial can wrap entries inline at render time. If the persisted `<name>` property is not already on the form via some other include path, also load it from the corresponding YAML schema in `self.included` so the form partial can read `f.object.<name>` directly.
 
    ```ruby
    def self.included(descendant)
      descendant.include Hyrax::FormFields(:<name>)
      descendant.property :<name>_attributes,
                          virtual: true,
-                         populator: :<name>_attributes_populator,
-                         prepopulator: :<name>_attributes_prepopulator
+                         populator: :<name>_attributes_populator
    end
    ```
 
-   Whether to load the persisted property depends on where the schema is included on application forms. `BasedNearFieldBehavior` skips this step because adopter forms include `Hyrax::FormFields(:basic_metadata)` directly, which already registers `based_near`. `RedirectsFieldBehavior` includes it because the redirects schema is engine-level and not part of any per-form include — without the include here, non-flexible forms would not have the property registered, and the partial's `f.object.redirects` call would crash. A flexible install's m3 loader redefines the property on each instance harmlessly when this include is present.
+   Whether to load the persisted property depends on where the schema is included on application forms. `BasedNearFieldBehavior` skips this step because adopter forms include `Hyrax::FormFields(:basic_metadata)` directly, which already registers `based_near`. `RedirectsFieldBehavior` does not include the schema either; the persisted `redirects` property is provided by either the m3 loader (flexible mode) or by a per-class-level include on `ResourceForm` (non-flexible mode). Either way, when the schema is engine-level and not on a per-form include path, an extra `descendant.include Hyrax::FormFields(:<name>)` here is the third option.
 
 2. **Composes via `super` in `deserialize!`**, then deletes its own renamed key.
 
@@ -68,7 +67,7 @@ A Field Behavior is a module that:
 
    Drop empty rows and rows marked `_destroy` here. Normalize values here too — the persisted shape should be canonical so non-form callers (importers, console, validators) don't have to re-normalize.
 
-4. **Provides a prepopulator** that hydrates the persisted value into a render-friendly object.
+4. **Optionally, provides a prepopulator** that wraps each persisted entry in a presenter the view can use. If you skip the prepopulator, the form partial can wrap entries inline at render time instead — useful when the view needs more control over which entries get wrapped or when wrapping should happen lazily.
 
    ```ruby
    def <name>_attributes_prepopulator
@@ -76,6 +75,8 @@ A Field Behavior is a module that:
      self.<name> = Array(<name>).map { |entry| MyPresenter.wrap(entry) }
    end
    ```
+
+   `BasedNearFieldBehavior` uses a prepopulator; `RedirectsFieldBehavior` wraps inline in the partial.
 
 5. **Is `prepend`ed onto every subclass** in `ResourceForm.inherited`:
 
@@ -126,7 +127,7 @@ When adding a Field Behavior, work through these:
 ### 1. What does each entry look like?
 
 - **Single value per entry** (URI string, scalar): see `BasedNearFieldBehavior`.
-- **Multiple sub-fields per entry** (path + canonical + sequence; or label + value + lang): see `RedirectsFieldBehavior`.
+- **Multiple sub-fields per entry** (path + is_display_url; or label + value + lang): see `RedirectsFieldBehavior`.
 
 ### 2. Persisted as what?
 
@@ -135,7 +136,7 @@ When adding a Field Behavior, work through these:
 
 ### 3. Does the view need a presenter?
 
-- **Yes** if the view calls `.something` accessors on each entry. Build a small Ruby class with `path` / `value` / etc. readers and a `wrap(input)` class method that accepts both raw and already-wrapped input. The prepopulator wraps every entry; the view can rely on the presenter API.
+- **Yes** if the view calls `.something` accessors on each entry. Build a small Ruby class with `path` / `value` / etc. readers and a `wrap(input)` class method that accepts both raw and already-wrapped input. Either the prepopulator wraps every entry up front (the `BasedNearFieldBehavior` pattern), or the form partial wraps entries inline at render time (the `RedirectsFieldBehavior` pattern). Either way the view code can rely on the presenter API.
 - **No** if the view reads keys directly. Skip the presenter and let the view call `entry['key']`.
 
 ### 4. What happens to invalid input?
@@ -144,9 +145,9 @@ The populator drops empty rows and `_destroy` rows. Format validation belongs in
 
 ### 5. Is the property optional on some forms?
 
-Always guard with `respond_to?(:<name>)` at the top of populator and prepopulator. Adopter forms whose models don't include the schema get a no-op rather than a crash.
+Always guard with `respond_to?(:<name>)` at the top of the populator (and the prepopulator, if you have one). Adopter forms whose models don't include the schema get a no-op rather than a crash.
 
-## Exemplar: `BasedNearFieldBehavior`
+## Example: `BasedNearFieldBehavior`
 
 ```ruby
 module Hyrax
@@ -193,18 +194,20 @@ end
 - **View-side shape:** array of `Hyrax::ControlledVocabularies::Location` instances.
 - **Diff from a plain `_attributes` setup:** `deserialize!` strips `based_near` after the rename so `from_hash` doesn't overwrite the property with raw fragment hashes; the populator merges adds/removes onto the existing `model.based_near` so partial form submissions are non-destructive.
 
-## Exemplar: `RedirectsFieldBehavior`
+## Example: `RedirectsFieldBehavior`
 
 ```ruby
 module Hyrax
   module RedirectsFieldBehavior
     def self.included(descendant)
       return unless Hyrax.config.redirects_enabled?
-      descendant.include Hyrax::FormFields(:redirects)
+      # Declare the radio-group scalar before redirects_attributes so Reform
+      # deserializes it first; the populator reads its value while building
+      # per-row entries.
+      descendant.property :redirects_display_url_index, virtual: true
       descendant.property :redirects_attributes,
                           virtual: true,
-                          populator: :redirects_attributes_populator,
-                          prepopulator: :redirects_attributes_prepopulator
+                          populator: :redirects_attributes_populator
     end
 
     def deserialize!(params)
@@ -221,28 +224,20 @@ module Hyrax
     def redirects_attributes_populator(fragment:, **_options)
       return unless respond_to?(:redirects)
       return unless Hyrax.config.redirects_active?
-      entries = Array(fragment&.values)
-                .reject { |row| row['_destroy'].to_s == 'true' || row['path'].to_s.strip.empty? }
-                .each_with_index.map do |row, i|
-        { 'path' => Hyrax::RedirectPathNormalizer.call(row['path']),
-          'canonical' => row['canonical'].to_s == 'true',
-          'sequence' => row['sequence'].presence&.to_i || i }
-      end
-      self.redirects = entries
-    end
-
-    def redirects_attributes_prepopulator
-      return unless respond_to?(:redirects)
-      return unless Hyrax.config.redirects_active?
-      self.redirects = Array(redirects).map { |entry| Hyrax::Redirect.wrap(entry) }
+      pairs = redirects_fragment_pairs(fragment)
+      self.redirects = pairs.sort_by { |k, _row| k.to_i }
+                            .map { |k, row| redirects_entry_from(k, row) }
+                            .compact
     end
   end
 end
 ```
 
-- **Persisted shape:** array of plain hashes (`'path'`, `'canonical'`, `'sequence'`). Declared with `type: hash, multiple: true` in `config/metadata/redirects.yaml` and loaded onto the form via `Hyrax::FormFields(:redirects)` in `self.included`.
-- **View-side shape:** array of `Hyrax::Redirect` presenters, exposing `.path` / `.canonical` / `.sequence`.
-- **Diff from BasedNear:** entries carry multiple sub-fields, so the persisted shape is a hash rather than a string. The populator normalizes paths up front (canonical form lives in storage). The behavior is feature-gated — every callback consults `Hyrax.config.redirects_active?`. The behavior also loads the persisted `redirects` property from YAML in `self.included`, since `Hyrax::Schema(:redirects)` puts the attribute on the model but the form needs the property registered separately for the partial's `f.object.redirects` call to work.
+The populator folds a sibling `redirects_display_url_index` scalar (a single radio-group value) into per-row `is_display_url` flags. When the index is unset (e.g. Bulkrax import), the row's own `is_display_url` value is honored.
+
+- **Persisted shape:** array of plain hashes (`'path'`, `'is_display_url'`). Declared with `type: hash, multiple: true` in `config/metadata/redirects.yaml`.
+- **View-side shape:** array of `Hyrax::Redirect` presenters, exposing `.path` and `.is_display_url`. The form partial wraps each persisted hash inline rather than via a prepopulator.
+- **Diff from BasedNear:** entries carry multiple sub-fields, so the persisted shape is a hash rather than a string. The populator normalizes paths up front (canonical form lives in storage). The behavior is feature-gated — every callback consults `Hyrax.config.redirects_active?`.
 
 ## Wiring on `ResourceForm`
 
@@ -277,12 +272,11 @@ Example for `RedirectsFieldBehavior`:
 
 ```ruby
 # In the host app's Bulkrax field-mapping configuration
-'path'      => { from: ['redirect_path'],      object: 'redirects', nested_attributes: true },
-'canonical' => { from: ['redirect_canonical'], object: 'redirects', nested_attributes: true },
-'sequence'  => { from: ['redirect_sequence'],  object: 'redirects', nested_attributes: true },
+'path'           => { from: ['redirect_path'],           object: 'redirects', nested_attributes: true },
+'is_display_url' => { from: ['redirect_is_display_url'], object: 'redirects', nested_attributes: true }
 ```
 
-CSV columns are `redirect_path_1`, `redirect_canonical_1`, `redirect_sequence_1`, `redirect_path_2`, …
+CSV columns are `redirect_path_1`, `redirect_is_display_url_1`, `redirect_path_2`, `redirect_is_display_url_2`, …
 
 Conventions:
 

--- a/documentation/redirects.md
+++ b/documentation/redirects.md
@@ -98,7 +98,7 @@ The `display_label` and `range` entries are required for profile validation. `di
 
 The `indexing: [editor_only]` entry and the `view:` block together opt the redirects field into the show-page display described below in [Displaying redirect aliases on show pages](#displaying-redirect-aliases-on-show-pages). Both are required for that display to appear with editor-or-admin visibility. Note the placement: `editor_only` is an entry in the `indexing:` array (read by `Hyrax::SchemaLoader::AttributeDefinition#editor_only?`); `render_term`, `render_as`, and `html_dl` are inside the `view:` block. Non-flexible mode structures `editor_only` differently — see [Schema details](#schema-details-flexible-false-mode) below.
 
-Each redirect entry is a plain hash with `path`, `canonical`, and `sequence` keys, persisted as JSONB on the parent resource. The `type: hash` token resolves to `Dry::Types['hash']`, which round-trips entries through Postgres without the sub-field stripping a nested `Valkyrie::Resource` would suffer. `available_on.class` must include at least one work or collection class declared in this profile's top-level `classes:` block; substitute the class names your profile declares (`Image`, `Etd`, `Oer`, etc.) as appropriate.
+Each redirect entry is a plain hash with `path` and `is_display_url` keys, persisted as JSONB on the parent resource. The `type: hash` token resolves to `Dry::Types['hash']`, which round-trips entries through Postgres without the sub-field stripping a nested `Valkyrie::Resource` would suffer. `available_on.class` must include at least one work or collection class declared in this profile's top-level `classes:` block; substitute the class names your profile declares (`Image`, `Etd`, `Oer`, etc.) as appropriate.
 
 Validation matrix on profile save (with the config on):
 
@@ -142,7 +142,7 @@ When the config is on, this schema is loaded and `Hyrax::Work` / `Hyrax::PcdmCol
 attribute :redirects, Valkyrie::Types::Array.of(Dry::Types['hash'])
 ```
 
-Each entry is a plain hash with `path`, `canonical`, and `sequence` keys. Entries persist as JSONB on the parent resource, so sub-fields round-trip cleanly without an intermediate nested-resource schema mangling them. `Hyrax::Redirect` is retained as a thin Ruby presenter the form view consumes; non-form code (validator, indexer, sync step) reads the persisted hash directly.
+Each entry is a plain hash with `path` and `is_display_url` keys. Entries persist as JSONB on the parent resource, so sub-fields round-trip cleanly without an intermediate nested-resource schema mangling them. `Hyrax::Redirect` is retained as a thin Ruby presenter the form view consumes; non-form code (validator, indexer, sync step) reads the persisted hash directly.
 
 When the config is off, the loader filters `redirects.yaml` out of the schema set entirely. The file is on disk but invisible to `permissive_schema_for_valkrie_adapter`, `Hyrax::Schema(:redirects)`, and any other consumer of the simple schema loader.
 
@@ -180,7 +180,7 @@ The validator enforces six rules on the `redirects` attribute:
 | Reserved prefix | path equals or starts with one of `Hyrax.config.reserved_redirect_prefixes` (defaults to the routes Hyrax itself reserves) | the path is reserved by the application and may not be used as an alias |
 | Intra-record uniqueness | the same path appears more than once on a single record | `is listed more than once on this record` |
 | Global uniqueness | the path is already in use on a different record (excluding the current record's own id) | `is already in use by another record` |
-| At most one canonical | more than one entry has `canonical: true` | `at most one redirect entry may be marked canonical` |
+| At most one display URL | more than one entry has `is_display_url: true` | `at most one redirect entry may be marked as the display URL` |
 
 ### Reserved-prefix list
 
@@ -340,23 +340,22 @@ Institutions migrating from another repository typically have hundreds to thousa
 
 ### CSV column format
 
-Each redirect entry maps to three numbered columns: `redirect_path_<n>`, `redirect_canonical_<n>`, `redirect_sequence_<n>`. A row with two redirects, one canonical:
+Each redirect entry maps to two numbered columns: `redirect_path_<n>` and `redirect_is_display_url_<n>`. A row with two redirects, one marked as the display URL:
 
 ```csv
-source_identifier,title,redirect_path_1,redirect_canonical_1,redirect_sequence_1,redirect_path_2,redirect_canonical_2,redirect_sequence_2
+source_identifier,title,redirect_path_1,redirect_is_display_url_1,redirect_path_2,redirect_is_display_url_2
 work-001,My Work,/handle/12345/678,true,0,/old/path/678,false,1
 ```
 
-`canonical` accepts the literal string `true` or `false` (boolean strings, not `1`/`0`). At most one entry per record may be canonical. `sequence` is an integer that orders the entries; if omitted, Bulkrax uses the column position.
+`is_display_url` accepts the literal string `true` or `false` (boolean strings, not `1`/`0`). At most one entry per record may be marked as the display URL.
 
 ### Field-mapping configuration
 
 Add to the host app's Bulkrax field-mapping configuration (usually `config/initializers/default_bulkrax_mappings.rb` or a per-tenant override):
 
 ```ruby
-'path'      => { from: ['redirect_path'],      object: 'redirects', nested_attributes: true },
-'canonical' => { from: ['redirect_canonical'], object: 'redirects', nested_attributes: true },
-'sequence'  => { from: ['redirect_sequence'],  object: 'redirects', nested_attributes: true },
+'path'           => { from: ['redirect_path'],           object: 'redirects', nested_attributes: true },
+'is_display_url' => { from: ['redirect_is_display_url'], object: 'redirects', nested_attributes: true }
 ```
 
 See [field_behaviors.md](forms/field_behaviors.md#wiring-up-bulkrax-imports) for the conventions around the `nested_attributes: true` flag.
@@ -375,7 +374,7 @@ If the redirects feature was just enabled (config + Flipflop turned on) and exis
 
 - **"is reserved by the application and may not be used as an alias"** — the path matches a reserved prefix. Choose a different path or extend `Hyrax.config.reserved_redirect_prefixes` if the conflict is intentional.
 - **"is already in use by another record"** — the path is registered as a redirect on a different work or collection. Paths are globally unique.
-- **"at most one redirect entry may be marked canonical"** — multiple rows in the same CSV record have `redirect_canonical_<n>=true`. Only one entry per record may be canonical.
+- **"at most one redirect entry may be marked as the display URL"** — multiple rows in the same CSV record have `redirect_is_display_url_<n>=true`. Only one entry per record may be marked as the display URL.
 - **m3 profile validation: "redirects property is required"** (flexible mode) — the Flipflop is on but the m3 profile doesn't declare the `redirects` property. Add it per the section above.
 - **m3 profile validation: "the property will be ignored"** (flexible mode, config off) — a stale `redirects` property is declared but the config is off. Either remove the property from the profile or re-enable the config.
 

--- a/documentation/redirects.md
+++ b/documentation/redirects.md
@@ -176,7 +176,7 @@ The validator enforces six rules on the `redirects` attribute:
 | Rule | Trigger | Error |
 |---|---|---|
 | Path is present | `entry.path` is blank | `redirect path can't be blank` |
-| Path format | path doesn't start with `/`, contains whitespace, `?`, or `#` | `is not a valid redirect path` |
+| Path format | path doesn't start with `/`, or contains any character outside the RFC 3986 path set (alphanumerics, `-._~`, sub-delims `!$&'()*+,;=`, `:`, `@`, `/`, and `%XX` percent-encoding) | `is not a valid redirect path` |
 | Reserved prefix | path equals or starts with one of `Hyrax.config.reserved_redirect_prefixes` (defaults to the routes Hyrax itself reserves) | the path is reserved by the application and may not be used as an alias |
 | Intra-record uniqueness | the same path appears more than once on a single record | `is listed more than once on this record` |
 | Global uniqueness | the path is already in use on a different record (excluding the current record's own id) | `is already in use by another record` |

--- a/documentation/redirects.md
+++ b/documentation/redirects.md
@@ -203,11 +203,13 @@ Global uniqueness is enforced by a Postgres table, `hyrax_redirect_paths`, with 
 
 | Column           | Purpose                                                                                                              |
 | ---------------- | -------------------------------------------------------------------------------------------------------------------- |
-| `from_path`      | The alias path the visitor types. Unique B-tree indexed — the primary request-time lookup key.                       |
-| `to_path`        | Where the visitor should be sent. For now, the resource's canonical UUID path on every row.                          |
-| `permalink_path` | The resource's canonical UUID path (e.g. `/concern/generic_works/<uuid>` or `/collections/<uuid>`).                  |
+| `from_path`      | The URL the visitor entered (an alias or the UUID URL itself). Unique B-tree indexed — the primary request-time lookup key. |
+| `to_path`        | The URL the address bar should display after the resolver routes the request. Equals the display alias's `from_path` on rows for resources with a display URL; equals `permalink_path` otherwise. |
+| `permalink_path` | The resource's canonical UUID path (e.g. `/concern/generic_works/<uuid>` or `/collections/<uuid>`). Constant per resource. |
 | `resource_id`    | The UUID of the work or collection. Indexed (non-unique) for the per-resource sync described below.                  |
-| `is_display_url` | Boolean. Defaults to `false`. Reserved for the display-URL feature.                                                  |
+| `is_display_url` | Boolean. `true` on the row whose `from_path` is the record's chosen display URL; `false` everywhere else.            |
+
+When a resource has a display URL set, the sync step writes one row per alias plus an extra row whose `from_path` is the UUID URL, so visitors hitting the bare UUID URL are also routed to the display alias.
 
 The unique index on `from_path` gives the hard guarantee that no two records can share an alias even under concurrent saves.
 
@@ -410,7 +412,7 @@ Alternatively, gate the inclusion of the calling code itself on `Hyrax.config.re
 - `documentation/flexible_metadata.md` — m3 profile fundamentals and how the redirects feature interacts with flexible metadata.
 - `documentation/forms/field_behaviors.md` — the Field Behavior pattern used by `Hyrax::RedirectsFieldBehavior` to wire the form's nested-attribute property.
 - `Hyrax::Redirect` (`app/models/hyrax/redirect.rb`) — thin Ruby presenter for a single redirect entry; used on the form's render path.
-- `Hyrax::RedirectsFieldBehavior` (`app/forms/concerns/hyrax/redirects_field_behavior.rb`) — form-side wiring for the `redirects` and `redirects_attributes` properties: loads the persisted property from `config/metadata/redirects.yaml` via `Hyrax::FormFields(:redirects)`, and owns the populator/prepopulator and the `deserialize!` strip for the nested-attributes payload.
+- `Hyrax::RedirectsFieldBehavior` (`app/forms/concerns/hyrax/redirects_field_behavior.rb`) — form-side wiring for the `redirects_attributes` virtual property and the `redirects_display_url_index` radio-group scalar. Owns the populator (which folds the radio-group index into per-row `is_display_url` flags) and the `deserialize!` strip for the nested-attributes payload. The form partial wraps each persisted hash in a `Hyrax::Redirect` presenter inline at render time.
 - `Hyrax::Indexers::RedirectsIndexer` (`app/indexers/hyrax/indexers/redirects_indexer.rb`) — the indexer mixin. Emits `redirects_path_ssim` (resolver lookup) and `redirects_path_tesim` (show-page display).
 - `Hyrax::SolrDocument::Metadata` (`app/models/concerns/hyrax/solr_document/metadata.rb`) — declares the `redirects_path` attribute on `SolrDocument`, bound to the `redirects_path_tesim` Solr field. This is what makes `solr_document.redirects_path` (and therefore `presenter.redirects_path` via `MissingMethodBehavior`) available to the show-page renderer.
 - `Hyrax::Renderers::RedirectsLabelAttributeRenderer` (`app/renderers/hyrax/renderers/redirects_label_attribute_renderer.rb`) — show-page renderer that turns each redirect path into a clickable link.

--- a/lib/hyrax/transactions/steps/sync_redirect_paths.rb
+++ b/lib/hyrax/transactions/steps/sync_redirect_paths.rb
@@ -76,9 +76,20 @@ module Hyrax
             path = entry['path'] || entry[:path]
             next if path.blank? || seen.include?(path)
             seen << path
-            flag = entry['is_display_url'] || entry[:is_display_url]
-            acc << { from_path: path, is_display_url: flag ? true : false }
+            acc << { from_path: path, is_display_url: display_url_flag(entry) }
           end
+        end
+
+        # Boolean-cast the stored value so importer/console writes that leave a
+        # string like "false" or "0" in the JSONB hash don't end up as truthy.
+        # Returns false when the key is absent.
+        def display_url_flag(entry)
+          raw = if entry.key?('is_display_url')
+                  entry['is_display_url']
+                elsif entry.key?(:is_display_url)
+                  entry[:is_display_url]
+                end
+          ActiveModel::Type::Boolean.new.cast(raw) || false
         end
 
         def build_alias_row(entry, resource_id, permalink, display_path, now)

--- a/lib/hyrax/transactions/steps/sync_redirect_paths.rb
+++ b/lib/hyrax/transactions/steps/sync_redirect_paths.rb
@@ -11,6 +11,24 @@ module Hyrax
       # ActiveRecord::RecordNotUnique and this step returns Failure, which
       # short-circuits the enclosing transaction.
       #
+      # Every row carries the resource's canonical UUID URL in
+      # `permalink_path`. Column semantics:
+      #
+      # - `from_path` — the URL the visitor entered (an alias or the UUID
+      #   URL itself).
+      # - `to_path` — the URL the address bar should display after the
+      #   resolver routes the request. For the display row, equals its own
+      #   `from_path` (the visitor stays at the display URL). For
+      #   non-display rows, points at the display row's `from_path` (the
+      #   visitor lands at the user-facing display URL). When no entry is
+      #   marked, every alias's `to_path` is the UUID URL.
+      # - `permalink_path` — the resource's canonical UUID URL. Constant
+      #   per resource across all rows.
+      #
+      # When a display URL is set, the sync step also writes an extra row
+      # with `from_path = permalink_path` so visitors hitting the bare
+      # UUID URL are routed to the display alias.
+      #
       # No-op when the redirects feature is off (config or Flipflop) or when
       # the resource doesn't carry the redirects attribute.
       #
@@ -41,39 +59,69 @@ module Hyrax
 
         def build_rows(object)
           permalink = Hyrax::PermalinkPath.call(object)
+          entries = entries_for(object)
+          display_path = entries.find { |e| e[:is_display_url] }&.dig(:from_path)
           resource_id = object.id.to_s
           now = Time.current
-          alias_paths_for(object).map do |alias_path|
-            { from_path: alias_path,
-              to_path: permalink,
-              permalink_path: permalink,
-              resource_id: resource_id,
-              is_display_url: false,
-              created_at: now, updated_at: now }
-          end
+          alias_rows = entries.map { |entry| build_alias_row(entry, resource_id, permalink, display_path, now) }
+          alias_rows << build_permalink_row(resource_id, permalink, display_path, now) if display_path
+          alias_rows
         end
 
         # Valkyrie's JSONValueMapper symbolizes hash keys on read; accept either.
         # Paths are normalized at write time by Hyrax::RedirectsNormalization.
-        def alias_paths_for(object)
-          Array(object.redirects).map { |entry| entry['path'] || entry[:path] }.reject(&:blank?).uniq
+        def entries_for(object)
+          seen = Set.new
+          Array(object.redirects).each_with_object([]) do |entry, acc|
+            path = entry['path'] || entry[:path]
+            next if path.blank? || seen.include?(path)
+            seen << path
+            flag = entry['is_display_url'] || entry[:is_display_url]
+            acc << { from_path: path, is_display_url: flag ? true : false }
+          end
+        end
+
+        def build_alias_row(entry, resource_id, permalink, display_path, now)
+          to_path = if entry[:is_display_url]
+                      entry[:from_path]
+                    elsif display_path
+                      display_path
+                    else
+                      permalink
+                    end
+          { from_path: entry[:from_path],
+            to_path: to_path,
+            permalink_path: permalink,
+            resource_id: resource_id,
+            is_display_url: entry[:is_display_url],
+            created_at: now, updated_at: now }
+        end
+
+        def build_permalink_row(resource_id, permalink, display_path, now)
+          { from_path: permalink,
+            to_path: display_path,
+            permalink_path: permalink,
+            resource_id: resource_id,
+            is_display_url: false,
+            created_at: now, updated_at: now }
         end
 
         # @return [Array<String>, nil] the union of old + new from_paths that
         #   need cache invalidation, or nil when nothing changed.
         def replace_rows(object, rows)
-          desired_paths = rows.map { |r| r[:from_path] }.sort
+          desired = rows.map { |r| [r[:from_path], r[:to_path], r[:is_display_url]] }.sort
 
           Hyrax::RedirectPath.transaction do
-            existing_paths = Hyrax::RedirectPath.where(resource_id: object.id.to_s).pluck(:from_path).sort
-            return nil if desired_paths == existing_paths
+            existing = Hyrax::RedirectPath.where(resource_id: object.id.to_s)
+                                          .pluck(:from_path, :to_path, :is_display_url)
+            return nil if desired == existing.sort
 
             Hyrax::RedirectPath.where(resource_id: object.id.to_s).delete_all
             # rubocop:disable Rails/SkipsModelValidations -- the DB unique index on `from_path` is the validation we rely on; bulk insert is intentional
             Hyrax::RedirectPath.insert_all!(rows) if rows.any?
             # rubocop:enable Rails/SkipsModelValidations
 
-            (existing_paths | desired_paths)
+            (existing.map(&:first) | rows.map { |r| r[:from_path] })
           end
         end
       end

--- a/spec/forms/concerns/hyrax/redirects_field_behavior_spec.rb
+++ b/spec/forms/concerns/hyrax/redirects_field_behavior_spec.rb
@@ -3,7 +3,7 @@
 RSpec.describe Hyrax::RedirectsFieldBehavior do
   let(:form_class) do
     Class.new do
-      attr_accessor :redirects
+      attr_accessor :redirects, :redirects_display_url_index
 
       def self.property(*); end
 
@@ -44,9 +44,9 @@ RSpec.describe Hyrax::RedirectsFieldBehavior do
       expect(property_target).to receive(:property).with(
         :redirects_attributes,
         virtual: true,
-        populator: :redirects_attributes_populator,
-        prepopulator: :redirects_attributes_prepopulator
+        populator: :redirects_attributes_populator
       )
+      expect(property_target).to receive(:property).with(:redirects_display_url_index, virtual: true)
       property_target.include(described_class)
     end
 
@@ -72,21 +72,21 @@ RSpec.describe Hyrax::RedirectsFieldBehavior do
   describe '#redirects_attributes_populator' do
     it 'normalizes paths and produces the persisted hash shape' do
       fragment = {
-        '0' => { 'path' => '  /foo/  ', 'canonical' => 'true' },
-        '1' => { 'path' => '/bar', 'canonical' => 'false', 'sequence' => '5' }
+        '0' => { 'path' => '  /foo/  ', 'is_display_url' => 'true' },
+        '1' => { 'path' => '/bar', 'is_display_url' => 'false' }
       }
       form.send(:redirects_attributes_populator, fragment: fragment)
 
       expect(form.redirects).to eq([
-                                     { 'path' => '/foo', 'canonical' => true, 'sequence' => 0 },
-                                     { 'path' => '/bar', 'canonical' => false, 'sequence' => 5 }
+                                     { 'path' => '/foo', 'is_display_url' => true },
+                                     { 'path' => '/bar', 'is_display_url' => false }
                                    ])
     end
 
     it 'drops rows marked for destruction' do
       fragment = {
-        '0' => { 'path' => '/keep', 'canonical' => 'false' },
-        '1' => { 'path' => '/drop', 'canonical' => 'false', '_destroy' => 'true' }
+        '0' => { 'path' => '/keep', 'is_display_url' => 'false' },
+        '1' => { 'path' => '/drop', 'is_display_url' => 'false', '_destroy' => 'true' }
       }
       form.send(:redirects_attributes_populator, fragment: fragment)
 
@@ -95,8 +95,8 @@ RSpec.describe Hyrax::RedirectsFieldBehavior do
 
     it 'drops rows with a blank path' do
       fragment = {
-        '0' => { 'path' => '/keep', 'canonical' => 'false' },
-        '1' => { 'path' => '   ', 'canonical' => 'false' }
+        '0' => { 'path' => '/keep', 'is_display_url' => 'false' },
+        '1' => { 'path' => '   ', 'is_display_url' => 'false' }
       }
       form.send(:redirects_attributes_populator, fragment: fragment)
 
@@ -110,25 +110,77 @@ RSpec.describe Hyrax::RedirectsFieldBehavior do
 
       expect(form.redirects).to eq('untouched')
     end
-  end
 
-  describe '#redirects_attributes_prepopulator' do
-    it 'wraps each persisted hash entry in a Hyrax::Redirect presenter' do
-      form.redirects = [{ 'path' => '/foo', 'canonical' => true, 'sequence' => 0 }]
-      form.send(:redirects_attributes_prepopulator)
+    context 'with redirects_display_url_index set (form radio group)' do
+      let(:fragment) do
+        {
+          '0' => { 'path' => '/foo' },
+          '1' => { 'path' => '/bar' },
+          '2' => { 'path' => '/baz' }
+        }
+      end
 
-      expect(form.redirects.first).to be_a(Hyrax::Redirect)
-      expect(form.redirects.first.path).to eq('/foo')
-      expect(form.redirects.first.canonical).to be(true)
+      it 'marks only the selected row as is_display_url' do
+        form.redirects_display_url_index = '1'
+        form.send(:redirects_attributes_populator, fragment: fragment)
+
+        flags = form.redirects.map { |e| [e['path'], e['is_display_url']] }
+        expect(flags).to eq([['/foo', false], ['/bar', true], ['/baz', false]])
+      end
+
+      it 'leaves every row as is_display_url=false when the index is blank' do
+        form.redirects_display_url_index = ''
+        form.send(:redirects_attributes_populator, fragment: fragment)
+
+        expect(form.redirects.map { |e| e['is_display_url'] }).to all(be false)
+      end
+
+      it 'silently ignores a selected index pointing at a row dropped for blank path' do
+        form.redirects_display_url_index = '1'
+        fragment_with_blank = { '0' => { 'path' => '/foo' }, '1' => { 'path' => '   ' } }
+        form.send(:redirects_attributes_populator, fragment: fragment_with_blank)
+
+        expect(form.redirects.map { |e| [e['path'], e['is_display_url']] }).to eq([['/foo', false]])
+      end
+
+      it 'silently ignores a selected index past the end of the fragment' do
+        form.redirects_display_url_index = '99'
+        form.send(:redirects_attributes_populator, fragment: fragment)
+
+        expect(form.redirects.map { |e| e['is_display_url'] }).to all(be false)
+      end
     end
 
-    it 'is a no-op when the feature is inactive' do
-      allow(Hyrax.config).to receive(:redirects_active?).and_return(false)
-      original = [{ 'path' => '/foo' }]
-      form.redirects = original
-      form.send(:redirects_attributes_prepopulator)
+    context 'with redirects_display_url_index nil (Bulkrax-style import path)' do
+      it 'falls back to per-row is_display_url values' do
+        form.redirects_display_url_index = nil
+        fragment = {
+          '0' => { 'path' => '/foo', 'is_display_url' => 'true' },
+          '1' => { 'path' => '/bar', 'is_display_url' => 'false' }
+        }
+        form.send(:redirects_attributes_populator, fragment: fragment)
 
-      expect(form.redirects).to be(original)
+        expect(form.redirects).to eq([
+                                       { 'path' => '/foo', 'is_display_url' => true },
+                                       { 'path' => '/bar', 'is_display_url' => false }
+                                     ])
+      end
+    end
+
+    context 'when fragment is ActionController::Parameters (real form submit)' do
+      it 'unwraps the params object and folds the index' do
+        form.redirects_display_url_index = '1'
+        params = ActionController::Parameters.new(
+          '0' => { 'path' => '/foo' },
+          '1' => { 'path' => '/bar' }
+        )
+        form.send(:redirects_attributes_populator, fragment: params)
+
+        expect(form.redirects).to eq([
+                                       { 'path' => '/foo', 'is_display_url' => false },
+                                       { 'path' => '/bar', 'is_display_url' => true }
+                                     ])
+      end
     end
   end
 end

--- a/spec/lib/hyrax/transactions/steps/sync_redirect_paths_spec.rb
+++ b/spec/lib/hyrax/transactions/steps/sync_redirect_paths_spec.rb
@@ -37,13 +37,11 @@ RSpec.describe Hyrax::Transactions::Steps::SyncRedirectPaths do
         expect(paths).to contain_exactly('/handle/1', '/handle/2')
       end
 
-      it 'populates to_path and permalink_path with the canonical UUID URL on every row' do
+      it 'populates permalink_path with the canonical UUID URL on every row' do
         result = step.call(resource)
         expect(result).to be_success
         rows = Hyrax::RedirectPath.where(resource_id: resource_id)
-        expect(rows.pluck(:to_path)).to all(eq(permalink))
         expect(rows.pluck(:permalink_path)).to all(eq(permalink))
-        expect(rows.pluck(:is_display_url)).to all(be(false))
       end
 
       it 'busts the cache for both old and new paths' do
@@ -51,6 +49,80 @@ RSpec.describe Hyrax::Transactions::Steps::SyncRedirectPaths do
         expect(Hyrax::RedirectCacheBuster).to receive(:call)
           .with(array_including('/old', '/handle/1', '/handle/2'))
         step.call(resource)
+      end
+    end
+
+    context 'with no entry marked as display URL' do
+      it 'writes is_display_url=false and to_path=permalink_path on every row' do
+        result = step.call(resource)
+        expect(result).to be_success
+        rows = Hyrax::RedirectPath.where(resource_id: resource_id)
+        expect(rows.pluck(:is_display_url)).to all(be false)
+        expect(rows.pluck(:to_path)).to all(eq(permalink))
+      end
+    end
+
+    context 'with one entry marked as the display URL' do
+      let(:redirects) do
+        [{ 'path' => '/handle/1', 'is_display_url' => true },
+         { 'path' => '/handle/2', 'is_display_url' => false }]
+      end
+
+      it 'writes the display row pointing at itself, non-display rows at the display path, and adds a permalink row' do
+        step.call(resource)
+        rows = Hyrax::RedirectPath.where(resource_id: resource_id)
+        expect(rows.pluck(:from_path, :to_path, :is_display_url)).to contain_exactly(
+          ['/handle/1', '/handle/1', true],
+          ['/handle/2', '/handle/1', false],
+          [permalink,   '/handle/1', false]
+        )
+      end
+    end
+
+    context 'when the display flag moves between saves' do
+      before do
+        existing_row(from_path: '/handle/1', resource_id: resource_id, is_display_url: true, to_path: '/handle/1')
+        existing_row(from_path: '/handle/2', resource_id: resource_id, is_display_url: false, to_path: '/handle/1')
+        existing_row(from_path: permalink, resource_id: resource_id, is_display_url: false, to_path: '/handle/1')
+      end
+
+      let(:redirects) do
+        [{ 'path' => '/handle/1', 'is_display_url' => false },
+         { 'path' => '/handle/2', 'is_display_url' => true }]
+      end
+
+      it 'rewrites the alias rows and the permalink row to point at the new display path' do
+        result = step.call(resource)
+        expect(result).to be_success
+        rows = Hyrax::RedirectPath.where(resource_id: resource_id)
+        expect(rows.pluck(:from_path, :to_path, :is_display_url)).to contain_exactly(
+          ['/handle/1', '/handle/2', false],
+          ['/handle/2', '/handle/2', true],
+          [permalink,   '/handle/2', false]
+        )
+      end
+    end
+
+    context 'when the display flag is cleared on a save' do
+      before do
+        existing_row(from_path: '/handle/1', resource_id: resource_id, is_display_url: true, to_path: '/handle/1')
+        existing_row(from_path: '/handle/2', resource_id: resource_id, is_display_url: false, to_path: '/handle/1')
+        existing_row(from_path: permalink, resource_id: resource_id, is_display_url: false, to_path: '/handle/1')
+      end
+
+      let(:redirects) do
+        [{ 'path' => '/handle/1', 'is_display_url' => false },
+         { 'path' => '/handle/2', 'is_display_url' => false }]
+      end
+
+      it 'removes the permalink row and writes alias rows pointing at the permalink' do
+        result = step.call(resource)
+        expect(result).to be_success
+        rows = Hyrax::RedirectPath.where(resource_id: resource_id)
+        expect(rows.pluck(:from_path, :to_path, :is_display_url)).to contain_exactly(
+          ['/handle/1', permalink, false],
+          ['/handle/2', permalink, false]
+        )
       end
     end
 

--- a/spec/lib/hyrax/transactions/steps/sync_redirect_paths_spec.rb
+++ b/spec/lib/hyrax/transactions/steps/sync_redirect_paths_spec.rb
@@ -79,6 +79,23 @@ RSpec.describe Hyrax::Transactions::Steps::SyncRedirectPaths do
       end
     end
 
+    context 'with string is_display_url values (importer/console write)' do
+      let(:redirects) do
+        [{ 'path' => '/handle/1', 'is_display_url' => 'true' },
+         { 'path' => '/handle/2', 'is_display_url' => 'false' }]
+      end
+
+      it 'boolean-casts the string values so only the truthy entry marks the display URL' do
+        step.call(resource)
+        rows = Hyrax::RedirectPath.where(resource_id: resource_id)
+        expect(rows.pluck(:from_path, :is_display_url)).to contain_exactly(
+          ['/handle/1', true],
+          ['/handle/2', false],
+          [permalink,   false]
+        )
+      end
+    end
+
     context 'when the display flag moves between saves' do
       before do
         existing_row(from_path: '/handle/1', resource_id: resource_id, is_display_url: true, to_path: '/handle/1')

--- a/spec/models/concerns/hyrax/redirects_normalization_spec.rb
+++ b/spec/models/concerns/hyrax/redirects_normalization_spec.rb
@@ -32,11 +32,10 @@ RSpec.describe Hyrax::RedirectsNormalization do
     end
 
     it 'preserves non-path keys on the entry' do
-      resource.redirects = [{ 'path' => '/foo/', 'canonical' => true, 'sequence' => 0 }]
+      resource.redirects = [{ 'path' => '/foo/', 'is_display_url' => true }]
       entry = resource.redirects.first
       expect(entry['path']).to eq('/foo')
-      expect(entry['canonical']).to be true
-      expect(entry['sequence']).to eq(0)
+      expect(entry['is_display_url']).to be true
     end
 
     it 'normalizes every entry in a multi-entry array' do

--- a/spec/models/hyrax/redirect_spec.rb
+++ b/spec/models/hyrax/redirect_spec.rb
@@ -2,22 +2,20 @@
 
 RSpec.describe Hyrax::Redirect do
   describe '#initialize' do
-    it 'accepts a path, canonical flag, and sequence' do
-      r = described_class.new(path: '/handle/12345/678', canonical: true, sequence: 0)
+    it 'accepts a path and is_display_url flag' do
+      r = described_class.new(path: '/handle/12345/678', is_display_url: true)
       expect(r.path).to eq('/handle/12345/678')
-      expect(r.canonical).to be true
-      expect(r.sequence).to eq(0)
+      expect(r.is_display_url).to be true
     end
 
-    it 'defaults canonical to false' do
+    it 'defaults is_display_url to false' do
       r = described_class.new(path: '/foo')
-      expect(r.canonical).to be false
+      expect(r.is_display_url).to be false
     end
 
-    it 'allows path and sequence to be nil (e.g. for the trailing blank row in the form view)' do
+    it 'allows path to be nil (e.g. for the trailing blank row in the form view)' do
       r = described_class.new(path: nil)
       expect(r.path).to be_nil
-      expect(r.sequence).to be_nil
     end
   end
 
@@ -32,18 +30,18 @@ RSpec.describe Hyrax::Redirect do
     end
 
     it 'builds a presenter from a string-keyed hash (JSONB shape)' do
-      r = described_class.wrap('path' => '/foo', 'canonical' => true, 'sequence' => 2)
-      expect(r).to have_attributes(path: '/foo', canonical: true, sequence: 2)
+      r = described_class.wrap('path' => '/foo', 'is_display_url' => true)
+      expect(r).to have_attributes(path: '/foo', is_display_url: true)
     end
 
     it 'builds a presenter from a symbol-keyed hash' do
-      r = described_class.wrap(path: '/foo', canonical: true, sequence: 2)
-      expect(r).to have_attributes(path: '/foo', canonical: true, sequence: 2)
+      r = described_class.wrap(path: '/foo', is_display_url: true)
+      expect(r).to have_attributes(path: '/foo', is_display_url: true)
     end
 
-    it 'defaults canonical to false when omitted' do
+    it 'defaults is_display_url to false when omitted' do
       r = described_class.wrap('path' => '/foo')
-      expect(r.canonical).to be false
+      expect(r.is_display_url).to be false
     end
 
     it 'raises ArgumentError when input cannot be coerced to a hash' do
@@ -53,8 +51,8 @@ RSpec.describe Hyrax::Redirect do
 
   describe '#to_h and #as_json' do
     it 'returns a string-keyed hash matching the persisted shape' do
-      r = described_class.new(path: '/foo', canonical: true, sequence: 1)
-      expected = { 'path' => '/foo', 'canonical' => true, 'sequence' => 1 }
+      r = described_class.new(path: '/foo', is_display_url: true)
+      expected = { 'path' => '/foo', 'is_display_url' => true }
       expect(r.to_h).to eq(expected)
       expect(r.as_json).to eq(expected)
     end
@@ -62,8 +60,8 @@ RSpec.describe Hyrax::Redirect do
 
   describe '#==' do
     it 'compares equal on attribute values' do
-      a = described_class.new(path: '/x', canonical: true, sequence: 0)
-      b = described_class.new(path: '/x', canonical: true, sequence: 0)
+      a = described_class.new(path: '/x', is_display_url: true)
+      b = described_class.new(path: '/x', is_display_url: true)
       expect(a).to eq(b)
     end
 
@@ -74,8 +72,8 @@ RSpec.describe Hyrax::Redirect do
     end
 
     it 'is not equal to a Hash with the same shape (presenters and hashes are distinct types)' do
-      r = described_class.new(path: '/x', canonical: false, sequence: nil)
-      expect(r).not_to eq('path' => '/x', 'canonical' => false, 'sequence' => nil)
+      r = described_class.new(path: '/x', is_display_url: false)
+      expect(r).not_to eq('path' => '/x', 'is_display_url' => false)
     end
   end
 end

--- a/spec/services/hyrax/flexible_schema_validators/redirects_validator_spec.rb
+++ b/spec/services/hyrax/flexible_schema_validators/redirects_validator_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe Hyrax::FlexibleSchemaValidators::RedirectsValidator do
 
         it 'warns that the property will be ignored' do
           validator.validate!
-          expect(warnings).to include(/redirects.*Hyrax\.config\.redirects_enabled\? is false/)
+          expect(warnings).to include(I18n.t('hyrax.flexible_schema_validators.redirects_validator.warnings.config_disabled'))
           expect(errors).to be_empty
         end
       end
@@ -72,7 +72,7 @@ RSpec.describe Hyrax::FlexibleSchemaValidators::RedirectsValidator do
 
         it 'warns that the property will be ignored' do
           validator.validate!
-          expect(warnings).to include(/redirects.*:redirects feature flag is off/)
+          expect(warnings).to include(I18n.t('hyrax.flexible_schema_validators.redirects_validator.warnings.flipflop_disabled'))
           expect(errors).to be_empty
         end
       end
@@ -80,7 +80,7 @@ RSpec.describe Hyrax::FlexibleSchemaValidators::RedirectsValidator do
       context 'and the m3 profile has no `redirects` property' do
         let(:profile) { profile_without_redirects }
 
-        it 'is silent (the tenant has not opted in)' do
+        it 'is silent (the redirects feature has not been opted in to)' do
           validator.validate!
           expect(errors).to be_empty
           expect(warnings).to be_empty
@@ -99,7 +99,7 @@ RSpec.describe Hyrax::FlexibleSchemaValidators::RedirectsValidator do
 
         it 'records an error that the property is required' do
           validator.validate!
-          expect(errors).to include(/m3 profile must declare a `redirects` property/)
+          expect(errors).to include(I18n.t('hyrax.flexible_schema_validators.redirects_validator.errors.property_required'))
         end
       end
 
@@ -128,7 +128,7 @@ RSpec.describe Hyrax::FlexibleSchemaValidators::RedirectsValidator do
 
         it 'records an error that the property must be available on a declared work or collection class' do
           validator.validate!
-          expect(errors).to include(/`redirects`.*available on.*work or collection class/)
+          expect(errors).to include(I18n.t('hyrax.flexible_schema_validators.redirects_validator.errors.invalid_available_on'))
         end
       end
 
@@ -147,7 +147,7 @@ RSpec.describe Hyrax::FlexibleSchemaValidators::RedirectsValidator do
 
         it 'records an error that the property must be available on a declared work or collection class' do
           validator.validate!
-          expect(errors).to include(/`redirects`.*available on.*work or collection class/)
+          expect(errors).to include(I18n.t('hyrax.flexible_schema_validators.redirects_validator.errors.invalid_available_on'))
         end
       end
 
@@ -165,7 +165,7 @@ RSpec.describe Hyrax::FlexibleSchemaValidators::RedirectsValidator do
 
         it 'records an error that the property must declare type: hash' do
           validator.validate!
-          expect(errors).to include(/`redirects`.*declare `type: hash`/)
+          expect(errors).to include(I18n.t('hyrax.flexible_schema_validators.redirects_validator.errors.invalid_type', actual_type: 'nil'))
         end
       end
     end

--- a/spec/validators/hyrax/redirect_validator_spec.rb
+++ b/spec/validators/hyrax/redirect_validator_spec.rb
@@ -142,6 +142,47 @@ RSpec.describe Hyrax::RedirectValidator do
       end
     end
 
+    context 'with an unsafe character in the path' do
+      # Cover characters outside RFC 3986's allowed path chars. These would
+      # otherwise round-trip into Rails routing and lead to error pages.
+      [
+        '/bad"link"',
+        '/bad<script>',
+        '/bad>here',
+        '/bad{here}',
+        '/bad|pipe',
+        '/bad\\backslash',
+        '/bad`tick',
+        "/bad\nnewline"
+      ].each do |bad_path|
+        it "rejects #{bad_path.inspect} with a format error" do
+          record.redirects = [entry(path: bad_path, is_display_url: false)]
+          record.valid?
+          expect(record.errors[:redirects]).to include(t(:invalid_format, path: bad_path))
+        end
+      end
+    end
+
+    context 'with characters that RFC 3986 allows' do
+      # Make sure tightening the regex didn't reject legitimate alias chars.
+      # These pop up in legacy URLs (DSpace handles, bepress paths, etc).
+      [
+        '/handle/12345/678',
+        '/path-with-dashes_and.dots',
+        '/has(parens)and+plus',
+        "/with'apostrophe",
+        '/colon:and@at',
+        '/pct-encoded/%20space',
+        '/extension.html'
+      ].each do |good_path|
+        it "accepts #{good_path.inspect}" do
+          record.redirects = [entry(path: good_path, is_display_url: false)]
+          record.valid?
+          expect(record.errors[:redirects]).not_to include(t(:invalid_format, path: good_path))
+        end
+      end
+    end
+
     context 'with a path under a reserved Hyrax prefix' do
       let(:entries) { [entry(path: '/concern/generic_works/abc', is_display_url: false)] }
 

--- a/spec/validators/hyrax/redirect_validator_spec.rb
+++ b/spec/validators/hyrax/redirect_validator_spec.rb
@@ -256,6 +256,21 @@ RSpec.describe Hyrax::RedirectValidator do
         expect(record.errors[:redirects]).to be_empty
       end
     end
+
+    context 'when entries contain string is_display_url values (importer/console write)' do
+      let(:entries) do
+        [
+          entry(path: '/a', is_display_url: 'true'),
+          entry(path: '/b', is_display_url: 'false')
+        ]
+      end
+
+      it 'does not flag at-most-one when only one entry is truthy after casting' do
+        record.redirects = entries
+        record.valid?
+        expect(record.errors[:redirects]).not_to include(t(:multiple_display_url))
+      end
+    end
   end
 
   describe '#display_url_for' do
@@ -270,6 +285,14 @@ RSpec.describe Hyrax::RedirectValidator do
 
     it 'returns nil when the flag is absent' do
       expect(validator.send(:display_url_for, 'path' => '/x')).to be_nil
+    end
+
+    it 'casts string values written by importers/console to booleans' do
+      expect(validator.send(:display_url_for, 'is_display_url' => 'true')).to be(true)
+      expect(validator.send(:display_url_for, 'is_display_url' => 'false')).to be(false)
+      expect(validator.send(:display_url_for, 'is_display_url' => '1')).to be(true)
+      expect(validator.send(:display_url_for, 'is_display_url' => '0')).to be(false)
+      expect(validator.send(:display_url_for, 'is_display_url' => '')).to be_nil
     end
   end
 end

--- a/spec/validators/hyrax/redirect_validator_spec.rb
+++ b/spec/validators/hyrax/redirect_validator_spec.rb
@@ -16,8 +16,8 @@ RSpec.describe Hyrax::RedirectValidator do
       r.redirects = entries
     end
   end
-  def entry(path:, canonical: false)
-    { 'path' => path, 'canonical' => canonical }
+  def entry(path:, is_display_url: false)
+    { 'path' => path, 'is_display_url' => is_display_url }
   end
   let(:entries) { [] }
 
@@ -28,7 +28,7 @@ RSpec.describe Hyrax::RedirectValidator do
 
   describe '#validate_each' do
     context 'when the redirects feature is active' do
-      let(:entries) { [entry(path: '/handle/12345/678', canonical: true)] }
+      let(:entries) { [entry(path: '/handle/12345/678', is_display_url: true)] }
 
       it 'is valid' do
         record.valid?
@@ -38,7 +38,7 @@ RSpec.describe Hyrax::RedirectValidator do
 
     context 'when the redirects feature is inactive' do
       before { allow(Hyrax.config).to receive(:redirects_active?).and_return(false) }
-      let(:entries) { [entry(path: 'no-leading-slash', canonical: false)] }
+      let(:entries) { [entry(path: 'no-leading-slash', is_display_url: false)] }
 
       it 'short-circuits without recording errors' do
         record.valid?
@@ -107,7 +107,7 @@ RSpec.describe Hyrax::RedirectValidator do
     end
 
     context 'with a blank path' do
-      let(:entries) { [entry(path: '', canonical: false)] }
+      let(:entries) { [entry(path: '', is_display_url: false)] }
 
       it 'records a blank-path error' do
         record.valid?
@@ -116,7 +116,7 @@ RSpec.describe Hyrax::RedirectValidator do
     end
 
     context 'with a path missing a leading slash' do
-      let(:entries) { [entry(path: 'handle/12345/678', canonical: false)] }
+      let(:entries) { [entry(path: 'handle/12345/678', is_display_url: false)] }
 
       it 'records a format error' do
         record.valid?
@@ -125,7 +125,7 @@ RSpec.describe Hyrax::RedirectValidator do
     end
 
     context 'with whitespace in the path' do
-      let(:entries) { [entry(path: '/has space', canonical: false)] }
+      let(:entries) { [entry(path: '/has space', is_display_url: false)] }
 
       it 'records a format error' do
         record.valid?
@@ -134,7 +134,7 @@ RSpec.describe Hyrax::RedirectValidator do
     end
 
     context 'with a query string in the path' do
-      let(:entries) { [entry(path: '/foo?bar=baz', canonical: false)] }
+      let(:entries) { [entry(path: '/foo?bar=baz', is_display_url: false)] }
 
       it 'records a format error' do
         record.valid?
@@ -143,7 +143,7 @@ RSpec.describe Hyrax::RedirectValidator do
     end
 
     context 'with a path under a reserved Hyrax prefix' do
-      let(:entries) { [entry(path: '/concern/generic_works/abc', canonical: false)] }
+      let(:entries) { [entry(path: '/concern/generic_works/abc', is_display_url: false)] }
 
       it 'records a reserved-prefix error' do
         record.valid?
@@ -152,7 +152,7 @@ RSpec.describe Hyrax::RedirectValidator do
     end
 
     context 'with a path that exactly matches a reserved prefix' do
-      let(:entries) { [entry(path: '/dashboard', canonical: false)] }
+      let(:entries) { [entry(path: '/dashboard', is_display_url: false)] }
 
       it 'records a reserved-prefix error' do
         record.valid?
@@ -163,8 +163,8 @@ RSpec.describe Hyrax::RedirectValidator do
     context 'with two entries sharing the same path on the same record' do
       let(:entries) do
         [
-          entry(path: '/handle/1', canonical: false),
-          entry(path: '/handle/1', canonical: false)
+          entry(path: '/handle/1', is_display_url: false),
+          entry(path: '/handle/1', is_display_url: false)
         ]
       end
 
@@ -177,8 +177,8 @@ RSpec.describe Hyrax::RedirectValidator do
     context 'with two entries that normalize to the same canonical path' do
       let(:entries) do
         [
-          entry(path: '/handle/1', canonical: false),
-          entry(path: '/handle/1/', canonical: false)
+          entry(path: '/handle/1', is_display_url: false),
+          entry(path: '/handle/1/', is_display_url: false)
         ]
       end
 
@@ -189,7 +189,7 @@ RSpec.describe Hyrax::RedirectValidator do
     end
 
     context 'with a reserved prefix typed with a trailing slash' do
-      let(:entries) { [entry(path: '/dashboard/', canonical: false)] }
+      let(:entries) { [entry(path: '/dashboard/', is_display_url: false)] }
 
       it 'records a reserved-prefix error' do
         record.valid?
@@ -198,7 +198,7 @@ RSpec.describe Hyrax::RedirectValidator do
     end
 
     context 'when the path is taken on another record' do
-      let(:entries) { [entry(path: '/handle/12345/678', canonical: false)] }
+      let(:entries) { [entry(path: '/handle/12345/678', is_display_url: false)] }
 
       before do
         allow(Hyrax::RedirectsLookup)
@@ -214,7 +214,7 @@ RSpec.describe Hyrax::RedirectValidator do
     end
 
     context 'when a non-canonical form of the path is taken on another record' do
-      let(:entries) { [entry(path: '/handle/12345/678/', canonical: false)] }
+      let(:entries) { [entry(path: '/handle/12345/678/', is_display_url: false)] }
 
       before do
         allow(Hyrax::RedirectsLookup)
@@ -229,47 +229,47 @@ RSpec.describe Hyrax::RedirectValidator do
       end
     end
 
-    context 'when more than one entry is marked canonical' do
+    context 'when more than one entry is marked as the display URL' do
       let(:entries) do
         [
-          entry(path: '/a', canonical: true),
-          entry(path: '/b', canonical: true)
+          entry(path: '/a', is_display_url: true),
+          entry(path: '/b', is_display_url: true)
         ]
       end
 
-      it 'records an at-most-one-canonical error' do
+      it 'records an at-most-one-display-url error' do
         record.valid?
-        expect(record.errors[:redirects]).to include(t(:multiple_canonical))
+        expect(record.errors[:redirects]).to include(t(:multiple_display_url))
       end
     end
 
-    context 'when zero entries are marked canonical' do
+    context 'when zero entries are marked as the display URL' do
       let(:entries) do
         [
-          entry(path: '/a', canonical: false),
-          entry(path: '/b', canonical: false)
+          entry(path: '/a', is_display_url: false),
+          entry(path: '/b', is_display_url: false)
         ]
       end
 
-      it 'is valid (canonical is optional)' do
+      it 'is valid (display URL is optional)' do
         record.valid?
         expect(record.errors[:redirects]).to be_empty
       end
     end
   end
 
-  describe '#canonical_for' do
+  describe '#display_url_for' do
     it 'returns the stored false flag rather than nil' do
-      expect(validator.send(:canonical_for, 'canonical' => false)).to be(false)
-      expect(validator.send(:canonical_for, canonical: false)).to be(false)
+      expect(validator.send(:display_url_for, 'is_display_url' => false)).to be(false)
+      expect(validator.send(:display_url_for, is_display_url: false)).to be(false)
     end
 
     it 'returns true when the flag is set' do
-      expect(validator.send(:canonical_for, 'canonical' => true)).to be(true)
+      expect(validator.send(:display_url_for, 'is_display_url' => true)).to be(true)
     end
 
     it 'returns nil when the flag is absent' do
-      expect(validator.send(:canonical_for, 'path' => '/x')).to be_nil
+      expect(validator.send(:display_url_for, 'path' => '/x')).to be_nil
     end
   end
 end


### PR DESCRIPTION
## Summary
Adds a Display URL radio column to the redirect aliases form so editors can pick which registered alias should serve as the record's user-facing URL. The save populates the new `to_path`/`permalink_path`/`is_display_url` columns.

Refs notch8/palni_palci_knapsack#653

## Details
- The Aliases tab gains a Display URL column with a radio per row plus a "None (use the record's UUID URL)" option. 
- `SyncRedirectPaths` writes a new row pattern:

After saving a work with three aliases (`/solar-powered`, `/gggg`, `/and-a-second-one`) and `/solar-powered` selected as the Display URL, `hyrax_redirect_paths` looks like:

| from_path                                  | to_path          | permalink_path                              | is_display_url |
| ------------------------------------------ | ---------------- | ------------------------------------------- | -------------- |
| `/gggg`                                    | `/solar-powered` | `/concern/generic_works/4313f093-d68b-...`  | false          |
| `/and-a-second-one`                        | `/solar-powered` | `/concern/generic_works/4313f093-d68b-...`  | false          |
| `/solar-powered`                           | `/solar-powered` | `/concern/generic_works/4313f093-d68b-...`  | true           |
| `/concern/generic_works/4313f093-d68b-...` | `/solar-powered` | `/concern/generic_works/4313f093-d68b-...`  | false          |

Four rows total — one per alias, plus an extra row for the UUID URL so a visitor hitting the bare permalink is also routed to the display URL. Every row carries the resource's UUID URL in `permalink_path`. The display row's `to_path` equals its own `from_path` (the visitor stays at the display URL); every other row's `to_path` points at the display alias.

With no Display URL selected, the table holds one row per alias and `to_path = permalink_path` on each — no extra UUID-URL row.
