### PR TITLE
Add rich_text input, sanitized HTML rendering, and view: { position: featured }

### DIFF
--- a/app/assets/javascripts/hyrax.js
+++ b/app/assets/javascripts/hyrax.js
@@ -47,6 +47,7 @@
 //= require hyrax/copy_permalink_button
 //= require hyrax/redirects
 //= require hyrax/compound_metadata
+//= require hyrax/rich_text_editor
 //= require hyrax/dashboard_actions
 //= require hyrax/batch
 //= require hyrax/flot_stats

--- a/app/assets/javascripts/hyrax/rich_text_editor.js
+++ b/app/assets/javascripts/hyrax/rich_text_editor.js
@@ -89,4 +89,4 @@
   document.addEventListener('DOMContentLoaded', bind);
   document.addEventListener('turbo:load', bind);
   document.addEventListener('turbolinks:load', bind);
-})();
+}());

--- a/app/assets/javascripts/hyrax/rich_text_editor.js
+++ b/app/assets/javascripts/hyrax/rich_text_editor.js
@@ -15,8 +15,19 @@
   // Block-format dropdown (formatselect): paragraph plus the heading levels the
   // renderer allows, so editors can apply H1-H4 without typing markup.
   var BLOCK_FORMATS = 'Paragraph=p; Heading 1=h1; Heading 2=h2; Heading 3=h3; Heading 4=h4';
-  // Keep stored markup aligned with HtmlAttributeRenderer's allow-list.
-  var VALID_ELEMENTS = 'p,br,strong/b,em/i,u,s,a[href|title|target|rel],ul,ol,li,blockquote,h1,h2,h3,h4,h5,h6,code,pre,span';
+  // Keep stored markup aligned with HtmlAttributeRenderer's allow-list (ALLOWED_TAGS
+  // + ALLOWED_ATTRIBUTES). Anything the editor strips here that the renderer would
+  // otherwise allow causes confusing paste/save/re-open round-trips, so the two
+  // lists must stay in sync.
+  var VALID_ELEMENTS = [
+    'p', 'br', 'hr', 'span', 'div',
+    'strong/b', 'em/i', 'u', 's', 'strike', 'sub', 'sup',
+    'a[href|title|target|rel]',
+    'ul', 'ol[start]', 'li',
+    'blockquote', 'pre', 'code',
+    'h1', 'h2', 'h3', 'h4', 'h5', 'h6',
+    'table', 'thead', 'tbody', 'tr', 'th', 'td'
+  ].join(',');
 
   function uniqueId() {
     return 'rich-text-' + Date.now() + '-' + Math.floor(Math.random() * 100000);

--- a/app/assets/javascripts/hyrax/rich_text_editor.js
+++ b/app/assets/javascripts/hyrax/rich_text_editor.js
@@ -10,8 +10,11 @@
 // Applications may override this file (or the toolbar/plugins below) to swap in
 // a different editor; with no JS at all the field degrades to a plain textarea.
 (function () {
-  var TOOLBAR = 'undo redo | bold italic underline | bullist numlist | blockquote link | removeformat | code';
+  var TOOLBAR = 'undo redo | formatselect | bold italic underline | bullist numlist | blockquote link | removeformat | code';
   var PLUGINS = 'lists link autolink code';
+  // Block-format dropdown (formatselect): paragraph plus the heading levels the
+  // renderer allows, so editors can apply H1-H4 without typing markup.
+  var BLOCK_FORMATS = 'Paragraph=p; Heading 1=h1; Heading 2=h2; Heading 3=h3; Heading 4=h4';
   // Keep stored markup aligned with HtmlAttributeRenderer's allow-list.
   var VALID_ELEMENTS = 'p,br,strong/b,em/i,u,s,a[href|title|target|rel],ul,ol,li,blockquote,h1,h2,h3,h4,h5,h6,code,pre,span';
 
@@ -29,6 +32,11 @@
       branding: false,
       plugins: PLUGINS,
       toolbar: TOOLBAR,
+      block_formats: BLOCK_FORMATS,
+      // Fill the field width; without this TinyMCE uses its default size and looks
+      // cramped inside the multi_value widget's input-group wrapper. The companion
+      // rule in hyrax/_tinymce.scss handles that wrapper's flex layout.
+      width: '100%',
       valid_elements: VALID_ELEMENTS
     });
   }

--- a/app/assets/javascripts/hyrax/rich_text_editor.js
+++ b/app/assets/javascripts/hyrax/rich_text_editor.js
@@ -1,0 +1,84 @@
+// Attaches a TinyMCE WYSIWYG editor to any textarea that the flexible
+// rich-text edit field renders for a `form: { input_type: rich_text }` property.
+// The edit field (records/edit_fields/_rich_text) emits
+// `<textarea class="rich-text">` (single-valued) or a multi_value widget of such
+// textareas with an "Add another" control; this turns each into a
+// what-you-see-is-what-you-get editor whose HTML output is stored on the field
+// and rendered (sanitized) on the show page by Hyrax::Renderers::HtmlAttributeRenderer.
+//
+// TinyMCE ships with Hyrax (tinymce-rails), so apps get the editor by default.
+// Applications may override this file (or the toolbar/plugins below) to swap in
+// a different editor; with no JS at all the field degrades to a plain textarea.
+(function () {
+  var TOOLBAR = 'undo redo | bold italic underline | bullist numlist | blockquote link | removeformat | code';
+  var PLUGINS = 'lists link autolink code';
+  // Keep stored markup aligned with HtmlAttributeRenderer's allow-list.
+  var VALID_ELEMENTS = 'p,br,strong/b,em/i,u,s,a[href|title|target|rel],ul,ol,li,blockquote,h1,h2,h3,h4,h5,h6,code,pre,span';
+
+  function uniqueId() {
+    return 'rich-text-' + Date.now() + '-' + Math.floor(Math.random() * 100000);
+  }
+
+  function initEditor(textarea) {
+    if (typeof tinymce === 'undefined' || !textarea) { return; }
+    // TinyMCE keys editors by id; ensure each textarea has a unique, un-bound id.
+    if (!textarea.id || tinymce.get(textarea.id)) { textarea.id = uniqueId(); }
+    tinymce.init({
+      target: textarea,
+      menubar: false,
+      branding: false,
+      plugins: PLUGINS,
+      toolbar: TOOLBAR,
+      valid_elements: VALID_ELEMENTS
+    });
+  }
+
+  function initAll() {
+    if (typeof tinymce === 'undefined') { return; }
+    var nodes = document.querySelectorAll('textarea.rich-text');
+    for (var i = 0; i < nodes.length; i++) {
+      if (!tinymce.get(nodes[i].id)) { initEditor(nodes[i]); }
+    }
+  }
+
+  // When the multi_value "Add another" control clones a field, the clone carries
+  // a stale copy of the source editor's TinyMCE DOM. Strip it, then initialize a
+  // fresh editor on the cloned textarea.
+  function onManagedFieldAdd(_event, added) {
+    if (typeof window.jQuery === 'undefined') { return; }
+    var $ = window.jQuery;
+    // hydra-editor triggers this event *before* it appends the cloned field to
+    // the listing, so defer until the node is attached to the DOM. Initializing
+    // TinyMCE on a detached node breaks the subsequent append.
+    setTimeout(function () {
+      var $added = $(added);
+      var $textarea = $added.is('textarea.rich-text') ? $added : $added.find('textarea.rich-text');
+      if (!$textarea.length) { $textarea = $added.closest('li').find('textarea.rich-text'); }
+      if (!$textarea.length) { return; }
+
+      var $li = $textarea.closest('li');
+      // Remove any cloned TinyMCE chrome so we can rebind cleanly.
+      $li.find('.tox-tinymce, .mce-tinymce').remove();
+
+      var textarea = $textarea[0];
+      textarea.style.display = '';
+      textarea.removeAttribute('aria-hidden');
+      textarea.value = '';
+      textarea.id = uniqueId();
+      initEditor(textarea);
+    }, 0);
+  }
+
+  function bind() {
+    initAll();
+    if (typeof window.jQuery !== 'undefined') {
+      // Rebind defensively (off then on) so Turbo re-renders don't stack handlers.
+      window.jQuery(document).off('managed_field:add.hyraxRichText')
+            .on('managed_field:add.hyraxRichText', onManagedFieldAdd);
+    }
+  }
+
+  document.addEventListener('DOMContentLoaded', bind);
+  document.addEventListener('turbo:load', bind);
+  document.addEventListener('turbolinks:load', bind);
+})();

--- a/app/assets/stylesheets/hyrax/_tinymce.scss
+++ b/app/assets/stylesheets/hyrax/_tinymce.scss
@@ -24,5 +24,9 @@
 // wrapper they otherwise render at TinyMCE's default width and look cramped next to
 // the inline "Remove" control. Let the editor use the full field width and wrap the
 // append control beneath it, so the box matches other full-width fields.
-.form-group .listing .field-wrapper.input-group { flex-wrap: wrap; width: 100%; }
-.form-group .listing .field-wrapper .tox-tinymce { flex: 1 1 100%; }
+//
+// Scoped to `.rich-text-field` (set via `wrapper_html` in
+// records/edit_fields/_rich_text) so other multi-value inputs keep their default
+// inline layout.
+.rich-text-field .listing .field-wrapper.input-group { flex-wrap: wrap; width: 100%; }
+.rich-text-field .listing .field-wrapper .tox-tinymce { flex: 1 1 100%; }

--- a/app/assets/stylesheets/hyrax/_tinymce.scss
+++ b/app/assets/stylesheets/hyrax/_tinymce.scss
@@ -25,4 +25,4 @@
 // the inline "Remove" control. Let the editor use the full field width and wrap the
 // append control beneath it, so the box matches other full-width fields.
 .form-group .listing .field-wrapper.input-group { flex-wrap: wrap; width: 100%; }
-.form-group .listing .field-wrapper .tox-tinymce { flex: 1 1 100%; width: 100% !important; }
+.form-group .listing .field-wrapper .tox-tinymce { flex: 1 1 100%; }

--- a/app/assets/stylesheets/hyrax/_tinymce.scss
+++ b/app/assets/stylesheets/hyrax/_tinymce.scss
@@ -18,3 +18,11 @@
 .tox .tox-tbtn--bespoke .tox-tbtn__select-label { overflow: visible !important; }
 .tox .tox-tbtn { overflow: visible !important; }
 .tox-tinymce { overflow: visible !important; }
+
+// Rich-text (`form: { input_type: rich_text }`) editors are block WYSIWYG fields,
+// not single-line inputs. Inside the multi_value widget's `input-group input-append`
+// wrapper they otherwise render at TinyMCE's default width and look cramped next to
+// the inline "Remove" control. Let the editor use the full field width and wrap the
+// append control beneath it, so the box matches other full-width fields.
+.form-group .listing .field-wrapper.input-group { flex-wrap: wrap; width: 100%; }
+.form-group .listing .field-wrapper .tox-tinymce { flex: 1 1 100%; width: 100% !important; }

--- a/app/forms/hyrax/forms/resource_form.rb
+++ b/app/forms/hyrax/forms/resource_form.rb
@@ -289,6 +289,22 @@ module Hyrax
         secondary_terms.any? || secondary_compound_terms.any?
       end
 
+      ##
+      # The form input widget requested for a term via the schema's
+      # `form: { input_type: ... }` option (e.g. `:rich_text`). Used by the
+      # edit-field partial lookup to render a richer editor than the default
+      # text input. Returns +nil+ when no input type is declared.
+      #
+      # @param [#to_sym] term
+      # @return [Symbol, nil]
+      def input_type(term)
+        definition = _form_field_definitions[term.to_sym] || _form_field_definitions[term.to_s]
+        return if definition.nil?
+
+        value = definition[:input_type]
+        value&.to_sym
+      end
+
       delegate :flexible?, to: :model
 
       private

--- a/app/helpers/hyrax/attributes_helper.rb
+++ b/app/helpers/hyrax/attributes_helper.rb
@@ -91,9 +91,12 @@ module Hyrax
       view_options
     end
 
-    # Returns true when the field should render on the work show page.
-    # Honors these view options:
+    # Returns true when the field should render in the work show page's
+    # standard attribute list. Honors these view options:
     #   * `show_page: false` — suppresses the field on the show page for everyone.
+    #   * `position: featured` — the field is rendered elsewhere (e.g. near the
+    #     top of the show page), so it is omitted from the attribute list to
+    #     avoid duplicating it.
     #   * `admin_only: true` — only visible to admins.
     #   * `editor_only: true` — only visible to users the presenter reports as editors.
     # Setting both `admin_only` and `editor_only` is effectively equivalent to
@@ -101,6 +104,7 @@ module Hyrax
     # guards, but a plain editor of the record still fails the admin guard.
     def field_visible?(view_options, presenter)
       return false if view_options[:show_page] == false
+      return false if view_options[:position].to_s == 'featured'
       return false if view_options[:admin_only] && !current_user&.admin?
       return false if view_options[:editor_only] && !presenter.try(:editor?)
       true

--- a/app/helpers/hyrax/attributes_helper.rb
+++ b/app/helpers/hyrax/attributes_helper.rb
@@ -94,9 +94,9 @@ module Hyrax
     # Returns true when the field should render in the work show page's
     # standard attribute list. Honors these view options:
     #   * `show_page: false` — suppresses the field on the show page for everyone.
-    #   * `position: featured` — the field is rendered elsewhere (e.g. near the
-    #     top of the show page), so it is omitted from the attribute list to
-    #     avoid duplicating it.
+    #   * `position: featured` — the field is rendered prominently near the top
+    #     of the show page by the `featured_attributes` partial instead, so it is
+    #     omitted from the attribute list to avoid duplicating it.
     #   * `admin_only: true` — only visible to admins.
     #   * `editor_only: true` — only visible to users the presenter reports as editors.
     # Setting both `admin_only` and `editor_only` is effectively equivalent to

--- a/app/helpers/hyrax/rich_text_edit_field_behavior.rb
+++ b/app/helpers/hyrax/rich_text_edit_field_behavior.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module Hyrax
+  ##
+  # Prepended onto hydra-editor's +RecordsHelperBehavior+ so that any metadata
+  # field declared with `form: { input_type: rich_text }` renders the shared
+  # rich-text editor partial, while every other field falls back to the normal
+  # field-partial lookup.
+  #
+  # This covers all edit-field render sites (work form, collection form, file
+  # set form, and downstream overrides) through the single
+  # +render_edit_field_partial+ entry point, so no view templates need to change.
+  #
+  # It is engine-agnostic: the partial it renders emits a plain textarea with the
+  # `rich-text` class; applications attach their own editor (TinyMCE, etc.) to
+  # that hook. No markdown/HTML engine is required here.
+  #
+  # @see Hyrax::Forms::ResourceForm#input_type
+  # @see records/edit_fields/_rich_text
+  module RichTextEditFieldBehavior
+    def render_edit_field_partial(field_name, locals)
+      form = locals[:f]&.object
+      if form.respond_to?(:input_type) && form.input_type(field_name).to_s == 'rich_text'
+        return render('records/edit_fields/rich_text', locals.merge(key: field_name))
+      end
+
+      super
+    end
+  end
+end

--- a/app/helpers/hyrax/rich_text_edit_field_behavior.rb
+++ b/app/helpers/hyrax/rich_text_edit_field_behavior.rb
@@ -20,9 +20,7 @@ module Hyrax
   module RichTextEditFieldBehavior
     def render_edit_field_partial(field_name, locals)
       form = locals[:f]&.object
-      if form.respond_to?(:input_type) && form.input_type(field_name).to_s == 'rich_text'
-        return render('records/edit_fields/rich_text', locals.merge(key: field_name))
-      end
+      return render('records/edit_fields/rich_text', locals.merge(key: field_name)) if form.respond_to?(:input_type) && form.input_type(field_name).to_s == 'rich_text'
 
       super
     end

--- a/app/renderers/hyrax/renderers/html_attribute_renderer.rb
+++ b/app/renderers/hyrax/renderers/html_attribute_renderer.rb
@@ -50,20 +50,42 @@ module Hyrax
       # values in `markdown()`). Sanitized rich text should render identically
       # regardless of that flag.
       def attribute_value_to_html(value)
-        sanitized = sanitize(value.to_s, tags: ALLOWED_TAGS, attributes: ALLOWED_ATTRIBUTES)
+        sanitized = sanitize_rich_text(value.to_s)
         return sanitized if microdata_value_attributes(field).blank?
 
-        # Return the assembled span as a plain string (matching the base
-        # AttributeRenderer#attribute_value_to_html contract); the caller in
-        # #render applies html_safe once to the full markup. `sanitized` is
-        # already allow-list sanitized, so no unsafe content is reintroduced.
-        "<span#{html_attributes(microdata_value_attributes(field))}>#{sanitized}</span>"
+        # Wrap in a block-level <div> (not <span>) when carrying microdata: the
+        # allow-list permits block elements (p, div, table, ...) and nesting
+        # those inside a <span> is invalid HTML. Returned as a plain string per
+        # the base AttributeRenderer#attribute_value_to_html contract; #render
+        # applies html_safe once to the full markup. `sanitized` is already
+        # allow-list sanitized, so no unsafe content is reintroduced.
+        "<div#{html_attributes(microdata_value_attributes(field))}>#{sanitized}</div>"
       end
 
       # Kept for callers/subclasses that invoke +li_value+ directly; mirrors the
       # sanitizing behavior above.
       def li_value(value)
-        sanitize(value.to_s, tags: ALLOWED_TAGS, attributes: ALLOWED_ATTRIBUTES)
+        sanitize_rich_text(value.to_s)
+      end
+
+      # Allow-list sanitize, then ensure any author-supplied `target="_blank"`
+      # link also carries `rel="noopener noreferrer"`. Without it, the opened
+      # page can reach back through `window.opener` (reverse tabnabbing); Hyrax
+      # adds this rel consistently elsewhere (e.g. LicenseAttributeRenderer).
+      def sanitize_rich_text(value)
+        harden_blank_target_links(sanitize(value, tags: ALLOWED_TAGS, attributes: ALLOWED_ATTRIBUTES))
+      end
+
+      def harden_blank_target_links(html)
+        return html unless html.to_s.include?('target')
+
+        fragment = Nokogiri::HTML.fragment(html)
+        fragment.css('a[target="_blank"]').each do |anchor|
+          anchor['rel'] = (anchor['rel'].to_s.split + %w[noopener noreferrer]).uniq.join(' ')
+        end
+        # Plain String per the attribute_value_to_html contract; #render applies
+        # html_safe once. The content is already allow-list sanitized above.
+        fragment.to_html
       end
     end
   end

--- a/app/renderers/hyrax/renderers/html_attribute_renderer.rb
+++ b/app/renderers/hyrax/renderers/html_attribute_renderer.rb
@@ -53,7 +53,11 @@ module Hyrax
         sanitized = sanitize(value.to_s, tags: ALLOWED_TAGS, attributes: ALLOWED_ATTRIBUTES)
         return sanitized if microdata_value_attributes(field).blank?
 
-        "<span#{html_attributes(microdata_value_attributes(field))}>#{sanitized}</span>".html_safe
+        # Return the assembled span as a plain string (matching the base
+        # AttributeRenderer#attribute_value_to_html contract); the caller in
+        # #render applies html_safe once to the full markup. `sanitized` is
+        # already allow-list sanitized, so no unsafe content is reintroduced.
+        "<span#{html_attributes(microdata_value_attributes(field))}>#{sanitized}</span>"
       end
 
       # Kept for callers/subclasses that invoke +li_value+ directly; mirrors the

--- a/app/renderers/hyrax/renderers/html_attribute_renderer.rb
+++ b/app/renderers/hyrax/renderers/html_attribute_renderer.rb
@@ -41,8 +41,23 @@ module Hyrax
 
       private
 
-      # Override the base renderer's escaping behavior: render the stored markup
-      # as sanitized HTML instead of escaping it.
+      # Render the stored markup as sanitized HTML.
+      #
+      # We override +attribute_value_to_html+ (not just +li_value+) so this
+      # renderer fully owns its output and is unaffected by any markdown/escaping
+      # decorator an application may prepend onto the base AttributeRenderer
+      # (e.g. Hyku's `treat_some_user_inputs_as_markdown` feature flag wraps
+      # values in `markdown()`). Sanitized rich text should render identically
+      # regardless of that flag.
+      def attribute_value_to_html(value)
+        sanitized = sanitize(value.to_s, tags: ALLOWED_TAGS, attributes: ALLOWED_ATTRIBUTES)
+        return sanitized if microdata_value_attributes(field).blank?
+
+        "<span#{html_attributes(microdata_value_attributes(field))}>#{sanitized}</span>".html_safe
+      end
+
+      # Kept for callers/subclasses that invoke +li_value+ directly; mirrors the
+      # sanitizing behavior above.
       def li_value(value)
         sanitize(value.to_s, tags: ALLOWED_TAGS, attributes: ALLOWED_ATTRIBUTES)
       end

--- a/app/renderers/hyrax/renderers/html_attribute_renderer.rb
+++ b/app/renderers/hyrax/renderers/html_attribute_renderer.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+module Hyrax
+  module Renderers
+    ##
+    # Renders an attribute whose value is stored as HTML markup (for example,
+    # the output of a rich-text / WYSIWYG editor field) as *sanitized* HTML.
+    #
+    # Selected by setting `render_as: :html` on the attribute, e.g. from a
+    # flexible-metadata profile:
+    #
+    #     my_field:
+    #       form:
+    #         input_type: rich_text
+    #       view:
+    #         render_as: html
+    #
+    # Unlike the default {AttributeRenderer}, which HTML-escapes values, this
+    # renderer passes the stored markup through `ActionView`'s allow-list
+    # `sanitize` helper so a known-safe subset of tags/attributes renders while
+    # scripts, event handlers, and unknown tags are stripped. The renderer does
+    # not depend on any markdown engine.
+    class HtmlAttributeRenderer < AttributeRenderer
+      include ActionView::Helpers::SanitizeHelper
+
+      # Inline + block tags appropriate for narrative rich text. Intentionally
+      # excludes anything that can execute or load remote content (script,
+      # iframe, object, style, img with onerror, etc.).
+      ALLOWED_TAGS = %w[
+        p br span div
+        b strong i em u s strike sub sup
+        a
+        ul ol li
+        blockquote pre code
+        h1 h2 h3 h4 h5 h6
+        hr
+        table thead tbody tr th td
+      ].freeze
+
+      ALLOWED_ATTRIBUTES = %w[href title target rel start].freeze
+
+      private
+
+      # Override the base renderer's escaping behavior: render the stored markup
+      # as sanitized HTML instead of escaping it.
+      def li_value(value)
+        sanitize(value.to_s, tags: ALLOWED_TAGS, attributes: ALLOWED_ATTRIBUTES)
+      end
+    end
+  end
+end

--- a/app/services/hyrax/flexible_schema_validator_service.rb
+++ b/app/services/hyrax/flexible_schema_validator_service.rb
@@ -40,6 +40,7 @@ module Hyrax
       validate_sort_properties
       validate_redirects
       validate_compound
+      validate_rich_text
     end
 
     # The default JSON schema used when no custom schema is provided.
@@ -140,6 +141,16 @@ module Hyrax
     # @return [void]
     def validate_compound
       FlexibleSchemaValidators::CompoundValidator.new(profile: profile, errors: @errors).validate!
+    end
+
+    # Warns (does not block) when a property declares
+    # `form: { input_type: rich_text }` alongside a controlled-vocabulary
+    # configuration, since rich text stores free-form HTML and bypasses the
+    # controlled input.
+    #
+    # @return [void]
+    def validate_rich_text
+      FlexibleSchemaValidators::RichTextValidator.new(profile, @warnings).validate!
     end
 
     # Validates that a `label` property exists and that it is available on

--- a/app/services/hyrax/flexible_schema_validators/rich_text_validator.rb
+++ b/app/services/hyrax/flexible_schema_validators/rich_text_validator.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+module Hyrax
+  module FlexibleSchemaValidators
+    # Warns when a property is declared with `form: { input_type: rich_text }`
+    # but is also configured as a controlled value. A rich-text field stores
+    # free-form HTML, which is incompatible with a curated/authority value, and
+    # the rich-text editor pre-empts the controlled widget at the single
+    # edit-field render entry point, so the dropdown/autocomplete is silently
+    # dropped. `rich_text` is meant only for free-text string properties.
+    #
+    # Flexible mode has no single declarative "controlled" flag, so this keys on
+    # what the profile declares (or what Hyrax/Hyku render by convention):
+    #   * a real `controlled_values.sources` entry, i.e. a local or remote
+    #     authority - anything other than the `"null"` free-text sentinel
+    #     (Hyku renders these as a select or autocomplete), or
+    #   * a built-in property rendered with a controlled widget by field-name
+    #     convention regardless of declared sources (dedicated edit-field
+    #     partials / authority services), or
+    #   * a compound subproperty declared `type: controlled`.
+    class RichTextValidator
+      # Built-in properties Hyrax renders with a controlled widget by field-name
+      # convention, even when their profile entry leaves
+      # `controlled_values.sources` as the `"null"` sentinel.
+      CONTROLLED_BY_CONVENTION = %w[
+        rights_statement license resource_type based_near language access_right
+      ].freeze
+
+      def initialize(profile, warnings)
+        @profile = profile
+        @warnings = warnings
+      end
+
+      def validate!
+        (@profile['properties'] || {}).each do |name, config|
+          next unless config.is_a?(Hash) && rich_text?(config)
+
+          key, options = conflict_for(name, config)
+          next unless key
+
+          @warnings << I18n.t("hyrax.flexible_schema_validators.rich_text_validator.warnings.#{key}", **options)
+        end
+      end
+
+      private
+
+      def rich_text?(config)
+        config.dig('form', 'input_type').to_s == 'rich_text'
+      end
+
+      # @return [Array(Symbol, Hash), nil] the i18n warning key and its
+      #   interpolation options, or nil when the property is free-text (a valid
+      #   target for rich_text).
+      def conflict_for(name, config)
+        sources = real_sources(config)
+        if sources.present?
+          [:controlled_sources, { property: name, sources: sources.join(', ') }]
+        elsif CONTROLLED_BY_CONVENTION.include?(name.to_s)
+          [:built_in, { property: name }]
+        elsif config['type'].to_s == 'controlled'
+          [:controlled_type, { property: name }]
+        end
+      end
+
+      # Controlled-vocabulary sources, excluding the `"null"` sentinel (and
+      # blanks) the profile uses to mean "free text / no authority".
+      def real_sources(config)
+        Array(config.dig('controlled_values', 'sources')).reject do |source|
+          value = source.to_s.strip
+          value.empty? || value.casecmp('null').zero?
+        end
+      end
+    end
+  end
+end

--- a/app/views/hyrax/base/_featured_attributes.html.erb
+++ b/app/views/hyrax/base/_featured_attributes.html.erb
@@ -1,0 +1,28 @@
+<%# Renders any property flagged `view: { position: featured }` prominently near
+    the top of the work show page, above the standard metadata table. This is the
+    default implementation of `position: featured`: the same hook that hides the
+    field from the attribute list (Hyrax::AttributesHelper#field_visible?) is paired
+    here with a place to actually display it, so the directive is self-contained.
+
+    Profile-driven (not tied to a specific field) and works whether or not flexible
+    metadata is enabled, since view_options_for resolves view definitions in both
+    modes. Values are rendered as sanitized HTML using the same allow-list as
+    Hyrax::Renderers::HtmlAttributeRenderer, so a `render_as: html` field looks
+    identical here and in the metadata table.
+
+    Host apps that override base/show.html.erb (or ship custom show themes) should
+    render this partial wherever they want featured fields to appear. %>
+<% view_options_for(presenter).each do |field, view_options| %>
+  <% next unless view_options.with_indifferent_access[:position].to_s == 'featured' %>
+  <% render_field = conform_field(field, view_options) %>
+  <% next unless presenter.respond_to?(render_field) %>
+  <% featured_value = Array(presenter.public_send(render_field)).join(' ').to_s %>
+  <% next if featured_value.blank? %>
+  <section class="work-featured-attribute card mb-4 attribute-<%= field %>">
+    <div class="card-body">
+      <%= sanitize(featured_value,
+                   tags: Hyrax::Renderers::HtmlAttributeRenderer::ALLOWED_TAGS,
+                   attributes: Hyrax::Renderers::HtmlAttributeRenderer::ALLOWED_ATTRIBUTES) %>
+    </div>
+  </section>
+<% end %>

--- a/app/views/hyrax/base/_featured_attributes.html.erb
+++ b/app/views/hyrax/base/_featured_attributes.html.erb
@@ -11,15 +11,23 @@
     identical here and in the metadata table.
 
     Host apps that override base/show.html.erb (or ship custom show themes) should
-    render this partial wherever they want featured fields to appear. %>
+    render this partial wherever they want featured fields to appear.
+
+    More than one property may be featured: each renders as its own labeled card,
+    stacked in profile order. The label is resolved the same way as the standard
+    metadata table (conform_options), so a featured field reads identically here. %>
 <% view_options_for(presenter).each do |field, view_options| %>
   <% next unless view_options.with_indifferent_access[:position].to_s == 'featured' %>
   <% render_field = conform_field(field, view_options) %>
   <% next unless presenter.respond_to?(render_field) %>
   <% featured_value = Array(presenter.public_send(render_field)).join(' ').to_s %>
   <% next if featured_value.blank? %>
+  <% featured_label = conform_options(field, view_options)[:label] %>
   <section class="work-featured-attribute card mb-4 attribute-<%= field %>">
     <div class="card-body">
+      <% if featured_label.present? %>
+        <h2 class="h5 work-featured-attribute-label"><%= featured_label %></h2>
+      <% end %>
       <%= sanitize(featured_value,
                    tags: Hyrax::Renderers::HtmlAttributeRenderer::ALLOWED_TAGS,
                    attributes: Hyrax::Renderers::HtmlAttributeRenderer::ALLOWED_ATTRIBUTES) %>

--- a/app/views/hyrax/base/show.html.erb
+++ b/app/views/hyrax/base/show.html.erb
@@ -12,6 +12,7 @@
   <div itemscope itemtype="http://schema.org/CreativeWork" class="col-12">
     <%= render 'work_title', presenter: @presenter %>
     <%= render 'show_actions', presenter: @presenter %>
+    <%= render 'featured_attributes', presenter: @presenter %>
     <div class="card">
       <div class="card-body">
         <div class="row">

--- a/app/views/records/edit_fields/_rich_text.html.erb
+++ b/app/views/records/edit_fields/_rich_text.html.erb
@@ -1,17 +1,15 @@
 <%# Rich-text edit field. Rendered for flexible-metadata fields declared with
-    `form: { input_type: rich_text }`. Engine-agnostic: emits a plain textarea
+    `form: { input_type: rich_text }`. Engine-agnostic: emits plain textareas
     carrying the `rich-text` class so applications can attach their own WYSIWYG
-    editor (e.g. TinyMCE) to that hook. Degrades to a normal textarea with no JS.
+    editor (e.g. TinyMCE) to that hook. Degrades to normal textareas with no JS.
 
-    Rich text is authored as a single HTML blob, so we always render one
-    textarea. When the underlying property is multi-valued (flexible metadata
-    defines every property as an array), we name the field as an array element
-    so it round-trips through the existing permitted-params handling. %>
+    Multi-valued properties render the standard multi_value widget (with its
+    "Add another" control) using textareas; single-valued properties render one
+    textarea. Applications should (re)initialize their editor on
+    `managed_field:add` so cloned fields become editors too. %>
 <% if f.object.multiple?(key) %>
-  <%= f.input key, as: :text, required: f.object.required?(key),
-        input_html: { class: 'form-control rich-text', rows: '14',
-                      name: "#{f.object_name}[#{key}][]",
-                      value: Array(f.object.send(key)).first } %>
+  <%= f.input key, as: :multi_value, required: f.object.required?(key),
+        input_html: { type: 'textarea', class: 'form-control rich-text', rows: '14' } %>
 <% else %>
   <%= f.input key, as: :text, required: f.object.required?(key),
         input_html: { class: 'form-control rich-text', rows: '14' } %>

--- a/app/views/records/edit_fields/_rich_text.html.erb
+++ b/app/views/records/edit_fields/_rich_text.html.erb
@@ -1,0 +1,18 @@
+<%# Rich-text edit field. Rendered for flexible-metadata fields declared with
+    `form: { input_type: rich_text }`. Engine-agnostic: emits a plain textarea
+    carrying the `rich-text` class so applications can attach their own WYSIWYG
+    editor (e.g. TinyMCE) to that hook. Degrades to a normal textarea with no JS.
+
+    Rich text is authored as a single HTML blob, so we always render one
+    textarea. When the underlying property is multi-valued (flexible metadata
+    defines every property as an array), we name the field as an array element
+    so it round-trips through the existing permitted-params handling. %>
+<% if f.object.multiple?(key) %>
+  <%= f.input key, as: :text, required: f.object.required?(key),
+        input_html: { class: 'form-control rich-text', rows: '14',
+                      name: "#{f.object_name}[#{key}][]",
+                      value: Array(f.object.send(key)).first } %>
+<% else %>
+  <%= f.input key, as: :text, required: f.object.required?(key),
+        input_html: { class: 'form-control rich-text', rows: '14' } %>
+<% end %>

--- a/app/views/records/edit_fields/_rich_text.html.erb
+++ b/app/views/records/edit_fields/_rich_text.html.erb
@@ -9,10 +9,15 @@
     "Add another" control) using textareas; single-valued properties render one
     textarea. The default initializer re-binds on `managed_field:add` so cloned
     fields become editors too. %>
+<%# `rich-text-field` on the wrapper scopes hyrax/_tinymce.scss's flex-layout
+    rules to rich-text editors only, so other multi-value inputs keep their
+    default layout. %>
 <% if f.object.multiple?(key) %>
   <%= f.input key, as: :multi_value, required: f.object.required?(key),
+        wrapper_html: { class: 'rich-text-field' },
         input_html: { type: 'textarea', class: 'form-control rich-text', rows: '14' } %>
 <% else %>
   <%= f.input key, as: :text, required: f.object.required?(key),
+        wrapper_html: { class: 'rich-text-field' },
         input_html: { class: 'form-control rich-text', rows: '14' } %>
 <% end %>

--- a/app/views/records/edit_fields/_rich_text.html.erb
+++ b/app/views/records/edit_fields/_rich_text.html.erb
@@ -1,12 +1,14 @@
-<%# Rich-text edit field. Rendered for flexible-metadata fields declared with
-    `form: { input_type: rich_text }`. Engine-agnostic: emits plain textareas
-    carrying the `rich-text` class so applications can attach their own WYSIWYG
-    editor (e.g. TinyMCE) to that hook. Degrades to normal textareas with no JS.
+<%# Rich-text edit field. Rendered for fields declared with
+    `form: { input_type: rich_text }`. Emits textareas carrying the `rich-text`
+    class; hyrax/rich_text_editor.js attaches a TinyMCE WYSIWYG editor to that
+    hook by default (tinymce-rails ships with Hyrax). The class is also a clean
+    override point: apps can attach a different editor, and with no JS the field
+    degrades to a plain textarea.
 
     Multi-valued properties render the standard multi_value widget (with its
     "Add another" control) using textareas; single-valued properties render one
-    textarea. Applications should (re)initialize their editor on
-    `managed_field:add` so cloned fields become editors too. %>
+    textarea. The default initializer re-binds on `managed_field:add` so cloned
+    fields become editors too. %>
 <% if f.object.multiple?(key) %>
   <%= f.input key, as: :multi_value, required: f.object.required?(key),
         input_html: { type: 'textarea', class: 'form-control rich-text', rows: '14' } %>

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -1429,6 +1429,11 @@ en:
         warnings:
           config_disabled: "m3 profile declares a `redirects` property but Hyrax.config.redirects_enabled? is false; the property will be ignored"
           flipflop_disabled: "m3 profile declares a `redirects` property but the :redirects feature flag is off; the property will be ignored"
+      rich_text_validator:
+        warnings:
+          controlled_sources: "m3 profile property `%{property}` declares `form: { input_type: rich_text }` but also a controlled vocabulary (`controlled_values.sources: %{sources}`); rich text stores free-form HTML and will bypass the controlled input. Use `rich_text` only on free-text properties."
+          built_in: "m3 profile property `%{property}` declares `form: { input_type: rich_text }`, but `%{property}` is rendered with a controlled vocabulary input; rich text stores free-form HTML and will bypass it. Use `rich_text` only on free-text properties."
+          controlled_type: "m3 profile compound subproperty `%{property}` is `type: controlled` but declares `form: { input_type: rich_text }`; rich text stores free-form HTML and conflicts with a controlled value."
       sort_properties_validator:
         warnings:
           message: "%{property} must be defined on %{classes} to support sorting on that property, unless you have indexed %{property}_ssi on some other field."

--- a/documentation/flexible_metadata.md
+++ b/documentation/flexible_metadata.md
@@ -132,6 +132,26 @@ context_narrative:
     render_as: html         # sanitize + render the stored markup as HTML on the show page
 ```
 
+## Featured display
+
+**`view: { position: featured }`** promotes a field out of the standard metadata table and renders it prominently near the top of the work show page:
+
+- `field_visible?` returns false for a featured field (the same hook that hides `admin_only`/`editor_only` fields), so it is **not** duplicated in the attribute table.
+- The `hyrax/base/_featured_attributes` partial renders every featured field above the metadata card. The default `hyrax/base/show.html.erb` includes this partial, so the directive works out of the box. Values are sanitized with the same allow-list as `Hyrax::Renderers::HtmlAttributeRenderer`, so a field that also declares `render_as: html` looks identical featured and in the table.
+
+It pairs naturally with `render_as: html` for a rich-text "narrative" field, but works on any property:
+
+```yaml
+# add to either schema mode's `view:` block
+  view:
+    render_as: html        # optional: sanitize + render stored markup as HTML
+    position: featured      # promote above the metadata table
+```
+
+Host applications that override `hyrax/base/show.html.erb` (or ship custom show themes) are responsible for rendering `<%= render 'featured_attributes', presenter: @presenter %>` wherever they want featured fields to appear; an override that omits it will simply not show them.
+
+This is intentionally **not** covered by an m3 profile validator: the profile cannot know what an app's templates render.
+
 ## Related features
 
 - **URL Redirects** (`HYRAX_REDIRECTS_ENABLED`): when enabled, the redirects feature requires a `redirects` property in the m3 profile (when also Flipflop-enabled per tenant). See [`documentation/redirects.md`](redirects.md) for the full schema and gating model.

--- a/documentation/flexible_metadata.md
+++ b/documentation/flexible_metadata.md
@@ -102,6 +102,8 @@ A string property can be edited with a rich-text (WYSIWYG) editor and rendered a
 
 The editor stores HTML directly, so no markdown engine is involved. Sanitization happens at render time; applications may additionally sanitize on save as defense in depth.
 
+`rich_text` is for free-text properties only. Declaring it on a controlled-vocabulary property (one whose `controlled_values.sources` names a real authority, a built-in controlled field such as `rights_statement`/`license`/`resource_type`, or a `type: controlled` compound subproperty) replaces the controlled input with a free-text editor and stores arbitrary HTML where a controlled value is expected. Saving such a profile raises a validation warning; see `Hyrax::FlexibleSchemaValidators::RichTextValidator`.
+
 ```yaml
 # HYRAX_FLEXIBLE=false (config/metadata/*.yaml)
 context_narrative:

--- a/documentation/flexible_metadata.md
+++ b/documentation/flexible_metadata.md
@@ -93,6 +93,43 @@ admin_note:
 
 Use `admin_only` in place of `editor_only` to restrict visibility to admins only.
 
+## Rich-text fields
+
+A string property can be edited with a rich-text (WYSIWYG) editor and rendered as sanitized HTML. This works in both flexible and non-flexible mode and is driven by two independent directives:
+
+- **`form: { input_type: rich_text }`** — the edit form renders the field through `records/edit_fields/_rich_text`, which emits a `<textarea class="rich-text">` (one per value; multi-valued fields keep the standard "Add another" control). `hyrax/rich_text_editor.js` attaches a **TinyMCE** WYSIWYG editor to every `textarea.rich-text` by default (tinymce-rails ships with Hyrax) and re-binds on the `managed_field:add` event so cloned rows become editors too. The `rich-text` class is also a clean override point — an app can attach a different editor — and with no JS the field degrades to a plain textarea.
+- **`view: { render_as: html }`** — the show page renders the stored markup through `Hyrax::Renderers::HtmlAttributeRenderer`, which runs Rails' `sanitize` against a fixed tag/attribute allow-list (headings, lists, links, emphasis, tables; `href`/`title`/`target`/`rel`/`start`). Unsafe markup (`<script>`, `onclick`, …) is stripped at render time. This renderer owns its output, so it is unaffected by the `treat_some_user_inputs_as_markdown` Flipflop flag or any markdown decorator.
+
+The editor stores HTML directly, so no markdown engine is involved. Sanitization happens at render time; applications may additionally sanitize on save as defense in depth.
+
+```yaml
+# HYRAX_FLEXIBLE=false (config/metadata/*.yaml)
+context_narrative:
+  type: string
+  multiple: false
+  predicate: http://purl.org/dc/terms/description
+  form:
+    input_type: rich_text   # WYSIWYG (TinyMCE) editor on the edit form
+  view:
+    render_as: html         # sanitize + render the stored markup as HTML on the show page
+```
+
+```yaml
+# HYRAX_FLEXIBLE=true (m3 profile)
+context_narrative:
+  available_on:
+    class:
+      - GenericWorkResource
+  data_type: string
+  indexing:
+    - context_narrative_tesim
+  property_uri: http://purl.org/dc/terms/description
+  form:
+    input_type: rich_text   # WYSIWYG (TinyMCE) editor on the edit form
+  view:
+    render_as: html         # sanitize + render the stored markup as HTML on the show page
+```
+
 ## Related features
 
 - **URL Redirects** (`HYRAX_REDIRECTS_ENABLED`): when enabled, the redirects feature requires a `redirects` property in the m3 profile (when also Flipflop-enabled per tenant). See [`documentation/redirects.md`](redirects.md) for the full schema and gating model.

--- a/lib/hyrax/engine.rb
+++ b/lib/hyrax/engine.rb
@@ -103,6 +103,15 @@ module Hyrax
       end
     end
 
+    # Teach the edit-field partial lookup to honor `form: { input_type: rich_text }`
+    # by rendering the shared rich-text editor partial. Prepended onto hydra-editor's
+    # helper so all render_edit_field_partial call sites are covered.
+    initializer 'hyrax.rich_text_edit_field' do
+      ActiveSupport::Reloader.to_prepare do
+        RecordsHelperBehavior.prepend(Hyrax::RichTextEditFieldBehavior) if defined?(RecordsHelperBehavior)
+      end
+    end
+
     initializer 'routing' do
       require 'hyrax/rails/routes'
     end

--- a/spec/forms/hyrax/forms/resource_form_spec.rb
+++ b/spec/forms/hyrax/forms/resource_form_spec.rb
@@ -950,4 +950,51 @@ RSpec.describe Hyrax::Forms::ResourceForm do
       end
     end
   end
+
+  describe '#input_type' do
+    # Stub the underlying field definitions so this is a focused unit test of the
+    # lookup/coercion logic, independent of flexible mode and the loaded profile.
+    before { allow(form).to receive(:_form_field_definitions).and_return(definitions) }
+
+    context 'when the definition declares an input_type' do
+      let(:definitions) { { 'summary' => { input_type: :rich_text } } }
+
+      it 'looks the term up by its string name' do
+        expect(form.input_type('summary')).to eq(:rich_text)
+      end
+
+      it 'accepts a symbol term' do
+        expect(form.input_type(:summary)).to eq(:rich_text)
+      end
+
+      it 'coerces a string input_type value to a symbol' do
+        definitions['summary'] = { input_type: 'rich_text' }
+        expect(form.input_type(:summary)).to eq(:rich_text)
+      end
+    end
+
+    context 'when the definitions are keyed by symbol' do
+      let(:definitions) { { summary: { input_type: :rich_text } } }
+
+      it 'finds the term through the symbol lookup' do
+        expect(form.input_type('summary')).to eq(:rich_text)
+      end
+    end
+
+    context 'when the term is absent' do
+      let(:definitions) { {} }
+
+      it 'returns nil' do
+        expect(form.input_type(:missing)).to be_nil
+      end
+    end
+
+    context 'when the definition has no input_type' do
+      let(:definitions) { { 'summary' => {} } }
+
+      it 'returns nil' do
+        expect(form.input_type(:summary)).to be_nil
+      end
+    end
+  end
 end

--- a/spec/helpers/hyrax/attributes_helper_spec.rb
+++ b/spec/helpers/hyrax/attributes_helper_spec.rb
@@ -98,6 +98,32 @@ RSpec.describe Hyrax::AttributesHelper, type: :helper do
       end
     end
 
+    context 'when position is featured' do
+      let(:view_options) { { position: 'featured' } }
+
+      it 'is false so the field is not duplicated in the attribute list' do
+        allow(helper).to receive(:current_user).and_return(non_admin_user)
+        expect(helper.field_visible?(view_options, non_editor_presenter)).to be false
+      end
+
+      it 'is false even for admins' do
+        allow(helper).to receive(:current_user).and_return(admin_user)
+        expect(helper.field_visible?(view_options, editor_presenter)).to be false
+      end
+
+      it 'accepts a symbol value' do
+        allow(helper).to receive(:current_user).and_return(non_admin_user)
+        expect(helper.field_visible?({ position: :featured }, non_editor_presenter)).to be false
+      end
+    end
+
+    context 'when position is set to a non-featured value' do
+      it 'does not suppress the field' do
+        allow(helper).to receive(:current_user).and_return(non_admin_user)
+        expect(helper.field_visible?({ position: 'sidebar' }, non_editor_presenter)).to be true
+      end
+    end
+
     context 'when admin_only is set' do
       let(:view_options) { { admin_only: true } }
 

--- a/spec/helpers/hyrax/rich_text_edit_field_behavior_spec.rb
+++ b/spec/helpers/hyrax/rich_text_edit_field_behavior_spec.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+RSpec.describe Hyrax::RichTextEditFieldBehavior do
+  # Minimal stand-in for hydra-editor's RecordsHelperBehavior, providing the
+  # fallback #render_edit_field_partial that the module reaches via `super`.
+  let(:base_module) do
+    Module.new do
+      def render_edit_field_partial(_field_name, _locals)
+        :fallback
+      end
+    end
+  end
+
+  let(:helper_class) do
+    base = base_module
+    Class.new do
+      include base
+      prepend Hyrax::RichTextEditFieldBehavior
+
+      # Stub Rails' #render so we can assert what would be rendered.
+      def render(partial, locals)
+        { partial: partial, locals: locals }
+      end
+    end
+  end
+
+  let(:helper) { helper_class.new }
+  let(:f) { double('form_builder', object: form) }
+
+  context 'when the field is declared as rich_text' do
+    let(:form) { double('form') }
+
+    before { allow(form).to receive(:input_type).with(:narrative).and_return(:rich_text) }
+
+    it 'renders the shared rich_text edit-field partial' do
+      result = helper.render_edit_field_partial(:narrative, f: f)
+
+      expect(result[:partial]).to eq('records/edit_fields/rich_text')
+      expect(result[:locals]).to include(key: :narrative, f: f)
+    end
+  end
+
+  context 'when the field declares no rich_text input type' do
+    let(:form) { double('form') }
+
+    before { allow(form).to receive(:input_type).with(:title).and_return(nil) }
+
+    it 'falls back to the default partial lookup' do
+      expect(helper.render_edit_field_partial(:title, f: f)).to eq(:fallback)
+    end
+  end
+
+  context 'when the form does not support input_type (e.g. legacy forms)' do
+    let(:form) { Object.new }
+
+    it 'falls back to the default partial lookup' do
+      expect(helper.render_edit_field_partial(:title, f: f)).to eq(:fallback)
+    end
+  end
+end

--- a/spec/renderers/hyrax/renderers/html_attribute_renderer_spec.rb
+++ b/spec/renderers/hyrax/renderers/html_attribute_renderer_spec.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+RSpec.describe Hyrax::Renderers::HtmlAttributeRenderer do
+  let(:field) { :context_narrative }
+  let(:renderer) { described_class.new(field, [value]) }
+
+  subject(:html) { renderer.render }
+
+  describe '#render' do
+    context 'with allowed markup' do
+      let(:value) do
+        '<p>Hello <strong>world</strong> ' \
+          '<a href="https://example.com" title="more">link</a></p>'
+      end
+
+      it 'preserves allowed tags' do
+        expect(html).to include('<strong>world</strong>')
+      end
+
+      it 'preserves allowed attributes' do
+        expect(html).to include('href="https://example.com"').and include('title="more"')
+      end
+
+      it 'returns an html-safe string' do
+        expect(html).to be_html_safe
+      end
+    end
+
+    context 'with disallowed markup' do
+      let(:value) do
+        '<a href="https://example.com" onclick="steal()">ok</a>' \
+          '<script>alert("xss")</script>' \
+          '<img src="x" onerror="alert(1)">'
+      end
+
+      it 'keeps the safe parts of allowed tags' do
+        expect(html).to include('href="https://example.com"')
+      end
+
+      it 'strips event-handler attributes' do
+        expect(html).not_to include('onclick')
+      end
+
+      it 'strips <script> tags' do
+        expect(html).not_to include('<script')
+      end
+
+      it 'strips disallowed tags' do
+        expect(html).not_to include('<img')
+      end
+    end
+
+    context 'with a blank value' do
+      let(:value) { nil }
+
+      it 'renders nothing' do
+        expect(renderer.render).to eq('')
+      end
+    end
+  end
+end

--- a/spec/renderers/hyrax/renderers/html_attribute_renderer_spec.rb
+++ b/spec/renderers/hyrax/renderers/html_attribute_renderer_spec.rb
@@ -57,4 +57,14 @@ RSpec.describe Hyrax::Renderers::HtmlAttributeRenderer do
       end
     end
   end
+
+  # The renderer must own its value rendering so that a markdown/escaping
+  # decorator prepended onto the base AttributeRenderer by a downstream app
+  # (e.g. Hyku's `treat_some_user_inputs_as_markdown` flag wraps values in
+  # `markdown()`) cannot intercept and re-process sanitized HTML.
+  describe 'rendering ownership (flag independence)' do
+    it 'overrides attribute_value_to_html on the class itself' do
+      expect(described_class.instance_method(:attribute_value_to_html).owner).to eq(described_class)
+    end
+  end
 end

--- a/spec/renderers/hyrax/renderers/html_attribute_renderer_spec.rb
+++ b/spec/renderers/hyrax/renderers/html_attribute_renderer_spec.rb
@@ -49,6 +49,23 @@ RSpec.describe Hyrax::Renderers::HtmlAttributeRenderer do
       end
     end
 
+    context 'with a target="_blank" link' do
+      let(:value) { '<p><a href="https://example.com" target="_blank">x</a></p>' }
+
+      it 'adds rel="noopener noreferrer" to prevent reverse tabnabbing' do
+        expect(html).to include('rel="noopener noreferrer"')
+      end
+    end
+
+    context 'with a target="_blank" link that already declares a rel' do
+      let(:value) { '<p><a href="https://example.com" target="_blank" rel="nofollow">x</a></p>' }
+
+      it 'preserves the existing rel and de-duplicates the safety tokens' do
+        expect(html).to include('nofollow').and include('noopener').and include('noreferrer')
+        expect(html.scan('noopener').size).to eq(1)
+      end
+    end
+
     context 'with a blank value' do
       let(:value) { nil }
 

--- a/spec/services/hyrax/flexible_schema_validators/rich_text_validator_spec.rb
+++ b/spec/services/hyrax/flexible_schema_validators/rich_text_validator_spec.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+RSpec.describe Hyrax::FlexibleSchemaValidators::RichTextValidator do
+  subject(:validator) { described_class.new(profile, warnings) }
+  let(:warnings) { [] }
+
+  def rich_text_form
+    { 'form' => { 'input_type' => 'rich_text' } }
+  end
+
+  describe '#validate!' do
+    context 'when a rich_text property is free text (no controlled vocabulary)' do
+      let(:profile) do
+        { 'properties' => {
+          'context_narrative' => rich_text_form.merge('controlled_values' => { 'sources' => ['null'] })
+        } }
+      end
+
+      it 'does not warn' do
+        validator.validate!
+        expect(warnings).to be_empty
+      end
+    end
+
+    context 'when a rich_text property declares a real controlled_values source' do
+      let(:profile) do
+        { 'properties' => {
+          'subject' => rich_text_form.merge('controlled_values' => { 'sources' => ['loc/subjects'] })
+        } }
+      end
+
+      it 'warns about the controlled-vocabulary conflict and names the source' do
+        validator.validate!
+        expect(warnings).to contain_exactly(a_string_including('subject', 'loc/subjects', 'rich_text'))
+      end
+    end
+
+    context 'when rich_text is declared on a built-in controlled field' do
+      let(:profile) { { 'properties' => { 'rights_statement' => rich_text_form } } }
+
+      it 'warns even though no real source is declared' do
+        validator.validate!
+        expect(warnings).to contain_exactly(a_string_including('rights_statement', 'rich_text'))
+      end
+    end
+
+    context 'when rich_text is declared on a compound subproperty that is type: controlled' do
+      let(:profile) do
+        { 'properties' => {
+          'compound_rights_statement' => rich_text_form.merge('type' => 'controlled', 'authority' => 'rights_statements')
+        } }
+      end
+
+      it 'warns about the controlled type conflict' do
+        validator.validate!
+        expect(warnings).to contain_exactly(a_string_including('compound_rights_statement', 'controlled'))
+      end
+    end
+
+    context 'when a controlled property does not use rich_text' do
+      let(:profile) do
+        { 'properties' => {
+          'rights_statement' => { 'controlled_values' => { 'sources' => ['rights_statements'] } }
+        } }
+      end
+
+      it 'does not warn' do
+        validator.validate!
+        expect(warnings).to be_empty
+      end
+    end
+
+    context 'when the profile has no properties' do
+      let(:profile) { {} }
+
+      it 'does not raise' do
+        expect { validator.validate! }.not_to raise_error
+      end
+    end
+  end
+end

--- a/spec/views/hyrax/base/_featured_attributes.html.erb_spec.rb
+++ b/spec/views/hyrax/base/_featured_attributes.html.erb_spec.rb
@@ -1,8 +1,9 @@
 # frozen_string_literal: true
 
 # Covers the default rendering of `view: { position: featured }`: a property so
-# flagged renders prominently above the metadata table as sanitized HTML,
-# disallowed tags are stripped, and non-featured or blank fields render nothing.
+# flagged renders prominently above the metadata table as a labeled, sanitized
+# HTML card. Multiple featured properties each render their own card; non-featured
+# or blank fields render nothing.
 RSpec.describe 'hyrax/base/featured_attributes', type: :view do
   let(:ability) { double }
   let(:solr_document) { SolrDocument.new(has_model_ssim: 'GenericWork') }
@@ -11,8 +12,10 @@ RSpec.describe 'hyrax/base/featured_attributes', type: :view do
 
   before do
     # conform_field maps a (possibly flexible) field to the presenter method name;
-    # for these specs the field name is the method name.
+    # for these specs the field name is the method name. conform_options resolves
+    # the human label the same way the metadata table does.
     allow(view).to receive(:conform_field) { |field, _opts| field }
+    allow(view).to receive(:conform_options) { |field, _opts| { label: field.to_s.titleize } }
   end
 
   context 'with a field flagged view: { position: featured }' do
@@ -23,12 +26,33 @@ RSpec.describe 'hyrax/base/featured_attributes', type: :view do
         .and_return(['<p>Featured <strong>narrative</strong></p><script>alert(1)</script>'])
     end
 
-    it 'renders the value as sanitized HTML, stripping disallowed tags' do
+    it 'renders the value as a labeled card, stripping disallowed tags' do
       render 'hyrax/base/featured_attributes', presenter: presenter
 
+      expect(page).to have_css('section.work-featured-attribute.attribute-description h2', text: 'Description')
       expect(page).to have_css('section.work-featured-attribute.attribute-description strong', text: 'narrative')
       expect(rendered).to include('<strong>narrative</strong>')
       expect(rendered).not_to include('<script>')
+    end
+  end
+
+  context 'with more than one field flagged featured' do
+    before do
+      allow(view).to receive(:view_options_for).with(presenter)
+                                               .and_return('description' => { 'position' => 'featured' },
+                                                           'abstract' => { 'position' => 'featured' })
+      allow(presenter).to receive(:description).and_return(['First featured block'])
+      allow(presenter).to receive(:abstract).and_return(['Second featured block'])
+    end
+
+    it 'renders each featured property as its own labeled card' do
+      render 'hyrax/base/featured_attributes', presenter: presenter
+
+      expect(page).to have_css('section.work-featured-attribute', count: 2)
+      expect(page).to have_css('section.attribute-description h2', text: 'Description')
+      expect(page).to have_css('section.attribute-description', text: 'First featured block')
+      expect(page).to have_css('section.attribute-abstract h2', text: 'Abstract')
+      expect(page).to have_css('section.attribute-abstract', text: 'Second featured block')
     end
   end
 

--- a/spec/views/hyrax/base/_featured_attributes.html.erb_spec.rb
+++ b/spec/views/hyrax/base/_featured_attributes.html.erb_spec.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+# Covers the default rendering of `view: { position: featured }`: a property so
+# flagged renders prominently above the metadata table as sanitized HTML,
+# disallowed tags are stripped, and non-featured or blank fields render nothing.
+RSpec.describe 'hyrax/base/featured_attributes', type: :view do
+  let(:ability) { double }
+  let(:solr_document) { SolrDocument.new(has_model_ssim: 'GenericWork') }
+  let(:presenter) { Hyrax::WorkShowPresenter.new(solr_document, ability) }
+  let(:page) { Capybara::Node::Simple.new(rendered) }
+
+  before do
+    # conform_field maps a (possibly flexible) field to the presenter method name;
+    # for these specs the field name is the method name.
+    allow(view).to receive(:conform_field) { |field, _opts| field }
+  end
+
+  context 'with a field flagged view: { position: featured }' do
+    before do
+      allow(view).to receive(:view_options_for).with(presenter)
+                                               .and_return('description' => { 'position' => 'featured', 'render_as' => 'html' })
+      allow(presenter).to receive(:description)
+        .and_return(['<p>Featured <strong>narrative</strong></p><script>alert(1)</script>'])
+    end
+
+    it 'renders the value as sanitized HTML, stripping disallowed tags' do
+      render 'hyrax/base/featured_attributes', presenter: presenter
+
+      expect(page).to have_css('section.work-featured-attribute.attribute-description strong', text: 'narrative')
+      expect(rendered).to include('<strong>narrative</strong>')
+      expect(rendered).not_to include('<script>')
+    end
+  end
+
+  context 'when no field is flagged featured' do
+    before do
+      allow(view).to receive(:view_options_for).with(presenter)
+                                               .and_return('title' => { 'position' => 'inline' })
+      allow(presenter).to receive(:title).and_return(['A title'])
+    end
+
+    it 'renders nothing' do
+      render 'hyrax/base/featured_attributes', presenter: presenter
+
+      expect(rendered.strip).to be_blank
+    end
+  end
+
+  context 'when the featured field is blank' do
+    before do
+      allow(view).to receive(:view_options_for).with(presenter)
+                                               .and_return('description' => { 'position' => 'featured' })
+      allow(presenter).to receive(:description).and_return([])
+    end
+
+    it 'does not render an empty featured section' do
+      render 'hyrax/base/featured_attributes', presenter: presenter
+
+      expect(page).not_to have_css('section.work-featured-attribute')
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Adds two related, generic metadata directives for string properties, both working in flexible and non-flexible modes:

1. **`rich_text` form input** - a WYSIWYG editor on the edit form and a sanitized-HTML renderer on the show page.
2. **`view: { position: featured }`** - promotes a field out of the standard metadata table and renders it prominently at the top of the work show page (folded in from #7499; see "Featured display" below).

They compose naturally - a rich-text "narrative" field declared `input_type: rich_text` + `render_as: html` + `position: featured` is authored in TinyMCE and displayed, sanitized, as a featured block above the metadata table - but each directive is independent.

### Rich text

- **`form: { input_type: rich_text }`** renders the field through `records/edit_fields/_rich_text` (a `<textarea class="rich-text">`, one per value, with the standard multi-value "Add another" control). `hyrax/rich_text_editor.js` attaches a TinyMCE editor by default (tinymce-rails ships with Hyrax) and re-binds on `managed_field:add` so cloned rows become editors too. The `rich-text` class is a clean override hook, and the field degrades to a plain textarea with no JS.
- **`view: { render_as: html }`** renders stored markup on the show page through `Hyrax::Renderers::HtmlAttributeRenderer`, which runs Rails `sanitize` against a fixed tag/attribute allow-list. It owns its output, so it is unaffected by the `treat_some_user_inputs_as_markdown` flag or markdown decorators.

<img width="2704" height="1454" alt="image" src="https://github.com/user-attachments/assets/8fdd84b5-7d86-4056-a56b-149329502269" />

<details> 

## Validation

`rich_text` is for free-text properties only. This PR adds `Hyrax::FlexibleSchemaValidators::RichTextValidator` (warning-level, wired into `FlexibleSchemaValidatorService#validate!`). Saving or importing an m3 profile that declares `form: { input_type: rich_text }` on a controlled property raises a non-blocking warning, because rich text would bypass the controlled input and store free-form HTML where a controlled value is expected. "Controlled" is detected from what the profile declares (or what Hyrax/Hyku render by convention):

- a real `controlled_values.sources` authority (local or remote, i.e. anything but the `"null"` free-text sentinel),
- a built-in controlled field by name (`rights_statement`, `license`, `resource_type`, `based_near`, `language`, `access_right`), or
- a `type: controlled` compound subproperty.

See the "Rich-text fields" and "Featured display" sections of `documentation/flexible_metadata.md`.

### Validator output (verified in koppie)

Saving/importing a profile with these properties surfaces, via `Hyrax::FlexibleSchemaValidatorService` warnings:

```text
rights_statement  (input_type: rich_text + controlled_values.sources: rights_statements)
  => m3 profile property `rights_statement` declares `form: { input_type: rich_text }` but also a
     controlled vocabulary (`controlled_values.sources: rights_statements`); rich text stores free-form
     HTML and will bypass the controlled input. Use `rich_text` only on free-text properties.

subject  (input_type: rich_text + controlled_values.sources: loc/subjects)   # remote authority
  => m3 profile property `subject` declares `form: { input_type: rich_text }` but also a controlled
     vocabulary (`controlled_values.sources: loc/subjects`); rich text stores free-form HTML and will
     bypass the controlled input. Use `rich_text` only on free-text properties.

context_narrative  (input_type: rich_text + controlled_values.sources: "null")   # genuine free text
  => (no warning)
```
</details> 

## Featured display

**`view: { position: featured }`** is now a complete, self-contained directive (this folds in #7499, which originally only did the hiding half and depended on this PR's `HtmlAttributeRenderer` constants):

- `field_visible?` returns false for a featured field (the same hook that hides `admin_only`/`editor_only`), so it is **not** duplicated in the standard attribute table.
- The new generic `hyrax/base/_featured_attributes` partial renders every featured field above the metadata card, and the default `hyrax/base/show.html.erb` includes it - so the directive renders out of the box rather than requiring each host app to write template code. Values are sanitized with the same allow-list as `HtmlAttributeRenderer`, so a `render_as: html` field looks identical featured and in the table.
- Host apps that override `base/show.html.erb` (or ship custom show themes) render `<%= render 'featured_attributes', presenter: @presenter %>` wherever they want featured fields; an override that omits it simply won't show them.

This is intentionally **not** covered by an m3 profile validator: the profile cannot know what an app's templates render.

### Verified in koppie

- **Non-flexible (`HYRAX_FLEXIBLE=false`):** tagged `abstract` with `position: featured`, created a work with HTML, confirmed the featured block renders at the top, the `<script>` is stripped (link preserved), and the abstract is absent from the metadata table. Screenshot below.
- **Flexible (`HYRAX_FLEXIBLE=true`):** confirmed `M3SchemaLoader#view_definitions_for` surfaces `position: featured` and `field_visible?` returns false for the field. `field_visible?` and the partial consume the same `view_options_for` hash in both modes.

<img width="1920" height="1474" alt="featured-non-flexible" src="https://github.com/user-attachments/assets/4a7fece3-6766-4612-9074-3aa6cc970e25" />
<img width="1200" height="1546" alt="featured-flexible-on" src="https://github.com/user-attachments/assets/bf436f9b-0812-4deb-92f5-2019847caebb" />
<img width="1200" height="1376" alt="featured-flexible-not-declared" src="https://github.com/user-attachments/assets/4e6a2f31-a3a0-4b34-a735-4b9bf5c4e73f" />

multiple featured: 

<img width="1174" height="609" alt="image" src="https://github.com/user-attachments/assets/ad743ade-84c8-44dc-8440-bbaf69e1f466" />


## Notes

Split out of #7492 (a single 17-file PR) so each feature reviews independently:
- this PR: `rich_text` input + sanitized show-page HTML + `view: { position: featured }` (folds in #7499)
- #7498: catalog `render_as: html` rendering + `search_results_truncate`

Ref: https://github.com/research-technologies/enact_knapsack/issues/40



🤖 Generated with [Claude Code](https://claude.com/claude-code)
