### PR TITLE
Fix compound metadata round-trip in flexible mode (data loss + mangled one-field entries)

### DIFF
--- a/app/models/concerns/hyrax/compound_normalization.rb
+++ b/app/models/concerns/hyrax/compound_normalization.rb
@@ -67,11 +67,25 @@ module Hyrax
       arr.map { |entry| entry.is_a?(::Hash) ? entry.transform_keys(&:to_s) : entry }
     end
 
-    # Multi-key splay: `[[:a, 1], [:b, 2]]` -> `[{a: 1, b: 2}]`. Returns nil
-    # if the input doesn't look like a pair array.
+    # Rebuild entries from an array of [key, value] pairs. Pairs arrive two
+    # different ways and need different repairs:
+    #
+    # * ONE entry with several fields, splayed apart:
+    #   `[[:a, 1], [:b, 2]]` -> `[{a: 1, b: 2}]`
+    # * SEVERAL entries with one field each, each unwrapped to its pair:
+    #   `[[:a, 1], [:a, 2]]` -> `[{a: 1}, {a: 2}]`
+    #
+    # A repeated key is the tell: one splayed entry can never repeat a key, so
+    # repeats always mean "one entry per pair". Merging those into a single
+    # hash would quietly keep only the last value - saving two contributors
+    # with just names and getting one back. When every key is distinct the two
+    # origins are indistinguishable here, so keep the single-entry reading
+    # (the far more common shape). Returns nil if the input doesn't look like
+    # a pair array.
     def self.collapse_pair_array(arr)
       return nil if arr.empty?
       return nil unless arr.all? { |e| pair?(e) }
+      return arr.map { |pair| ::Hash[[pair]] } if arr.map { |pair| pair.first.to_s }.uniq.length < arr.length
       [::Hash[arr]]
     end
 

--- a/app/models/concerns/hyrax/flexibility.rb
+++ b/app/models/concerns/hyrax/flexibility.rb
@@ -77,9 +77,27 @@ module Hyrax
         schema_version = attributes[:schema_version]
         contexts = attributes[:contexts] || []
         struct.singleton_class.attributes(Hyrax::Schema(self, schema_loader: Hyrax::Schema.m3_schema_loader, schema_version:, contexts:).attributes)
+        attributes = normalize_compound_attributes(struct, attributes)
         clean_attributes = safe ? struct.singleton_class.schema.call_safe(attributes) { |output = attributes| return yield output } : struct.singleton_class.schema.call_unsafe(attributes)
         struct.__send__(:initialize, clean_attributes)
         struct
+      end
+
+      # Put compound entries back together before the schema coerces them.
+      # Reading a work back from Postgres can hand us a compound whose entry
+      # hashes were taken apart into loose [key, value] pairs (see
+      # Hyrax::CompoundNormalization for the how and why). This is the one spot
+      # on the flexible-mode reload path that already knows which attributes
+      # are compounds - the singleton schema was applied on the line above -
+      # so repair the values here, before coercion sees them. Without this,
+      # the class-level normalization hook never fires in flexible mode (the
+      # class schema carries no compounds) and the broken shape either raises
+      # in coercion or reaches the instance looking like pairs, not entries.
+      def normalize_compound_attributes(struct, attributes)
+        compound_names = Hyrax::CompoundSchema.new(struct.singleton_class.schema).compound_names
+        return attributes if compound_names.empty?
+
+        Hyrax::CompoundNormalization.normalize_attrs(attributes, compound_names)
       end
     end
 

--- a/lib/hyrax/engine.rb
+++ b/lib/hyrax/engine.rb
@@ -27,6 +27,9 @@ module Hyrax
     require 'hydra/derivatives'
     require 'hyrax/active_fedora_dummy_model'
     require 'hyrax/controller_resource'
+    # Preserve compound entry boundaries on the Postgres read path (any adapter
+    # routing through Valkyrie's ORMConverter). See the decorator for why.
+    require 'hyrax/valkyrie_persistence/postgres/orm_converter_decorator'
     require 'hyrax/form_fields'
     require 'hyrax/indexer'
     require 'hyrax/model_decorator'

--- a/lib/hyrax/valkyrie_persistence/postgres/orm_converter_decorator.rb
+++ b/lib/hyrax/valkyrie_persistence/postgres/orm_converter_decorator.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+module Hyrax
+  module ValkyriePersistence
+    module Postgres
+      # OVERRIDE Valkyrie v3.5.1 — preserve compound entry boundaries on read.
+      #
+      # Valkyrie's Postgres read path (`JSONValueMapper`'s `EnumeratorValue`)
+      # treats a single-key Hash as an enumerable and unwraps it to its
+      # `[key, value]` pair. For a compound attribute persisted as an array of
+      # one-field entry hashes — e.g. `[{ "name" => "Ada" }, { "role" => "Editor" }]`
+      # — every entry is splayed, and the array collapses to
+      # `[["name", "Ada"], ["role", "Editor"]]`, indistinguishable from a single
+      # two-field entry. Downstream the two entries silently merge into one,
+      # losing data on an ordinary save/reload.
+      #
+      # The raw JSONB on disk still holds the whole entries (the loss is purely
+      # in the read conversion), so this override reads the compound attributes
+      # straight from `orm_object.metadata` — bypassing the splay — and re-keys
+      # each entry to match what the schema expects. It is scoped to the
+      # resource's declared compounds only (via {Hyrax::CompoundSchema}); every
+      # other attribute stays on Valkyrie's stock conversion path untouched.
+      #
+      # Compound discovery reads the effective schema, so this works in both flex
+      # modes. {Hyrax::CompoundNormalization} and {Hyrax::Flexibility#load} remain
+      # as the read-path repair for entry points that do not pass through this
+      # converter (e.g. `.new` from a raw attribute hash, Wings conversion).
+      module ORMConverterDecorator
+        private
+
+        # OVERRIDE: re-read compound attributes from the raw metadata without
+        # the single-key-hash splay; leave all other attributes to `super`.
+        def rdf_metadata
+          base = super
+          names = compound_attribute_names
+          return base if names.empty?
+
+          base.merge(unsplayed_compound_metadata(names))
+        end
+
+        # The compound attribute names declared for this record's resource class,
+        # as strings (the keys present in the raw metadata hash). Empty when the
+        # class has no compounds or the schema cannot be resolved — in which case
+        # the override is inert and stock behavior stands.
+        #
+        # Resolves the class straight from the ORM object's `internal_resource`
+        # column rather than `#resource_klass`: the latter reads through
+        # `#attributes` -> `#rdf_metadata`, which this module overrides, so
+        # calling it here would recurse.
+        def compound_attribute_names
+          klass = Valkyrie.config.resource_class_resolver.call(orm_object.internal_resource)
+          Hyrax::CompoundSchema.for(klass).compound_names.map(&:to_s)
+        rescue StandardError
+          []
+        end
+
+        # For each compound key present in the raw JSONB, rebuild the value as an
+        # array of whole entry hashes with symbolized keys — the shape the schema
+        # coercion expects — instead of the splayed pairs `super` produced.
+        def unsplayed_compound_metadata(names)
+          raw = orm_object.metadata
+          names.each_with_object({}) do |name, acc|
+            next unless raw.key?(name)
+
+            entries = Array.wrap(raw[name]).map do |entry|
+              entry.is_a?(::Hash) ? entry.symbolize_keys : entry
+            end
+            acc[name] = entries
+          end
+        end
+      end
+    end
+  end
+end
+
+Valkyrie::Persistence::Postgres::ORMConverter.prepend(
+  Hyrax::ValkyriePersistence::Postgres::ORMConverterDecorator
+)

--- a/spec/models/concerns/hyrax/compound_distinct_key_round_trip_spec.rb
+++ b/spec/models/concerns/hyrax/compound_distinct_key_round_trip_spec.rb
@@ -15,8 +15,14 @@
 # The only place that signal still exists is the conversion boundary itself,
 # before the unwrap - i.e. Freyja/Frigg's ORMConverter. This spec drives a real
 # persister save/reload (the merge does NOT reproduce through .new/.load alone)
-# and expects both entries to survive. It is EXPECTED TO FAIL until a
-# compound-scoped read override lands in the Hyrax adapter layer.
+# and expects both entries to survive.
+#
+# Postgres-only: compounds are stored as JSONB, and this is the JSONB read path.
+# The Fedora adapter cannot serialize a plain-hash compound to RDF at all (its
+# NestedProperty mapper only handles nested Valkyrie resources, i.e. hashes with
+# an :internal_resource key), so the compound feature targets the Postgres path.
+# The example skips on a Fedora-backed persister, matching
+# spec/forms/hyrax/forms/compound_metadata_form_spec.rb.
 RSpec.describe 'compound distinct-key entries survive a persist/reload round-trip' do
   let(:profile) { YAML.safe_load_file(Hyrax::Engine.root.join('spec', 'fixtures', 'files', 'm3_profile.yaml')) }
   let(:test_profile) do
@@ -68,6 +74,13 @@ RSpec.describe 'compound distinct-key entries survive a persist/reload round-tri
   end
 
   it 'keeps two one-field entries with different keys as two separate entries' do
+    # Gate on the configured metadata adapter, not Hyrax.persister: other specs
+    # routinely stub Hyrax.persister, and a leaked stub made this run (and fail)
+    # on the Wings/Fedora stack. The adapter class is config-level and far less
+    # likely to be left mutated across examples.
+    skip 'requires the Postgres metadata adapter (compounds are JSONB)' unless
+      Valkyrie.config.metadata_adapter.is_a?(Valkyrie::Persistence::Postgres::MetadataAdapter)
+
     work = Hyrax::Test::CompoundRoundTrip::TestWork.new(title: ['t'])
     work.participants = [{ 'name' => 'Ada' }, { 'role' => 'Editor' }]
 

--- a/spec/models/concerns/hyrax/compound_distinct_key_round_trip_spec.rb
+++ b/spec/models/concerns/hyrax/compound_distinct_key_round_trip_spec.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+# Persist -> reload round-trip for the one compound shape the read-path repair
+# (Hyrax::CompoundNormalization) cannot recover on its own: several one-field
+# entries whose keys DIFFER.
+#
+# Valkyrie's Postgres read path (EnumeratorValue in JSONValueMapper) unwraps each
+# single-key hash to its [key, value] pair before Hyrax sees the value, so
+# [{name: 'Ada'}, {role: 'Editor'}] arrives as [[:name, 'Ada'], [:role, 'Editor']]
+# - byte-identical to ONE entry {name:, role:} splayed apart. With distinct keys
+# there is no signal left at the repair layer to tell the two origins apart, so
+# the repair keeps the single-entry reading and the two people silently merge
+# into one (the role misattributed to the wrong person).
+#
+# The only place that signal still exists is the conversion boundary itself,
+# before the unwrap - i.e. Freyja/Frigg's ORMConverter. This spec drives a real
+# persister save/reload (the merge does NOT reproduce through .new/.load alone)
+# and expects both entries to survive. It is EXPECTED TO FAIL until a
+# compound-scoped read override lands in the Hyrax adapter layer.
+RSpec.describe 'compound distinct-key entries survive a persist/reload round-trip' do
+  let(:profile) { YAML.safe_load_file(Hyrax::Engine.root.join('spec', 'fixtures', 'files', 'm3_profile.yaml')) }
+  let(:test_profile) do
+    YAML.safe_load(<<-YAML)
+      classes:
+        Hyrax::Test::CompoundRoundTrip::TestWork:
+          display_label: Test Work
+      properties:
+        title:
+          available_on:
+            class: [Hyrax::Test::CompoundRoundTrip::TestWork]
+        participants:
+          type: hash
+          data_type: array
+          available_on:
+            class: [Hyrax::Test::CompoundRoundTrip::TestWork]
+        participant_name:
+          type: string
+          name: name
+          available_on:
+            properties: [participants]
+        participant_role:
+          type: string
+          name: role
+          available_on:
+            properties: [participants]
+    YAML
+  end
+  let(:schema) { Hyrax::FlexibleSchema.create(profile: profile.deep_merge(test_profile)) }
+
+  before(:all) do
+    module Hyrax::Test::CompoundRoundTrip
+      class TestWork < Hyrax::Resource; end
+    end
+  end
+
+  after(:all) do
+    Hyrax::Test::CompoundRoundTrip.send(:remove_const, :TestWork)
+  end
+
+  before do
+    allow(Hyrax.config).to receive(:flexible?).and_return(true)
+    allow(Hyrax::FlexibleSchema).to receive(:find_by).and_return(schema)
+    Hyrax::Test::CompoundRoundTrip::TestWork.acts_as_flexible_resource
+  end
+
+  after do
+    allow(Hyrax.config).to receive(:flexible?).and_return(false)
+  end
+
+  it 'keeps two one-field entries with different keys as two separate entries' do
+    work = Hyrax::Test::CompoundRoundTrip::TestWork.new(title: ['t'])
+    work.participants = [{ 'name' => 'Ada' }, { 'role' => 'Editor' }]
+
+    saved = Hyrax.persister.save(resource: work)
+    reloaded = Hyrax.query_service.find_by(id: saved.id)
+
+    expect(reloaded.participants).to eq([{ 'name' => 'Ada' }, { 'role' => 'Editor' }])
+  end
+end

--- a/spec/models/concerns/hyrax/compound_normalization_spec.rb
+++ b/spec/models/concerns/hyrax/compound_normalization_spec.rb
@@ -30,6 +30,16 @@ RSpec.describe Hyrax::CompoundNormalization do
         .to eq([{ 'given_name' => 'Ada', 'family' => 'Lovelace' }])
     end
 
+    it 'rebuilds one entry per pair when a key repeats (several one-field entries)' do
+      # JSONValueMapper also unwraps each one-key hash in a multi-entry value
+      # to its [key, value] pair, so a persisted [{name: A}, {name: B}] arrives
+      # as pairs too. A repeated key can only mean separate entries - one
+      # splayed entry never repeats a key - so do not merge them into one hash
+      # (that silently keeps only the last value).
+      expect(Hyrax::CompoundNormalization.normalize_compound([[:name, 'A'], [:name, 'B']]))
+        .to eq([{ 'name' => 'A' }, { 'name' => 'B' }])
+    end
+
     it 'leaves a well-formed array of hashes unchanged (stringifying keys)' do
       expect(Hyrax::CompoundNormalization.normalize_compound([{ given_name: 'Ada' }]))
         .to eq([{ 'given_name' => 'Ada' }])

--- a/spec/models/concerns/hyrax/compound_normalization_spec.rb
+++ b/spec/models/concerns/hyrax/compound_normalization_spec.rb
@@ -55,6 +55,42 @@ RSpec.describe Hyrax::CompoundNormalization do
     end
   end
 
+  # These pin behavior that is a deliberate consequence of an information limit,
+  # not an accident: by the time Valkyrie's EnumeratorValue has unwrapped single-key
+  # hashes, some origins are indistinguishable here. Changing any of these is a
+  # behavior change, not a cleanup - the comments say why each reading was chosen.
+  describe 'information-limited disambiguation (load-bearing choices)' do
+    it 'reads distinct-key pairs as ONE multi-field entry, not several one-field entries' do
+      # [[:name, A], [:role, R]] is genuinely ambiguous once unwrapped: it could be
+      # one entry {name:, role:} splayed apart, or two one-field entries with
+      # different keys. Only the repeated-key case is decidable; with distinct keys
+      # we keep the single-entry reading (the common shape, and the non-lossy
+      # default). Do not "fix" this to split - the signal to do so does not survive
+      # Valkyrie's read path; that would require a Valkyrie-layer change.
+      expect(Hyrax::CompoundNormalization.normalize_compound([[:name, 'Ada'], [:role, 'Author']]))
+        .to eq([{ 'name' => 'Ada', 'role' => 'Author' }])
+    end
+
+    it 'splits correctly when two pairs share a key and a third is distinct' do
+      # The repeated key (:name) proves these are separate entries, so every pair
+      # becomes its own one-field entry - including the distinct :role pair.
+      expect(Hyrax::CompoundNormalization.normalize_compound([[:name, 'A'], [:name, 'B'], [:role, 'X']]))
+        .to eq([{ 'name' => 'A' }, { 'name' => 'B' }, { 'role' => 'X' }])
+    end
+
+    it 'leaves a flat pair whose value is non-scalar untouched (conservative guard)' do
+      # collapse_flat_pair only rebuilds a one-field entry when the value is a
+      # scalar - the only shape a real compound subproperty produces. A value that
+      # is an Array or Hash is not a recognizable splayed entry, so it is left for
+      # schema coercion to accept or reject loudly, rather than silently mangled
+      # into a fabricated entry.
+      expect(Hyrax::CompoundNormalization.normalize_compound([:aliases, %w[x y]]))
+        .to eq([:aliases, %w[x y]])
+      expect(Hyrax::CompoundNormalization.normalize_compound([:meta, { 'k' => 'v' }]))
+        .to eq([:meta, { 'k' => 'v' }])
+    end
+  end
+
   describe 'round-trip through the class constructor' do
     it 'normalizes splayed compound input passed to .new' do
       resource = resource_class.new(contributors: [[:given_name, 'Ada']])

--- a/spec/models/concerns/hyrax/flexibility_spec.rb
+++ b/spec/models/concerns/hyrax/flexibility_spec.rb
@@ -27,6 +27,28 @@ RSpec.describe 'Hyrax::Flexibility' do
           available_on:
             class:
             - Hyrax::Test::Flexibility::TestWork
+        participants:
+          type: hash
+          data_type: array
+          available_on:
+            class:
+            - Hyrax::Test::Flexibility::TestWork
+          display_label:
+            default: Participants
+          view:
+            render_as: compound
+        participant_name:
+          type: string
+          name: name
+          available_on:
+            properties:
+            - participants
+        participant_role:
+          type: string
+          name: role
+          available_on:
+            properties:
+            - participants
     YAML
   end
 
@@ -71,6 +93,36 @@ RSpec.describe 'Hyrax::Flexibility' do
       it 'loads the attributes' do
         instance = flexibility_class.new(title: ['Test Title'])
         expect(instance.title).to eq(['Test Title'])
+      end
+    end
+
+    # Reloading from Postgres can hand .load compound values whose entry
+    # hashes were taken apart on the way out of the database (see
+    # Hyrax::CompoundNormalization): one entry's hash arrives as loose
+    # [key, value] pairs, and a one-field entry arrives as a single flat
+    # pair. These examples feed .new exactly those wire shapes and expect
+    # whole entries back.
+    context 'when a compound value arrives in the database wire shape' do
+      it 'repairs one splayed multi-field entry into a single hash' do
+        instance = flexibility_class.new(participants: [[:name, 'Ada'], [:role, 'Author']])
+        expect(instance.participants).to eq([{ 'name' => 'Ada', 'role' => 'Author' }])
+      end
+
+      it 'repairs several one-field entries without losing any (repeated key)' do
+        instance = flexibility_class.new(participants: [[:name, 'Ada'], [:name, 'Grace']])
+        expect(instance.participants).to eq([{ 'name' => 'Ada' }, { 'name' => 'Grace' }])
+      end
+
+      it 'repairs a single one-field entry from a flat pair' do
+        instance = flexibility_class.new(participants: ['name', 'Ada'])
+        expect(instance.participants).to eq([{ 'name' => 'Ada' }])
+      end
+
+      it 'passes well-formed entries through untouched' do
+        instance = flexibility_class.new(participants: [{ 'name' => 'Ada', 'role' => 'Author' },
+                                                        { 'name' => 'Grace', 'role' => 'Editor' }])
+        expect(instance.participants).to eq([{ 'name' => 'Ada', 'role' => 'Author' },
+                                             { 'name' => 'Grace', 'role' => 'Editor' }])
       end
     end
   end

--- a/spec/models/hyrax/flexible_schema_spec.rb
+++ b/spec/models/hyrax/flexible_schema_spec.rb
@@ -35,9 +35,14 @@ RSpec.describe Hyrax::FlexibleSchema, :clean_repo, type: :model do
 
     context 'when a property declares an xsd:anyURI range' do
       it "maps the type to 'uri'" do
-        profile_data['properties']['title']['range'] = 'http://www.w3.org/2001/XMLSchema#anyURI'
+        # Use `abstract`: the fixture declares three properties whose `name:`
+        # resolves to `title` (title, title_primary, title_alternative), and
+        # attributes_for keys by resolved name so the last one wins - changing
+        # `properties.title` and reading back attributes['title'] asserts
+        # against a different property. `abstract` has no such shadow.
+        profile_data['properties']['abstract']['range'] = 'http://www.w3.org/2001/XMLSchema#anyURI'
         attributes = subject.attributes_for('GenericWork')
-        expect(attributes['title']['type']).to eq('uri')
+        expect(attributes['abstract']['type']).to eq('uri')
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -233,6 +233,14 @@ RSpec.configure do |config|
   end
 
   config.before do |example|
+    # Reset the locale before every example. Controller actions set
+    # `I18n.locale = params[:locale]` (see Hyrax::Controller#set_locale) without
+    # restoring it, so a controller/request spec that passes `locale: 'fr'`
+    # leaves I18n.locale = :fr for the rest of the process, breaking later specs
+    # that render views (e.g. "Translation missing: fr...."). Starting each
+    # example from the default keeps that leak from crossing example boundaries.
+    I18n.locale = I18n.default_locale
+
     if example.metadata[:type] == :feature && Capybara.current_driver != :rack_test
       # Preserve the flexible_schemas table across feature specs. The
       # before(:suite) block creates a FlexibleSchema from the allinson


### PR DESCRIPTION
### What's wrong

In flexible mode, compound metadata can come back from the database broken. Saving works fine - reading back is the problem. Three cases, all triggered by entries that fill exactly one field:

1. **You can lose data.** Save a work with two contributors that each have just a name:
   ```ruby
   participants: [{'name' => 'A'}, {'name' => 'B'}]
   ```
   Read it back and you get loose pairs instead of entries: `[["name", "A"], ["name", "B"]]`. Depending on the app, that either crashes, renders as garbage, or merges into one entry so B survives and A is gone. The database row still has both - only the read loses it.

2. **One-field entries break.** Save an identifier with just a value, read it back, and you get `["value", "doi:..."]` instead of `[{"value" => "doi:..."}]`.

3. **Different one-field entries silently merge.** Save two entries that each fill a *different* single field - one participant with only a name, another with only a role:
   ```ruby
   participants: [{'name' => 'Ada'}, {'role' => 'Editor'}]
   ```
   Read it back and the two collapse into one entry, `{'name' => 'Ada', 'role' => 'Editor'}` - the role misattributed to Ada. This is an ordinary partial-data shape (e.g. a draft, or a half-filled lookup row), not a contrived one.

### Why it happens

On the way out of Postgres, valkyrie unwraps a one-key hash to its `[key, value]` pair (a Hash responds to `#each`). So several one-field entries arrive looking exactly like ONE entry that got splayed into pairs. The information that they were separate entries is gone before the model sees the value. Two further problems compounded it:

- `Hyrax::CompoundNormalization`'s repair never ran in flexible mode - its class-level hook gets the compound list from the class schema, which is empty in flex mode (compounds are applied per instance).
- Even when the repair did run, it merged repeated-key pairs into a single hash, keeping only the last value.

### The fix

Three changes:

- **`Hyrax::CompoundNormalization.collapse_pair_array`**: a repeated key can only mean separate one-field entries (one splayed entry never repeats a key), so rebuild one entry per pair instead of merging them.
- **`Hyrax::Flexibility.load`**: repair compound values right after the singleton schema is applied and right before coercion - the one spot on the flexible reload path that knows which attributes are compounds. (Coercion would otherwise re-splay two single-key entries even after the read path handed them back whole.)
- **`Valkyrie::Persistence::Postgres::ORMConverter` (decorated)**: read declared compound attributes straight from the stored JSON, before the one-key-hash unwrap, so different-field entries (case 3) are never flattened in the first place. The stored row is intact; only the read had been losing the boundaries. Scoped to declared compound attributes, so every other attribute stays on valkyrie's stock path. It sits on the shared converter, so it applies regardless of which Postgres-backed adapter an install uses, and works the same in both flex modes. A [PR for the valkyrie-side fix is proposed](https://github.com/samvera/valkyrie/pull/996) so the decorator can be removed in the future.

The three are complementary, not redundant: the converter recovers the boundaries that only survive in the raw row (case 3); the reload-path repair stops coercion re-splaying single-key entries and also covers entry points that do not go through the converter (`.new` from a raw hash, Wings conversion, fixtures); `collapse_pair_array` is the shared repair both rely on.

### How to see it yourself (koppie, before this fix)

```bash
docker exec -e HYRAX_FLEXIBLE=true -e HYRAX_DISABLE_INCLUDE_METADATA=true \
  -e HYRAX_FLEXIBLE_CLASSES="GenericWork,CollectionResource,Hyrax::FileSet,AdminSetResource" \
  koppie-web-1 sh -lc 'cd /app/samvera/hyrax-webapp && bundle exec rails console'
```

```ruby
Hyrax::FlexibleSchema.create_default_schema
w = Hyrax.persister.save(resource: GenericWork.new(title: ['t'], participants: [{'name' => 'Ada'}, {'role' => 'Editor'}]))
Hyrax.query_service.find_by(id: w.id).participants
# before: [{"name"=>"Ada", "role"=>"Editor"}]   (two entries merged into one)
# after:  [{"name"=>"Ada"}, {"role"=>"Editor"}]
```


