### PR TITLE
Strip default locale from default_url_options

### DIFF
--- a/app/assets/javascripts/hyrax/select_work_type.es6
+++ b/app/assets/javascripts/hyrax/select_work_type.es6
@@ -42,9 +42,12 @@ export default class SelectWorkType {
       let url = this.form.find('input[type="radio"]:checked').data(this.type)
       const select = this.form.find('select')
 
-      // Only append admin_set_id if the select exists and has a value
+      // Only append admin_set_id if the select exists and has a value.
+      // Pick the right separator: URLs lose their locale query string when
+      // I18n.locale == I18n.default_locale, so we cannot assume `?` is present.
       if (select.length && select.val()) {
-          url = url + "&admin_set_id=" + select.val()
+          const separator = url.indexOf('?') === -1 ? '?' : '&'
+          url = url + separator + "admin_set_id=" + select.val()
       }
       return url
   }

--- a/app/controllers/concerns/hyrax/controller.rb
+++ b/app/controllers/concerns/hyrax/controller.rb
@@ -27,9 +27,15 @@ module Hyrax::Controller
     hyrax.dashboard_path
   end
 
-  # Ensure that the locale choice is persistent across requests
+  # Ensure that the locale choice is persistent across requests, but only
+  # when it differs from the default. Appending +?locale=+ for the default
+  # locale on every URL pollutes sitemaps, canonical tags, and outbound
+  # links, which causes search engines to index and rank duplicate
+  # locale-parameterized URLs as canonical.
   def default_url_options
-    super.merge(locale: I18n.locale)
+    opts = super
+    opts[:locale] = I18n.locale unless I18n.locale == I18n.default_locale
+    opts
   end
 
   # @note for Blacklight 6/7 compatibility

--- a/app/presenters/hyrax/admin_set_presenter.rb
+++ b/app/presenters/hyrax/admin_set_presenter.rb
@@ -51,7 +51,7 @@ module Hyrax
     end
 
     def show_path
-      Hyrax::Engine.routes.url_helpers.admin_admin_set_path(id, locale: I18n.locale)
+      Hyrax::Engine.routes.url_helpers.admin_admin_set_path(id, locale: (I18n.locale unless I18n.locale == I18n.default_locale))
     end
 
     def available_parent_collections(*)

--- a/app/presenters/hyrax/collection_presenter.rb
+++ b/app/presenters/hyrax/collection_presenter.rb
@@ -138,7 +138,7 @@ module Hyrax
     end
 
     def show_path
-      Hyrax::Engine.routes.url_helpers.dashboard_collection_path(id, locale: I18n.locale)
+      Hyrax::Engine.routes.url_helpers.dashboard_collection_path(id, locale: (I18n.locale unless I18n.locale == I18n.default_locale))
     end
 
     ##

--- a/app/presenters/hyrax/file_set_presenter.rb
+++ b/app/presenters/hyrax/file_set_presenter.rb
@@ -69,7 +69,7 @@ module Hyrax
     end
 
     def stats_path
-      Hyrax::Engine.routes.url_helpers.stats_file_path(self, locale: I18n.locale)
+      Hyrax::Engine.routes.url_helpers.stats_file_path(self, locale: (I18n.locale unless I18n.locale == I18n.default_locale))
     end
 
     def events(size = 100)

--- a/app/presenters/hyrax/work_show_presenter.rb
+++ b/app/presenters/hyrax/work_show_presenter.rb
@@ -199,7 +199,7 @@ module Hyrax
     end
 
     def stats_path
-      Hyrax::Engine.routes.url_helpers.stats_work_path(self, locale: I18n.locale)
+      Hyrax::Engine.routes.url_helpers.stats_work_path(self, locale: (I18n.locale unless I18n.locale == I18n.default_locale))
     end
 
     def model

--- a/app/renderers/hyrax/renderers/faceted_attribute_renderer.rb
+++ b/app/renderers/hyrax/renderers/faceted_attribute_renderer.rb
@@ -9,7 +9,7 @@ module Hyrax
       end
 
       def search_path(value)
-        Rails.application.routes.url_helpers.search_catalog_path("f[#{search_field}][]": value, locale: I18n.locale)
+        Rails.application.routes.url_helpers.search_catalog_path("f[#{search_field}][]": value, locale: (I18n.locale unless I18n.locale == I18n.default_locale))
       end
 
       def search_field

--- a/app/renderers/hyrax/renderers/linked_attribute_renderer.rb
+++ b/app/renderers/hyrax/renderers/linked_attribute_renderer.rb
@@ -10,7 +10,7 @@ module Hyrax
 
       def search_path(value)
         Rails.application.routes.url_helpers.search_catalog_path(
-          search_field: search_field, q: ERB::Util.h(value), locale: I18n.locale
+          search_field: search_field, q: ERB::Util.h(value), locale: (I18n.locale unless I18n.locale == I18n.default_locale)
         )
       end
 

--- a/spec/controllers/concerns/hyrax/controller_spec.rb
+++ b/spec/controllers/concerns/hyrax/controller_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+RSpec.describe Hyrax::Controller, type: :controller do
+  controller(ApplicationController) do
+    def index
+      render plain: 'ok'
+    end
+  end
+
+  describe '#default_url_options' do
+    around do |example|
+      original_locale = I18n.locale
+      example.run
+      I18n.locale = original_locale
+    end
+
+    context 'when the current locale is the default' do
+      it 'omits :locale so URLs are not polluted with ?locale=' do
+        I18n.locale = I18n.default_locale
+        expect(controller.default_url_options).not_to have_key(:locale)
+      end
+    end
+
+    context 'when the current locale differs from the default' do
+      it 'includes :locale to preserve user locale across requests' do
+        non_default = (I18n.available_locales - [I18n.default_locale]).first
+        skip 'no non-default locale available' if non_default.nil?
+
+        I18n.locale = non_default
+        expect(controller.default_url_options[:locale]).to eq(non_default)
+      end
+    end
+  end
+end

--- a/spec/controllers/concerns/hyrax/works_controller_behavior_spec.rb
+++ b/spec/controllers/concerns/hyrax/works_controller_behavior_spec.rb
@@ -70,7 +70,7 @@ RSpec.describe Hyrax::WorksControllerBehavior, :clean_repo, type: :controller do
     it 'redirects to new user login' do
       get :create, params: {}
 
-      expect(response).to redirect_to paths.new_user_session_path(locale: :en)
+      expect(response).to redirect_to paths.new_user_session_path
     end
 
     context 'with a logged in user' do
@@ -82,7 +82,7 @@ RSpec.describe Hyrax::WorksControllerBehavior, :clean_repo, type: :controller do
         get :create, params: { test_simple_work: { title: 'comet in moominland' } }
 
         expect(response)
-          .to redirect_to paths.send(work_route_path, id: assigns(:curation_concern).id, locale: :en)
+          .to redirect_to paths.send(work_route_path, id: assigns(:curation_concern).id)
       end
 
       it 'sets current user as depositor' do
@@ -306,7 +306,7 @@ RSpec.describe Hyrax::WorksControllerBehavior, :clean_repo, type: :controller do
   describe '#destroy' do
     it 'redirect to user login' do
       delete :destroy, params: { id: work.id }
-      expect(response).to redirect_to paths.new_user_session_path(locale: :en)
+      expect(response).to redirect_to paths.new_user_session_path
     end
 
     context 'with a logged in user' do
@@ -361,7 +361,7 @@ RSpec.describe Hyrax::WorksControllerBehavior, :clean_repo, type: :controller do
     it 'redirects to new user login' do
       get :edit, params: { id: work.id }
 
-      expect(response).to redirect_to paths.new_user_session_path(locale: :en)
+      expect(response).to redirect_to paths.new_user_session_path
     end
 
     context 'with a logged in user' do
@@ -433,7 +433,7 @@ RSpec.describe Hyrax::WorksControllerBehavior, :clean_repo, type: :controller do
   describe '#new' do
     it 'redirect to user login' do
       get :new
-      expect(response).to redirect_to paths.new_user_session_path(locale: :en)
+      expect(response).to redirect_to paths.new_user_session_path
     end
 
     context 'with a logged in user' do
@@ -521,7 +521,7 @@ RSpec.describe Hyrax::WorksControllerBehavior, :clean_repo, type: :controller do
     it 'redirects to new user login' do
       get :show, params: { id: work.id }
 
-      expect(response).to redirect_to paths.new_user_session_path(locale: :en)
+      expect(response).to redirect_to paths.new_user_session_path
     end
 
     context 'when indexed as public' do
@@ -549,7 +549,7 @@ RSpec.describe Hyrax::WorksControllerBehavior, :clean_repo, type: :controller do
     it 'redirects to new user login' do
       patch :update, params: { id: work.id }
 
-      expect(response).to redirect_to paths.new_user_session_path(locale: :en)
+      expect(response).to redirect_to paths.new_user_session_path
     end
 
     context 'when the user has edit access' do
@@ -561,7 +561,7 @@ RSpec.describe Hyrax::WorksControllerBehavior, :clean_repo, type: :controller do
         patch :update, params: { id: work.id, test_simple_work: { title: 'new title' } }
 
         expect(response)
-          .to redirect_to paths.send(work_route_path, id: work.id, locale: :en)
+          .to redirect_to paths.send(work_route_path, id: work.id)
       end
 
       it 'updates the work metadata' do

--- a/spec/controllers/hyrax/admin/permission_template_accesses_controller_spec.rb
+++ b/spec/controllers/hyrax/admin/permission_template_accesses_controller_spec.rb
@@ -69,7 +69,6 @@ RSpec.describe Hyrax::Admin::PermissionTemplateAccessesController do
 
             expect(response)
               .to redirect_to(hyrax.edit_admin_admin_set_path(source_id,
-                                                              locale: 'en',
                                                               anchor: 'participants'))
           end
 
@@ -107,7 +106,6 @@ RSpec.describe Hyrax::Admin::PermissionTemplateAccessesController do
 
             expect(response)
               .to redirect_to(hyrax.edit_admin_admin_set_path(source_id,
-                                                                   locale: 'en',
                                                                    anchor: 'participants'))
           end
 
@@ -150,7 +148,6 @@ RSpec.describe Hyrax::Admin::PermissionTemplateAccessesController do
 
             expect(response)
               .to redirect_to(hyrax.edit_dashboard_collection_path(source_id,
-                                                                   locale: 'en',
                                                                    anchor: 'sharing'))
           end
 
@@ -182,7 +179,6 @@ RSpec.describe Hyrax::Admin::PermissionTemplateAccessesController do
 
             expect(response)
               .to redirect_to(hyrax.edit_dashboard_collection_path(source_id,
-                                                                   locale: 'en',
                                                                    anchor: 'sharing'))
           end
 

--- a/spec/controllers/hyrax/admin/permission_templates_controller_spec.rb
+++ b/spec/controllers/hyrax/admin/permission_templates_controller_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe Hyrax::Admin::PermissionTemplatesController do
         expect(controller).to receive(:authorize!).with(:update, Hyrax::PermissionTemplate)
         expect(form).to receive(:update).with(ActionController::Parameters.new(form_attributes).permit!).and_return(updated: true, content_tab: 'participants')
         put :update, params: input_params
-        expect(response).to redirect_to(hyrax.edit_admin_admin_set_path(permission_template.source_id, locale: 'en', anchor: 'participants'))
+        expect(response).to redirect_to(hyrax.edit_admin_admin_set_path(permission_template.source_id, anchor: 'participants'))
         expect(flash[:notice]).to eq(I18n.t('participants', scope: 'hyrax.admin.admin_sets.form.permission_update_notices'))
       end
     end
@@ -64,7 +64,7 @@ RSpec.describe Hyrax::Admin::PermissionTemplatesController do
         expect(controller).to receive(:authorize!).with(:update, Hyrax::PermissionTemplate)
         expect(form).to receive(:update).with(ActionController::Parameters.new(form_attributes).permit!).and_return(updated: true, content_tab: 'sharing')
         put :update, params: input_params
-        expect(response).to redirect_to(hyrax.edit_dashboard_collection_path(permission_template.source_id, locale: 'en', anchor: 'sharing'))
+        expect(response).to redirect_to(hyrax.edit_dashboard_collection_path(permission_template.source_id, anchor: 'sharing'))
         expect(flash[:notice]).to eq(I18n.t('sharing', scope: 'hyrax.dashboard.collections.form.permission_update_notices'))
       end
 
@@ -79,7 +79,7 @@ RSpec.describe Hyrax::Admin::PermissionTemplatesController do
           expect(controller).to receive(:authorize!).with(:update, Hyrax::PermissionTemplate)
           expect(form).to receive(:update).with(ActionController::Parameters.new(form_attributes).permit!).and_return(updated: true, content_tab: 'sharing')
           put :update, params: input_params
-          expect(response).to redirect_to(hyrax.edit_dashboard_collection_path(permission_template.source_id, locale: 'en', anchor: 'sharing'))
+          expect(response).to redirect_to(hyrax.edit_dashboard_collection_path(permission_template.source_id, anchor: 'sharing'))
 
           updated = Hyrax::PermissionTemplate.find_by(id: permission_template.id)
           expect(updated.release_date.strftime('%Y-%m-%d')).to eq(release_date)

--- a/spec/controllers/hyrax/admin/strategies_controller_spec.rb
+++ b/spec/controllers/hyrax/admin/strategies_controller_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe Hyrax::Admin::StrategiesController do
         patch :update, params: { feature_id: feature.id, id: strategy }
 
         expect(response.location)
-          .to include Hyrax::Engine.routes.url_helpers.admin_features_path(locale: 'en')
+          .to include Hyrax::Engine.routes.url_helpers.admin_features_path
       end
     end
   end

--- a/spec/controllers/hyrax/admin/workflow_roles_controller_spec.rb
+++ b/spec/controllers/hyrax/admin/workflow_roles_controller_spec.rb
@@ -7,9 +7,9 @@ RSpec.describe Hyrax::Admin::WorkflowRolesController do
       end
 
       it "is successful" do
-        expect(controller).to receive(:add_breadcrumb).with('Home', root_path(locale: 'en'))
-        expect(controller).to receive(:add_breadcrumb).with('Dashboard', dashboard_path(locale: 'en'))
-        expect(controller).to receive(:add_breadcrumb).with('Workflow Roles', admin_workflow_roles_path(locale: 'en'))
+        expect(controller).to receive(:add_breadcrumb).with('Home', root_path)
+        expect(controller).to receive(:add_breadcrumb).with('Dashboard', dashboard_path)
+        expect(controller).to receive(:add_breadcrumb).with('Workflow Roles', admin_workflow_roles_path)
         get :index
         expect(response).to be_successful
         expect(assigns[:presenter]).to be_kind_of Hyrax::Admin::WorkflowRolesPresenter
@@ -20,7 +20,7 @@ RSpec.describe Hyrax::Admin::WorkflowRolesController do
     context "when they don't have permission" do
       it "throws a CanCan error" do
         get :index
-        expect(response).to redirect_to main_app.new_user_session_path(locale: 'en')
+        expect(response).to redirect_to main_app.new_user_session_path
       end
     end
   end
@@ -46,7 +46,7 @@ RSpec.describe Hyrax::Admin::WorkflowRolesController do
     context "when they don't have permission" do
       it 'throws a CanCan error' do
         post :create, params: { sipity_workflow_responsibility: {} }
-        expect(response).to redirect_to main_app.new_user_session_path(locale: 'en')
+        expect(response).to redirect_to main_app.new_user_session_path
       end
     end
   end
@@ -70,7 +70,7 @@ RSpec.describe Hyrax::Admin::WorkflowRolesController do
     context "when they don't have permission" do
       it "throws a CanCan error" do
         get :index
-        expect(response).to redirect_to main_app.new_user_session_path(locale: 'en')
+        expect(response).to redirect_to main_app.new_user_session_path
       end
     end
   end

--- a/spec/controllers/hyrax/api/zotero_controller_spec.rb
+++ b/spec/controllers/hyrax/api/zotero_controller_spec.rb
@@ -112,7 +112,7 @@ RSpec.describe Hyrax::API::ZoteroController, type: :controller do
 
       specify do
         expect(subject).to have_http_status(:found)
-        expect(subject).to redirect_to(routes.url_helpers.edit_dashboard_profile_path(user, locale: 'en'))
+        expect(subject).to redirect_to(routes.url_helpers.edit_dashboard_profile_path(user))
         expect(flash[:alert]).to eq 'Malformed request from Zotero'
       end
     end
@@ -125,7 +125,7 @@ RSpec.describe Hyrax::API::ZoteroController, type: :controller do
 
       specify do
         expect(subject).to have_http_status(:found)
-        expect(subject).to redirect_to(routes.url_helpers.edit_dashboard_profile_path(user, locale: 'en'))
+        expect(subject).to redirect_to(routes.url_helpers.edit_dashboard_profile_path(user))
         expect(flash[:alert]).to eq 'You have not yet connected to Zotero'
       end
     end
@@ -153,7 +153,7 @@ RSpec.describe Hyrax::API::ZoteroController, type: :controller do
       specify do
         expect(subject).to have_http_status(:found)
         expect(Hyrax::Arkivo::CreateSubscriptionJob).to have_received(:perform_later)
-        expect(subject).to redirect_to(routes.url_helpers.dashboard_profile_path(user, locale: 'en'))
+        expect(subject).to redirect_to(routes.url_helpers.dashboard_profile_path(user))
         expect(flash[:alert]).to be_nil
         expect(flash[:notice]).to eq 'Successfully connected to Zotero!'
         expect(user.reload.zotero_userid).to eq zuserid

--- a/spec/controllers/hyrax/batch_edits_controller_spec.rb
+++ b/spec/controllers/hyrax/batch_edits_controller_spec.rb
@@ -12,9 +12,9 @@ RSpec.describe Hyrax::BatchEditsController, type: :controller do
 
   shared_examples('tests that edit page loads') do
     it "is successful" do
-      expect(controller).to receive(:add_breadcrumb).with('Home', Hyrax::Engine.routes.url_helpers.root_path(locale: 'en'))
-      expect(controller).to receive(:add_breadcrumb).with(I18n.t('hyrax.dashboard.title'), Hyrax::Engine.routes.url_helpers.dashboard_path(locale: 'en'))
-      expect(controller).to receive(:add_breadcrumb).with(I18n.t('hyrax.dashboard.my.works'), Hyrax::Engine.routes.url_helpers.my_works_path(locale: 'en'))
+      expect(controller).to receive(:add_breadcrumb).with('Home', Hyrax::Engine.routes.url_helpers.root_path)
+      expect(controller).to receive(:add_breadcrumb).with(I18n.t('hyrax.dashboard.title'), Hyrax::Engine.routes.url_helpers.dashboard_path)
+      expect(controller).to receive(:add_breadcrumb).with(I18n.t('hyrax.dashboard.my.works'), Hyrax::Engine.routes.url_helpers.my_works_path)
       get :edit
       expect(response).to be_successful
       expect(response).to render_template('dashboard')
@@ -75,7 +75,7 @@ RSpec.describe Hyrax::BatchEditsController, type: :controller do
 
       it "is successful" do
         put :update, params: { update_type: "delete_all" }
-        expect(response).to redirect_to(dashboard_path(locale: 'en'))
+        expect(response).to redirect_to(dashboard_path)
         expect { GenericWork.find(one.id) }.to raise_error(Ldp::Gone)
         expect { GenericWork.find(two.id) }.to raise_error(Ldp::Gone)
         expect(GenericWork).to exist(three.id)
@@ -83,7 +83,7 @@ RSpec.describe Hyrax::BatchEditsController, type: :controller do
 
       it "redirects to the return controller" do
         put :update, params: { update_type: "delete_all", return_controller: mycontroller }
-        expect(response).to redirect_to(Hyrax::Engine.routes.url_for(controller: mycontroller, only_path: true, locale: 'en'))
+        expect(response).to redirect_to(Hyrax::Engine.routes.url_for(controller: mycontroller, only_path: true))
       end
 
       it "updates the records" do
@@ -190,7 +190,7 @@ RSpec.describe Hyrax::BatchEditsController, type: :controller do
 
       it "is successful" do
         put :update, params: { update_type: "delete_all" }
-        expect(response).to redirect_to(dashboard_path(locale: 'en'))
+        expect(response).to redirect_to(dashboard_path)
         expect { work1 }.to raise_error(Valkyrie::Persistence::ObjectNotFoundError)
         expect { work2 }.to raise_error(Valkyrie::Persistence::ObjectNotFoundError)
         expect { work3 }.not_to raise_error(Valkyrie::Persistence::ObjectNotFoundError)
@@ -198,7 +198,7 @@ RSpec.describe Hyrax::BatchEditsController, type: :controller do
 
       it "redirects to the return controller" do
         put :update, params: { update_type: "delete_all", return_controller: mycontroller }
-        expect(response).to redirect_to(Hyrax::Engine.routes.url_for(controller: mycontroller, only_path: true, locale: 'en'))
+        expect(response).to redirect_to(Hyrax::Engine.routes.url_for(controller: mycontroller, only_path: true))
       end
 
       it "updates the records" do

--- a/spec/controllers/hyrax/batch_uploads_controller_spec.rb
+++ b/spec/controllers/hyrax/batch_uploads_controller_spec.rb
@@ -33,9 +33,9 @@ RSpec.describe Hyrax::BatchUploadsController do
     let(:curation_concern) { double(human_readable_type: 'Works by Batch') }
 
     it "is successful" do
-      expect(controller).to receive(:add_breadcrumb).with(I18n.t('hyrax.controls.home'), Hyrax::Engine.routes.url_helpers.root_path(locale: 'en'))
-      expect(controller).to receive(:add_breadcrumb).with(I18n.t('hyrax.dashboard.title'), Hyrax::Engine.routes.url_helpers.dashboard_path(locale: 'en'))
-      expect(controller).to receive(:add_breadcrumb).with(I18n.t('hyrax.dashboard.my.works'), Hyrax::Engine.routes.url_helpers.my_works_path(locale: 'en'))
+      expect(controller).to receive(:add_breadcrumb).with(I18n.t('hyrax.controls.home'), Hyrax::Engine.routes.url_helpers.root_path)
+      expect(controller).to receive(:add_breadcrumb).with(I18n.t('hyrax.dashboard.title'), Hyrax::Engine.routes.url_helpers.dashboard_path)
+      expect(controller).to receive(:add_breadcrumb).with(I18n.t('hyrax.dashboard.my.works'), Hyrax::Engine.routes.url_helpers.my_works_path)
       expect(controller).to receive(:add_breadcrumb).with(I18n.t('hyrax.batch_uploads.new.breadcrumb'), Hyrax::Engine.routes.url_helpers.new_batch_upload_path)
       get :new
       expect(response).to be_successful
@@ -51,7 +51,7 @@ RSpec.describe Hyrax::BatchUploadsController do
       end
       it 'redirects with an error message' do
         post :create, params: post_params.merge(format: :html)
-        expect(response).to redirect_to Hyrax::Engine.routes.url_helpers.my_works_path(locale: 'en')
+        expect(response).to redirect_to Hyrax::Engine.routes.url_helpers.my_works_path
         expect(flash[:alert]).to include('Feature disabled by administrator')
       end
       context 'when json is requested' do
@@ -73,7 +73,7 @@ RSpec.describe Hyrax::BatchUploadsController do
                 expected_shared_params,
                 Hyrax::BatchCreateOperation)
         post :create, params: post_params
-        expect(response).to redirect_to Hyrax::Engine.routes.url_helpers.my_works_path(locale: 'en')
+        expect(response).to redirect_to Hyrax::Engine.routes.url_helpers.my_works_path
         expect(flash[:notice]).to be_html_safe
         expect(flash[:notice]).to include("Your files are being processed")
       end
@@ -97,7 +97,7 @@ RSpec.describe Hyrax::BatchUploadsController do
                 expected_shared_params,
                 a_kind_of(Hyrax::BatchCreateOperation))
         post :create, params: post_params
-        expect(response).to redirect_to Hyrax::Engine.routes.url_helpers.my_works_path(locale: 'en')
+        expect(response).to redirect_to Hyrax::Engine.routes.url_helpers.my_works_path
         expect(flash[:notice]).to include("Your files are being processed")
       end
     end
@@ -116,7 +116,7 @@ RSpec.describe Hyrax::BatchUploadsController do
       it 'redirects to managed works page' do
         allow(BatchCreateJob).to receive(:perform_later)
         post :create, params: post_params
-        expect(response).to redirect_to Hyrax::Engine.routes.url_helpers.dashboard_works_path(locale: 'en')
+        expect(response).to redirect_to Hyrax::Engine.routes.url_helpers.dashboard_works_path
       end
     end
   end

--- a/spec/controllers/hyrax/citations_controller_spec.rb
+++ b/spec/controllers/hyrax/citations_controller_spec.rb
@@ -12,8 +12,8 @@ RSpec.describe Hyrax::CitationsController do
       end
 
       it "is successful" do
-        expect(controller).to receive(:add_breadcrumb).with('Home', Hyrax::Engine.routes.url_helpers.root_path(locale: 'en'))
-        expect(controller).to receive(:add_breadcrumb).with('Dashboard', Hyrax::Engine.routes.url_helpers.dashboard_path(locale: 'en'))
+        expect(controller).to receive(:add_breadcrumb).with('Home', Hyrax::Engine.routes.url_helpers.root_path)
+        expect(controller).to receive(:add_breadcrumb).with('Dashboard', Hyrax::Engine.routes.url_helpers.dashboard_path)
         get :work, params: { id: work }
         expect(response).to be_successful
         expect(response).to render_template('layouts/hyrax/1_column')
@@ -30,7 +30,7 @@ RSpec.describe Hyrax::CitationsController do
 
       it "redirects to the home page" do
         get :work, params: { id: work }
-        expect(response).to redirect_to main_app.root_path(locale: 'en')
+        expect(response).to redirect_to main_app.root_path
         expect(flash[:alert]).to eq "You are not authorized to access this page."
       end
     end
@@ -38,7 +38,7 @@ RSpec.describe Hyrax::CitationsController do
     context "when a user is not logged in" do
       it "redirects to the user login page" do
         get :work, params: { id: work }
-        expect(response).to redirect_to main_app.new_user_session_path(locale: 'en')
+        expect(response).to redirect_to main_app.new_user_session_path
         expect(flash[:alert]).to eq "You are not authorized to access this page."
         expect(session['user_return_to']).to eq request.url
       end
@@ -51,8 +51,8 @@ RSpec.describe Hyrax::CitationsController do
       end
 
       it "is successful" do
-        expect(controller).to receive(:add_breadcrumb).with('Home', Hyrax::Engine.routes.url_helpers.root_path(locale: 'en'))
-        expect(controller).to receive(:add_breadcrumb).with('Dashboard', Hyrax::Engine.routes.url_helpers.dashboard_path(locale: 'en'))
+        expect(controller).to receive(:add_breadcrumb).with('Home', Hyrax::Engine.routes.url_helpers.root_path)
+        expect(controller).to receive(:add_breadcrumb).with('Dashboard', Hyrax::Engine.routes.url_helpers.dashboard_path)
         get :work, params: { id: work }
         expect(response).to be_successful
         expect(response).to render_template('layouts/hyrax/1_column')
@@ -71,8 +71,8 @@ RSpec.describe Hyrax::CitationsController do
       end
 
       it "is successful" do
-        expect(controller).to receive(:add_breadcrumb).with('Home', Hyrax::Engine.routes.url_helpers.root_path(locale: 'en'))
-        expect(controller).to receive(:add_breadcrumb).with('Dashboard', Hyrax::Engine.routes.url_helpers.dashboard_path(locale: 'en'))
+        expect(controller).to receive(:add_breadcrumb).with('Home', Hyrax::Engine.routes.url_helpers.root_path)
+        expect(controller).to receive(:add_breadcrumb).with('Dashboard', Hyrax::Engine.routes.url_helpers.dashboard_path)
         get :file, params: { id: file_set }
         expect(response).to be_successful
         expect(response).to render_template('layouts/hyrax/1_column')
@@ -83,7 +83,7 @@ RSpec.describe Hyrax::CitationsController do
     context "with an unauthenticated user" do
       it "is not successful" do
         get :file, params: { id: file_set }
-        expect(response).to redirect_to main_app.new_user_session_path(locale: 'en')
+        expect(response).to redirect_to main_app.new_user_session_path
         expect(flash[:alert]).to eq "You are not authorized to access this page."
         expect(session['user_return_to']).to eq request.url
       end

--- a/spec/controllers/hyrax/collections_controller_spec.rb
+++ b/spec/controllers/hyrax/collections_controller_spec.rb
@@ -39,10 +39,10 @@ RSpec.describe Hyrax::CollectionsController, clean_repo: true do
       end
 
       it "returns the collection and its members" do # rubocop:disable RSpec/ExampleLength
-        expect(controller).to receive(:add_breadcrumb).with('Home', Hyrax::Engine.routes.url_helpers.root_path(locale: 'en'))
-        expect(controller).to receive(:add_breadcrumb).with('Dashboard', Hyrax::Engine.routes.url_helpers.dashboard_path(locale: 'en'))
-        expect(controller).to receive(:add_breadcrumb).with('Collections', Hyrax::Engine.routes.url_helpers.my_collections_path(locale: 'en'))
-        expect(controller).to receive(:add_breadcrumb).with('My collection', collection_path(collection.id, locale: 'en'), { "aria-current" => "page" })
+        expect(controller).to receive(:add_breadcrumb).with('Home', Hyrax::Engine.routes.url_helpers.root_path)
+        expect(controller).to receive(:add_breadcrumb).with('Dashboard', Hyrax::Engine.routes.url_helpers.dashboard_path)
+        expect(controller).to receive(:add_breadcrumb).with('Collections', Hyrax::Engine.routes.url_helpers.my_collections_path)
+        expect(controller).to receive(:add_breadcrumb).with('My collection', collection_path(collection.id), { "aria-current" => "page" })
         get :show, params: { id: collection }
         expect(response).to be_successful
         expect(response).to render_template("layouts/hyrax/1_column")
@@ -77,10 +77,10 @@ RSpec.describe Hyrax::CollectionsController, clean_repo: true do
 
       context "without a referer" do
         it "sets breadcrumbs" do
-          expect(controller).to receive(:add_breadcrumb).with('Home', Hyrax::Engine.routes.url_helpers.root_path(locale: 'en'))
-          expect(controller).to receive(:add_breadcrumb).with('Dashboard', Hyrax::Engine.routes.url_helpers.dashboard_path(locale: 'en'))
-          expect(controller).to receive(:add_breadcrumb).with('Collections', Hyrax::Engine.routes.url_helpers.my_collections_path(locale: 'en'))
-          expect(controller).to receive(:add_breadcrumb).with('My collection', collection_path(collection.id, locale: 'en'), { "aria-current" => "page" })
+          expect(controller).to receive(:add_breadcrumb).with('Home', Hyrax::Engine.routes.url_helpers.root_path)
+          expect(controller).to receive(:add_breadcrumb).with('Dashboard', Hyrax::Engine.routes.url_helpers.dashboard_path)
+          expect(controller).to receive(:add_breadcrumb).with('Collections', Hyrax::Engine.routes.url_helpers.my_collections_path)
+          expect(controller).to receive(:add_breadcrumb).with('My collection', collection_path(collection.id), { "aria-current" => "page" })
           get :show, params: { id: collection }
           expect(response).to be_successful
         end
@@ -92,10 +92,10 @@ RSpec.describe Hyrax::CollectionsController, clean_repo: true do
         end
 
         it "sets breadcrumbs" do
-          expect(controller).to receive(:add_breadcrumb).with('Home', Hyrax::Engine.routes.url_helpers.root_path(locale: 'en'))
-          expect(controller).to receive(:add_breadcrumb).with('Dashboard', Hyrax::Engine.routes.url_helpers.dashboard_path(locale: 'en'))
-          expect(controller).to receive(:add_breadcrumb).with('Collections', Hyrax::Engine.routes.url_helpers.my_collections_path(locale: 'en'))
-          expect(controller).to receive(:add_breadcrumb).with('My collection', collection_path(collection.id, locale: 'en'), { "aria-current" => "page" })
+          expect(controller).to receive(:add_breadcrumb).with('Home', Hyrax::Engine.routes.url_helpers.root_path)
+          expect(controller).to receive(:add_breadcrumb).with('Dashboard', Hyrax::Engine.routes.url_helpers.dashboard_path)
+          expect(controller).to receive(:add_breadcrumb).with('Collections', Hyrax::Engine.routes.url_helpers.my_collections_path)
+          expect(controller).to receive(:add_breadcrumb).with('My collection', collection_path(collection.id), { "aria-current" => "page" })
           get :show, params: { id: collection }
           expect(response).to be_successful
         end
@@ -112,9 +112,9 @@ RSpec.describe Hyrax::CollectionsController, clean_repo: true do
 
     context "without a referer" do
       it "sets breadcrumbs" do
-        expect(controller).not_to receive(:add_breadcrumb).with(I18n.t('hyrax.dashboard.title'), Hyrax::Engine.routes.url_helpers.dashboard_path(locale: 'en'))
-        expect(controller).not_to receive(:add_breadcrumb).with('Your Collections', Hyrax::Engine.routes.url_helpers.my_collections_path(locale: 'en'))
-        expect(controller).not_to receive(:add_breadcrumb).with('My collection', collection_path(collection.id, locale: 'en'))
+        expect(controller).not_to receive(:add_breadcrumb).with(I18n.t('hyrax.dashboard.title'), Hyrax::Engine.routes.url_helpers.dashboard_path)
+        expect(controller).not_to receive(:add_breadcrumb).with('Your Collections', Hyrax::Engine.routes.url_helpers.my_collections_path)
+        expect(controller).not_to receive(:add_breadcrumb).with('My collection', collection_path(collection.id))
 
         get :show, params: { id: collection }
         expect(response).to be_successful
@@ -127,9 +127,9 @@ RSpec.describe Hyrax::CollectionsController, clean_repo: true do
       end
 
       it "sets breadcrumbs" do
-        expect(controller).not_to receive(:add_breadcrumb).with(I18n.t('hyrax.dashboard.title'), Hyrax::Engine.routes.url_helpers.dashboard_path(locale: 'en'))
-        expect(controller).not_to receive(:add_breadcrumb).with('Your Collections', Hyrax::Engine.routes.url_helpers.my_collections_path(locale: 'en'))
-        expect(controller).to receive(:add_breadcrumb).with('My collection', collection_path(collection.id, locale: 'en'), { "aria-current" => "page" })
+        expect(controller).not_to receive(:add_breadcrumb).with(I18n.t('hyrax.dashboard.title'), Hyrax::Engine.routes.url_helpers.dashboard_path)
+        expect(controller).not_to receive(:add_breadcrumb).with('Your Collections', Hyrax::Engine.routes.url_helpers.my_collections_path)
+        expect(controller).to receive(:add_breadcrumb).with('My collection', collection_path(collection.id), { "aria-current" => "page" })
         get :show, params: { id: collection }
         expect(response).to be_successful
       end

--- a/spec/controllers/hyrax/dashboard/collection_members_controller_spec.rb
+++ b/spec/controllers/hyrax/dashboard/collection_members_controller_spec.rb
@@ -84,7 +84,7 @@ RSpec.describe Hyrax::Dashboard::CollectionMembersController, :clean_repo do
           post :update_members, params: parameters
 
           expect(response)
-            .to redirect_to routes.url_helpers.dashboard_collection_path(collection, locale: 'en')
+            .to redirect_to routes.url_helpers.dashboard_collection_path(collection)
         end
       end
 
@@ -153,7 +153,7 @@ RSpec.describe Hyrax::Dashboard::CollectionMembersController, :clean_repo do
           post(:update_members, params: parameters)
 
           expect(response)
-            .to redirect_to routes.url_helpers.dashboard_collection_path(collection, locale: 'en')
+            .to redirect_to routes.url_helpers.dashboard_collection_path(collection)
         end
       end
 
@@ -199,7 +199,7 @@ RSpec.describe Hyrax::Dashboard::CollectionMembersController, :clean_repo do
           post(:update_members, params: parameters)
 
           expect(flash[:alert]).to eq 'You do not have sufficient privileges to any of the selected members'
-          expect(response).to redirect_to routes.url_helpers.dashboard_collections_path(locale: 'en')
+          expect(response).to redirect_to routes.url_helpers.dashboard_collections_path
         end
       end
     end
@@ -234,7 +234,7 @@ RSpec.describe Hyrax::Dashboard::CollectionMembersController, :clean_repo do
           post :update_members, params: parameters
 
           expect(response)
-            .to redirect_to routes.url_helpers.dashboard_collection_path(collection, locale: 'en')
+            .to redirect_to routes.url_helpers.dashboard_collection_path(collection)
         end
       end
 
@@ -303,7 +303,7 @@ RSpec.describe Hyrax::Dashboard::CollectionMembersController, :clean_repo do
           post(:update_members, params: parameters)
 
           expect(response)
-            .to redirect_to routes.url_helpers.dashboard_collection_path(collection, locale: 'en')
+            .to redirect_to routes.url_helpers.dashboard_collection_path(collection)
         end
       end
 
@@ -349,7 +349,7 @@ RSpec.describe Hyrax::Dashboard::CollectionMembersController, :clean_repo do
           post(:update_members, params: parameters)
 
           expect(flash[:alert]).to eq 'You do not have sufficient privileges to any of the selected members'
-          expect(response).to redirect_to routes.url_helpers.dashboard_collections_path(locale: 'en')
+          expect(response).to redirect_to routes.url_helpers.dashboard_collections_path
         end
       end
     end
@@ -463,7 +463,7 @@ RSpec.describe Hyrax::Dashboard::CollectionMembersController, :clean_repo do
             expect(flash[:alert])
               .to eq 'You do not have sufficient privileges to any of the selected members'
             expect(response)
-              .to redirect_to routes.url_helpers.dashboard_collections_path(locale: 'en')
+              .to redirect_to routes.url_helpers.dashboard_collections_path
           end
         end
       end
@@ -485,7 +485,7 @@ RSpec.describe Hyrax::Dashboard::CollectionMembersController, :clean_repo do
         expect(flash[:alert])
           .to eq 'You do not have sufficient privileges to add members to the collection'
         expect(response)
-          .to redirect_to routes.url_helpers.dashboard_collections_path(locale: 'en')
+          .to redirect_to routes.url_helpers.dashboard_collections_path
       end
     end
 
@@ -541,7 +541,7 @@ RSpec.describe Hyrax::Dashboard::CollectionMembersController, :clean_repo do
                        #{other_collection_of_type.title.first.gsub(' ', '\s')})}x
 
         expect(response)
-          .to redirect_to routes.url_helpers.dashboard_collection_path(collection, locale: 'en')
+          .to redirect_to routes.url_helpers.dashboard_collection_path(collection)
       end
     end
   end

--- a/spec/controllers/hyrax/dashboard/collections_controller_spec.rb
+++ b/spec/controllers/hyrax/dashboard/collections_controller_spec.rb
@@ -304,7 +304,7 @@ RSpec.describe Hyrax::Dashboard::CollectionsController, :clean_repo do
               .to change { queries.find_members_of(collection: collection).map(&:id) }
               .to contain_exactly(asset1.id, asset2.id, asset3.id)
 
-            expect(response).to redirect_to routes.url_helpers.edit_dashboard_collection_path(collection, locale: 'en')
+            expect(response).to redirect_to routes.url_helpers.edit_dashboard_collection_path(collection)
           end
 
           it "adds members to the collection from other than the edit form" do
@@ -315,7 +315,7 @@ RSpec.describe Hyrax::Dashboard::CollectionsController, :clean_repo do
               .to change { queries.find_members_of(collection: collection).map(&:id) }
               .to contain_exactly(asset1.id, asset2.id, asset3.id)
 
-            expect(response).to redirect_to routes.url_helpers.dashboard_collection_path(collection, locale: 'en')
+            expect(response).to redirect_to routes.url_helpers.dashboard_collection_path(collection)
           end
 
           it "removes members from the collection" do
@@ -616,16 +616,16 @@ RSpec.describe Hyrax::Dashboard::CollectionsController, :clean_repo do
           it "returns the collection and its members" do
             expect(controller)
               .to receive(:add_breadcrumb)
-              .with('Home', Hyrax::Engine.routes.url_helpers.root_path(locale: 'en'))
+              .with('Home', Hyrax::Engine.routes.url_helpers.root_path)
             expect(controller)
               .to receive(:add_breadcrumb)
-              .with('Dashboard', Hyrax::Engine.routes.url_helpers.dashboard_path(locale: 'en'))
+              .with('Dashboard', Hyrax::Engine.routes.url_helpers.dashboard_path)
             expect(controller)
               .to receive(:add_breadcrumb)
-              .with('Collections', Hyrax::Engine.routes.url_helpers.my_collections_path(locale: 'en'))
+              .with('Collections', Hyrax::Engine.routes.url_helpers.my_collections_path)
             expect(controller)
               .to receive(:add_breadcrumb)
-              .with('My collection', collection_path(collection.id, locale: 'en'), { "aria-current" => "page" })
+              .with('My collection', collection_path(collection.id), { "aria-current" => "page" })
 
             get :show, params: { id: collection }
 
@@ -661,10 +661,10 @@ RSpec.describe Hyrax::Dashboard::CollectionsController, :clean_repo do
 
           context "without a referer" do
             it "sets breadcrumbs" do
-              expect(controller).to receive(:add_breadcrumb).with('Home', Hyrax::Engine.routes.url_helpers.root_path(locale: 'en'))
-              expect(controller).to receive(:add_breadcrumb).with('Dashboard', Hyrax::Engine.routes.url_helpers.dashboard_path(locale: 'en'))
-              expect(controller).to receive(:add_breadcrumb).with('Collections', Hyrax::Engine.routes.url_helpers.my_collections_path(locale: 'en'))
-              expect(controller).to receive(:add_breadcrumb).with('My collection', collection_path(collection.id, locale: 'en'), { "aria-current" => "page" })
+              expect(controller).to receive(:add_breadcrumb).with('Home', Hyrax::Engine.routes.url_helpers.root_path)
+              expect(controller).to receive(:add_breadcrumb).with('Dashboard', Hyrax::Engine.routes.url_helpers.dashboard_path)
+              expect(controller).to receive(:add_breadcrumb).with('Collections', Hyrax::Engine.routes.url_helpers.my_collections_path)
+              expect(controller).to receive(:add_breadcrumb).with('My collection', collection_path(collection.id), { "aria-current" => "page" })
               get :show, params: { id: collection }
               expect(response).to be_successful
             end
@@ -676,10 +676,10 @@ RSpec.describe Hyrax::Dashboard::CollectionsController, :clean_repo do
             end
 
             it "sets breadcrumbs" do
-              expect(controller).to receive(:add_breadcrumb).with('Home', Hyrax::Engine.routes.url_helpers.root_path(locale: 'en'))
-              expect(controller).to receive(:add_breadcrumb).with('Dashboard', Hyrax::Engine.routes.url_helpers.dashboard_path(locale: 'en'))
-              expect(controller).to receive(:add_breadcrumb).with('Collections', Hyrax::Engine.routes.url_helpers.my_collections_path(locale: 'en'))
-              expect(controller).to receive(:add_breadcrumb).with('My collection', collection_path(collection.id, locale: 'en'), { "aria-current" => "page" })
+              expect(controller).to receive(:add_breadcrumb).with('Home', Hyrax::Engine.routes.url_helpers.root_path)
+              expect(controller).to receive(:add_breadcrumb).with('Dashboard', Hyrax::Engine.routes.url_helpers.dashboard_path)
+              expect(controller).to receive(:add_breadcrumb).with('Collections', Hyrax::Engine.routes.url_helpers.my_collections_path)
+              expect(controller).to receive(:add_breadcrumb).with('My collection', collection_path(collection.id), { "aria-current" => "page" })
               get :show, params: { id: collection }
               expect(response).to be_successful
             end
@@ -727,7 +727,7 @@ RSpec.describe Hyrax::Dashboard::CollectionsController, :clean_repo do
             delete :destroy, params: { id: collection }
 
             expect(response).to have_http_status(:found)
-            expect(response).to redirect_to(Hyrax::Engine.routes.url_helpers.my_collections_path(locale: 'en'))
+            expect(response).to redirect_to(Hyrax::Engine.routes.url_helpers.my_collections_path)
             expect(flash[:notice]).to eq "Collection was successfully deleted"
           end
 
@@ -776,10 +776,10 @@ RSpec.describe Hyrax::Dashboard::CollectionsController, :clean_repo do
 
         context "without a referer" do
           it "sets breadcrumbs" do
-            expect(controller).to receive(:add_breadcrumb).with('Home', Hyrax::Engine.routes.url_helpers.root_path(locale: 'en'))
-            expect(controller).to receive(:add_breadcrumb).with('Dashboard', Hyrax::Engine.routes.url_helpers.dashboard_path(locale: 'en'))
-            expect(controller).to receive(:add_breadcrumb).with('Collections', Hyrax::Engine.routes.url_helpers.my_collections_path(locale: 'en'))
-            expect(controller).to receive(:add_breadcrumb).with(I18n.t("hyrax.collection.edit_view"), collection_path(collection.id, locale: 'en'), { "aria-current" => "page" })
+            expect(controller).to receive(:add_breadcrumb).with('Home', Hyrax::Engine.routes.url_helpers.root_path)
+            expect(controller).to receive(:add_breadcrumb).with('Dashboard', Hyrax::Engine.routes.url_helpers.dashboard_path)
+            expect(controller).to receive(:add_breadcrumb).with('Collections', Hyrax::Engine.routes.url_helpers.my_collections_path)
+            expect(controller).to receive(:add_breadcrumb).with(I18n.t("hyrax.collection.edit_view"), collection_path(collection.id), { "aria-current" => "page" })
             get :edit, params: { id: collection }
             expect(response).to be_successful
           end
@@ -789,10 +789,10 @@ RSpec.describe Hyrax::Dashboard::CollectionsController, :clean_repo do
           before { request.env['HTTP_REFERER'] = 'http://test.host/foo' }
 
           it "sets breadcrumbs" do
-            expect(controller).to receive(:add_breadcrumb).with('Home', Hyrax::Engine.routes.url_helpers.root_path(locale: 'en'))
-            expect(controller).to receive(:add_breadcrumb).with('Dashboard', Hyrax::Engine.routes.url_helpers.dashboard_path(locale: 'en'))
-            expect(controller).to receive(:add_breadcrumb).with('Collections', Hyrax::Engine.routes.url_helpers.my_collections_path(locale: 'en'))
-            expect(controller).to receive(:add_breadcrumb).with(I18n.t("hyrax.collection.edit_view"), collection_path(collection.id, locale: 'en'), { "aria-current" => "page" })
+            expect(controller).to receive(:add_breadcrumb).with('Home', Hyrax::Engine.routes.url_helpers.root_path)
+            expect(controller).to receive(:add_breadcrumb).with('Dashboard', Hyrax::Engine.routes.url_helpers.dashboard_path)
+            expect(controller).to receive(:add_breadcrumb).with('Collections', Hyrax::Engine.routes.url_helpers.my_collections_path)
+            expect(controller).to receive(:add_breadcrumb).with(I18n.t("hyrax.collection.edit_view"), collection_path(collection.id), { "aria-current" => "page" })
 
             get :edit, params: { id: collection }
 
@@ -826,9 +826,9 @@ RSpec.describe Hyrax::Dashboard::CollectionsController, :clean_repo do
           end
 
           it "sets breadcrumbs" do
-            expect(controller).to receive(:add_breadcrumb).with('Home', root_path(locale: 'en'))
-            expect(controller).to receive(:add_breadcrumb).with('Dashboard', dashboard_path(locale: 'en'))
-            expect(controller).to receive(:add_breadcrumb).with('Collections', my_collections_path(locale: 'en'))
+            expect(controller).to receive(:add_breadcrumb).with('Home', root_path)
+            expect(controller).to receive(:add_breadcrumb).with('Dashboard', dashboard_path)
+            expect(controller).to receive(:add_breadcrumb).with('Collections', my_collections_path)
             get :index, params: { per_page: 1 }
           end
         end

--- a/spec/controllers/hyrax/dashboard/profiles_controller_spec.rb
+++ b/spec/controllers/hyrax/dashboard/profiles_controller_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe Hyrax::Dashboard::ProfilesController do
         it "allows user to edit another user's profile" do
           get :edit, params: { id: another_user.to_param }
           expect(response).to be_successful
-          expect(response).not_to redirect_to(routes.url_helpers.dashboard_profile_path(another_user.to_param, locale: 'en'))
+          expect(response).not_to redirect_to(routes.url_helpers.dashboard_profile_path(another_user.to_param))
           expect(flash[:alert]).to be_nil
         end
       end
@@ -85,7 +85,7 @@ RSpec.describe Hyrax::Dashboard::ProfilesController do
       expect(UserEditProfileEventJob).to receive(:perform_later).with(user)
       f = fixture_file_upload('/1.5mb-avatar.jpg', 'image/jpg')
       post :update, params: { id: user.user_key, user: { avatar: f } }
-      expect(response).to redirect_to(routes.url_helpers.dashboard_profile_path(user.to_param, locale: 'en'))
+      expect(response).to redirect_to(routes.url_helpers.dashboard_profile_path(user.to_param))
       expect(flash[:notice]).to include("Your profile has been updated")
       expect(User.find_by_user_key(user.user_key).avatar?).to be true
     end
@@ -93,14 +93,14 @@ RSpec.describe Hyrax::Dashboard::ProfilesController do
       expect(UserEditProfileEventJob).to receive(:perform_later).never
       f = fixture_file_upload('/image.jp2', 'image/jp2')
       post :update, params: { id: user.user_key, user: { avatar: f } }
-      expect(response).to redirect_to(routes.url_helpers.edit_dashboard_profile_path(user.to_param, locale: 'en'))
+      expect(response).to redirect_to(routes.url_helpers.edit_dashboard_profile_path(user.to_param))
       expect(flash[:alert]).to include("Avatar You are not allowed to upload \"jp2\" files, allowed types: jpg, jpeg, png, gif, bmp, tif, tiff")
     end
     it "validates the size of an avatar" do
       f = fixture_file_upload('/4-20.png', 'image/png')
       expect(UserEditProfileEventJob).to receive(:perform_later).never
       post :update, params: { id: user.user_key, user: { avatar: f } }
-      expect(response).to redirect_to(routes.url_helpers.edit_dashboard_profile_path(user.to_param, locale: 'en'))
+      expect(response).to redirect_to(routes.url_helpers.edit_dashboard_profile_path(user.to_param))
       expect(flash[:alert]).to include("Avatar file size must be less than 2MB")
     end
 
@@ -113,7 +113,7 @@ RSpec.describe Hyrax::Dashboard::ProfilesController do
       it "deletes an avatar" do
         expect(UserEditProfileEventJob).to receive(:perform_later).with(user)
         post :update, params: { id: user.user_key, user: { remove_avatar: 'true' } }
-        expect(response).to redirect_to(routes.url_helpers.dashboard_profile_path(user.to_param, locale: 'en'))
+        expect(response).to redirect_to(routes.url_helpers.dashboard_profile_path(user.to_param))
         expect(flash[:notice]).to include("Your profile has been updated")
         expect(User.find_by_user_key(user.user_key).avatar?).to be false
       end
@@ -121,7 +121,7 @@ RSpec.describe Hyrax::Dashboard::ProfilesController do
 
     it "sets an social handles" do
       post :update, params: { id: user.user_key, user: { twitter_handle: 'twit', facebook_handle: 'face', linkedin_handle: "link", orcid: '0000-0000-1111-2222' } }
-      expect(response).to redirect_to(routes.url_helpers.dashboard_profile_path(user.to_param, locale: 'en'))
+      expect(response).to redirect_to(routes.url_helpers.dashboard_profile_path(user.to_param))
       expect(flash[:notice]).to include("Your profile has been updated")
       u = User.find_by_user_key(user.user_key)
       expect(u.twitter_handle).to eq 'twit'
@@ -133,7 +133,7 @@ RSpec.describe Hyrax::Dashboard::ProfilesController do
     it 'displays a flash when invalid ORCID is entered' do
       expect(user.orcid).to be_blank
       post :update, params: { id: user.user_key, user: { orcid: 'foobar' } }
-      expect(response).to redirect_to(routes.url_helpers.edit_dashboard_profile_path(user.to_param, locale: 'en'))
+      expect(response).to redirect_to(routes.url_helpers.edit_dashboard_profile_path(user.to_param))
       expect(flash[:alert]).to include('Orcid must be a string of 19 characters, e.g., "0000-0000-0000-0000"')
     end
 
@@ -147,7 +147,7 @@ RSpec.describe Hyrax::Dashboard::ProfilesController do
         expect do
           post :update, params: { id: user.user_key, 'remove_trophy_' + work.id => 'yes' }
         end.to change { user.trophies.count }.by(-1)
-        expect(response).to redirect_to(routes.url_helpers.dashboard_profile_path(user.to_param, locale: 'en'))
+        expect(response).to redirect_to(routes.url_helpers.dashboard_profile_path(user.to_param))
         expect(flash[:notice]).to include("Your profile has been updated")
       end
     end

--- a/spec/controllers/hyrax/dashboard/works_controller_spec.rb
+++ b/spec/controllers/hyrax/dashboard/works_controller_spec.rb
@@ -9,6 +9,6 @@ RSpec.describe Hyrax::Dashboard::WorksController, type: :controller do
   describe "#search_facet_path" do
     subject { controller.send(:search_facet_path, id: 'keyword_sim') }
 
-    it { is_expected.to eq "/dashboard/works/facet/keyword_sim?locale=en" }
+    it { is_expected.to eq "/dashboard/works/facet/keyword_sim" }
   end
 end

--- a/spec/controllers/hyrax/file_sets_controller_spec.rb
+++ b/spec/controllers/hyrax/file_sets_controller_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe Hyrax::FileSetsController do
               .from(true)
               .to(false)
 
-            expect(response).to redirect_to main_app.hyrax_generic_work_path(work, locale: 'en')
+            expect(response).to redirect_to main_app.hyrax_generic_work_path(work)
           end
         end
       end
@@ -58,16 +58,16 @@ RSpec.describe Hyrax::FileSetsController do
 
           expect(controller)
             .to receive(:add_breadcrumb)
-            .with('Home', Hyrax::Engine.routes.url_helpers.root_path(locale: 'en'))
+            .with('Home', Hyrax::Engine.routes.url_helpers.root_path)
           expect(controller)
             .to receive(:add_breadcrumb)
-            .with(I18n.t('hyrax.dashboard.title'), engine_helpers.dashboard_path(locale: 'en'))
+            .with(I18n.t('hyrax.dashboard.title'), engine_helpers.dashboard_path)
           expect(controller)
             .to receive(:add_breadcrumb)
-            .with(I18n.t('hyrax.dashboard.my.works'), engine_helpers.my_works_path(locale: 'en'))
+            .with(I18n.t('hyrax.dashboard.my.works'), engine_helpers.my_works_path)
           expect(controller)
             .to receive(:add_breadcrumb)
-            .with(I18n.t('hyrax.file_set.browse_view'), app_helpers.hyrax_file_set_path(file_set, locale: 'en'))
+            .with(I18n.t('hyrax.file_set.browse_view'), app_helpers.hyrax_file_set_path(file_set))
 
           get :edit, params: { id: file_set }
 
@@ -110,7 +110,7 @@ RSpec.describe Hyrax::FileSetsController do
             end.to have_enqueued_job(ContentUpdateEventJob).exactly(:once)
 
             expect(response)
-              .to redirect_to main_app.hyrax_file_set_path(file_set, locale: 'en')
+              .to redirect_to main_app.hyrax_file_set_path(file_set)
             expect(assigns[:file_set].modified_date)
               .not_to be file_set.modified_date
           end
@@ -330,11 +330,11 @@ RSpec.describe Hyrax::FileSetsController do
           end
 
           it "shows me the file and set breadcrumbs" do
-            expect(controller).to receive(:add_breadcrumb).with('Home', Hyrax::Engine.routes.url_helpers.root_path(locale: 'en'))
-            expect(controller).to receive(:add_breadcrumb).with('Dashboard', Hyrax::Engine.routes.url_helpers.dashboard_path(locale: 'en'))
-            expect(controller).to receive(:add_breadcrumb).with('Works', Hyrax::Engine.routes.url_helpers.my_works_path(locale: 'en'))
-            expect(controller).to receive(:add_breadcrumb).with('test title', main_app.hyrax_generic_work_path(work.id, locale: 'en'))
-            expect(controller).to receive(:add_breadcrumb).with('test file', main_app.hyrax_file_set_path(file_set, locale: 'en'))
+            expect(controller).to receive(:add_breadcrumb).with('Home', Hyrax::Engine.routes.url_helpers.root_path)
+            expect(controller).to receive(:add_breadcrumb).with('Dashboard', Hyrax::Engine.routes.url_helpers.dashboard_path)
+            expect(controller).to receive(:add_breadcrumb).with('Works', Hyrax::Engine.routes.url_helpers.my_works_path)
+            expect(controller).to receive(:add_breadcrumb).with('test title', main_app.hyrax_generic_work_path(work.id))
+            expect(controller).to receive(:add_breadcrumb).with('test file', main_app.hyrax_file_set_path(file_set))
             get :show, params: { id: file_set }
             expect(response).to be_successful
             expect(flash).to be_empty
@@ -354,11 +354,11 @@ RSpec.describe Hyrax::FileSetsController do
           end
 
           it "shows me the breadcrumbs" do
-            expect(controller).to receive(:add_breadcrumb).with('Home', Hyrax::Engine.routes.url_helpers.root_path(locale: 'en'))
-            expect(controller).to receive(:add_breadcrumb).with('Dashboard', Hyrax::Engine.routes.url_helpers.dashboard_path(locale: 'en'))
-            expect(controller).to receive(:add_breadcrumb).with('Works', Hyrax::Engine.routes.url_helpers.my_works_path(locale: 'en'))
-            expect(controller).to receive(:add_breadcrumb).with('test title', main_app.hyrax_generic_work_path(work.id, locale: 'en'))
-            expect(controller).to receive(:add_breadcrumb).with('test file', main_app.hyrax_file_set_path(file_set, locale: 'en'))
+            expect(controller).to receive(:add_breadcrumb).with('Home', Hyrax::Engine.routes.url_helpers.root_path)
+            expect(controller).to receive(:add_breadcrumb).with('Dashboard', Hyrax::Engine.routes.url_helpers.dashboard_path)
+            expect(controller).to receive(:add_breadcrumb).with('Works', Hyrax::Engine.routes.url_helpers.my_works_path)
+            expect(controller).to receive(:add_breadcrumb).with('test title', main_app.hyrax_generic_work_path(work.id))
+            expect(controller).to receive(:add_breadcrumb).with('test file', main_app.hyrax_file_set_path(file_set))
             get :show, params: { id: file_set }
             expect(response).to be_successful
           end
@@ -447,7 +447,7 @@ RSpec.describe Hyrax::FileSetsController do
           get :show, params: { id: private_file_set }
 
           expect(response)
-            .to fail_redirect_and_flash(main_app.new_user_session_path(locale: 'en'),
+            .to fail_redirect_and_flash(main_app.new_user_session_path,
                                         'You are not authorized to access this page.')
         end
 
@@ -586,16 +586,16 @@ RSpec.describe Hyrax::FileSetsController do
 
           expect(controller)
             .to receive(:add_breadcrumb)
-            .with('Home', Hyrax::Engine.routes.url_helpers.root_path(locale: 'en'))
+            .with('Home', Hyrax::Engine.routes.url_helpers.root_path)
           expect(controller)
             .to receive(:add_breadcrumb)
-            .with(I18n.t('hyrax.dashboard.title'), engine_helpers.dashboard_path(locale: 'en'))
+            .with(I18n.t('hyrax.dashboard.title'), engine_helpers.dashboard_path)
           expect(controller)
             .to receive(:add_breadcrumb)
-            .with(I18n.t('hyrax.dashboard.my.works'), engine_helpers.my_works_path(locale: 'en'))
+            .with(I18n.t('hyrax.dashboard.my.works'), engine_helpers.my_works_path)
           expect(controller)
             .to receive(:add_breadcrumb)
-            .with(I18n.t('hyrax.file_set.browse_view'), app_helpers.hyrax_file_set_path(file_set, locale: 'en'))
+            .with(I18n.t('hyrax.file_set.browse_view'), app_helpers.hyrax_file_set_path(file_set))
 
           get :edit, params: { id: file_set }
 
@@ -783,13 +783,13 @@ RSpec.describe Hyrax::FileSetsController do
       describe "#show" do
         context "without a referer" do
           it "shows me the file and set breadcrumbs" do
-            expect(controller).to receive(:add_breadcrumb).with('Home', Hyrax::Engine.routes.url_helpers.root_path(locale: 'en'))
-            expect(controller).to receive(:add_breadcrumb).with('Dashboard', Hyrax::Engine.routes.url_helpers.dashboard_path(locale: 'en'))
-            expect(controller).to receive(:add_breadcrumb).with('Works', Hyrax::Engine.routes.url_helpers.my_works_path(locale: 'en'))
-            expect(controller).to receive(:add_breadcrumb).with('test title', main_app.hyrax_generic_work_path(work.id, locale: 'en'))
-            expect(controller).to receive(:add_breadcrumb).with('image.jp2', main_app.hyrax_file_set_path(file_set, locale: 'en'))
+            expect(controller).to receive(:add_breadcrumb).with('Home', Hyrax::Engine.routes.url_helpers.root_path)
+            expect(controller).to receive(:add_breadcrumb).with('Dashboard', Hyrax::Engine.routes.url_helpers.dashboard_path)
+            expect(controller).to receive(:add_breadcrumb).with('Works', Hyrax::Engine.routes.url_helpers.my_works_path)
+            expect(controller).to receive(:add_breadcrumb).with('test title', main_app.hyrax_generic_work_path(work.id))
+            expect(controller).to receive(:add_breadcrumb).with('image.jp2', main_app.hyrax_file_set_path(file_set))
             allow(controller.main_app).to receive(:polymorphic_path).and_call_original
-            allow(controller.main_app).to receive(:polymorphic_path).with(instance_of(Hyrax::WorkShowPresenter)).and_return("/concern/generic_works/#{work.id}?locale=en")
+            allow(controller.main_app).to receive(:polymorphic_path).with(instance_of(Hyrax::WorkShowPresenter)).and_return("/concern/generic_works/#{work.id}")
             get :show, params: { id: file_set }
             expect(response).to be_successful
             expect(flash).to be_empty
@@ -806,13 +806,13 @@ RSpec.describe Hyrax::FileSetsController do
           end
 
           it "shows me the breadcrumbs" do
-            expect(controller).to receive(:add_breadcrumb).with('Home', Hyrax::Engine.routes.url_helpers.root_path(locale: 'en'))
-            expect(controller).to receive(:add_breadcrumb).with('Dashboard', Hyrax::Engine.routes.url_helpers.dashboard_path(locale: 'en'))
-            expect(controller).to receive(:add_breadcrumb).with('Works', Hyrax::Engine.routes.url_helpers.my_works_path(locale: 'en'))
-            expect(controller).to receive(:add_breadcrumb).with('test title', main_app.hyrax_generic_work_path(work.id, locale: 'en'))
-            expect(controller).to receive(:add_breadcrumb).with('image.jp2', main_app.hyrax_file_set_path(file_set, locale: 'en'))
+            expect(controller).to receive(:add_breadcrumb).with('Home', Hyrax::Engine.routes.url_helpers.root_path)
+            expect(controller).to receive(:add_breadcrumb).with('Dashboard', Hyrax::Engine.routes.url_helpers.dashboard_path)
+            expect(controller).to receive(:add_breadcrumb).with('Works', Hyrax::Engine.routes.url_helpers.my_works_path)
+            expect(controller).to receive(:add_breadcrumb).with('test title', main_app.hyrax_generic_work_path(work.id))
+            expect(controller).to receive(:add_breadcrumb).with('image.jp2', main_app.hyrax_file_set_path(file_set))
             allow(controller.main_app).to receive(:polymorphic_path).and_call_original
-            allow(controller.main_app).to receive(:polymorphic_path).with(instance_of(Hyrax::WorkShowPresenter)).and_return("/concern/generic_works/#{work.id}?locale=en")
+            allow(controller.main_app).to receive(:polymorphic_path).with(instance_of(Hyrax::WorkShowPresenter)).and_return("/concern/generic_works/#{work.id}")
             get :show, params: { id: file_set }
             expect(response).to be_successful
           end
@@ -847,7 +847,7 @@ RSpec.describe Hyrax::FileSetsController do
         describe '#show' do
           it 'allows access to the file' do
             allow(controller.main_app).to receive(:polymorphic_path).and_call_original
-            allow(controller.main_app).to receive(:polymorphic_path).with(instance_of(Hyrax::WorkShowPresenter)).and_return("/concern/generic_works/#{work.id}?locale=en")
+            allow(controller.main_app).to receive(:polymorphic_path).with(instance_of(Hyrax::WorkShowPresenter)).and_return("/concern/generic_works/#{work.id}")
 
             get :show, params: { id: file_set }
 
@@ -868,7 +868,7 @@ RSpec.describe Hyrax::FileSetsController do
       let(:query_service) { Hyrax.query_service }
       before do
         allow(controller.main_app).to receive(:polymorphic_path).and_call_original
-        allow(controller.main_app).to receive(:polymorphic_path).with(instance_of(Hyrax::WorkShowPresenter)).and_return("/concern/generic_works/#{public_work.id}?locale=en")
+        allow(controller.main_app).to receive(:polymorphic_path).with(instance_of(Hyrax::WorkShowPresenter)).and_return("/concern/generic_works/#{public_work.id}")
         allow(controller)
           .to receive(:additional_response_formats)
           .with(ActionController::MimeResponds::Collector)
@@ -889,7 +889,7 @@ RSpec.describe Hyrax::FileSetsController do
           get :show, params: { id: private_file_set }
 
           expect(response)
-            .to fail_redirect_and_flash(main_app.new_user_session_path(locale: 'en'),
+            .to fail_redirect_and_flash(main_app.new_user_session_path,
                                         'You are not authorized to access this page.')
         end
 
@@ -919,7 +919,7 @@ RSpec.describe Hyrax::FileSetsController do
             .to receive(:additional_response_formats)
             .with(ActionController::MimeResponds::Collector)
           allow(controller.main_app).to receive(:polymorphic_path).and_call_original
-          allow(controller.main_app).to receive(:polymorphic_path).with(instance_of(Hyrax::WorkShowPresenter)).and_return("/concern/generic_works/#{active_work.id}?locale=en")
+          allow(controller.main_app).to receive(:polymorphic_path).with(instance_of(Hyrax::WorkShowPresenter)).and_return("/concern/generic_works/#{active_work.id}")
         end
         it "shows active parent" do
           get :show, params: { id: active_file_set }

--- a/spec/controllers/hyrax/generic_works_controller_json_spec.rb
+++ b/spec/controllers/hyrax/generic_works_controller_json_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe Hyrax::GenericWorksController, :active_fedora do
         expect(assigns[:curation_concern]).to be_instance_of GenericWork
         expect(controller).to render_template('hyrax/base/show')
         expect(response.code).to eq "201"
-        expect(response.location).to eq main_app.hyrax_generic_work_path(model, locale: 'en')
+        expect(response.location).to eq main_app.hyrax_generic_work_path(model)
       end
     end
 
@@ -82,7 +82,7 @@ RSpec.describe Hyrax::GenericWorksController, :active_fedora do
         expect(controller).to render_template('hyrax/base/show')
         expect(response.code).to eq "200"
         created_resource = assigns[:curation_concern]
-        expect(response.location).to eq main_app.hyrax_generic_work_path(created_resource, locale: 'en')
+        expect(response.location).to eq main_app.hyrax_generic_work_path(created_resource)
       end
     end
 

--- a/spec/controllers/hyrax/generic_works_controller_spec.rb
+++ b/spec/controllers/hyrax/generic_works_controller_spec.rb
@@ -58,10 +58,10 @@ RSpec.describe Hyrax::GenericWorksController, :active_fedora do
 
       context "without a referer" do
         it "sets breadcrumbs with complete path" do
-          expect(controller).to receive(:add_breadcrumb).with('Home', main_app.root_path(locale: 'en'))
-          expect(controller).not_to receive(:add_breadcrumb).with('Dashboard', hyrax.dashboard_path(locale: 'en'))
-          expect(controller).not_to receive(:add_breadcrumb).with('Your Works', hyrax.my_works_path(locale: 'en'))
-          expect(controller).to receive(:add_breadcrumb).with('public thing', main_app.hyrax_generic_work_path(work.id, locale: 'en'))
+          expect(controller).to receive(:add_breadcrumb).with('Home', main_app.root_path)
+          expect(controller).not_to receive(:add_breadcrumb).with('Dashboard', hyrax.dashboard_path)
+          expect(controller).not_to receive(:add_breadcrumb).with('Your Works', hyrax.my_works_path)
+          expect(controller).to receive(:add_breadcrumb).with('public thing', main_app.hyrax_generic_work_path(work.id))
           get :show, params: { id: work }
           expect(response).to be_successful
           expect(response).to render_template("layouts/hyrax/1_column")
@@ -74,10 +74,10 @@ RSpec.describe Hyrax::GenericWorksController, :active_fedora do
         end
 
         it "sets breadcrumbs to authorized pages" do
-          expect(controller).to receive(:add_breadcrumb).with('Home', main_app.root_path(locale: 'en'))
-          expect(controller).not_to receive(:add_breadcrumb).with('Dashboard', hyrax.dashboard_path(locale: 'en'))
-          expect(controller).not_to receive(:add_breadcrumb).with('Your Works', hyrax.my_works_path(locale: 'en'))
-          expect(controller).to receive(:add_breadcrumb).with('public thing', main_app.hyrax_generic_work_path(work.id, locale: 'en'))
+          expect(controller).to receive(:add_breadcrumb).with('Home', main_app.root_path)
+          expect(controller).not_to receive(:add_breadcrumb).with('Dashboard', hyrax.dashboard_path)
+          expect(controller).not_to receive(:add_breadcrumb).with('Your Works', hyrax.my_works_path)
+          expect(controller).to receive(:add_breadcrumb).with('public thing', main_app.hyrax_generic_work_path(work.id))
           get :show, params: { id: work }
           expect(response).to be_successful
           expect(response).to render_template("layouts/hyrax/1_column")
@@ -96,10 +96,10 @@ RSpec.describe Hyrax::GenericWorksController, :active_fedora do
 
       context "without a referer" do
         it "sets breadcrumbs" do
-          expect(controller).to receive(:add_breadcrumb).with('Home', Hyrax::Engine.routes.url_helpers.root_path(locale: 'en'))
-          expect(controller).to receive(:add_breadcrumb).with('Dashboard', hyrax.dashboard_path(locale: 'en'))
-          expect(controller).to receive(:add_breadcrumb).with('Works', hyrax.my_works_path(locale: 'en'))
-          expect(controller).to receive(:add_breadcrumb).with('test title', main_app.hyrax_generic_work_path(work.id, locale: 'en'))
+          expect(controller).to receive(:add_breadcrumb).with('Home', Hyrax::Engine.routes.url_helpers.root_path)
+          expect(controller).to receive(:add_breadcrumb).with('Dashboard', hyrax.dashboard_path)
+          expect(controller).to receive(:add_breadcrumb).with('Works', hyrax.my_works_path)
+          expect(controller).to receive(:add_breadcrumb).with('test title', main_app.hyrax_generic_work_path(work.id))
           get :show, params: { id: work }
           expect(response).to be_successful
         end
@@ -111,10 +111,10 @@ RSpec.describe Hyrax::GenericWorksController, :active_fedora do
         end
 
         it "sets breadcrumbs" do
-          expect(controller).to receive(:add_breadcrumb).with('Home', Hyrax::Engine.routes.url_helpers.root_path(locale: 'en'))
-          expect(controller).to receive(:add_breadcrumb).with('Dashboard', hyrax.dashboard_path(locale: 'en'))
-          expect(controller).to receive(:add_breadcrumb).with('Works', hyrax.my_works_path(locale: 'en'))
-          expect(controller).to receive(:add_breadcrumb).with('test title', main_app.hyrax_generic_work_path(work.id, locale: 'en'))
+          expect(controller).to receive(:add_breadcrumb).with('Home', Hyrax::Engine.routes.url_helpers.root_path)
+          expect(controller).to receive(:add_breadcrumb).with('Dashboard', hyrax.dashboard_path)
+          expect(controller).to receive(:add_breadcrumb).with('Works', hyrax.my_works_path)
+          expect(controller).to receive(:add_breadcrumb).with('test title', main_app.hyrax_generic_work_path(work.id))
           get :show, params: { id: work }
           expect(response).to be_successful
           expect(response).to render_template("layouts/hyrax/1_column")
@@ -284,7 +284,7 @@ RSpec.describe Hyrax::GenericWorksController, :active_fedora do
       it 'creates a work' do
         allow(controller).to receive(:curation_concern).and_return(work)
         post :create, params: { generic_work: { title: ['a title'] } }
-        expect(response).to redirect_to main_app.hyrax_generic_work_path(work, locale: 'en')
+        expect(response).to redirect_to main_app.hyrax_generic_work_path(work)
       end
     end
 
@@ -337,7 +337,7 @@ RSpec.describe Hyrax::GenericWorksController, :active_fedora do
         expect(flash[:notice]).to eq "Your files are being processed by Hyrax in the background. " \
                                      "The metadata and access controls you specified are being applied. " \
                                      "You may need to refresh this page to see these updates."
-        expect(response).to redirect_to main_app.hyrax_generic_work_path(work, locale: 'en')
+        expect(response).to redirect_to main_app.hyrax_generic_work_path(work)
       end
 
       context "from browse everything" do
@@ -391,7 +391,7 @@ RSpec.describe Hyrax::GenericWorksController, :active_fedora do
             expect(flash[:notice]).to eq "Your files are being processed by Hyrax in the background. " \
                                          "The metadata and access controls you specified are being applied. " \
                                          "You may need to refresh this page to see these updates."
-            expect(response).to redirect_to main_app.hyrax_generic_work_path(work, locale: 'en')
+            expect(response).to redirect_to main_app.hyrax_generic_work_path(work)
           end
         end
       end
@@ -403,10 +403,10 @@ RSpec.describe Hyrax::GenericWorksController, :active_fedora do
       let(:work) { create(:private_generic_work, user: user) }
 
       it 'shows me the page and sets breadcrumbs' do
-        expect(controller).to receive(:add_breadcrumb).with("Home", root_path(locale: 'en'))
-        expect(controller).to receive(:add_breadcrumb).with("Dashboard", hyrax.dashboard_path(locale: 'en'))
-        expect(controller).to receive(:add_breadcrumb).with("Works", hyrax.my_works_path(locale: 'en'))
-        expect(controller).to receive(:add_breadcrumb).with(work.title.first, main_app.hyrax_generic_work_path(work.id, locale: 'en'))
+        expect(controller).to receive(:add_breadcrumb).with("Home", root_path)
+        expect(controller).to receive(:add_breadcrumb).with("Dashboard", hyrax.dashboard_path)
+        expect(controller).to receive(:add_breadcrumb).with("Works", hyrax.my_works_path)
+        expect(controller).to receive(:add_breadcrumb).with(work.title.first, main_app.hyrax_generic_work_path(work.id))
         expect(controller).to receive(:add_breadcrumb).with('Edit', main_app.edit_hyrax_generic_work_path(work.id))
 
         get :edit, params: { id: work }
@@ -459,7 +459,7 @@ RSpec.describe Hyrax::GenericWorksController, :active_fedora do
       context "when the work has no file sets" do
         it 'updates the work' do
           patch :update, params: { id: work, generic_work: {} }
-          expect(response).to redirect_to main_app.hyrax_generic_work_path(work, locale: 'en')
+          expect(response).to redirect_to main_app.hyrax_generic_work_path(work)
         end
       end
 
@@ -469,7 +469,7 @@ RSpec.describe Hyrax::GenericWorksController, :active_fedora do
         end
         it 'updates the work' do
           patch :update, params: { id: work, generic_work: {} }
-          expect(response).to redirect_to main_app.hyrax_generic_work_path(work, locale: 'en')
+          expect(response).to redirect_to main_app.hyrax_generic_work_path(work)
         end
       end
 
@@ -487,14 +487,14 @@ RSpec.describe Hyrax::GenericWorksController, :active_fedora do
 
           it 'prompts to change the files access' do
             patch :update, params: { id: work, generic_work: { visibility: 'restricted' } }
-            expect(response).to redirect_to hyrax.confirm_access_permission_path(controller.curation_concern, locale: 'en')
+            expect(response).to redirect_to hyrax.confirm_access_permission_path(controller.curation_concern)
           end
         end
 
         context 'when the work has no file sets' do
           it "doesn't prompt to change the files access" do
             patch :update, params: { id: work, generic_work: {} }
-            expect(response).to redirect_to main_app.hyrax_generic_work_path(work, locale: 'en')
+            expect(response).to redirect_to main_app.hyrax_generic_work_path(work)
           end
         end
       end
@@ -528,7 +528,7 @@ RSpec.describe Hyrax::GenericWorksController, :active_fedora do
 
       it 'someone elses private work should update the work' do
         patch :update, params: { id: work, generic_work: {} }
-        expect(response).to redirect_to main_app.hyrax_generic_work_path(work, locale: 'en')
+        expect(response).to redirect_to main_app.hyrax_generic_work_path(work)
       end
     end
   end
@@ -544,7 +544,7 @@ RSpec.describe Hyrax::GenericWorksController, :active_fedora do
 
     it 'deletes the work' do
       delete :destroy, params: { id: work_to_be_deleted }
-      expect(response).to redirect_to Hyrax::Engine.routes.url_helpers.my_works_path(locale: 'en')
+      expect(response).to redirect_to Hyrax::Engine.routes.url_helpers.my_works_path
       expect(GenericWork).not_to exist(work_to_be_deleted.id)
     end
 
@@ -556,7 +556,7 @@ RSpec.describe Hyrax::GenericWorksController, :active_fedora do
       it 'deletes the work and updates the parent collection' do
         delete :destroy, params: { id: work_to_be_deleted }
         expect(GenericWork).not_to exist(work_to_be_deleted.id)
-        expect(response).to redirect_to Hyrax::Engine.routes.url_helpers.my_works_path(locale: 'en')
+        expect(response).to redirect_to Hyrax::Engine.routes.url_helpers.my_works_path
         expect(parent_collection.reload.members).to eq []
       end
     end

--- a/spec/controllers/hyrax/my/collections_controller_spec.rb
+++ b/spec/controllers/hyrax/my/collections_controller_spec.rb
@@ -7,9 +7,9 @@ RSpec.describe Hyrax::My::CollectionsController, :clean_repo, type: :controller 
 
     describe "#index" do
       it "sets breadcrumbs" do
-        expect(controller).to receive(:add_breadcrumb).with('Home', root_path(locale: 'en'))
-        expect(controller).to receive(:add_breadcrumb).with('Dashboard', dashboard_path(locale: 'en'))
-        expect(controller).to receive(:add_breadcrumb).with('Collections', my_collections_path(locale: 'en'))
+        expect(controller).to receive(:add_breadcrumb).with('Home', root_path)
+        expect(controller).to receive(:add_breadcrumb).with('Dashboard', dashboard_path)
+        expect(controller).to receive(:add_breadcrumb).with('Collections', my_collections_path)
         get :index, params: { per_page: 1 }
       end
 
@@ -44,7 +44,7 @@ RSpec.describe Hyrax::My::CollectionsController, :clean_repo, type: :controller 
   describe "#search_facet_path" do
     it do
       expect(controller.send(:search_facet_path, id: 'keyword_sim'))
-        .to eq "/dashboard/my/collections/facet/keyword_sim?locale=en"
+        .to eq "/dashboard/my/collections/facet/keyword_sim"
     end
   end
 

--- a/spec/controllers/hyrax/my/shares_controller_spec.rb
+++ b/spec/controllers/hyrax/my/shares_controller_spec.rb
@@ -52,6 +52,6 @@ RSpec.describe Hyrax::My::SharesController, :clean_repo, type: :controller do
   describe "#search_facet_path" do
     subject { controller.send(:search_facet_path, id: 'keyword_sim') }
 
-    it { is_expected.to eq "/dashboard/shares/facet/keyword_sim?locale=en" }
+    it { is_expected.to eq "/dashboard/shares/facet/keyword_sim" }
   end
 end

--- a/spec/controllers/hyrax/my/works_controller_spec.rb
+++ b/spec/controllers/hyrax/my/works_controller_spec.rb
@@ -17,9 +17,9 @@ RSpec.describe Hyrax::My::WorksController, type: :controller do
 
     it "shows search results and breadcrumbs" do
       expect_any_instance_of(Hyrax::SearchService).to receive(:search_results).and_return([response, doc_list])
-      expect(controller).to receive(:add_breadcrumb).with('Home', root_path(locale: 'en'))
-      expect(controller).to receive(:add_breadcrumb).with('Dashboard', dashboard_path(locale: 'en'))
-      expect(controller).to receive(:add_breadcrumb).with('Works', my_works_path(locale: 'en'))
+      expect(controller).to receive(:add_breadcrumb).with('Home', root_path)
+      expect(controller).to receive(:add_breadcrumb).with('Dashboard', dashboard_path)
+      expect(controller).to receive(:add_breadcrumb).with('Works', my_works_path)
       expect(collection_service).to receive(:all_search_results).with(:deposit).and_return([my_collection])
       get :index, params: { per_page: 2 }
       expect(assigns[:document_list].length).to eq 2
@@ -50,6 +50,6 @@ RSpec.describe Hyrax::My::WorksController, type: :controller do
   describe "#search_facet_path" do
     subject { controller.send(:search_facet_path, id: 'keyword_sim') }
 
-    it { is_expected.to eq "/dashboard/my/works/facet/keyword_sim?locale=en" }
+    it { is_expected.to eq "/dashboard/my/works/facet/keyword_sim" }
   end
 end

--- a/spec/controllers/hyrax/notifications_controller_spec.rb
+++ b/spec/controllers/hyrax/notifications_controller_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe Hyrax::NotificationsController, type: :controller do
     it "deletes message" do
       expect(mock_box).to receive(:destroy).with("4")
       delete :destroy, params: { id: "4" }
-      expect(response).to redirect_to(routes.url_helpers.notifications_path(locale: 'en'))
+      expect(response).to redirect_to(routes.url_helpers.notifications_path)
     end
   end
 end

--- a/spec/controllers/hyrax/permissions_controller_spec.rb
+++ b/spec/controllers/hyrax/permissions_controller_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe Hyrax::PermissionsController do
           .to have_enqueued_job(VisibilityCopyJob)
           .with(work)
 
-        expect(response).to redirect_to main_app.hyrax_monograph_path(work, locale: 'en')
+        expect(response).to redirect_to main_app.hyrax_monograph_path(work)
         expect(flash[:notice]).to eq 'Updating file permissions. This may take a few minutes. You may want to refresh your browser or return to this record later to see the updated file permissions.'
       end
     end
@@ -35,7 +35,7 @@ RSpec.describe Hyrax::PermissionsController do
           .to have_enqueued_job(VisibilityCopyJob)
           .with(work)
 
-        expect(response).to redirect_to main_app.hyrax_monograph_path(work, locale: 'en')
+        expect(response).to redirect_to main_app.hyrax_monograph_path(work)
         expect(flash[:notice]).to eq 'Updating file access levels. This may take a few minutes. ' \
                                      'You may want to refresh your browser or return to this record ' \
                                      'later to see the updated file access levels.'

--- a/spec/controllers/hyrax/single_use_links_controller_spec.rb
+++ b/spec/controllers/hyrax/single_use_links_controller_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe Hyrax::SingleUseLinksController, type: :controller do
         it "returns a link for downloading" do
           post 'create_download', params: { id: file }
           expect(response).to be_successful
-          expect(response.body).to eq Hyrax::Engine.routes.url_helpers.download_single_use_link_url(hash, host: request.host, locale: 'en')
+          expect(response.body).to eq Hyrax::Engine.routes.url_helpers.download_single_use_link_url(hash, host: request.host)
         end
       end
 
@@ -35,7 +35,7 @@ RSpec.describe Hyrax::SingleUseLinksController, type: :controller do
         it "returns a link for showing" do
           post 'create_show', params: { id: file }
           expect(response).to be_successful
-          expect(response.body).to eq Hyrax::Engine.routes.url_helpers.show_single_use_link_url(hash, host: request.host, locale: 'en')
+          expect(response.body).to eq Hyrax::Engine.routes.url_helpers.show_single_use_link_url(hash, host: request.host)
         end
       end
     end

--- a/spec/controllers/hyrax/single_use_links_viewer_controller_spec.rb
+++ b/spec/controllers/hyrax/single_use_links_viewer_controller_spec.rb
@@ -13,11 +13,11 @@ RSpec.describe Hyrax::SingleUseLinksViewerController do
 
   describe "retrieval links" do
     let :show_link do
-      SingleUseLink.create item_id: file.id, path: Rails.application.routes.url_helpers.hyrax_file_set_path(id: file, locale: 'en')
+      SingleUseLink.create item_id: file.id, path: Rails.application.routes.url_helpers.hyrax_file_set_path(id: file)
     end
 
     let :download_link do
-      SingleUseLink.create item_id: file.id, path: Hyrax::Engine.routes.url_helpers.download_path(id: file.id.to_s, locale: 'en')
+      SingleUseLink.create item_id: file.id, path: Hyrax::Engine.routes.url_helpers.download_path(id: file.id.to_s)
     end
 
     let(:show_link_hash) { show_link.download_key }

--- a/spec/controllers/hyrax/stats_controller_spec.rb
+++ b/spec/controllers/hyrax/stats_controller_spec.rb
@@ -17,10 +17,10 @@ RSpec.describe Hyrax::StatsController do
 
   def test_loading_file_set_with_user_access # rubocop:disable Metrics/AbcSize
     expect(Hyrax::FileUsage).to receive(:new).with(file_set.id).and_return(usage)
-    expect(controller).to receive(:add_breadcrumb).with('Home', Hyrax::Engine.routes.url_helpers.root_path(locale: 'en'))
-    expect(controller).to receive(:add_breadcrumb).with(I18n.t('hyrax.dashboard.title'), Hyrax::Engine.routes.url_helpers.dashboard_path(locale: 'en'))
-    expect(controller).to receive(:add_breadcrumb).with(I18n.t('hyrax.dashboard.my.works'), Hyrax::Engine.routes.url_helpers.my_works_path(locale: 'en'))
-    expect(controller).to receive(:add_breadcrumb).with(I18n.t('hyrax.file_set.browse_view'), Rails.application.routes.url_helpers.hyrax_file_set_path(file_set, locale: 'en'))
+    expect(controller).to receive(:add_breadcrumb).with('Home', Hyrax::Engine.routes.url_helpers.root_path)
+    expect(controller).to receive(:add_breadcrumb).with(I18n.t('hyrax.dashboard.title'), Hyrax::Engine.routes.url_helpers.dashboard_path)
+    expect(controller).to receive(:add_breadcrumb).with(I18n.t('hyrax.dashboard.my.works'), Hyrax::Engine.routes.url_helpers.my_works_path)
+    expect(controller).to receive(:add_breadcrumb).with(I18n.t('hyrax.file_set.browse_view'), Rails.application.routes.url_helpers.hyrax_file_set_path(file_set))
     get :file, params: { id: file_set }
     expect(response).to be_successful
     expect(response).to render_template('stats/file')
@@ -34,7 +34,7 @@ RSpec.describe Hyrax::StatsController do
 
   def test_loading_file_user_no_access_signed_in
     get :file, params: { id: file_set }
-    expect(response).to redirect_to(Hyrax::Engine.routes.url_helpers.root_path(locale: 'en'))
+    expect(response).to redirect_to(Hyrax::Engine.routes.url_helpers.root_path)
   end
 
   context 'with ActiveFedora objects', :active_fedora do
@@ -76,10 +76,10 @@ RSpec.describe Hyrax::StatsController do
       it 'renders the stats view' do
         expect(Hyrax::Analytics).to receive(:daily_events_for_id).with(work.id, 'work-view').and_return([])
         expect(Hyrax::Analytics).to receive(:daily_events_for_id).with(work.id, 'file-set-in-work-download').and_return([])
-        expect(controller).to receive(:add_breadcrumb).with('Home', Hyrax::Engine.routes.url_helpers.root_path(locale: 'en'))
-        expect(controller).to receive(:add_breadcrumb).with(I18n.t('hyrax.dashboard.my.works'), Hyrax::Engine.routes.url_helpers.my_works_path(locale: 'en'))
-        expect(controller).to receive(:add_breadcrumb).with(I18n.t('hyrax.dashboard.title'), Hyrax::Engine.routes.url_helpers.dashboard_path(locale: 'en'))
-        expect(controller).to receive(:add_breadcrumb).with('Test title', main_app.hyrax_generic_work_path(work, locale: 'en'))
+        expect(controller).to receive(:add_breadcrumb).with('Home', Hyrax::Engine.routes.url_helpers.root_path)
+        expect(controller).to receive(:add_breadcrumb).with(I18n.t('hyrax.dashboard.my.works'), Hyrax::Engine.routes.url_helpers.my_works_path)
+        expect(controller).to receive(:add_breadcrumb).with(I18n.t('hyrax.dashboard.title'), Hyrax::Engine.routes.url_helpers.dashboard_path)
+        expect(controller).to receive(:add_breadcrumb).with('Test title', main_app.hyrax_generic_work_path(work))
         get :work, params: { id: work }
         expect(response).to be_successful
         expect(response).to render_template('stats/work')
@@ -128,10 +128,10 @@ RSpec.describe Hyrax::StatsController do
       xit 'renders the stats view' do
         expect(Hyrax::Analytics).to receive(:daily_events_for_id).with(work.id, 'work-view').and_return([])
         expect(Hyrax::Analytics).to receive(:daily_events_for_id).with(work.id, 'file-set-in-work-download').and_return([])
-        expect(controller).to receive(:add_breadcrumb).with('Home', Hyrax::Engine.routes.url_helpers.root_path(locale: 'en'))
-        expect(controller).to receive(:add_breadcrumb).with(I18n.t('hyrax.dashboard.my.works'), Hyrax::Engine.routes.url_helpers.my_works_path(locale: 'en'))
-        expect(controller).to receive(:add_breadcrumb).with(I18n.t('hyrax.dashboard.title'), Hyrax::Engine.routes.url_helpers.dashboard_path(locale: 'en'))
-        expect(controller).to receive(:add_breadcrumb).with('Test title', main_app.hyrax_monograph_path(work, locale: 'en'))
+        expect(controller).to receive(:add_breadcrumb).with('Home', Hyrax::Engine.routes.url_helpers.root_path)
+        expect(controller).to receive(:add_breadcrumb).with(I18n.t('hyrax.dashboard.my.works'), Hyrax::Engine.routes.url_helpers.my_works_path)
+        expect(controller).to receive(:add_breadcrumb).with(I18n.t('hyrax.dashboard.title'), Hyrax::Engine.routes.url_helpers.dashboard_path)
+        expect(controller).to receive(:add_breadcrumb).with('Test title', main_app.hyrax_monograph_path(work))
         get :work, params: { id: work }
         expect(response).to be_successful
         expect(response).to render_template('stats/work')

--- a/spec/controllers/hyrax/transfers_controller_spec.rb
+++ b/spec/controllers/hyrax/transfers_controller_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe Hyrax::TransfersController, type: :controller do
             }
           }
         end.to change(ProxyDepositRequest, :count).by(1)
-        expect(response).to redirect_to routes.url_helpers.transfers_path(locale: 'en')
+        expect(response).to redirect_to routes.url_helpers.transfers_path
         expect(flash[:notice]).to eq('Transfer request created')
         proxy_request = another_user.proxy_deposit_requests.first
         expect(proxy_request.work_id).to eq(work.id)
@@ -130,7 +130,7 @@ RSpec.describe Hyrax::TransfersController, type: :controller do
     end
 
     def common_response_tests
-      expect(response).to redirect_to routes.url_helpers.transfers_path(locale: 'en')
+      expect(response).to redirect_to routes.url_helpers.transfers_path
       expect(flash[:notice]).to eq("Transfer complete")
       expect(assigns[:proxy_deposit_request].status).to eq('accepted')
     end
@@ -233,7 +233,7 @@ RSpec.describe Hyrax::TransfersController, type: :controller do
     end
 
     def common_rejection_tests
-      expect(response).to redirect_to routes.url_helpers.transfers_path(locale: 'en')
+      expect(response).to redirect_to routes.url_helpers.transfers_path
       expect(flash[:notice]).to eq("Transfer rejected")
       expect(assigns[:proxy_deposit_request].status).to eq('rejected')
     end
@@ -281,7 +281,7 @@ RSpec.describe Hyrax::TransfersController, type: :controller do
     end
 
     def common_cancellation_tests
-      expect(response).to redirect_to routes.url_helpers.transfers_path(locale: 'en')
+      expect(response).to redirect_to routes.url_helpers.transfers_path
       expect(flash[:notice]).to eq("Transfer canceled")
     end
 

--- a/spec/controllers/hyrax/uploads_controller_spec.rb
+++ b/spec/controllers/hyrax/uploads_controller_spec.rb
@@ -128,7 +128,7 @@ RSpec.describe Hyrax::UploadsController do
     context "when not signed in" do
       it "is redirected to sign in" do
         delete :destroy, params: { id: uploaded_file }
-        expect(response).to redirect_to main_app.new_user_session_path(locale: 'en')
+        expect(response).to redirect_to main_app.new_user_session_path
       end
     end
   end

--- a/spec/controllers/hyrax/workflow_actions_controller_spec.rb
+++ b/spec/controllers/hyrax/workflow_actions_controller_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe Hyrax::WorkflowActionsController, type: :controller do
       sign_in(user)
 
       put :update, params: { id: work.to_param, workflow_action: { name: 'advance', comment: '' } }
-      expect(response).to redirect_to(main_app.hyrax_monograph_path(work, locale: 'en'))
+      expect(response).to redirect_to(main_app.hyrax_monograph_path(work))
     end
 
     context 'when responding to json' do

--- a/spec/features/browse_dashboard_works_spec.rb
+++ b/spec/features/browse_dashboard_works_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe "Browse Dashboard", :clean_repo, type: :feature do
     click_link "Published"
     within("#document_#{mp3_work.id}") do
       expect(page).to have_link("Display all details of Test Document MP3",
-                                href: hyrax_monograph_path(mp3_work, locale: 'en'))
+                                href: hyrax_monograph_path(mp3_work))
     end
     click_link("Remove constraint Status: Published")
 

--- a/spec/features/collection_type_spec.rb
+++ b/spec/features/collection_type_spec.rb
@@ -35,9 +35,9 @@ RSpec.describe 'collection_type', type: :feature do
       expect(page).to have_content 'Collection Type'
 
       expect(page).to have_link('Edit', count: 3)
-      expect(page).to have_link('Edit', href: hyrax.edit_admin_collection_type_path(admin_set_type.id, locale: 'en'))
-      expect(page).to have_link('Edit', href: hyrax.edit_admin_collection_type_path(user_collection_type.id, locale: 'en'))
-      expect(page).to have_link('Edit', href: hyrax.edit_admin_collection_type_path(exhibit_collection_type.id, locale: 'en'))
+      expect(page).to have_link('Edit', href: hyrax.edit_admin_collection_type_path(admin_set_type.id))
+      expect(page).to have_link('Edit', href: hyrax.edit_admin_collection_type_path(user_collection_type.id))
+      expect(page).to have_link('Edit', href: hyrax.edit_admin_collection_type_path(exhibit_collection_type.id))
       expect(page).to have_button('Delete', count: 2) # 1: Collection Type, 2: delete modal
     end
   end

--- a/spec/features/dashboard/collection_spec.rb
+++ b/spec/features/dashboard/collection_spec.rb
@@ -275,7 +275,7 @@ RSpec.describe 'collection', type: :feature, clean_repo: true do
 
       it "has properly formed collection type buttons" do
         expect(page).not_to have_selector("input[data-path$='collections/new&collection_type_id=#{collection_type.id}']")
-        expect(page).to have_selector("input[data-path$='collections/new?locale=en&collection_type_id=#{collection_type.id}']")
+        expect(page).to have_selector("input[data-path$='collections/new?collection_type_id=#{collection_type.id}']")
       end
     end
 
@@ -371,15 +371,15 @@ RSpec.describe 'collection', type: :feature, clean_repo: true do
     def check_tr_data_attributes(id, type)
       url_fragment = get_url_fragment(type)
       expect(page).to have_selector("tr[data-id='#{id}'][data-colls-hash]")
-      expect(page).to have_selector("tr[data-post-url='/dashboard/collections/#{id}/within?locale=en']")
-      expect(page).to have_selector("tr[data-post-delete-url='/#{url_fragment}/#{id}?locale=en']")
+      expect(page).to have_selector("tr[data-post-url='/dashboard/collections/#{id}/within']")
+      expect(page).to have_selector("tr[data-post-delete-url='/#{url_fragment}/#{id}']")
     end
 
     # Check data attributes have been transferred from table row to the modal
     def check_modal_data_attributes(id, type)
       url_fragment = get_url_fragment(type)
       expect(page).to have_selector("div[data-id='#{id}']")
-      expect(page).to have_selector("div[data-post-delete-url='/#{url_fragment}/#{id}?locale=en']")
+      expect(page).to have_selector("div[data-post-delete-url='/#{url_fragment}/#{id}']")
     end
 
     def get_url_fragment(type)

--- a/spec/features/edit_work_spec.rb
+++ b/spec/features/edit_work_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe 'Editing a work', :clean_repo, type: :feature do
       choose('monograph_visibility_open')
       check('agreement')
       click_on('Save changes')
-      expect(page).to have_current_path(hyrax_monograph_path(work, locale: 'en'))
+      expect(page).to have_current_path(hyrax_monograph_path(work))
       within(".work-title-wrapper") do
         expect(page).to have_content('Public')
       end

--- a/spec/features/file_manager_spec.rb
+++ b/spec/features/file_manager_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe "file manager" do
     expect(page).to have_selector("a[href='/concern/parent/#{work.id}/file_sets/#{file_set.id}']")
 
     # has a link back to parent
-    expect(page).to have_link work.title.first, href: hyrax_monograph_path(id: work.id, locale: :en)
+    expect(page).to have_link work.title.first, href: hyrax_monograph_path(id: work.id)
 
     # renders a form for each member
     expect(page).to have_selector("#sortable form", count: work.member_ids.length)

--- a/spec/features/search_spec.rb
+++ b/spec/features/search_spec.rb
@@ -70,8 +70,8 @@ RSpec.shared_examples "search functionality" do |_adapter|
       # profile property name ("keyword") rather than the original catalog
       # controller value ("keywords").
       kw_itemprop = Hyrax.config.flexible? ? "keyword" : "keywords"
-      expect(page.body).to include "<span itemprop=\"#{kw_itemprop}\"><a href=\"/catalog?f%5Bkeyword_sim%5D%5B%5D=taco&amp;locale=en\">taco</a></span>"
-      expect(page.body).to include "<span itemprop=\"#{kw_itemprop}\"><a href=\"/catalog?f%5Bkeyword_sim%5D%5B%5D=mustache&amp;locale=en\">mustache</a></span>"
+      expect(page.body).to include "<span itemprop=\"#{kw_itemprop}\"><a href=\"/catalog?f%5Bkeyword_sim%5D%5B%5D=taco\">taco</a></span>"
+      expect(page.body).to include "<span itemprop=\"#{kw_itemprop}\"><a href=\"/catalog?f%5Bkeyword_sim%5D%5B%5D=mustache\">mustache</a></span>"
     end
   end
 end

--- a/spec/features/users_spec.rb
+++ b/spec/features/users_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe "User Profile", type: :feature do
     sign_in user
   end
   let(:user) { create(:user) }
-  let(:profile_path) { Hyrax::Engine.routes.url_helpers.user_path(user, locale: 'en') }
+  let(:profile_path) { Hyrax::Engine.routes.url_helpers.user_path(user) }
 
   context 'when visiting user profile with highlighted works' do
     let(:work) { valkyrie_create(:monograph, title: 'Test Monograph 123', depositor: user.user_key) }
@@ -18,7 +18,7 @@ RSpec.describe "User Profile", type: :feature do
       expect(page).to have_content(user.email)
 
       within '.highlighted-works' do
-        expect(page).to have_link('Test Monograph 123', href: "/concern/monographs/#{work.id}?locale=en")
+        expect(page).to have_link('Test Monograph 123', href: "/concern/monographs/#{work.id}")
       end
 
       within '.panel-user' do
@@ -33,7 +33,7 @@ RSpec.describe "User Profile", type: :feature do
 
   context 'user profile' do
     let!(:dewey) { create(:user, display_name: 'Melvil Dewey') }
-    let(:dewey_path) { Hyrax::Engine.routes.url_helpers.user_path(dewey, locale: 'en') }
+    let(:dewey_path) { Hyrax::Engine.routes.url_helpers.user_path(dewey) }
 
     it 'is searchable' do
       visit profile_path

--- a/spec/javascripts/settings_spec.js
+++ b/spec/javascripts/settings_spec.js
@@ -40,7 +40,7 @@ describe("Settings", function() {
 
 // Generate a form that collection type settings
 function settingsForm() {
-    return '<form class="simple_form edit_collection_type" id="edit_collection_type" action="/admin/collection_types/3?locale=en" accept-charset="UTF-8" method="post"><input name="utf8" type="hidden" value="&#x2713;" /><input type="hidden" name="_method" value="patch" /><input type="hidden" name="authenticity_token" value="2Si+G8crN9SzhkKeVUl6gAZofiPFvm49ma998urlMgtW5fHbfzQlv71P9y8i8LybucAc3AkSrk9uwnF99jmz0A==" />' +
+    return '<form class="simple_form edit_collection_type" id="edit_collection_type" action="/admin/collection_types/3" accept-charset="UTF-8" method="post"><input name="utf8" type="hidden" value="&#x2713;" /><input type="hidden" name="_method" value="patch" /><input type="hidden" name="authenticity_token" value="2Si+G8crN9SzhkKeVUl6gAZofiPFvm49ma998urlMgtW5fHbfzQlv71P9y8i8LybucAc3AkSrk9uwnF99jmz0A==" />' +
         '  <div class="tab-content">' +
         '    <div id="settings" class="tab-pane">' +
         '      <div class="panel panel-default labels">' +
@@ -67,7 +67,7 @@ function settingsForm() {
         '    </div>' +
         '    <div class="panel-footer">' +
         '      <input type="submit" name="update_collection_type" value="Save changes" class="btn btn-primary" onclick="confirmation_needed = false;" id="update_submit" data-disable-with="Save changes" />' +
-        '      <a class="btn btn-link" href="/admin/collection_types?locale=en">Cancel</a>' +
+        '      <a class="btn btn-link" href="/admin/collection_types">Cancel</a>' +
         '    </div>' +
         '  </div>' +
         '</form>';

--- a/spec/presenters/hyrax/admin_set_presenter_spec.rb
+++ b/spec/presenters/hyrax/admin_set_presenter_spec.rb
@@ -70,7 +70,7 @@ RSpec.describe Hyrax::AdminSetPresenter, :clean_repo do
 
     subject { presenter.show_path }
 
-    it { is_expected.to eq "/admin/admin_sets/#{admin_set.id}?locale=en" }
+    it { is_expected.to eq "/admin/admin_sets/#{admin_set.id}" }
   end
 
   describe '#managed_access' do

--- a/spec/presenters/hyrax/collection_presenter_spec.rb
+++ b/spec/presenters/hyrax/collection_presenter_spec.rb
@@ -156,7 +156,7 @@ RSpec.describe Hyrax::CollectionPresenter do
   describe '#show_path' do
     subject { presenter.show_path }
 
-    it { is_expected.to eq "/dashboard/collections/#{solr_doc.id}?locale=en" }
+    it { is_expected.to eq "/dashboard/collections/#{solr_doc.id}" }
   end
 
   describe '#editor?' do

--- a/spec/presenters/hyrax/file_set_presenter_spec.rb
+++ b/spec/presenters/hyrax/file_set_presenter_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Hyrax::FileSetPresenter do
   end
 
   describe 'stats_path' do
-    its(:stats_path) { is_expected.to eq Hyrax::Engine.routes.url_helpers.stats_file_path(id: file_set, locale: 'en') }
+    its(:stats_path) { is_expected.to eq Hyrax::Engine.routes.url_helpers.stats_file_path(id: file_set) }
   end
 
   describe "#to_s" do

--- a/spec/presenters/hyrax/work_show_presenter_spec.rb
+++ b/spec/presenters/hyrax/work_show_presenter_spec.rb
@@ -205,7 +205,7 @@ RSpec.describe Hyrax::WorkShowPresenter do
     let(:work) { FactoryBot.valkyrie_create(:hyrax_work) }
     let(:solr_document) { SolrDocument.new(Hyrax::ValkyrieIndexer.for(resource: work).to_solr) }
 
-    it { expect(presenter.stats_path).to eq Hyrax::Engine.routes.url_helpers.stats_work_path(id: work, locale: 'en') }
+    it { expect(presenter.stats_path).to eq Hyrax::Engine.routes.url_helpers.stats_work_path(id: work) }
   end
 
   describe '#itemtype' do

--- a/spec/renderers/hyrax/renderers/faceted_attribute_renderer_spec.rb
+++ b/spec/renderers/hyrax/renderers/faceted_attribute_renderer_spec.rb
@@ -12,8 +12,8 @@ RSpec.describe Hyrax::Renderers::FacetedAttributeRenderer do
       %(
       <tr><th>Name</th>
       <td><ul class='tabular'>
-      <li class="attribute attribute-name"><a href="/catalog?f%5Bname_sim%5D%5B%5D=Bob&locale=en">Bob</a></li>
-      <li class="attribute attribute-name"><a href="/catalog?f%5Bname_sim%5D%5B%5D=Jessica&locale=en">Jessica</a></li>
+      <li class="attribute attribute-name"><a href="/catalog?f%5Bname_sim%5D%5B%5D=Bob">Bob</a></li>
+      <li class="attribute attribute-name"><a href="/catalog?f%5Bname_sim%5D%5B%5D=Jessica">Jessica</a></li>
       </ul></td></tr>
     )
     end
@@ -29,7 +29,7 @@ RSpec.describe Hyrax::Renderers::FacetedAttributeRenderer do
       let(:rendered_link_query) { URI.parse(rendered_link['href']).query }
 
       it "escapes content properly" do
-        expect(rendered_link_query).to eq "#{CGI.escape('f[name_sim][]')}=#{CGI.escape('John & Bob')}&locale=en"
+        expect(rendered_link_query).to eq "#{CGI.escape('f[name_sim][]')}=#{CGI.escape('John & Bob')}"
       end
     end
   end

--- a/spec/renderers/hyrax/renderers/linked_attribute_renderer_spec.rb
+++ b/spec/renderers/hyrax/renderers/linked_attribute_renderer_spec.rb
@@ -11,8 +11,8 @@ RSpec.describe Hyrax::Renderers::LinkedAttributeRenderer do
     let(:tr_content) do
       "<tr><th>Name</th>\n" \
        "<td><ul class='tabular'>" \
-       "<li class=\"attribute attribute-name\"><a href=\"/catalog?locale=en&q=Bob&amp;search_field=name\">Bob</a></li>\n" \
-       "<li class=\"attribute attribute-name\"><a href=\"/catalog?locale=en&q=Jessica&amp;search_field=name\">Jessica</a></li>\n" \
+       "<li class=\"attribute attribute-name\"><a href=\"/catalog?q=Bob&amp;search_field=name\">Bob</a></li>\n" \
+       "<li class=\"attribute attribute-name\"><a href=\"/catalog?q=Jessica&amp;search_field=name\">Jessica</a></li>\n" \
        "</ul></td></tr>"
     end
 

--- a/spec/views/hyrax/my/collections/_list_collections.html.erb_spec.rb
+++ b/spec/views/hyrax/my/collections/_list_collections.html.erb_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe 'hyrax/my/collections/_list_collections.html.erb', type: :view do
       expect(rendered).to have_selector("tr#document_#{id}")
       check_tr_data_attributes
       expect(rendered).to have_selector("tr[data-post-delete-url='/dashboard/collections/#{id}']")
-      expect(rendered).to have_link 'Collection Title', href: hyrax.dashboard_collection_path(id, locale: I18n.locale)
+      expect(rendered).to have_link 'Collection Title', href: hyrax.dashboard_collection_path(id)
       expect(rendered).to have_link 'Edit collection', href: hyrax.edit_dashboard_collection_path(id)
       expect(rendered).to have_link 'Delete collection'
       expect(rendered).to have_link 'Add to collection'


### PR DESCRIPTION
## Summary

`Hyrax::Controller#default_url_options` currently appends `locale: I18n.locale` to every URL the app generates, even when the active locale is the default. The result is that sitemap entries, canonical tags, and outbound links all carry `?locale=en` (or whichever locale is the default), and search engines index those locale-parameterized URLs as canonical.

This was originally reported downstream as a Hyku Up issue where Google was returning Italian/French/Spanish/Portuguese URLs as top results for English queries on a Hyku tenant whose default locale was English. The polluted sitemap was the discovery signal that drove Googlebot to index the locale-parameterized variants in the first place.

This PR makes the locale inclusion conditional: it is only added when the current locale differs from `I18n.default_locale`. That preserves the original intent of the method (persist a user's non-default locale across requests via route helpers) while keeping default-locale URLs clean.

Refs: notch8/hykuup_knapsack#677

## Behavior

| Active locale | Before | After |
| --- | --- | --- |
| `I18n.default_locale` | `{ locale: :en }` | `{}` |
| non-default (e.g. `:es`) | `{ locale: :es }` | `{ locale: :es }` |

## Test plan

- [ ] CI runs the new `spec/controllers/concerns/hyrax/controller_spec.rb` covering both branches
- [ ] Existing controller/feature specs still pass
- [ ] Manual check on a downstream Hyku app: hit `/sitemap` and confirm work URLs no longer contain `?locale=en`