### PR TITLE
Remove duplicate Clamby dependency from Koppie Gemfile

### DIFF
--- a/.koppie/Gemfile
+++ b/.koppie/Gemfile
@@ -12,7 +12,6 @@ gem 'bootsnap', '>= 1.1.0', require: false
 gem 'bootstrap', '~> 4.0'
 gem 'bulkrax', github: 'samvera/bulkrax', branch: 'grounded'
 gem 'clamby', '~> 1.6', require: ENV['HYRAX_CLAMAV'] == 'true'
-gem 'clamby', '~> 1.6'
 gem 'coffee-rails', '~> 4.2'
 gem 'dalli'
 gem 'devise'


### PR DESCRIPTION
## Summary
- remove the duplicate unconditional Clamby dependency from .koppie/Gemfile
- keep Clamby loaded only when HYRAX_CLAMAV=true

Fixes #7461