### PR TITLE
Read the flexible schema once per presenter, not once per property

### DIFF
--- a/app/presenters/hyrax/work_show_presenter.rb
+++ b/app/presenters/hyrax/work_show_presenter.rb
@@ -35,8 +35,7 @@ module Hyrax
       # work show page builds one presenter per member row) multiplies into
       # thousands of identical queries and minutes of render time on
       # member-heavy works.
-      properties = Hyrax::FlexibleSchema.current_version&.[]("properties") || {}
-      properties.each do |method_name, property_details|
+      Hyrax::FlexibleSchema.current_version["properties"].each do |method_name, property_details|
         index_keys = property_details["indexing"]
         next unless index_keys
 

--- a/app/presenters/hyrax/work_show_presenter.rb
+++ b/app/presenters/hyrax/work_show_presenter.rb
@@ -29,11 +29,14 @@ module Hyrax
     end
 
     def define_dynamic_methods # rubocop:disable Metrics/CyclomaticComplexity, Metrics/MethodLength
-      Hyrax::FlexibleSchema.default_properties.each do |prop|
-        method_name = prop.to_s
-        property_details = Hyrax::FlexibleSchema.current_version["properties"][method_name]
-        next unless property_details
-
+      # Fetch and parse the profile ONCE per call. FlexibleSchema.current_version
+      # loads the latest row and deserializes the whole profile JSONB, so calling
+      # it inside the loop (once per property, for every presenter built - and a
+      # work show page builds one presenter per member row) multiplies into
+      # thousands of identical queries and minutes of render time on
+      # member-heavy works.
+      properties = Hyrax::FlexibleSchema.current_version&.[]("properties") || {}
+      properties.each do |method_name, property_details|
         index_keys = property_details["indexing"]
         next unless index_keys
 

--- a/spec/presenters/hyrax/work_show_presenter_spec.rb
+++ b/spec/presenters/hyrax/work_show_presenter_spec.rb
@@ -22,6 +22,31 @@ RSpec.describe Hyrax::WorkShowPresenter do
 
   it { is_expected.to delegate_method(:to_s).to(:solr_document) }
 
+  describe '#define_dynamic_methods' do
+    let(:attributes) do
+      { "id" => '888888',
+        "title_tesim" => ['foo'],
+        "has_model_ssim" => ["GenericWork"],
+        "schema_version_ssi" => '1' }
+    end
+    let(:profile) do
+      { 'properties' => {
+        'abstract' => { 'indexing' => ['abstract_tesim'], 'multiple' => true }
+      } }
+    end
+
+    before { allow(Hyrax::FlexibleSchema).to receive(:current_version).and_return(profile) }
+
+    it 'defines a reader for each indexed profile property' do
+      expect(presenter).to respond_to(:abstract)
+    end
+
+    it 'reads the flexible schema once, not once per property' do
+      presenter
+      expect(Hyrax::FlexibleSchema).to have_received(:current_version).once
+    end
+  end
+
   it { is_expected.to respond_to(:suppressed?) }
   it { is_expected.to respond_to(:human_readable_type) }
   it { is_expected.to respond_to(:date_created) }


### PR DESCRIPTION
## What happens

With flexible metadata turned on, opening a work that has a lot of member works can take minutes. On one of our deployments, a portfolio work with ~100 members took **104-205 seconds** to render, and the load balancer's 60 second timeout turned that into a 504 for the user:

```
GET /concern/portfolios/... Completed 200 OK in 104613ms
(Views: 103171.6ms | ActiveRecord: 228.7ms (9383 queries, 9333 cached) | GC: 4009.8ms)
```

see workaround: 
- https://github.com/research-technologies/enact_knapsack/pull/39

## Why

`WorkShowPresenter#define_dynamic_methods` calls `Hyrax::FlexibleSchema.current_version` **inside** its loop over the profile's properties. Every one of those calls fetches the newest schema row from the database and deserializes the entire profile JSONB. So one presenter pays that price roughly once per property (~85 times with our profile), and a work show page builds a presenter for **every member row**. ~85 properties x ~100 member presenters is the 9,383-query storm above, and the repeated JSONB parsing is the 103 seconds of view time.

## The fix

Fetch the profile once at the top of the method and iterate its `properties` hash directly. The same dynamic methods get defined; the page goes from minutes to seconds.

Also added a regression spec: building a presenter for a flexible document reads the schema exactly once.

## Notes

- `FlexibleSchema.default_properties` is no longer used here (it was a second full fetch+parse). It has no other callers in hyrax, but it is public API so this PR leaves it alone.
- There is more cacheable work in this area (`M3SchemaLoader` re-parses definitions on every call), but that needs an invalidation story; this change needs none and removes the worst of the cost.

🤖 Generated with [Claude Code](https://claude.com/claude-code)