### PR TITLE
Add orcid sub-property type to compound metadata

### DIFF
--- a/.koppie/config/metadata_profiles/m3_profile.yaml
+++ b/.koppie/config/metadata_profiles/m3_profile.yaml
@@ -979,6 +979,17 @@ properties:
     indexing: [participant_role_sim, participant_role_tesim]
     form:
       cols: 4
+  # An ORCID iD sub-property. `badge_for:` binds the iD to a sibling so the
+  # show renderer appends an inline ORCID badge next to that sibling's value
+  # instead of rendering the iD as its own row.
+  participant_orcid:
+    type: orcid
+    subproperty_of: participants
+    group: identity
+    badge_for: participant_name
+    indexing: [participant_orcid_ssim]
+    form:
+      cols: 4
   identifiers:
     available_on:
       class:

--- a/.koppie/config/metadata_profiles/m3_profile.yaml
+++ b/.koppie/config/metadata_profiles/m3_profile.yaml
@@ -938,6 +938,7 @@ properties:
     available_on:
       class:
         - GenericWork
+        - Monograph
         - CollectionResource
     data_type: array
     type: hash

--- a/.koppie/config/metadata_profiles/m3_profile.yaml
+++ b/.koppie/config/metadata_profiles/m3_profile.yaml
@@ -968,6 +968,7 @@ properties:
     group: identity
     required: true
     indexing: [participant_name_sim, participant_name_tesim]
+    search_field: participant_name_sim
     form:
       cols: 4
   participant_role:

--- a/app/assets/javascripts/hyrax/compound_metadata.js
+++ b/app/assets/javascripts/hyrax/compound_metadata.js
@@ -3,8 +3,8 @@
 // rebinding. The sentinel guards against the IIFE running twice (Turbolinks
 // re-evaluates module scripts on some navigation paths), which would stack
 // duplicate listeners. Mirrors hyrax/redirects.js.
-(function() {
-    if (document.hyraxCompoundsBound) return;
+(function () {
+    if (document.hyraxCompoundsBound) { return; }
     document.hyraxCompoundsBound = true;
 
     // Bind select2 to a `work_or_url` sub-property. The v3 API (Hyrax bundles
@@ -58,41 +58,51 @@
     }
     document.addEventListener('turbolinks:load', bindAll);
 
-    document.addEventListener('click', function(event) {
+    // Remove a compound row: persisted rows are hidden + their `_destroy` flag
+    // flipped so the server-side populator drops them; unsaved rows are
+    // removed from the DOM outright. Returns true when the click was a
+    // remove-row gesture (so the dispatcher can stop further handling).
+    function handleRemoveClick(event) {
         var removeButton = event.target.closest('[data-hyrax-compound-remove-row]');
-        if (removeButton) {
-            var row = removeButton.closest('[data-hyrax-compound-row]');
-            if (!row) return;
-            var destroyFlag = row.querySelector('[data-hyrax-compound-destroy-flag]');
-            if (destroyFlag && destroyFlag.value !== undefined) {
-                // Persisted rows: flip the _destroy flag and hide so the
-                // populator drops the row server-side.
-                destroyFlag.value = '1';
-                row.style.display = 'none';
-            } else {
-                row.parentNode.removeChild(row);
-            }
-            return;
+        if (!removeButton) { return false; }
+        var row = removeButton.closest('[data-hyrax-compound-row]');
+        if (!row) { return true; }
+        var destroyFlag = row.querySelector('[data-hyrax-compound-destroy-flag]');
+        if (destroyFlag && destroyFlag.value !== undefined) {
+            destroyFlag.value = '1';
+            row.style.display = 'none';
+        } else {
+            row.parentNode.removeChild(row);
         }
+        return true;
+    }
 
+    // Add a compound row: clone the section's template, swap the `__INDEX__`
+    // placeholder for a monotonic counter, append, and bind any select2
+    // inputs the new row carries. Returns true when the click was an
+    // add-row gesture.
+    function handleAddClick(event) {
         var addButton = event.target.closest('[data-hyrax-compound-add-row]');
-        if (!addButton) return;
+        if (!addButton) { return false; }
         var section = addButton.closest('[data-hyrax-compound]');
-        if (!section) return;
+        if (!section) { return true; }
         var template = section.querySelector('[data-hyrax-compound-row-template]');
         var rowsHost = section.querySelector('[data-hyrax-compound-rows]');
-        if (!template || !rowsHost) return;
+        if (!template || !rowsHost) { return true; }
 
-        // Monotonic counter on the section; never recycle an index after a
-        // row is removed. Fallback to row count when the attribute is missing.
         var nextIndex = parseInt(section.dataset.nextIndex, 10);
         if (isNaN(nextIndex)) {
             nextIndex = rowsHost.querySelectorAll('[data-hyrax-compound-row]').length;
         }
         var html = template.innerHTML.replace(/__INDEX__/g, nextIndex);
         rowsHost.insertAdjacentHTML('beforeend', html);
-        // Bind select2 on any work_or_url inputs in the row just added.
         bindWorkOrUrlInputs(rowsHost.lastElementChild || rowsHost);
         section.dataset.nextIndex = String(nextIndex + 1);
+        return true;
+    }
+
+    document.addEventListener('click', function (event) {
+        if (handleRemoveClick(event)) { return; }
+        handleAddClick(event);
     });
-})();
+}());

--- a/app/assets/stylesheets/hyrax/_compound_metadata.scss
+++ b/app/assets/stylesheets/hyrax/_compound_metadata.scss
@@ -48,3 +48,17 @@
     margin-right: 0.25rem;
   }
 }
+
+// Small inline ORCID iD badge appended next to a sibling sub-property value
+// when a `type: orcid` sub-property declares `badge_for:`.
+.hyrax-compound-orcid-badge {
+  display: inline-block;
+  margin-left: 0.25rem;
+  vertical-align: baseline;
+
+  img {
+    height: 1em;
+    width: auto;
+    vertical-align: -0.125em;
+  }
+}

--- a/app/assets/stylesheets/hyrax/_compound_metadata.scss
+++ b/app/assets/stylesheets/hyrax/_compound_metadata.scss
@@ -58,7 +58,7 @@
 
   img {
     height: 1em;
-    width: auto;
     vertical-align: -0.125em;
+    width: auto;
   }
 }

--- a/app/assets/stylesheets/hyrax/_compound_metadata.scss
+++ b/app/assets/stylesheets/hyrax/_compound_metadata.scss
@@ -6,11 +6,11 @@
 // in _collections.scss) that would otherwise turn each entry into a bordered
 // flex row. These rules override it regardless of source order.
 .hyrax-compound-values {
+  border: 0 !important;
   display: block !important;
   flex-direction: column;
-  border: 0 !important;
-  padding: 0 !important;
   max-width: 100%;
+  padding: 0 !important;
 
   // Force block flow on the entries/sub-properties; the label/value spans stay
   // inline so each sub-property reads as "Label: value" on one wrapping line.
@@ -23,17 +23,17 @@
   .hyrax-compound-subproperty,
   .hyrax-compound-subproperty-label,
   .hyrax-compound-subproperty-value {
-    border: 0 !important;
-    padding: 0 !important;
-    margin: 0;
     background: none;
+    border: 0 !important;
+    margin: 0;
+    padding: 0 !important;
   }
 
   // A light divider between entries.
   .hyrax-compound-entry + .hyrax-compound-entry {
+    border-top: 1px solid $gray-200 !important;
     margin-top: 0.5rem;
     padding-top: 0.5rem !important;
-    border-top: 1px solid $gray-200 !important;
   }
 
   .hyrax-compound-subproperty {

--- a/app/forms/hyrax/forms/resource_form.rb
+++ b/app/forms/hyrax/forms/resource_form.rb
@@ -71,6 +71,7 @@ module Hyrax
       # `attributes:`), so it is replay-safe.
       validation(name: :default, inherit: true) do
         validates_with Hyrax::CompoundEntryValidator
+        validates_with Hyrax::OrcidSubpropertyValidator
       end
 
       ##

--- a/app/helpers/hyrax/compound_fields_helper.rb
+++ b/app/helpers/hyrax/compound_fields_helper.rb
@@ -145,13 +145,19 @@ module Hyrax
 
       alt = t('hyrax.compound_fields.orcid.badge_alt', default: 'ORCID iD')
       label = name.present? ? t('hyrax.compound_fields.orcid.badge_aria', name: name, default: "ORCID iD for #{name}") : alt
+      # `ActionController::Base.helpers.image_tag` (not the bare `image_tag`)
+      # resolves the asset path through a full view-equivalent context, so the
+      # badge image works the same whether the helper is called from a view
+      # (helper context) or from inside `CompoundAttributeRenderer` (a non-view
+      # Ruby object that only includes the helper module).
+      img = ActionController::Base.helpers.image_tag('orcid.png', alt: alt)
       link_to "https://orcid.org/#{bare_id}",
               class: 'hyrax-compound-orcid-badge',
               target: '_blank',
               rel: 'noopener noreferrer',
               'aria-label' => label,
               title: label do
-        image_tag('orcid.png', alt: alt)
+        img
       end
     end
 

--- a/app/helpers/hyrax/compound_fields_helper.rb
+++ b/app/helpers/hyrax/compound_fields_helper.rb
@@ -126,6 +126,35 @@ module Hyrax
         default: sub_property.to_s.humanize)
     end
 
+    ##
+    # Renders a small linked ORCID iD badge. The href targets
+    # `https://orcid.org/<id>`; the bare iD is extracted from either input form
+    # (bare or full URL) via {Hyrax::OrcidValidator.extract_bare_orcid}, so the
+    # caller does not need to normalize first.
+    #
+    # @param value [String, nil] a bare ORCID iD (`0000-0000-0000-0000`) or the
+    #   full URL form
+    # @param name [String, nil] the sibling's display value; used in the
+    #   accessibility / hover label ("ORCID iD for Hosseini, Mohammad").
+    #   When blank, falls back to the plain "ORCID iD" alt text.
+    # @return [ActiveSupport::SafeBuffer, nil] the badge HTML, or nil when
+    #   +value+ is blank or unparseable.
+    def orcid_badge(value, name: nil)
+      bare_id = Hyrax::OrcidValidator.extract_bare_orcid(from: value.to_s)
+      return nil if bare_id.blank?
+
+      alt = t('hyrax.compound_fields.orcid.badge_alt', default: 'ORCID iD')
+      label = name.present? ? t('hyrax.compound_fields.orcid.badge_aria', name: name, default: "ORCID iD for #{name}") : alt
+      link_to "https://orcid.org/#{bare_id}",
+              class: 'hyrax-compound-orcid-badge',
+              target: '_blank',
+              rel: 'noopener noreferrer',
+              'aria-label' => label,
+              title: label do
+        image_tag('orcid.png', alt: alt)
+      end
+    end
+
     private
 
     # Options from a QA local authority. Uses {Hyrax::TolerantSelectService} so

--- a/app/helpers/hyrax/compound_fields_helper.rb
+++ b/app/helpers/hyrax/compound_fields_helper.rb
@@ -145,20 +145,23 @@ module Hyrax
 
       alt = t('hyrax.compound_fields.orcid.badge_alt', default: 'ORCID iD')
       label = name.present? ? t('hyrax.compound_fields.orcid.badge_aria', name: name, default: "ORCID iD for #{name}") : alt
-      # `ActionController::Base.helpers.image_tag` (not the bare `image_tag`)
-      # resolves the asset path through a full view-equivalent context, so the
-      # badge image works the same whether the helper is called from a view
-      # (helper context) or from inside `CompoundAttributeRenderer` (a non-view
-      # Ruby object that only includes the helper module).
-      img = ActionController::Base.helpers.image_tag('orcid.png', alt: alt)
-      link_to "https://orcid.org/#{bare_id}",
-              class: 'hyrax-compound-orcid-badge',
-              target: '_blank',
-              rel: 'noopener noreferrer',
-              'aria-label' => label,
-              title: label do
-        img
-      end
+      # `ActionController::Base.helpers` is a view-equivalent proxy that
+      # resolves asset paths and tag helpers without needing the caller to
+      # carry `output_buffer`. Using it for both `image_tag` and `link_to`
+      # keeps the helper safe in either context: a view (where `self` already
+      # has output_buffer) or `Hyrax::Renderers::CompoundAttributeRenderer`
+      # (a non-view Ruby object). The non-block `link_to(content, url, opts)`
+      # form is required on Rails 6.1 — the block form calls `capture` which
+      # would raise `undefined method output_buffer=` on the renderer.
+      helpers = ActionController::Base.helpers
+      img = helpers.image_tag('orcid.png', alt: alt)
+      helpers.link_to(img,
+                      "https://orcid.org/#{bare_id}",
+                      class: 'hyrax-compound-orcid-badge',
+                      target: '_blank',
+                      rel: 'noopener noreferrer',
+                      'aria-label' => label,
+                      title: label)
     end
 
     private

--- a/app/renderers/hyrax/renderers/compound_attribute_renderer.rb
+++ b/app/renderers/hyrax/renderers/compound_attribute_renderer.rb
@@ -8,7 +8,10 @@ module Hyrax
     # sub-properties produced by the SolrDocument `compound_attribute` reader —
     # and renders as a block of its populated sub-properties. Sub-property labels
     # come from the `hyrax.compound_fields.<compound>.<subproperty>` i18n keys.
-    class CompoundAttributeRenderer < AttributeRenderer
+    class CompoundAttributeRenderer < AttributeRenderer # rubocop:disable Metrics/ClassLength
+      include ActionView::Helpers::AssetTagHelper
+      include Hyrax::CompoundFieldsHelper
+
       def render
         return '' if blank_values? && !options[:include_empty]
 
@@ -51,21 +54,33 @@ module Hyrax
         pairs = entry_to_pairs(entry)
         return '' if pairs.empty?
 
-        items = pairs.map { |sub_property, value| subproperty_markup(sub_property, value) }.join
+        bindings = badge_attachments(pairs)
+        visible = pairs.reject { |(sub_property, _)| bindings[:skip].include?(sub_property) }
+        return '' if visible.empty?
+
+        items = visible.map do |sub_property, value|
+          subproperty_markup(sub_property, value, attached_orcid: bindings[:attach][sub_property])
+        end.join
         %(<div class="hyrax-compound-entry">#{items}</div>)
       end
 
-      def subproperty_markup(sub_property, value)
+      def subproperty_markup(sub_property, value, attached_orcid: nil)
         label_html = ERB::Util.h(sub_property_label(sub_property))
+        value_html = value_markup(sub_property, value).to_s
+        if attached_orcid.present?
+          badge = orcid_badge(attached_orcid, name: display_value(sub_property, value).to_s).to_s
+          value_html = "#{value_html} #{badge}" unless badge.empty?
+        end
         %(<div class="hyrax-compound-subproperty">) +
           %(<span class="hyrax-compound-subproperty-label">#{label_html}:</span> ) +
-          %(<span class="hyrax-compound-subproperty-value">#{value_markup(sub_property, value)}</span>) +
+          %(<span class="hyrax-compound-subproperty-value">#{value_html}</span>) +
           %(</div>)
       end
 
-      # Display markup for one sub-property value, by sub-property type: `url` and
-      # `work_or_url` are linked; otherwise escaped text with controlled ids
-      # translated to their term.
+      # Display markup for one sub-property value, by sub-property type: `url`
+      # and `work_or_url` are linked; `orcid` renders as a standalone badge
+      # (used when no `badge_for:` sibling is bound); otherwise escaped text
+      # with controlled ids translated to their term.
       def value_markup(sub_property, value)
         return ERB::Util.h(display_value(sub_property, value)) if value.blank?
 
@@ -76,9 +91,33 @@ module Hyrax
           work_or_url_markup(value)
         when 'controlled'
           controlled_markup(sub_property, value)
+        when 'orcid'
+          orcid_badge(value).to_s
         else
           ERB::Util.h(display_value(sub_property, value))
         end
+      end
+
+      # For each row, decide which `type: orcid` sub-properties attach inline
+      # to a sibling rather than render as their own row. Returns
+      # `{ skip: [<source>...], attach: { <target> => <orcid_value> } }`.
+      # An orcid with no `badge_for:` (or whose target is blank in this row)
+      # is left in place and renders standalone via value_markup.
+      def badge_attachments(pairs)
+        return { skip: [], attach: {} } unless options[:subproperties].is_a?(Hash)
+
+        by_key = pairs.to_h
+        skip = []
+        attach = {}
+        pairs.each do |sub_property, value|
+          spec = subproperty_spec(sub_property)
+          next unless spec.is_a?(Hash) && spec[:type].to_s == 'orcid'
+          target = spec[:badge_for].to_s
+          next if target.blank? || by_key[target].blank?
+          skip << sub_property
+          attach[target] = value
+        end
+        { skip: skip, attach: attach }
       end
 
       # A controlled value displays its authority/value-list term. When the

--- a/app/renderers/hyrax/renderers/compound_attribute_renderer.rb
+++ b/app/renderers/hyrax/renderers/compound_attribute_renderer.rb
@@ -80,7 +80,9 @@ module Hyrax
       # Display markup for one sub-property value, by sub-property type: `url`
       # and `work_or_url` are linked; `orcid` renders as a standalone badge
       # (used when no `badge_for:` sibling is bound); otherwise escaped text
-      # with controlled ids translated to their term.
+      # with controlled ids translated to their term. A string sub-property
+      # that declares `search_field:` is wrapped in a facet search link to
+      # that Solr field, matching the scalar `render_as: faceted` behavior.
       def value_markup(sub_property, value)
         return ERB::Util.h(display_value(sub_property, value)) if value.blank?
 
@@ -94,8 +96,21 @@ module Hyrax
         when 'orcid'
           orcid_badge(value).to_s
         else
-          ERB::Util.h(display_value(sub_property, value))
+          string_markup(sub_property, value)
         end
+      end
+
+      # Plain string: facet-link the value when the sub-property opts in via
+      # `search_field:`, otherwise escape and emit verbatim.
+      def string_markup(sub_property, value)
+        spec = subproperty_spec(sub_property)
+        facet = spec.is_a?(Hash) ? spec[:search_field].to_s : ''
+        display = display_value(sub_property, value)
+        return ERB::Util.h(display) if facet.blank?
+
+        link_to(ERB::Util.h(display),
+                Rails.application.routes.url_helpers
+                     .search_catalog_path("f[#{ERB::Util.h(facet)}][]": value, locale: I18n.locale))
       end
 
       # For each row, decide which `type: orcid` sub-properties attach inline

--- a/app/renderers/hyrax/renderers/compound_attribute_renderer.rb
+++ b/app/renderers/hyrax/renderers/compound_attribute_renderer.rb
@@ -94,7 +94,9 @@ module Hyrax
         when 'controlled'
           controlled_markup(sub_property, value)
         when 'orcid'
-          orcid_badge(value).to_s
+          # When the value is unparseable, `orcid_badge` returns nil — fall
+          # back to escaped text so the stored value is still visible.
+          orcid_badge(value).presence || ERB::Util.h(value.to_s)
         else
           string_markup(sub_property, value)
         end
@@ -116,8 +118,10 @@ module Hyrax
       # For each row, decide which `type: orcid` sub-properties attach inline
       # to a sibling rather than render as their own row. Returns
       # `{ skip: [<source>...], attach: { <target> => <orcid_value> } }`.
-      # An orcid with no `badge_for:` (or whose target is blank in this row)
-      # is left in place and renders standalone via value_markup.
+      # An orcid is skipped (and the badge attached) only when its value
+      # parses to a bare iD via {Hyrax::OrcidValidator.extract_bare_orcid} —
+      # an unparseable value falls back to its own row so the stored value
+      # is still surfaced on the show page rather than silently dropped.
       def badge_attachments(pairs)
         return { skip: [], attach: {} } unless options[:subproperties].is_a?(Hash)
 
@@ -129,6 +133,7 @@ module Hyrax
           next unless spec.is_a?(Hash) && spec[:type].to_s == 'orcid'
           target = spec[:badge_for].to_s
           next if target.blank? || by_key[target].blank?
+          next if Hyrax::OrcidValidator.extract_bare_orcid(from: value.to_s).blank?
           skip << sub_property
           attach[target] = value
         end

--- a/app/services/hyrax/compound_schema.rb
+++ b/app/services/hyrax/compound_schema.rb
@@ -251,7 +251,8 @@ module Hyrax
         required: truthy?(opts['required']),
         group: opts['group']&.to_s,
         cols: (form['cols'] || DEFAULT_COLS).to_i,
-        as: form['as']&.to_s }
+        as: form['as']&.to_s,
+        badge_for: opts['badge_for']&.to_s }
     end
 
     # Whether the compound itself is required (at least one row must exist).

--- a/app/services/hyrax/compound_schema.rb
+++ b/app/services/hyrax/compound_schema.rb
@@ -252,7 +252,8 @@ module Hyrax
         group: opts['group']&.to_s,
         cols: (form['cols'] || DEFAULT_COLS).to_i,
         as: form['as']&.to_s,
-        badge_for: opts['badge_for']&.to_s }
+        badge_for: opts['badge_for']&.to_s,
+        search_field: opts['search_field']&.to_s }
     end
 
     # Whether the compound itself is required (at least one row must exist).

--- a/app/services/hyrax/flexible_schema_validators/compound_validator.rb
+++ b/app/services/hyrax/flexible_schema_validators/compound_validator.rb
@@ -52,10 +52,48 @@ module Hyrax
           return
         end
 
-        return unless config['type'].to_s == 'controlled'
-        return if config['authority'].present? || config['values'].present?
+        case config['type'].to_s
+        when 'controlled' then validate_controlled_source(name, config)
+        when 'orcid'      then validate_orcid(name, config, parent_name)
+        end
+      end
 
+      def validate_controlled_source(name, config)
+        return if config['authority'].present? || config['values'].present?
         @errors << t('controlled_without_source', property: name)
+      end
+
+      # An orcid sub-property must not declare an option source (it is a
+      # free-text iD, not a controlled vocabulary). Its optional `badge_for:`
+      # must name a sibling sub-property on the same compound parent — not
+      # itself, and not a property that lives outside the parent.
+      def validate_orcid(name, config, parent_name)
+        if config['authority'].present? || config['values'].present?
+          @errors << t('orcid_with_option_source',
+                       property: name,
+                       default: "Sub-property `#{name}` declares type: orcid and must not set authority: or values:.")
+        end
+        validate_badge_for(name, config, parent_name)
+      end
+
+      def validate_badge_for(name, config, parent_name)
+        badge_for = config['badge_for'].to_s
+        return if badge_for.blank?
+
+        if badge_for == name.to_s
+          @errors << t('orcid_badge_for_self',
+                       property: name,
+                       default: "Sub-property `#{name}` declares badge_for: pointing at itself.")
+          return
+        end
+
+        target = properties[badge_for]
+        return if target.is_a?(Hash) && target['subproperty_of'].to_s == parent_name
+
+        @errors << t('orcid_badge_for_unknown_sibling',
+                     property: name, target: badge_for, parent: parent_name,
+                     default: "Sub-property `#{name}` declares badge_for: `#{badge_for}`, " \
+                              "which is not a sibling sub-property of `#{parent_name}`.")
       end
 
       # A top-level `indexing:` on a parent would point the catalog at a

--- a/app/validators/hyrax/orcid_subproperty_validator.rb
+++ b/app/validators/hyrax/orcid_subproperty_validator.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+module Hyrax
+  # Validates every `type: orcid` sub-property value on a compound's persisted
+  # rows. A blank value is allowed (required-ness lives in
+  # {Hyrax::CompoundEntryValidator}); a non-blank value must match
+  # {Hyrax::OrcidValidator::ORCID_REGEXP} in either the bare-iD form
+  # (`0000-0000-0000-0000`) or the full `https://orcid.org/` URL form.
+  #
+  # Adds one error per offending row to `:base`, naming the compound and the
+  # offending sub-property — same keying convention {Hyrax::CompoundEntryValidator}
+  # uses so work and collection forms render the message cleanly. See
+  # documentation/compound_fields.md.
+  class OrcidSubpropertyValidator < ActiveModel::Validator
+    def validate(record)
+      schema = Hyrax::CompoundSchema.for(schema_source(record))
+      schema.definitions.each do |name, definition|
+        next unless record.respond_to?(name)
+        validate_compound(record, name, definition)
+      end
+    rescue StandardError => e
+      Hyrax.logger.debug("OrcidSubpropertyValidator: #{e.message}")
+    end
+
+    private
+
+    # The schema declarations live on the underlying resource, not the form
+    # wrapper: a Reform form exposes it as `model`. Fall back to the record
+    # itself (e.g. a plain ActiveModel object in unit tests).
+    def schema_source(record)
+      record.respond_to?(:model) ? record.model : record
+    end
+
+    def validate_compound(record, name, definition)
+      orcid_keys = definition[:subproperties].select { |_key, spec| spec[:type].to_s == 'orcid' }.keys
+      return if orcid_keys.empty?
+
+      Array(record.public_send(name)).each do |entry|
+        next unless entry.is_a?(Hash)
+        orcid_keys.each do |sub_property|
+          value = entry[sub_property] || entry[sub_property.to_sym]
+          next if value.blank?
+          next if Hyrax::OrcidValidator::ORCID_REGEXP.match?(value.to_s)
+          record.errors.add(:base, message_for(name, sub_property, value))
+        end
+      end
+    end
+
+    def message_for(name, sub_property, value)
+      I18n.t('hyrax.compound_fields.orcid.invalid',
+             compound: compound_label(name),
+             field: subproperty_label(name, sub_property),
+             value: value,
+             default: %("#{value}" is not a valid ORCID iD for #{compound_label(name)} > #{subproperty_label(name, sub_property)}.))
+    end
+
+    def compound_label(name)
+      I18n.t("hyrax.compound_fields.#{name}.label", default: name.to_s.humanize)
+    end
+
+    def subproperty_label(compound_name, sub_property)
+      I18n.t("hyrax.compound_fields.#{compound_name}.#{sub_property}", default: sub_property.to_s.humanize)
+    end
+  end
+end

--- a/app/views/hyrax/compounds/_compound_row.html.erb
+++ b/app/views/hyrax/compounds/_compound_row.html.erb
@@ -10,8 +10,8 @@
       row_label_singular - "Contributor", "License", etc.
 
     Each sub-property renders according to its declared `type:` (string,
-    controlled, url, work_or_url). db_table / geocode are future types; the
-    `else` branch is the extension seam.
+    controlled, url, work_or_url, orcid). db_table / geocode are future types;
+    the `else` branch is the extension seam.
 %>
 <% subproperties = definition[:subproperties] %>
 <% groups = definition[:groups] %>
@@ -56,6 +56,14 @@
               <%= url_field_tag input_name, value,
                                 id: input_id,
                                 class: 'form-control form-control-sm' %>
+            <% when 'orcid' %>
+              <%# A bare iD (0000-0000-0000-0000) or the full https://orcid.org/ URL.
+                  Hyrax::OrcidSubpropertyValidator normalizes either form on save. %>
+              <%= text_field_tag input_name, value,
+                                 id: input_id,
+                                 class: 'form-control form-control-sm',
+                                 placeholder: t('hyrax.compound_fields.orcid.placeholder', default: '0000-0000-0000-0000'),
+                                 autocomplete: 'off' %>
             <% when 'work_or_url' %>
               <%# select2 v3 (bound in compound_metadata.js) binds to this
                   hidden input; `data-label` pre-seeds the displayed text. %>

--- a/app/views/hyrax/compounds/_compound_row.html.erb
+++ b/app/views/hyrax/compounds/_compound_row.html.erb
@@ -58,7 +58,9 @@
                                 class: 'form-control form-control-sm' %>
             <% when 'orcid' %>
               <%# A bare iD (0000-0000-0000-0000) or the full https://orcid.org/ URL.
-                  Hyrax::OrcidSubpropertyValidator normalizes either form on save. %>
+                  Hyrax::OrcidSubpropertyValidator accepts either form (the show
+                  renderer extracts the bare iD via Hyrax::OrcidValidator);
+                  the stored value is kept as the user typed it. %>
               <%= text_field_tag input_name, value,
                                  id: input_id,
                                  class: 'form-control form-control-sm',

--- a/config/locales/hyrax.de.yml
+++ b/config/locales/hyrax.de.yml
@@ -864,6 +864,12 @@ de:
         number_of_results_to_display_per_page: Anzahl der Ergebnisse die pro Seite angezeigt werden
         results_per_page: "Ergebnisse pro Seite:"
         sort_by_html: "<span>Sortieren nach:</span>"
+    compound_fields:
+      orcid:
+        badge_alt: ORCID iD
+        badge_aria: ORCID iD von %{name}
+        invalid: "%{compound} > %{field}: \"%{value}\" ist keine gültige ORCID iD"
+        placeholder: 0000-0000-0000-0000
     contact_form:
       button_label: Senden
       email_label: Ihre E-Mail

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -870,6 +870,11 @@ en:
         title: Title
         participant_name: Name
         participant_role: Role
+      orcid:
+        badge_alt: ORCID iD
+        badge_aria: ORCID iD for %{name}
+        invalid: "%{compound} > %{field}: \"%{value}\" is not a valid ORCID iD"
+        placeholder: 0000-0000-0000-0000
       identifiers:
         label: Identifiers
         identifier: Identifier
@@ -1420,6 +1425,9 @@ en:
           unknown_parent: "m3 profile subproperty `%{property}` declares `subproperty_of: %{parent}`, but `%{parent}` is not a declared `type: hash` compound property"
           controlled_without_source: "m3 profile compound subproperty `%{property}` is `type: controlled` but declares neither `authority` nor `values`"
           top_level_indexing: "m3 profile compound property `%{property}` must not declare top-level `indexing`; declare `indexing` (or `index_keys`) on each subproperty instead"
+          orcid_with_option_source: "m3 profile compound subproperty `%{property}` is `type: orcid` and must not declare `authority` or `values` (ORCID iDs are free-text, not a controlled vocabulary)"
+          orcid_badge_for_self: "m3 profile compound subproperty `%{property}` declares `badge_for: %{property}` (it cannot point at itself)"
+          orcid_badge_for_unknown_sibling: "m3 profile compound subproperty `%{property}` declares `badge_for: %{target}`, but `%{target}` is not a sibling sub-property of `%{parent}`"
       redirects_validator:
         errors:
           invalid_available_on: "m3 profile `redirects` property must be available on at least one work or collection class declared in this profile"

--- a/config/locales/hyrax.es.yml
+++ b/config/locales/hyrax.es.yml
@@ -870,6 +870,12 @@ es:
         number_of_results_to_display_per_page: Número de resultados a mostrar por página
         results_per_page: "Resultados por página:"
         sort_by_html: "<span>Tipo:</span>"
+    compound_fields:
+      orcid:
+        badge_alt: ORCID iD
+        badge_aria: ORCID iD de %{name}
+        invalid: "%{compound} > %{field}: \"%{value}\" no es un ORCID iD válido"
+        placeholder: 0000-0000-0000-0000
     contact_form:
       button_label: Enviar
       email_label: Tu Correo Electrónico

--- a/config/locales/hyrax.fr.yml
+++ b/config/locales/hyrax.fr.yml
@@ -871,6 +871,12 @@ fr:
         number_of_results_to_display_per_page: Nombre de résultats à afficher par page
         results_per_page: "Résultats par page:"
         sort_by_html: "<span>Trier par:</span>"
+    compound_fields:
+      orcid:
+        badge_alt: Identifiant ORCID
+        badge_aria: Identifiant ORCID de %{name}
+        invalid: "%{compound} > %{field} : \"%{value}\" n'est pas un identifiant ORCID valide"
+        placeholder: 0000-0000-0000-0000
     contact_form:
       button_label: Envoyer
       email_label: Votre Email

--- a/config/locales/hyrax.it.yml
+++ b/config/locales/hyrax.it.yml
@@ -870,6 +870,12 @@ it:
         number_of_results_to_display_per_page: Numero di risultati da visualizzare per pagina
         results_per_page: "Risultati per la pagina:"
         sort_by_html: "<span>Ordina per:</span>"
+    compound_fields:
+      orcid:
+        badge_alt: ORCID iD
+        badge_aria: ORCID iD di %{name}
+        invalid: "%{compound} > %{field}: \"%{value}\" non è un ORCID iD valido"
+        placeholder: 0000-0000-0000-0000
     contact_form:
       button_label: Inviare
       email_label: La tua email

--- a/config/locales/hyrax.pt-BR.yml
+++ b/config/locales/hyrax.pt-BR.yml
@@ -863,6 +863,12 @@ pt-BR:
         number_of_results_to_display_per_page: Número de resultados exibidos por página
         results_per_page: "Resultados por página:"
         sort_by_html: "<span>Ordenar por:</span>"
+    compound_fields:
+      orcid:
+        badge_alt: ORCID iD
+        badge_aria: ORCID iD de %{name}
+        invalid: "%{compound} > %{field}: \"%{value}\" não é um ORCID iD válido"
+        placeholder: 0000-0000-0000-0000
     contact_form:
       button_label: Enviar
       email_label: Seu email

--- a/config/locales/hyrax.zh.yml
+++ b/config/locales/hyrax.zh.yml
@@ -868,6 +868,12 @@ zh:
         number_of_results_to_display_per_page: 数量的结果显示，每页
         results_per_page: 每页结果
         sort_by_html: "<跨>排序：</跨>"
+    compound_fields:
+      orcid:
+        badge_alt: ORCID iD
+        badge_aria: "%{name} 的 ORCID iD"
+        invalid: "%{compound} > %{field}：\"%{value}\" 不是有效的 ORCID iD"
+        placeholder: 0000-0000-0000-0000
     contact_form:
       button_label: 发送
       email_label: 您的邮件

--- a/config/metadata/compound_metadata.yaml
+++ b/config/metadata/compound_metadata.yaml
@@ -70,6 +70,19 @@ attributes:
     index_keys: [participant_role_sim, participant_role_tesim]
     form:
       cols: 4
+  # An ORCID iD sub-property. `badge_for:` binds the iD to a sibling so the
+  # show renderer appends an inline ORCID badge next to that sibling's value
+  # instead of rendering the iD as its own row. Accepts either the bare iD
+  # (0000-0000-0000-0000) or the full https://orcid.org/ URL; the validator
+  # rejects anything else.
+  participant_orcid:
+    type: orcid
+    subproperty_of: participants
+    group: identity
+    badge_for: participant_name
+    index_keys: [participant_orcid_ssim]
+    form:
+      cols: 4
 
   # A typed identifier: an open-entry value plus a controlled identifier type.
   # Named `identifiers` (plural) to avoid colliding with the scalar `identifier`

--- a/config/metadata/compound_metadata.yaml
+++ b/config/metadata/compound_metadata.yaml
@@ -57,6 +57,10 @@ attributes:
     group: identity
     required: true
     index_keys: [participant_name_sim, participant_name_tesim]
+    # `search_field:` opts a string sub-property into faceted-link display:
+    # on show, the value renders as a link to a catalog search filtered on
+    # the named Solr field, matching the scalar `render_as: faceted` path.
+    search_field: participant_name_sim
     form:
       cols: 4
   # A controlled sub-property can take its options from an inline list (below)

--- a/config/metadata_profiles/m3_profile.yaml
+++ b/config/metadata_profiles/m3_profile.yaml
@@ -994,6 +994,7 @@ properties:
     group: identity
     required: true
     indexing: [participant_name_sim, participant_name_tesim]
+    search_field: participant_name_sim
     form:
       cols: 4
   participant_role:

--- a/config/metadata_profiles/m3_profile.yaml
+++ b/config/metadata_profiles/m3_profile.yaml
@@ -963,7 +963,7 @@ properties:
       class:
         - Hyrax::Work
         - Monograph
-        - GenericWork
+        - GenericWorkResource
         - CollectionResource
     data_type: array
     type: hash

--- a/config/metadata_profiles/m3_profile.yaml
+++ b/config/metadata_profiles/m3_profile.yaml
@@ -962,6 +962,8 @@ properties:
     available_on:
       class:
         - Hyrax::Work
+        - Monograph
+        - GenericWork
         - CollectionResource
     data_type: array
     type: hash

--- a/config/metadata_profiles/m3_profile.yaml
+++ b/config/metadata_profiles/m3_profile.yaml
@@ -1005,6 +1005,17 @@ properties:
     indexing: [participant_role_sim, participant_role_tesim]
     form:
       cols: 4
+  # An ORCID iD sub-property. `badge_for:` binds the iD to a sibling so the
+  # show renderer appends an inline ORCID badge next to that sibling's value
+  # instead of rendering the iD as its own row.
+  participant_orcid:
+    type: orcid
+    subproperty_of: participants
+    group: identity
+    badge_for: participant_name
+    indexing: [participant_orcid_ssim]
+    form:
+      cols: 4
   identifiers:
     available_on:
       class:

--- a/documentation/compound_fields.md
+++ b/documentation/compound_fields.md
@@ -112,7 +112,7 @@ textarea). Supported `type:` values:
 
 | `type:`      | Renders as          | Notes |
 |--------------|---------------------|-------|
-| `string`     | text input          | The default when `type:` is omitted. |
+| `string`     | text input          | The default when `type:` is omitted. Add `search_field: <solr_field>` to wrap the show-page value in a link to a catalog search filtered on that Solr field (same affordance the scalar `render_as: faceted` path provides). |
 | `url`        | url input → auto-linked on show | The stored value is rendered as a clickable `<a href>` on show pages (matching the scalar `render_as: external_link` behavior). |
 | `work_or_url` | select2 typeahead → linked on show | Searches internal works (via the `compound_works` QA authority, backed by `Hyrax::CompoundWorkPickerBuilder`) **or** accepts a typed external URL. The stored value is a work id or a URL; on show, a work id links to the work's show page with its title (resolved by `Hyrax::CompoundWorkResolver`), a URL is auto-linked. |
 | `controlled` | `<select>` dropdown | Options come from either an inline `values:` list or a QA local authority named by `authority:` (see below). The row's stored value is preserved even if it is no longer offered, matching the `include_current_value` convention of the ordinary controlled-field partials. |

--- a/documentation/compound_fields.md
+++ b/documentation/compound_fields.md
@@ -116,6 +116,7 @@ textarea). Supported `type:` values:
 | `url`        | url input → auto-linked on show | The stored value is rendered as a clickable `<a href>` on show pages (matching the scalar `render_as: external_link` behavior). |
 | `work_or_url` | select2 typeahead → linked on show | Searches internal works (via the `compound_works` QA authority, backed by `Hyrax::CompoundWorkPickerBuilder`) **or** accepts a typed external URL. The stored value is a work id or a URL; on show, a work id links to the work's show page with its title (resolved by `Hyrax::CompoundWorkResolver`), a URL is auto-linked. |
 | `controlled` | `<select>` dropdown | Options come from either an inline `values:` list or a QA local authority named by `authority:` (see below). The row's stored value is preserved even if it is no longer offered, matching the `include_current_value` convention of the ordinary controlled-field partials. |
+| `orcid` | text input → ORCID iD badge on show | Accepts either a bare iD (`0000-0000-0000-0000`) or the full `https://orcid.org/` URL; `Hyrax::OrcidSubpropertyValidator` blocks save on a malformed value. On show, an optional `badge_for:` declaration attaches the iD inline as a linked badge next to the named sibling sub-property (matching Zenodo's "name [iD]" treatment) instead of rendering as its own row. See [ORCID badges](#orcid-badges) below. |
 
 A `controlled` sub-property sources its options one of two ways:
 
@@ -161,6 +162,56 @@ them. `geocode` generalizes the existing single-value controlled-URI location
 field — see `Hyrax::BasedNearFieldBehavior` and
 [`field_behaviors.md`](field_behaviors.md), which `geocode` is intended to
 replace once it lands.
+
+### ORCID badges (`type: orcid` + `badge_for:`)
+
+An `orcid` sub-property carries an [ORCID iD](https://orcid.org/) and can
+attach inline to a sibling sub-property as a small linked badge on the show
+page — matching Zenodo's treatment of author names. The sample
+`participants` compound demonstrates the pattern:
+
+```yaml
+participant_name:
+  type: string
+  subproperty_of: participants
+  group: identity
+  index_keys: [participant_name_sim, participant_name_tesim]
+  form: { cols: 4 }
+
+participant_orcid:
+  type: orcid
+  subproperty_of: participants
+  group: identity
+  badge_for: participant_name        # attach the badge to this sibling on show
+  index_keys: [participant_orcid_ssim]
+  form: { cols: 4 }
+```
+
+The form input accepts either the bare iD (`0000-0000-0000-0000`) or the
+full `https://orcid.org/` URL; `Hyrax::OrcidSubpropertyValidator` blocks
+save on a malformed value (a blank value is allowed —
+required-ness lives in `Hyrax::CompoundEntryValidator`).
+
+On the show page, `Hyrax::CompoundAttributeRenderer` consumes an orcid
+whose `badge_for:` names a sibling that has a value in the same row,
+appending a linked ORCID badge inside that sibling's value markup and
+omitting the orcid as its own labeled row. The badge points at
+`https://orcid.org/<id>` and carries an `aria-label` / `title` of "ORCID iD
+for <sibling value>" so screen readers and tooltips identify the link
+target. The bare iD is extracted from either input form via
+`Hyrax::OrcidValidator.extract_bare_orcid`.
+
+`badge_for:` is optional. An orcid sub-property declared without it — or
+one whose `badge_for:` target is blank in a given row — falls back to
+rendering as its own labeled row, with the badge icon + linked iD as the
+value. So the same `type: orcid` works whether or not it is bound.
+
+In flexible mode, `Hyrax::FlexibleSchemaValidators::CompoundValidator`
+catches misconfiguration on m3 profile save: a `type: orcid` sub-property
+must not declare `authority:` or `values:` (orcid is a free-text iD, not
+a controlled vocabulary), and `badge_for:` must name a sibling
+sub-property on the same compound parent — not itself, and not a property
+that lives outside the parent.
 
 ### Grouping (`group:` + `groups:`, optional)
 

--- a/spec/forms/hyrax/forms/compound_metadata_form_spec.rb
+++ b/spec/forms/hyrax/forms/compound_metadata_form_spec.rb
@@ -85,7 +85,8 @@ RSpec.describe 'Compound metadata form flow', type: :model, unless: Hyrax.config
     it 'populates the compound on the form during validate' do
       form.validate(params)
       expect(form.participants)
-        .to eq([{ 'participant_title' => 'Dr', 'participant_name' => 'Ada Lovelace', 'participant_role' => 'Author' }])
+        .to eq([{ 'participant_title' => 'Dr', 'participant_name' => 'Ada Lovelace',
+                  'participant_role' => 'Author', 'participant_orcid' => nil }])
       expect(form.identifiers)
         .to eq([{ 'identifier_value' => '10.1234/x', 'identifier_type' => 'DOI' }])
     end
@@ -94,7 +95,8 @@ RSpec.describe 'Compound metadata form flow', type: :model, unless: Hyrax.config
       form.validate(params)
       form.sync
       expect(form.model.participants)
-        .to eq([{ 'participant_title' => 'Dr', 'participant_name' => 'Ada Lovelace', 'participant_role' => 'Author' }])
+        .to eq([{ 'participant_title' => 'Dr', 'participant_name' => 'Ada Lovelace',
+                  'participant_role' => 'Author', 'participant_orcid' => nil }])
       expect(form.model.identifiers)
         .to eq([{ 'identifier_value' => '10.1234/x', 'identifier_type' => 'DOI' }])
     end
@@ -105,7 +107,8 @@ RSpec.describe 'Compound metadata form flow', type: :model, unless: Hyrax.config
           '1' => { 'participant_name' => 'Remove', '_destroy' => 'true' },
           '2' => { 'participant_title' => '', 'participant_name' => '', 'participant_role' => '' } })
       form.sync
-      expect(form.model.participants).to eq([{ 'participant_title' => nil, 'participant_name' => 'Keep', 'participant_role' => 'Author' }])
+      expect(form.model.participants).to eq([{ 'participant_title' => nil, 'participant_name' => 'Keep',
+                                               'participant_role' => 'Author', 'participant_orcid' => nil }])
     end
   end
 

--- a/spec/helpers/hyrax/compound_fields_helper_spec.rb
+++ b/spec/helpers/hyrax/compound_fields_helper_spec.rb
@@ -129,4 +129,50 @@ RSpec.describe Hyrax::CompoundFieldsHelper, type: :helper do
       end
     end
   end
+
+  describe '#orcid_badge' do
+    let(:bare_id) { '0000-0002-2385-985X' }
+
+    it 'returns nil when the value is blank' do
+      expect(helper.orcid_badge(nil)).to be_nil
+      expect(helper.orcid_badge('')).to be_nil
+    end
+
+    it 'returns nil for an unparseable value' do
+      expect(helper.orcid_badge('not-an-orcid')).to be_nil
+    end
+
+    it 'links to https://orcid.org/<id> with the bare iD when given the bare form' do
+      html = helper.orcid_badge(bare_id)
+      expect(html).to match(%r{href="https://orcid\.org/#{bare_id}"})
+    end
+
+    it 'links to https://orcid.org/<id> when given the full URL form' do
+      html = helper.orcid_badge("https://orcid.org/#{bare_id}")
+      expect(html).to match(%r{href="https://orcid\.org/#{bare_id}"})
+    end
+
+    it 'opens in a new tab with rel=noopener noreferrer' do
+      html = helper.orcid_badge(bare_id)
+      expect(html).to include('target="_blank"')
+      expect(html).to include('rel="noopener noreferrer"')
+    end
+
+    it 'uses the sibling name in the aria-label and title when provided' do
+      html = helper.orcid_badge(bare_id, name: 'Hosseini, Mohammad')
+      expect(html).to include('aria-label="ORCID iD for Hosseini, Mohammad"')
+      expect(html).to include('title="ORCID iD for Hosseini, Mohammad"')
+    end
+
+    it 'falls back to the plain alt text when no sibling name is given' do
+      html = helper.orcid_badge(bare_id)
+      expect(html).to include('aria-label="ORCID iD"')
+    end
+
+    it 'renders the orcid.png image with an alt attribute' do
+      html = helper.orcid_badge(bare_id)
+      expect(html).to match(/<img[^>]*alt="ORCID iD"/)
+      expect(html).to match(/<img[^>]*src="[^"]*orcid[^"]*\.png"/)
+    end
+  end
 end

--- a/spec/helpers/hyrax/compound_fields_helper_spec.rb
+++ b/spec/helpers/hyrax/compound_fields_helper_spec.rb
@@ -172,7 +172,9 @@ RSpec.describe Hyrax::CompoundFieldsHelper, type: :helper do
     it 'renders the orcid.png image with an alt attribute' do
       html = helper.orcid_badge(bare_id)
       expect(html).to match(/<img[^>]*alt="ORCID iD"/)
-      expect(html).to match(/<img[^>]*src="[^"]*orcid[^"]*\.png"/)
+      # Asset-pipeline-resolved path (rooted) so the image loads regardless of
+      # whether the helper is called from a view or from the renderer.
+      expect(html).to match(%r{<img[^>]*src="/[^"]*orcid[^"]*\.png})
     end
   end
 end

--- a/spec/renderers/hyrax/renderers/compound_attribute_renderer_spec.rb
+++ b/spec/renderers/hyrax/renderers/compound_attribute_renderer_spec.rb
@@ -120,6 +120,29 @@ RSpec.describe Hyrax::Renderers::CompoundAttributeRenderer do
     end
   end
 
+  describe 'string sub-property with search_field' do
+    let(:values) { [{ 'participant_name' => 'Hosseini, Mohammad' }] }
+    let(:subproperties) do
+      { 'participant_name' => { type: 'string', authority: nil, values: nil,
+                                search_field: 'participant_name_sim' } }
+    end
+    let(:renderer) { described_class.new(:participants, values, label: 'Participants', html_dl: true, subproperties: subproperties) }
+
+    it 'wraps the value in a link to the catalog search filtered by the named Solr field' do
+      markup = renderer.render_dl_row
+      expect(markup).to match(%r{<a href="/catalog\?[^"]*f%5Bparticipant_name_sim%5D[^"]*=Hosseini[^"]*"})
+      expect(markup).to include('Hosseini, Mohammad')
+    end
+
+    it 'leaves a value without search_field as plain escaped text' do
+      r = described_class.new(:participants,
+                              [{ 'participant_name' => 'Hosseini, Mohammad' }],
+                              label: 'Participants', html_dl: true,
+                              subproperties: { 'participant_name' => { type: 'string', search_field: nil } })
+      expect(r.render_dl_row).not_to match(%r{<a href="/catalog})
+    end
+  end
+
   describe 'orcid sub-property' do
     let(:bare_id) { '0000-0002-2385-985X' }
 

--- a/spec/renderers/hyrax/renderers/compound_attribute_renderer_spec.rb
+++ b/spec/renderers/hyrax/renderers/compound_attribute_renderer_spec.rb
@@ -188,6 +188,26 @@ RSpec.describe Hyrax::Renderers::CompoundAttributeRenderer do
       end
     end
 
+    context 'when the orcid value is unparseable' do
+      let(:values) { [{ 'participant_name' => 'Hosseini, Mohammad', 'participant_orcid' => 'not-an-id' }] }
+      let(:subproperties) do
+        { 'participant_name' => { type: 'string', authority: nil, values: nil, badge_for: nil },
+          'participant_orcid' => { type: 'orcid', authority: nil, values: nil, badge_for: 'participant_name' } }
+      end
+      let(:renderer) { described_class.new(:participants, values, label: 'Participants', html_dl: true, subproperties: subproperties) }
+
+      it 'falls back to its own row so the stored value is not dropped' do
+        markup = renderer.render_dl_row
+        expect(markup).to match(/Participant orcid:/)
+        expect(markup).to include('not-an-id')
+      end
+
+      it 'does not append a badge to the sibling' do
+        markup = renderer.render_dl_row
+        expect(markup).not_to include('hyrax-compound-orcid-badge')
+      end
+    end
+
     context 'when no badge_for: is declared' do
       let(:values) { [{ 'participant_name' => 'Ada', 'participant_orcid' => bare_id }] }
       let(:subproperties) do

--- a/spec/renderers/hyrax/renderers/compound_attribute_renderer_spec.rb
+++ b/spec/renderers/hyrax/renderers/compound_attribute_renderer_spec.rb
@@ -120,6 +120,67 @@ RSpec.describe Hyrax::Renderers::CompoundAttributeRenderer do
     end
   end
 
+  describe 'orcid sub-property' do
+    let(:bare_id) { '0000-0002-2385-985X' }
+
+    context 'when bound to a sibling via badge_for:' do
+      let(:values) { [{ 'participant_name' => 'Hosseini, Mohammad', 'participant_orcid' => bare_id }] }
+      let(:subproperties) do
+        { 'participant_name' => { type: 'string', authority: nil, values: nil, badge_for: nil },
+          'participant_orcid' => { type: 'orcid', authority: nil, values: nil, badge_for: 'participant_name' } }
+      end
+      let(:renderer) { described_class.new(:participants, values, label: 'Participants', html_dl: true, subproperties: subproperties) }
+
+      it 'appends the badge inside the sibling sub-property value' do
+        markup = renderer.render_dl_row
+        value_block = markup[/hyrax-compound-subproperty-value">.*?<\/span>/m, 0]
+        expect(value_block).to include('Hosseini, Mohammad')
+        expect(value_block).to include('hyrax-compound-orcid-badge')
+        expect(value_block).to include("https://orcid.org/#{bare_id}")
+      end
+
+      it 'does not render the orcid as its own sub-property row' do
+        markup = renderer.render_dl_row
+        expect(markup).not_to match(/Participant orcid:/)
+      end
+
+      it 'uses the sibling display value in the badge aria-label' do
+        markup = renderer.render_dl_row
+        expect(markup).to include('aria-label="ORCID iD for Hosseini, Mohammad"')
+      end
+    end
+
+    context 'when the badge_for: target is blank in this row' do
+      let(:values) { [{ 'participant_orcid' => bare_id }] }
+      let(:subproperties) do
+        { 'participant_name' => { type: 'string', authority: nil, values: nil, badge_for: nil },
+          'participant_orcid' => { type: 'orcid', authority: nil, values: nil, badge_for: 'participant_name' } }
+      end
+      let(:renderer) { described_class.new(:participants, values, label: 'Participants', html_dl: true, subproperties: subproperties) }
+
+      it 'falls back to rendering the orcid as its own sub-property row' do
+        markup = renderer.render_dl_row
+        expect(markup).to match(/Participant orcid:/)
+        expect(markup).to include("https://orcid.org/#{bare_id}")
+      end
+    end
+
+    context 'when no badge_for: is declared' do
+      let(:values) { [{ 'participant_name' => 'Ada', 'participant_orcid' => bare_id }] }
+      let(:subproperties) do
+        { 'participant_name' => { type: 'string', authority: nil, values: nil, badge_for: nil },
+          'participant_orcid' => { type: 'orcid', authority: nil, values: nil, badge_for: nil } }
+      end
+      let(:renderer) { described_class.new(:participants, values, label: 'Participants', html_dl: true, subproperties: subproperties) }
+
+      it 'renders the orcid as its own sub-property row' do
+        markup = renderer.render_dl_row
+        expect(markup).to match(/Participant orcid:/)
+        expect(markup).to include("https://orcid.org/#{bare_id}")
+      end
+    end
+  end
+
   describe 'work_or_url sub-property' do
     let(:subproperties) { { 'related_item' => { type: 'work_or_url', authority: nil, values: nil } } }
 

--- a/spec/services/hyrax/compound_schema_spec.rb
+++ b/spec/services/hyrax/compound_schema_spec.rb
@@ -192,11 +192,11 @@ RSpec.describe Hyrax::CompoundSchema do
       definition = schema.definition_for(:contributors)
       expect(definition[:subproperties]['role_label'])
         .to eq(type: 'controlled', authority: 'contributor_role', values: nil, index_keys: [],
-               display: false, required: false, group: 'role', cols: 6, as: nil)
+               display: false, required: false, group: 'role', cols: 6, as: nil, badge_for: nil)
       expect(definition[:subproperties]['given_name'])
         .to eq(type: 'string', authority: nil, values: nil,
                index_keys: %w[contributors_given_name_sim contributors_given_name_tesim],
-               display: true, required: false, group: 'identity', cols: 6, as: nil)
+               display: true, required: false, group: 'identity', cols: 6, as: nil, badge_for: nil)
     end
 
     it 'reads per-sub-property index_keys (literal Solr field names)' do
@@ -233,6 +233,45 @@ RSpec.describe Hyrax::CompoundSchema do
     it 'puts subproperties with no group in a single default (unlabeled) group' do
       groups = schema.definition_for(:identifiers)[:groups]
       expect(groups).to eq([{ key: nil, label: nil, fields: %w[value identifier_type] }])
+    end
+  end
+
+  describe 'orcid sub-property + badge_for' do
+    # A compound that carries a name + an orcid sub-property bound to the name
+    # via `badge_for:`. The schema service should pass `type` and `badge_for`
+    # through to the normalized spec untouched; the consumers (renderer, view,
+    # validator) read them from there.
+    let(:badge_resource_class) do
+      Class.new(Hyrax::Resource) do
+        def self.name
+          'TestResourceWithOrcidCompound'
+        end
+
+        attribute :participants,
+                  Valkyrie::Types::Array.of(Dry::Types['hash']).meta(
+                    subproperties: {
+                      'participant_name' => { 'type' => 'string' },
+                      'participant_orcid' => { 'type' => 'orcid', 'badge_for' => 'participant_name' }
+                    }
+                  )
+      end
+    end
+
+    subject(:badge_schema) { described_class.for(badge_resource_class) }
+
+    it 'preserves type: orcid as a sub-property type' do
+      expect(badge_schema.definition_for(:participants)[:subproperties]['participant_orcid'][:type])
+        .to eq('orcid')
+    end
+
+    it 'preserves badge_for: as a sibling reference' do
+      expect(badge_schema.definition_for(:participants)[:subproperties]['participant_orcid'][:badge_for])
+        .to eq('participant_name')
+    end
+
+    it 'leaves badge_for nil on sub-properties that do not declare it' do
+      expect(badge_schema.definition_for(:participants)[:subproperties]['participant_name'][:badge_for])
+        .to be_nil
     end
   end
 

--- a/spec/services/hyrax/compound_schema_spec.rb
+++ b/spec/services/hyrax/compound_schema_spec.rb
@@ -192,11 +192,13 @@ RSpec.describe Hyrax::CompoundSchema do
       definition = schema.definition_for(:contributors)
       expect(definition[:subproperties]['role_label'])
         .to eq(type: 'controlled', authority: 'contributor_role', values: nil, index_keys: [],
-               display: false, required: false, group: 'role', cols: 6, as: nil, badge_for: nil)
+               display: false, required: false, group: 'role', cols: 6, as: nil, badge_for: nil,
+               search_field: nil)
       expect(definition[:subproperties]['given_name'])
         .to eq(type: 'string', authority: nil, values: nil,
                index_keys: %w[contributors_given_name_sim contributors_given_name_tesim],
-               display: true, required: false, group: 'identity', cols: 6, as: nil, badge_for: nil)
+               display: true, required: false, group: 'identity', cols: 6, as: nil, badge_for: nil,
+               search_field: nil)
     end
 
     it 'reads per-sub-property index_keys (literal Solr field names)' do
@@ -272,6 +274,38 @@ RSpec.describe Hyrax::CompoundSchema do
     it 'leaves badge_for nil on sub-properties that do not declare it' do
       expect(badge_schema.definition_for(:participants)[:subproperties]['participant_name'][:badge_for])
         .to be_nil
+    end
+  end
+
+  describe 'search_field on a sub-property' do
+    # A compound where the name sub-property opts into faceted search via
+    # `search_field:`. The schema service should pass that through unchanged
+    # for the renderer to consume.
+    let(:searchable_resource_class) do
+      Class.new(Hyrax::Resource) do
+        def self.name
+          'TestResourceWithSearchableCompound'
+        end
+
+        attribute :participants,
+                  Valkyrie::Types::Array.of(Dry::Types['hash']).meta(
+                    subproperties: {
+                      'participant_name' => { 'type' => 'string',
+                                              'search_field' => 'participant_name_sim' }
+                    }
+                  )
+      end
+    end
+
+    subject(:searchable_schema) { described_class.for(searchable_resource_class) }
+
+    it 'preserves search_field as a Solr facet field reference' do
+      expect(searchable_schema.definition_for(:participants)[:subproperties]['participant_name'][:search_field])
+        .to eq('participant_name_sim')
+    end
+
+    it 'leaves search_field nil on sub-properties that do not declare it' do
+      expect(schema.definition_for(:contributors)[:subproperties]['given_name'][:search_field]).to be_nil
     end
   end
 

--- a/spec/services/hyrax/flexible_schema_validators/compound_validator_spec.rb
+++ b/spec/services/hyrax/flexible_schema_validators/compound_validator_spec.rb
@@ -115,5 +115,128 @@ RSpec.describe Hyrax::FlexibleSchemaValidators::CompoundValidator do
         expect(errors).to be_empty
       end
     end
+
+    context 'with a well-formed orcid sub-property bound to a sibling' do
+      let(:profile) do
+        {
+          'properties' => {
+            'participants' => { 'type' => 'hash' },
+            'participant_name' => { 'type' => 'string', 'subproperty_of' => 'participants' },
+            'participant_orcid' => { 'type' => 'orcid', 'subproperty_of' => 'participants', 'badge_for' => 'participant_name' }
+          }
+        }
+      end
+
+      it 'is valid' do
+        validator.validate!
+        expect(errors).to be_empty
+      end
+    end
+
+    context 'with a well-formed orcid sub-property and no badge_for' do
+      let(:profile) do
+        {
+          'properties' => {
+            'participants' => { 'type' => 'hash' },
+            'participant_orcid' => { 'type' => 'orcid', 'subproperty_of' => 'participants' }
+          }
+        }
+      end
+
+      it 'is valid' do
+        validator.validate!
+        expect(errors).to be_empty
+      end
+    end
+
+    context 'with an orcid sub-property that also declares values:' do
+      let(:profile) do
+        {
+          'properties' => {
+            'participants' => { 'type' => 'hash' },
+            'participant_orcid' => { 'type' => 'orcid', 'subproperty_of' => 'participants',
+                                     'values' => %w[Author Editor] }
+          }
+        }
+      end
+
+      it 'records an error' do
+        validator.validate!
+        expect(errors.join("\n")).to include('participant_orcid')
+        expect(errors.join("\n")).to match(/authority|values/i)
+      end
+    end
+
+    context 'with an orcid sub-property that also declares authority:' do
+      let(:profile) do
+        {
+          'properties' => {
+            'participants' => { 'type' => 'hash' },
+            'participant_orcid' => { 'type' => 'orcid', 'subproperty_of' => 'participants',
+                                     'authority' => 'participant_role' }
+          }
+        }
+      end
+
+      it 'records an error' do
+        validator.validate!
+        expect(errors.join("\n")).to include('participant_orcid')
+      end
+    end
+
+    context 'with an orcid sub-property whose badge_for points at itself' do
+      let(:profile) do
+        {
+          'properties' => {
+            'participants' => { 'type' => 'hash' },
+            'participant_orcid' => { 'type' => 'orcid', 'subproperty_of' => 'participants',
+                                     'badge_for' => 'participant_orcid' }
+          }
+        }
+      end
+
+      it 'records an error' do
+        validator.validate!
+        expect(errors.join("\n")).to include('participant_orcid')
+        expect(errors.join("\n")).to match(/itself/i)
+      end
+    end
+
+    context 'with an orcid sub-property whose badge_for points at a non-sibling' do
+      let(:profile) do
+        {
+          'properties' => {
+            'participants' => { 'type' => 'hash' },
+            'participant_orcid' => { 'type' => 'orcid', 'subproperty_of' => 'participants',
+                                     'badge_for' => 'unrelated_property' },
+            # Exists at the top level but is not a sibling of participant_orcid
+            'unrelated_property' => { 'type' => 'string' }
+          }
+        }
+      end
+
+      it 'records an error' do
+        validator.validate!
+        expect(errors.join("\n")).to include('participant_orcid')
+        expect(errors.join("\n")).to include('unrelated_property')
+      end
+    end
+
+    context 'with an orcid sub-property whose badge_for points at a missing sibling' do
+      let(:profile) do
+        {
+          'properties' => {
+            'participants' => { 'type' => 'hash' },
+            'participant_orcid' => { 'type' => 'orcid', 'subproperty_of' => 'participants',
+                                     'badge_for' => 'missing_sibling' }
+          }
+        }
+      end
+
+      it 'records an error' do
+        validator.validate!
+        expect(errors.join("\n")).to include('missing_sibling')
+      end
+    end
   end
 end

--- a/spec/validators/hyrax/orcid_subproperty_validator_spec.rb
+++ b/spec/validators/hyrax/orcid_subproperty_validator_spec.rb
@@ -1,0 +1,109 @@
+# frozen_string_literal: true
+
+RSpec.describe Hyrax::OrcidSubpropertyValidator do
+  let(:record_class) do
+    Class.new do
+      include ActiveModel::Validations
+      attr_accessor :participants
+      validates_with Hyrax::OrcidSubpropertyValidator
+    end
+  end
+  let(:record) { record_class.new.tap { |r| r.participants = entries } }
+  let(:entries) { [] }
+
+  # A schema with one orcid sub-property on the `participants` compound. The
+  # validator selects orcid sub-properties off the schema, so the spec stubs
+  # CompoundSchema.for to return a definition with one.
+  let(:definition) do
+    { required: false,
+      subproperties: {
+        'participant_name' => { type: 'string' },
+        'participant_orcid' => { type: 'orcid', badge_for: 'participant_name' }
+      } }
+  end
+  let(:schema) { instance_double(Hyrax::CompoundSchema, definitions: { participants: definition }) }
+
+  before do
+    allow(Hyrax::CompoundSchema).to receive(:for).and_return(schema)
+  end
+
+  context 'with no rows' do
+    it 'is valid' do
+      record.valid?
+      expect(record.errors[:base]).to be_empty
+    end
+  end
+
+  context 'with a row that omits the orcid' do
+    let(:entries) { [{ 'participant_name' => 'Hosseini, Mohammad' }] }
+
+    it 'is valid (orcid is optional)' do
+      record.valid?
+      expect(record.errors[:base]).to be_empty
+    end
+  end
+
+  context 'with a row that has a blank orcid' do
+    let(:entries) { [{ 'participant_name' => 'Hosseini, Mohammad', 'participant_orcid' => '' }] }
+
+    it 'is valid' do
+      record.valid?
+      expect(record.errors[:base]).to be_empty
+    end
+  end
+
+  context 'with a row whose orcid is in the bare-iD form' do
+    let(:entries) { [{ 'participant_name' => 'X', 'participant_orcid' => '0000-0002-2385-985X' }] }
+
+    it 'is valid' do
+      record.valid?
+      expect(record.errors[:base]).to be_empty
+    end
+  end
+
+  context 'with a row whose orcid is in the full URL form' do
+    let(:entries) { [{ 'participant_name' => 'X', 'participant_orcid' => 'https://orcid.org/0000-0002-2385-985X' }] }
+
+    it 'is valid' do
+      record.valid?
+      expect(record.errors[:base]).to be_empty
+    end
+  end
+
+  context 'with a row whose orcid is malformed' do
+    let(:entries) { [{ 'participant_name' => 'X', 'participant_orcid' => 'not-an-id' }] }
+
+    it 'adds one base error naming the compound and the sub-property' do
+      I18n.with_locale(:en) do
+        record.valid?
+        expect(record.errors[:base].size).to eq(1)
+        expect(record.errors[:base].first).to include('Participants').and include('Participant orcid')
+      end
+    end
+  end
+
+  context 'with multiple rows where only one orcid is malformed' do
+    let(:entries) do
+      [{ 'participant_name' => 'Ok', 'participant_orcid' => '0000-0001-2345-6789' },
+       { 'participant_name' => 'Bad', 'participant_orcid' => 'still-not-valid' }]
+    end
+
+    it 'adds an error only for the malformed row' do
+      record.valid?
+      expect(record.errors[:base].size).to eq(1)
+    end
+  end
+
+  context 'when a compound has no orcid sub-properties' do
+    let(:definition) do
+      { required: false,
+        subproperties: { 'plain' => { type: 'string' } } }
+    end
+    let(:entries) { [{ 'plain' => 'whatever' }] }
+
+    it 'does not touch the row' do
+      record.valid?
+      expect(record.errors[:base]).to be_empty
+    end
+  end
+end


### PR DESCRIPTION
## Summary
ORCID iD sub-property type for compound metadata. The iD renders as an inline
green badge next to a sibling sub-property (matching Zenodo); the sibling's
value links to a participant-name facet search.

Depends on #7479 (compound metadata foundation).

Issue: 
- https://github.com/research-technologies/enact_knapsack/issues/30

## Details
- New `type: orcid` recognized by the schema, form, show renderer, and m3
  profile validator. No per-field Ruby.
- Optional `badge_for: <sibling>` attaches the iD inline next to that sibling;
  falls back to a standalone labeled row when omitted or when the target is
  blank in the row.
- Optional `search_field:` on string sub-properties wraps the show-page value
  in a catalog facet link (compound analogue of `render_as: faceted`).
- `Hyrax::OrcidSubpropertyValidator` rejects malformed values on save; reuses
  the existing `Hyrax::OrcidValidator` regex.
- Wired into the sample `participants` compound (name + ORCID, name
  facet-linked).
- Works identically under `HYRAX_FLEXIBLE=false` and `=true`.
- Locale keys propagated to de, es, fr, it, pt-BR, zh.

## Testing

On a work or collection show page with a populated participant + ORCID:

1. The name is a link; the green ORCID badge appears next to it.
2. Clicking the name runs a participant-name facet search.
3. Clicking the badge opens the author's ORCID profile.

<details>
<summary>Show page — work (HYRAX_FLEXIBLE=false, koppie)</summary>

<img width="1200" height="863" alt="image" src="https://github.com/user-attachments/assets/c1f07f78-cf5d-4771-9d6b-bd2e865b69ec" />

</details>

<details>
<summary>Show page — work (HYRAX_FLEXIBLE=true, allinson)</summary>

<img width="1200" height="863" alt="image" src="https://github.com/user-attachments/assets/daa54aca-c587-4e26-9119-3e66c0342117" />

<img width="791" height="220" alt="image" src="https://github.com/user-attachments/assets/62fb89c2-c602-4d25-8d95-27c6eb0dcbba" />


</details>

<details>
<summary>Click the name → participant-name facet search</summary>

<img width="1200" height="863" alt="image" src="https://github.com/user-attachments/assets/e492d3d0-bd94-404d-a964-f499d28da682" />

</details>

<details>
<summary>Click the badge → ORCID profile</summary>

<img width="1200" height="863" alt="image" src="https://github.com/user-attachments/assets/b8929a78-5b51-408d-83cc-57e85836930f" />

</details>

🤖 Assisted by Claude Code