### PR TITLE
Fix red main: anyURI spec asserts through a name-shadowed property

### DIFF
--- a/spec/models/hyrax/flexible_schema_spec.rb
+++ b/spec/models/hyrax/flexible_schema_spec.rb
@@ -35,9 +35,14 @@ RSpec.describe Hyrax::FlexibleSchema, :clean_repo, type: :model do
 
     context 'when a property declares an xsd:anyURI range' do
       it "maps the type to 'uri'" do
-        profile_data['properties']['title']['range'] = 'http://www.w3.org/2001/XMLSchema#anyURI'
+        # Use `abstract`: the fixture declares three properties whose `name:`
+        # resolves to `title` (title, title_primary, title_alternative), and
+        # attributes_for keys by resolved name so the last one wins - changing
+        # `properties.title` and reading back attributes['title'] asserts
+        # against a different property. `abstract` has no such shadow.
+        profile_data['properties']['abstract']['range'] = 'http://www.w3.org/2001/XMLSchema#anyURI'
         attributes = subject.attributes_for('GenericWork')
-        expect(attributes['title']['type']).to eq('uri')
+        expect(attributes['abstract']['type']).to eq('uri')
       end
     end
   end


### PR DESCRIPTION
Main went red after #7486 merged, but the anyURI type mapping itself works fine. The new spec just looks at the wrong property.

The test changes `properties.title`'s range and then reads back `attributes_for('GenericWork')['title']`. Those are different things: the spec fixture has **three** properties whose `name:` resolves to `title` (`title`, `title_primary`, `title_alternative`), and `attributes_for` keys its result by resolved name, so the last one wins. The test changed the first one and read the third, which still has a `string` range - hence `expected "uri", got "string"`.

Fix: use `abstract`, which nothing shadows. Verified locally: `spec/models/hyrax/flexible_schema_spec.rb` now 14 examples, 0 failures.

(Found while chasing the same failure on #7487's CI - it inherits this from main.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
