### PR TITLE
Strip default locale from default_url_options

### DIFF
--- a/app/controllers/concerns/hyrax/controller.rb
+++ b/app/controllers/concerns/hyrax/controller.rb
@@ -27,9 +27,15 @@ module Hyrax::Controller
     hyrax.dashboard_path
   end
 
-  # Ensure that the locale choice is persistent across requests
+  # Ensure that the locale choice is persistent across requests, but only
+  # when it differs from the default. Appending +?locale=+ for the default
+  # locale on every URL pollutes sitemaps, canonical tags, and outbound
+  # links, which causes search engines to index and rank duplicate
+  # locale-parameterized URLs as canonical.
   def default_url_options
-    super.merge(locale: I18n.locale)
+    opts = super
+    opts[:locale] = I18n.locale unless I18n.locale == I18n.default_locale
+    opts
   end
 
   # @note for Blacklight 6/7 compatibility

--- a/spec/controllers/concerns/hyrax/controller_spec.rb
+++ b/spec/controllers/concerns/hyrax/controller_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+RSpec.describe Hyrax::Controller, type: :controller do
+  controller(ApplicationController) do
+    def index
+      render plain: 'ok'
+    end
+  end
+
+  describe '#default_url_options' do
+    around do |example|
+      original_locale = I18n.locale
+      example.run
+      I18n.locale = original_locale
+    end
+
+    context 'when the current locale is the default' do
+      it 'omits :locale so URLs are not polluted with ?locale=' do
+        I18n.locale = I18n.default_locale
+        expect(controller.default_url_options).not_to have_key(:locale)
+      end
+    end
+
+    context 'when the current locale differs from the default' do
+      it 'includes :locale to preserve user locale across requests' do
+        non_default = (I18n.available_locales - [I18n.default_locale]).first
+        skip 'no non-default locale available' if non_default.nil?
+
+        I18n.locale = non_default
+        expect(controller.default_url_options[:locale]).to eq(non_default)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

`Hyrax::Controller#default_url_options` currently appends `locale: I18n.locale` to every URL the app generates, even when the active locale is the default. The result is that sitemap entries, canonical tags, and outbound links all carry `?locale=en` (or whichever locale is the default), and search engines index those locale-parameterized URLs as canonical.

This was originally reported downstream as a Hyku Up issue where Google was returning Italian/French/Spanish/Portuguese URLs as top results for English queries on a Hyku tenant whose default locale was English. The polluted sitemap was the discovery signal that drove Googlebot to index the locale-parameterized variants in the first place.

This PR makes the locale inclusion conditional: it is only added when the current locale differs from `I18n.default_locale`. That preserves the original intent of the method (persist a user's non-default locale across requests via route helpers) while keeping default-locale URLs clean.

Refs: notch8/hykuup_knapsack#677

## Behavior

| Active locale | Before | After |
| --- | --- | --- |
| `I18n.default_locale` | `{ locale: :en }` | `{}` |
| non-default (e.g. `:es`) | `{ locale: :es }` | `{ locale: :es }` |

## Test plan

- [ ] CI runs the new `spec/controllers/concerns/hyrax/controller_spec.rb` covering both branches
- [ ] Existing controller/feature specs still pass
- [ ] Manual check on a downstream Hyku app: hit `/sitemap` and confirm work URLs no longer contain `?locale=en`