### PR TITLE
Fix analytics accessible_file_sets query

### DIFF
--- a/app/controllers/hyrax/admin/analytics/work_reports_controller.rb
+++ b/app/controllers/hyrax/admin/analytics/work_reports_controller.rb
@@ -53,16 +53,16 @@ module Hyrax
         end
 
         def accessible_file_sets
-          file_set_model_clause = "has_model_ssim:\"#{Hyrax::ModelRegistry.file_set_rdf_representations.join('" OR "')}\""
+          models = Hyrax::ModelRegistry.file_set_rdf_representations.map { |m| "\"#{m}\"" }
           if current_user.ability.admin?
             Hyrax::SolrService.query(
-              file_set_model_clause,
+              "has_model_ssim:(#{models.join(' OR ')})",
               fl: 'title_tesim, id',
               rows: 50_000
             )
           else
             Hyrax::SolrService.query(
-              "edit_access_person_ssim:#{current_user} AND #{file_set_model_clause}",
+              "edit_access_person_ssim:#{current_user} AND has_model_ssim:(#{models.join(' OR ')})",
               fl: 'title_tesim, id',
               rows: 50_000
             )

--- a/spec/controllers/hyrax/admin/analytics/work_reports_controller_spec.rb
+++ b/spec/controllers/hyrax/admin/analytics/work_reports_controller_spec.rb
@@ -3,12 +3,45 @@ require 'rails_helper'
 
 RSpec.describe Hyrax::Admin::Analytics::WorkReportsController, type: :controller do
   routes { Hyrax::Engine.routes }
+
+  around do |example|
+    current_reporting = Hyrax.config.analytics_reporting
+    Hyrax.config.analytics_reporting = true
+    example.run
+    Hyrax.config.analytics_reporting = current_reporting
+  end
+
   describe 'GET #index' do
     context 'when user is not logged in' do
       it 'redirects to the login page' do
         get :index
         expect(response).to be_redirect
         expect(flash[:alert]).to eq("You need to sign in or sign up before continuing.")
+      end
+    end
+
+    context 'when multiple file set model types are registered' do
+      let(:admin_user) { FactoryBot.create(:admin) }
+
+      before do
+        sign_in admin_user
+        allow(Hyrax::ModelRegistry).to receive(:file_set_rdf_representations)
+          .and_return(['FileSet', 'Hyrax::FileSet'])
+        allow(Hyrax::ModelRegistry).to receive(:work_rdf_representations)
+          .and_return(['GenericWork'])
+        allow(Hyrax::SolrService).to receive(:query).and_return([])
+        allow(Hyrax::Analytics).to receive(:top_events).and_return([])
+        allow(Hyrax::Analytics).to receive(:daily_events).and_return(double(results: []))
+      end
+
+      it 'constructs a valid solr query with parenthesized OR syntax for multiple file set models' do
+        expect(Hyrax::SolrService).to receive(:query)
+          .with('has_model_ssim:("FileSet" OR "Hyrax::FileSet")',
+                hash_including(fl: 'title_tesim, id', rows: 50_000))
+          .and_return([])
+
+        get :index
+        expect(response).to be_successful
       end
     end
   end


### PR DESCRIPTION
Fix analytics accessible_file_sets query when there are multiple file…_set classes by mirroring the behavior for accessible_works. Add a test

### Fixes

Fixes #issuenumber ; refs #issuenumber

### Summary

Fixes an issue with WorkReportsController.accessible_file_sets query construction by using the same approach as in accessible_works.

### Guidance for testing, such as acceptance criteria or new user interface behaviors:
New test in `spec/controllers/hyrax/admin/analytics/work_reports_controller_spec.rb` should fail without this update and pass with it. There were no existing unit tests to verify behavior of work_reports_controller past denying access.

### Type of change (for release notes)

notes-bugfix

### Detailed Description

In our local application, we have some tests for the WorkReportsController to verify some of our adjustments to analytics reporting, and we are working on our hyrax 4->5 migration. Our tests of the controller started failing without any changes to the class, and it appears to be because there are two fileset classes during transition but the solr query construction was incorrect producing `has_model_ssim:\"FileSet\" OR \"Hyrax::FileSet\"` instead of `has_model_ssim:(\"FileSet\" OR \"Hyrax::FileSet\")`, so it was triggering `no field name specified in query and no default specified via 'df' param` errors because of the lack of a field declaration on the `\"Hyrax::FileSet\"` filter parameter. This PR fixes that behavior by mirroring the approach used in `accessible_works`.

### Changes proposed in this pull request:
* Modifies query construction

@samvera/hyrax-code-reviewers
