### PR TITLE
Use display url as canonical in show html

### DIFF
--- a/app/helpers/hyrax/permalink_helper.rb
+++ b/app/helpers/hyrax/permalink_helper.rb
@@ -10,6 +10,13 @@ module Hyrax
       strip_query_string(request.base_url + Hyrax::PermalinkPath.call(presenter))
     end
 
+    # The URL used in the show page's `<link rel="canonical">` tag.
+    def canonical_url_for(presenter)
+      display_path = Hyrax.config.redirects_active? && Hyrax::RedirectsLookup.display_path_for(presenter.id.to_s)
+      return permalink_for(presenter) if display_path.blank?
+      strip_query_string(request.base_url + display_path)
+    end
+
     def copy_permalink_enabled?
       Flipflop.enabled?(:copy_permalink_button)
     end

--- a/app/services/hyrax/redirects_lookup.rb
+++ b/app/services/hyrax/redirects_lookup.rb
@@ -34,6 +34,16 @@ module Hyrax
       Hyrax::RedirectPath.find_by(from_path: normalized)
     end
 
+    # Returns the `from_path` of the row marked as the resource's display
+    # URL, or nil when no row is marked.
+    #
+    # @param resource_id [String]
+    # @return [String, nil]
+    def self.display_path_for(resource_id)
+      return nil if resource_id.blank?
+      Hyrax::RedirectPath.where(resource_id: resource_id, is_display_url: true).limit(1).pick(:from_path)
+    end
+
     def initialize(path, except_id: nil)
       @path = Hyrax::RedirectPathNormalizer.call(path)
       @except_id = except_id

--- a/app/views/hyrax/base/show.html.erb
+++ b/app/views/hyrax/base/show.html.erb
@@ -1,6 +1,6 @@
 <% provide :page_title, @presenter.page_title %>
 <% content_for :canonical_url do %>
-  <link rel="canonical" href="<%= permalink_for(@presenter) %>" />
+  <link rel="canonical" href="<%= canonical_url_for(@presenter) %>" />
 <% end %>
 
 <%= render 'shared/citations' %>

--- a/app/views/hyrax/collections/show.html.erb
+++ b/app/views/hyrax/collections/show.html.erb
@@ -1,6 +1,6 @@
 <% provide :page_title, construct_page_title(@presenter.title) %>
 <% content_for :canonical_url do %>
-  <link rel="canonical" href="<%= permalink_for(@presenter) %>" />
+  <link rel="canonical" href="<%= canonical_url_for(@presenter) %>" />
 <% end %>
 <div class="hyc-container" itemscope itemtype="http://schema.org/CollectionPage">
   <div class="row hyc-header">

--- a/spec/helpers/hyrax/permalink_helper_spec.rb
+++ b/spec/helpers/hyrax/permalink_helper_spec.rb
@@ -42,4 +42,49 @@ RSpec.describe Hyrax::PermalinkHelper, type: :helper do
       expect(helper.permalink_for(presenter)).to eq('http://example.test/concern/generic_works/abc-123')
     end
   end
+
+  describe '#canonical_url_for' do
+    let(:presenter) { double('Presenter', id: 'abc-123') }
+
+    before do
+      allow(helper.request).to receive(:base_url).and_return('http://example.test')
+      allow(Hyrax::PermalinkPath).to receive(:call).with(presenter).and_return('/concern/generic_works/abc-123')
+    end
+
+    context 'when redirects are inactive' do
+      before { allow(Hyrax.config).to receive(:redirects_active?).and_return(false) }
+
+      it 'returns the UUID permalink without querying the redirects table' do
+        expect(Hyrax::RedirectsLookup).not_to receive(:display_path_for)
+        expect(helper.canonical_url_for(presenter)).to eq('http://example.test/concern/generic_works/abc-123')
+      end
+    end
+
+    context 'when redirects are active but the record has no display URL row' do
+      before do
+        allow(Hyrax.config).to receive(:redirects_active?).and_return(true)
+        allow(Hyrax::RedirectsLookup).to receive(:display_path_for).with('abc-123').and_return(nil)
+      end
+
+      it 'falls back to the UUID permalink' do
+        expect(helper.canonical_url_for(presenter)).to eq('http://example.test/concern/generic_works/abc-123')
+      end
+    end
+
+    context 'when redirects are active and the record has a display URL row' do
+      before do
+        allow(Hyrax.config).to receive(:redirects_active?).and_return(true)
+        allow(Hyrax::RedirectsLookup).to receive(:display_path_for).with('abc-123').and_return('/preferred')
+      end
+
+      it 'returns the display alias as an absolute URL' do
+        expect(helper.canonical_url_for(presenter)).to eq('http://example.test/preferred')
+      end
+
+      it 'strips any query string from the resulting URL' do
+        allow(Hyrax::RedirectsLookup).to receive(:display_path_for).with('abc-123').and_return('/preferred?locale=en')
+        expect(helper.canonical_url_for(presenter)).to eq('http://example.test/preferred')
+      end
+    end
+  end
 end

--- a/spec/services/hyrax/redirects_lookup_spec.rb
+++ b/spec/services/hyrax/redirects_lookup_spec.rb
@@ -88,4 +88,51 @@ RSpec.describe Hyrax::RedirectsLookup do
       end
     end
   end
+
+  describe '.display_path_for' do
+    let(:resource_id) { 'res-1' }
+
+    def display_row(from_path:, resource_id:)
+      Hyrax::RedirectPath.create!(
+        from_path: from_path,
+        to_path: "/concern/generic_works/#{resource_id}",
+        permalink_path: "/concern/generic_works/#{resource_id}",
+        resource_id: resource_id,
+        is_display_url: true
+      )
+    end
+
+    context 'when a row for the resource is marked as the display URL' do
+      before do
+        existing_row(from_path: '/handle/aliased', resource_id: resource_id)
+        display_row(from_path: '/preferred', resource_id: resource_id)
+      end
+
+      it 'returns the from_path of the display row' do
+        expect(described_class.display_path_for(resource_id)).to eq('/preferred')
+      end
+    end
+
+    context 'when the resource has rows but none is marked as display URL' do
+      before { existing_row(from_path: '/handle/aliased', resource_id: resource_id) }
+
+      it 'returns nil' do
+        expect(described_class.display_path_for(resource_id)).to be_nil
+      end
+    end
+
+    context 'when the resource has no rows' do
+      it 'returns nil' do
+        expect(described_class.display_path_for(resource_id)).to be_nil
+      end
+    end
+
+    context 'with a blank resource_id' do
+      it 'returns nil without consulting the table' do
+        expect(Hyrax::RedirectPath).not_to receive(:where)
+        expect(described_class.display_path_for('')).to be_nil
+        expect(described_class.display_path_for(nil)).to be_nil
+      end
+    end
+  end
 end


### PR DESCRIPTION
### Fixes

Switches from permanent url (UUID url) to display url for `<link rel="canonical" href=...` in show pages.
