### PR TITLE
Stop flaky real-derivative run in ValkyrieCreateDerivativesJob spec

### DIFF
--- a/spec/jobs/valkyrie_create_derivatives_job_spec.rb
+++ b/spec/jobs/valkyrie_create_derivatives_job_spec.rb
@@ -27,6 +27,14 @@ RSpec.describe ValkyrieCreateDerivativesJob, perform_enqueued: true do
     # This job depends on routes existing for the work. SimpleWork doesn't here, so skip it.
     allow(ContentUpdateEventJob).to receive(:perform_later)
 
+    # Ingesting publishes `file.characterized`, whose listener enqueues a real
+    # ValkyrieCreateDerivativesJob. Under `perform_enqueued: true` that runs
+    # inline and shells out to ImageMagick on the fixture - which is slow and
+    # intermittently fails ("no decode delegate ...") on a temp-file race. The
+    # examples drive the job directly with a stubbed derivative service, so the
+    # listener-enqueued run is unwanted setup noise; suppress it.
+    allow(ValkyrieCreateDerivativesJob).to receive(:perform_later)
+
     # Using ValkyrieIngestJob here is slow and runs the job this spec is supposed to test.
     # It should instead be handled by factories once real files can be attached
     # in the Hyrax::Work and Hyrax::FileSet factories.


### PR DESCRIPTION
## Problem

`spec/jobs/valkyrie_create_derivatives_job_spec.rb:44` is flaky in CI (seen on multiple branches). The failure is not in the job logic, it is in the spec's setup:

```
MiniMagick::Error: `magick convert /tmp/mini_magick...[0] ...jpg` failed with status: 1
convert: no decode delegate for this image format `' @ error/constitute.c/ReadImage/746.
```

The empty format name (`` `' ``) is the signature of an empty / not-yet-flushed temp file, i.e. a filesystem race during real ImageMagick derivative generation.

## Why it happens

The describe block uses `perform_enqueued: true`, and the `before` hook ingests two files with `ValkyrieIngestJob.perform_now`. Ingest publishes `file.uploaded` -> `file.characterized`, and `Hyrax::Listeners::FileListener#on_file_characterized` enqueues a real `ValkyrieCreateDerivativesJob`. Under `perform_enqueued: true` that runs inline. The `Hyrax::DerivativeService.for` stub lives in the inner `before`, which has not run yet, so the listener-triggered job uses the real derivative service and shells out to ImageMagick, occasionally hitting the temp-file race above. The example dies in setup before reaching its own assertions.

## Fix

Stub `ValkyrieCreateDerivativesJob.perform_later` in the `before` hook so the listener-enqueued run is a no-op. The examples already drive the job directly via `perform_now` with a stubbed `Hyrax::DerivativeService`, so their assertions (`create_derivatives` twice, `save(resource: work)` once) are unchanged. This removes the real ImageMagick invocation entirely, eliminating both the flakiness and a chunk of setup time.

Verified locally (koppie): `1 example, 0 failures`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)