### PR TITLE
Map xsd:anyURI ranges to the uri type in flexible schemas

### DIFF
--- a/app/models/hyrax/flexible_schema.rb
+++ b/app/models/hyrax/flexible_schema.rb
@@ -255,6 +255,8 @@ class Hyrax::FlexibleSchema < ApplicationRecord
       nil
     when "http://www.w3.org/2001/XMLSchema#dateTime"
       'date_time'
+    when "http://www.w3.org/2001/XMLSchema#anyURI"
+      'uri'
     else
       range.split('#').last.underscore
     end

--- a/spec/models/hyrax/flexible_schema_spec.rb
+++ b/spec/models/hyrax/flexible_schema_spec.rb
@@ -32,6 +32,14 @@ RSpec.describe Hyrax::FlexibleSchema, :clean_repo, type: :model do
         expect(subject.attributes_for('NonExistentClass')).to be_nil
       end
     end
+
+    context 'when a property declares an xsd:anyURI range' do
+      it "maps the type to 'uri'" do
+        profile_data['properties']['title']['range'] = 'http://www.w3.org/2001/XMLSchema#anyURI'
+        attributes = subject.attributes_for('GenericWork')
+        expect(attributes['title']['type']).to eq('uri')
+      end
+    end
   end
 
   describe '#mappings_data_for' do


### PR DESCRIPTION
### What does this PR do?

Adds `http://www.w3.org/2001/XMLSchema#anyURI` to the special-cased ranges in `Hyrax::FlexibleSchema#lookup_type`, mapping it to the existing `'uri'` type (→ `Valkyrie::Types::URI`).

### Why?

A flexible-metadata (M3) profile that declares an `anyURI` range — the natural XSD type for `rights_statement`, `license`, `related_url`, and other URI-valued properties — currently breaks the work-type schema at load time: `lookup_type` derives `'any_uri'` from the range, and `SchemaLoader#type_for` raises `ArgumentError: Unrecognized type: any_uri` because `Valkyrie::Types::AnyUri` does not exist. There is no validator warning at profile-upload time, so the failure surfaces later as an opaque crash when the class schema loads.

This bites exactly the people flexible metadata is for: metadata librarians authoring profiles from XSD-typed property definitions. Hyku's own shipped profile works around it by declaring rights/license URIs as `xsd:string`, which silently loses the URI typing (and the `render_as: external_link` affordances downstream stay string-typed). We hit this building a production-shaped M3 profile from scratch and had to discover the workaround by reading `lookup_type`.

### How to test

Included spec: a property with an `anyURI` range resolves to type `'uri'` via `attributes_for`. Before this change it resolves to `'any_uri'`, which `type_for` rejects.

### Notes

One-line behavior change plus spec; profiles that already use `xsd:string` for URI fields are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)