### PR TITLE
Render render_as: html fields in the catalog with search_results_truncate

### DIFF
--- a/app/controllers/concerns/hyrax/flexible_catalog_behavior.rb
+++ b/app/controllers/concerns/hyrax/flexible_catalog_behavior.rb
@@ -100,7 +100,7 @@ module Hyrax
       # @param view_options [Hash] the view options ex: {"render_as"=>"linked", "html_dl"=>true}
       # @return [Boolean] to determine if the view_option_for_helper_method should be called
       def require_view_helper_method?(view_options)
-        view_options.present? && %w[external_link linked rights_statement].include?(view_options.dig('render_as'))
+        view_options.present? && %w[external_link linked rights_statement html].include?(view_options.dig('render_as'))
       end
 
       # Returns the helper method that will render the linked field correctly in the index view
@@ -111,6 +111,7 @@ module Hyrax
         return :iconify_auto_link if render_as == 'external_link'
         return :index_field_link if render_as == 'linked'
         return :rights_statement_links if render_as == 'rights_statement'
+        return :render_html_index_value if render_as == 'html'
       end
 
       def display_label_for(field_name, config)

--- a/app/controllers/concerns/hyrax/flexible_catalog_behavior.rb
+++ b/app/controllers/concerns/hyrax/flexible_catalog_behavior.rb
@@ -75,6 +75,13 @@ module Hyrax
               blacklight_config.index_fields[name].if = :render_optionally?
             end
 
+            # Carry an author-declared catalog truncation length onto the field
+            # config (`view: { search_results_truncate: N }`, or `false` to opt out)
+            # so render_html_index_value can honor it for render_as: html fields.
+            if view_options.is_a?(Hash) && view_options.key?('search_results_truncate')
+              blacklight_config.index_fields[name].search_results_truncate = view_options['search_results_truncate']
+            end
+
             qf = blacklight_config.search_fields['all_fields'].solr_parameters[:qf]
             unless qf.include?(name)
               qf << " #{name}"

--- a/app/helpers/hyrax/hyrax_helper_behavior.rb
+++ b/app/helpers/hyrax/hyrax_helper_behavior.rb
@@ -228,6 +228,29 @@ module Hyrax
       end
     end
 
+    # Blacklight index helper_method for properties stored as HTML markup
+    # (`form: { input_type: rich_text }`, `view: { render_as: html }`). Catalog
+    # search-result columns escape values by default, which dumps the raw tags;
+    # this renders a clean, truncated plain-text snippet instead. The full
+    # sanitized HTML still renders on the work show page via HtmlAttributeRenderer.
+    #
+    # Works the same in both metadata modes: in flexible mode FlexibleCatalogBehavior
+    # assigns this helper from the property's `render_as: html`; in non-flexible mode
+    # declare it on the field directly, e.g.
+    #   config.add_index_field 'my_html_field_tesim', helper_method: :render_html_index_value
+    #
+    # @param field [String, Hash{Symbol=>Array}] Blacklight passes a Hash with a
+    #   :value array (and :config); a bare String is also accepted.
+    # @return [String] truncated plain-text snippet, no markup
+    def render_html_index_value(field)
+      raw = field.is_a?(Hash) ? Array(field[:value]).join(' ') : field.to_s
+      # Tags -> spaces so block boundaries don't glue words together, strip any
+      # stragglers, decode entities (e.g. &rsquo; -> '), then collapse whitespace.
+      text = strip_tags(raw.gsub(/<[^>]+>/, ' '))
+      text = CGI.unescapeHTML(text).gsub(/\s+/, ' ').strip
+      truncate(text, length: 230, separator: ' ')
+    end
+
     # *Sometimes* a Blacklight index field helper_method
     # @param [String,User,Hash{Symbol=>Array}] args if a hash, the user_key must be under :value
     # @return [ActiveSupport::SafeBuffer] the html_safe link

--- a/app/helpers/hyrax/hyrax_helper_behavior.rb
+++ b/app/helpers/hyrax/hyrax_helper_behavior.rb
@@ -249,15 +249,27 @@ module Hyrax
     # @return [String] truncated plain-text snippet, no markup
     def render_html_index_value(field)
       raw = field.is_a?(Hash) ? Array(field[:value]).join(' ') : field.to_s
-      # Tags -> spaces so block boundaries don't glue words together, strip any
-      # stragglers, decode entities (e.g. &rsquo; -> '), then collapse whitespace.
-      text = strip_tags(raw.gsub(/<[^>]+>/, ' '))
-      text = CGI.unescapeHTML(text).gsub(/\s+/, ' ').strip
+      # Decode entities first (e.g. &lt;em&gt; -> <em>) so escaped markup is then
+      # removed by tag-stripping rather than resurfacing as literal tags; tags ->
+      # spaces so block boundaries don't glue words together; collapse whitespace.
+      decoded = CGI.unescapeHTML(raw)
+      text = strip_tags(decoded.gsub(/<[^>]+>/, ' ')).gsub(/\s+/, ' ').strip
 
       limit = field.is_a?(Hash) ? field[:config].try(:search_results_truncate) : nil
       return text if limit == false # `search_results_truncate: false` opts out of truncation
 
-      truncate(text, length: (limit || 230).to_i, separator: ' ')
+      truncate(text, length: html_index_truncate_length(limit), separator: ' ')
+    end
+
+    # Coerce the declared `search_results_truncate` value into a positive integer
+    # length, falling back to the 230-character default for nil or malformed
+    # values (e.g. a stray string or non-positive number) rather than producing a
+    # near-empty snippet. `false` is handled by the caller as an explicit opt-out.
+    # @api private
+    DEFAULT_HTML_INDEX_TRUNCATE = 230
+    def html_index_truncate_length(limit)
+      length = Integer(limit, exception: false)
+      length&.positive? ? length : DEFAULT_HTML_INDEX_TRUNCATE
     end
 
     # *Sometimes* a Blacklight index field helper_method

--- a/app/helpers/hyrax/hyrax_helper_behavior.rb
+++ b/app/helpers/hyrax/hyrax_helper_behavior.rb
@@ -239,6 +239,11 @@ module Hyrax
     # declare it on the field directly, e.g.
     #   config.add_index_field 'my_html_field_tesim', helper_method: :render_html_index_value
     #
+    # Truncation length is author-declarable per property; default is 230.
+    #   flexible:     view: { render_as: html, search_results_truncate: 300 }   # or false to disable
+    #   non-flexible: config.add_index_field 'x_tesim',
+    #                   helper_method: :render_html_index_value, search_results_truncate: 300
+    #
     # @param field [String, Hash{Symbol=>Array}] Blacklight passes a Hash with a
     #   :value array (and :config); a bare String is also accepted.
     # @return [String] truncated plain-text snippet, no markup
@@ -248,7 +253,11 @@ module Hyrax
       # stragglers, decode entities (e.g. &rsquo; -> '), then collapse whitespace.
       text = strip_tags(raw.gsub(/<[^>]+>/, ' '))
       text = CGI.unescapeHTML(text).gsub(/\s+/, ' ').strip
-      truncate(text, length: 230, separator: ' ')
+
+      limit = field.is_a?(Hash) ? field[:config].try(:search_results_truncate) : nil
+      return text if limit == false # `search_results_truncate: false` opts out of truncation
+
+      truncate(text, length: (limit || 230).to_i, separator: ' ')
     end
 
     # *Sometimes* a Blacklight index field helper_method

--- a/app/services/hyrax/flexible_schema_validator_service.rb
+++ b/app/services/hyrax/flexible_schema_validator_service.rb
@@ -40,6 +40,7 @@ module Hyrax
       validate_sort_properties
       validate_redirects
       validate_compound
+      validate_search_results_truncate
     end
 
     # The default JSON schema used when no custom schema is provided.
@@ -140,6 +141,15 @@ module Hyrax
     # @return [void]
     def validate_compound
       FlexibleSchemaValidators::CompoundValidator.new(profile: profile, errors: @errors).validate!
+    end
+
+    # Warns (does not block) when `view: { search_results_truncate: N }` is
+    # declared without `view: { render_as: html }`, where the setting is a
+    # silent no-op.
+    #
+    # @return [void]
+    def validate_search_results_truncate
+      FlexibleSchemaValidators::SearchResultsTruncateValidator.new(profile, @warnings).validate!
     end
 
     # Validates that a `label` property exists and that it is available on

--- a/app/services/hyrax/flexible_schema_validators/search_results_truncate_validator.rb
+++ b/app/services/hyrax/flexible_schema_validators/search_results_truncate_validator.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module Hyrax
+  module FlexibleSchemaValidators
+    # Warns when a property declares `view: { search_results_truncate: N }`
+    # without `view: { render_as: html }`. The truncation length is only honored
+    # by `render_html_index_value`, which is wired solely for `render_as: html`
+    # fields, so on any other field the setting is carried but never read - a
+    # silent no-op.
+    class SearchResultsTruncateValidator
+      def initialize(profile, warnings)
+        @profile = profile
+        @warnings = warnings
+      end
+
+      def validate!
+        (@profile['properties'] || {}).each do |name, config|
+          next unless config.is_a?(Hash)
+
+          view = config['view']
+          next unless view.is_a?(Hash) && view.key?('search_results_truncate')
+          next if view['render_as'].to_s == 'html'
+
+          @warnings << I18n.t(
+            'hyrax.flexible_schema_validators.search_results_truncate_validator.warnings.requires_html',
+            property: name
+          )
+        end
+      end
+    end
+  end
+end

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -1429,6 +1429,9 @@ en:
         warnings:
           config_disabled: "m3 profile declares a `redirects` property but Hyrax.config.redirects_enabled? is false; the property will be ignored"
           flipflop_disabled: "m3 profile declares a `redirects` property but the :redirects feature flag is off; the property will be ignored"
+      search_results_truncate_validator:
+        warnings:
+          requires_html: "m3 profile property `%{property}` declares `view: { search_results_truncate }` without `render_as: html`; the truncation length is only applied to `render_as: html` catalog fields, so it has no effect here."
       sort_properties_validator:
         warnings:
           message: "%{property} must be defined on %{classes} to support sorting on that property, unless you have indexed %{property}_ssi on some other field."

--- a/documentation/flexible_metadata.md
+++ b/documentation/flexible_metadata.md
@@ -99,7 +99,7 @@ A field declared `view: { render_as: html }` stores HTML markup. Without a rende
 
 In flexible mode `Hyrax::FlexibleCatalogBehavior` wires this helper automatically from `render_as: html`; in non-flexible mode declare it on the field, e.g. `config.add_index_field 'context_narrative_tesim', helper_method: :render_html_index_value`.
 
-The snippet length is author-declarable with `view: { search_results_truncate: N }` (`false` shows the full snippet; default 230). In non-flexible mode pass it as a field option (`search_results_truncate: N`).
+The snippet length is author-declarable with `view: { search_results_truncate: N }` (`false` shows the full snippet; default 230). In non-flexible mode pass it as a field option (`search_results_truncate: N`). `search_results_truncate` only applies to `render_as: html` fields; declaring it without `render_as: html` raises a validation warning (it would otherwise be a silent no-op).
 
 ```yaml
 # HYRAX_FLEXIBLE=true (m3 profile)

--- a/documentation/flexible_metadata.md
+++ b/documentation/flexible_metadata.md
@@ -93,6 +93,29 @@ admin_note:
 
 Use `admin_only` in place of `editor_only` to restrict visibility to admins only.
 
+## HTML fields in catalog search results
+
+A field declared `view: { render_as: html }` stores HTML markup. Without a render helper, Blacklight escapes the value and dumps raw tags into the search-results column. `Hyrax::HyraxHelperBehavior#render_html_index_value` instead renders a clean, truncated plain-text snippet (tags → spaces, stripped, entities decoded; default 230 characters).
+
+In flexible mode `Hyrax::FlexibleCatalogBehavior` wires this helper automatically from `render_as: html`; in non-flexible mode declare it on the field, e.g. `config.add_index_field 'context_narrative_tesim', helper_method: :render_html_index_value`.
+
+The snippet length is author-declarable with `view: { search_results_truncate: N }` (`false` shows the full snippet; default 230). In non-flexible mode pass it as a field option (`search_results_truncate: N`).
+
+```yaml
+# HYRAX_FLEXIBLE=true (m3 profile)
+context_narrative:
+  available_on:
+    class:
+      - GenericWorkResource
+  data_type: string
+  indexing:
+    - context_narrative_tesim
+  property_uri: http://purl.org/dc/terms/description
+  view:
+    render_as: html              # render the stored markup as HTML (sanitized) on the show page
+    search_results_truncate: 300 # optional; catalog snippet length, `false` to disable (default 230)
+```
+
 ## Related features
 
 - **URL Redirects** (`HYRAX_REDIRECTS_ENABLED`): when enabled, the redirects feature requires a `redirects` property in the m3 profile (when also Flipflop-enabled per tenant). See [`documentation/redirects.md`](redirects.md) for the full schema and gating model.

--- a/spec/controllers/concerns/hyrax/flexible_catalog_behavior_spec.rb
+++ b/spec/controllers/concerns/hyrax/flexible_catalog_behavior_spec.rb
@@ -94,6 +94,7 @@ RSpec.describe Hyrax::FlexibleCatalogBehavior, type: :controller do
           view:
             render_as: html
             html_dl: true
+            search_results_truncate: 50
     YAML
   end
 
@@ -198,6 +199,10 @@ RSpec.describe Hyrax::FlexibleCatalogBehavior, type: :controller do
 
         # department_tesim should not have helper methods
         expect(blacklight_config.index_fields['department_tesim'].helper_method).to be_nil
+      end
+
+      it 'carries an author-declared view.search_results_truncate onto the field config' do
+        expect(blacklight_config.index_fields['narrative_tesim'].search_results_truncate).to eq(50)
       end
 
       it 'have the render_optionally? condition added to the blacklight config' do

--- a/spec/controllers/concerns/hyrax/flexible_catalog_behavior_spec.rb
+++ b/spec/controllers/concerns/hyrax/flexible_catalog_behavior_spec.rb
@@ -81,6 +81,19 @@ RSpec.describe Hyrax::FlexibleCatalogBehavior, type: :controller do
           view:
             html_dl: true
             search_results: false
+        narrative:
+          available_on:
+            class:
+              - GenericWork
+          display_label:
+            default: Narrative
+          indexing:
+            - narrative_tesim
+          property_uri: http://purl.org/dc/terms/description
+          range: http://www.w3.org/2001/XMLSchema#string
+          view:
+            render_as: html
+            html_dl: true
     YAML
   end
 
@@ -178,6 +191,10 @@ RSpec.describe Hyrax::FlexibleCatalogBehavior, type: :controller do
         # medium_tesim should have index_field_link helper
         expect(blacklight_config.index_fields['medium_tesim'].helper_method).to eq(:index_field_link)
         expect(blacklight_config.index_fields['medium_tesim'].field_name).to eq('medium')
+
+        # narrative_tesim should have render_html_index_value helper (render_as: html)
+        expect(blacklight_config.index_fields['narrative_tesim'].helper_method).to eq(:render_html_index_value)
+        expect(blacklight_config.index_fields['narrative_tesim'].field_name).to eq('narrative')
 
         # department_tesim should not have helper methods
         expect(blacklight_config.index_fields['department_tesim'].helper_method).to be_nil
@@ -352,6 +369,11 @@ RSpec.describe Hyrax::FlexibleCatalogBehavior, type: :controller do
       expect(result).to be true
     end
 
+    it 'returns true for html render_as' do
+      result = controller.class.send(:require_view_helper_method?, { 'render_as' => 'html' })
+      expect(result).to be true
+    end
+
     it 'returns false for other render_as values' do
       result = controller.class.send(:require_view_helper_method?, { 'render_as' => 'faceted' })
       expect(result).to be false
@@ -377,6 +399,11 @@ RSpec.describe Hyrax::FlexibleCatalogBehavior, type: :controller do
     it 'returns :rights_statement_links for rights_statement' do
       result = controller.class.send(:view_option_for_helper_method, { 'render_as' => 'rights_statement' })
       expect(result).to eq(:rights_statement_links)
+    end
+
+    it 'returns :render_html_index_value for html' do
+      result = controller.class.send(:view_option_for_helper_method, { 'render_as' => 'html' })
+      expect(result).to eq(:render_html_index_value)
     end
   end
 

--- a/spec/helpers/hyrax_helper_spec.rb
+++ b/spec/helpers/hyrax_helper_spec.rb
@@ -323,6 +323,37 @@ RSpec.describe HyraxHelper, type: :helper do
     end
   end
 
+  describe "#render_html_index_value" do
+    it "strips tags and renders a plain-text snippet" do
+      html = '<h3>Title</h3><p>Body <strong>bold</strong> text.</p>'
+      expect(helper.render_html_index_value(html)).to eq('Title Body bold text.')
+    end
+
+    it "decodes HTML entities" do
+      expect(helper.render_html_index_value('<p>Bruce McLean&rsquo;s work</p>')).to eq('Bruce McLean’s work')
+    end
+
+    it "does not glue words across block boundaries" do
+      expect(helper.render_html_index_value('<li>one</li><li>two</li>')).to eq('one two')
+    end
+
+    it "truncates long values" do
+      result = helper.render_html_index_value("<p>#{'word ' * 100}</p>")
+      expect(result.length).to be <= 230
+      expect(result).to end_with('...')
+    end
+
+    it "accepts Blacklight's hash form with a :value array" do
+      arg = { value: ['<p>Hello <em>world</em></p>'], field: 'narrative_tesim' }
+      expect(helper.render_html_index_value(arg)).to eq('Hello world')
+    end
+
+    it "returns an empty string for blank values" do
+      expect(helper.render_html_index_value(nil)).to eq('')
+      expect(helper.render_html_index_value(value: [])).to eq('')
+    end
+  end
+
   describe "#license_links" do
     it "maps the url to a link with a label" do
       expect(helper.license_links(

--- a/spec/helpers/hyrax_helper_spec.rb
+++ b/spec/helpers/hyrax_helper_spec.rb
@@ -355,6 +355,29 @@ RSpec.describe HyraxHelper, type: :helper do
       expect(result).not_to end_with('...')
     end
 
+    it "strips markup that arrives as escaped entities" do
+      expect(helper.render_html_index_value('&lt;em&gt;hi&lt;/em&gt; there')).to eq('hi there')
+    end
+
+    it "falls back to the default length for a non-integer truncation value" do
+      arg = { value: ["<p>#{'word ' * 100}</p>"], config: double(search_results_truncate: 'oops') }
+      result = helper.render_html_index_value(arg)
+      expect(result.length).to be <= 230
+      expect(result).to end_with('...')
+    end
+
+    it "falls back to the default length for a non-positive truncation value" do
+      arg = { value: ["<p>#{'word ' * 100}</p>"], config: double(search_results_truncate: 0) }
+      result = helper.render_html_index_value(arg)
+      expect(result.length).to be <= 230
+      expect(result).to end_with('...')
+    end
+
+    it "coerces a numeric string truncation value" do
+      arg = { value: ["<p>#{'word ' * 100}</p>"], config: double(search_results_truncate: '20') }
+      expect(helper.render_html_index_value(arg).length).to be <= 20
+    end
+
     it "accepts Blacklight's hash form with a :value array" do
       arg = { value: ['<p>Hello <em>world</em></p>'], field: 'narrative_tesim' }
       expect(helper.render_html_index_value(arg)).to eq('Hello world')

--- a/spec/helpers/hyrax_helper_spec.rb
+++ b/spec/helpers/hyrax_helper_spec.rb
@@ -343,6 +343,18 @@ RSpec.describe HyraxHelper, type: :helper do
       expect(result).to end_with('...')
     end
 
+    it "honors a per-field truncation length from the field config" do
+      arg = { value: ["<p>#{'word ' * 100}</p>"], config: double(search_results_truncate: 20) }
+      expect(helper.render_html_index_value(arg).length).to be <= 20
+    end
+
+    it "skips truncation when search_results_truncate is false" do
+      arg = { value: ["<p>#{'word ' * 100}</p>"], config: double(search_results_truncate: false) }
+      result = helper.render_html_index_value(arg)
+      expect(result.length).to be > 230
+      expect(result).not_to end_with('...')
+    end
+
     it "accepts Blacklight's hash form with a :value array" do
       arg = { value: ['<p>Hello <em>world</em></p>'], field: 'narrative_tesim' }
       expect(helper.render_html_index_value(arg)).to eq('Hello world')

--- a/spec/services/hyrax/flexible_schema_validators/search_results_truncate_validator_spec.rb
+++ b/spec/services/hyrax/flexible_schema_validators/search_results_truncate_validator_spec.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+RSpec.describe Hyrax::FlexibleSchemaValidators::SearchResultsTruncateValidator do
+  subject(:validator) { described_class.new(profile, warnings) }
+  let(:warnings) { [] }
+
+  describe '#validate!' do
+    context 'when search_results_truncate is paired with render_as: html' do
+      let(:profile) do
+        { 'properties' => {
+          'context_narrative' => { 'view' => { 'render_as' => 'html', 'search_results_truncate' => 300 } }
+        } }
+      end
+
+      it 'does not warn' do
+        validator.validate!
+        expect(warnings).to be_empty
+      end
+    end
+
+    context 'when search_results_truncate is declared without render_as: html' do
+      let(:profile) do
+        { 'properties' => {
+          'note' => { 'view' => { 'search_results_truncate' => 300 } }
+        } }
+      end
+
+      it 'warns that the setting has no effect' do
+        validator.validate!
+        expect(warnings).to contain_exactly(a_string_including('note', 'search_results_truncate', 'render_as: html'))
+      end
+    end
+
+    context 'when search_results_truncate is set with a non-html render_as' do
+      let(:profile) do
+        { 'properties' => {
+          'note' => { 'view' => { 'render_as' => 'linked', 'search_results_truncate' => 50 } }
+        } }
+      end
+
+      it 'warns' do
+        validator.validate!
+        expect(warnings.size).to eq(1)
+      end
+    end
+
+    context 'when a field has render_as: html but no truncate setting' do
+      let(:profile) do
+        { 'properties' => { 'context_narrative' => { 'view' => { 'render_as' => 'html' } } } }
+      end
+
+      it 'does not warn' do
+        validator.validate!
+        expect(warnings).to be_empty
+      end
+    end
+
+    context 'when the profile has no properties' do
+      let(:profile) { {} }
+
+      it 'does not raise' do
+        expect { validator.validate! }.not_to raise_error
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Renders fields declared `view: { render_as: html }` cleanly in Blacklight search results, with author-declarable truncation.

- Without a render helper, Blacklight escapes the value and dumps raw HTML tags into the search-results column. `Hyrax::HyraxHelperBehavior#render_html_index_value` instead produces a clean, truncated plain-text snippet (tags to spaces, stripped, entities decoded; default 230 chars).
- In flexible mode `Hyrax::FlexibleCatalogBehavior` wires this helper automatically from `render_as: html`; in non-flexible mode it is declared as a field `helper_method`.
- Snippet length is author-declarable with **`view: { search_results_truncate: N }`** (`false` = full snippet; default 230).

BEFORE: context statements showed A LOT more text and literal html tags

AFTER: 

<img width="515" height="427" alt="image" src="https://github.com/user-attachments/assets/2b216ee4-3bce-4869-a7c9-4ec0ec03307a" />


## Validation

Adds `Hyrax::FlexibleSchemaValidators::SearchResultsTruncateValidator` (warning-level, wired into `FlexibleSchemaValidatorService#validate!`). Declaring `view: { search_results_truncate: N }` without `render_as: html` raises a non-blocking warning, because the truncation length is only applied to `render_as: html` catalog fields and is otherwise carried onto the Blacklight config but never read (a silent no-op).

## Notes

One of three PRs split out of #7492 (which was a single 17-file PR) so each feature reviews independently:
- #7497: `rich_text` input + sanitized show-page HTML
- #7499: `view: { position: featured }`
- this PR: catalog `render_as: html` rendering + `search_results_truncate`

Ref: https://github.com/research-technologies/enact_knapsack/issues/40

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### Validator output (verified in koppie)

```text
note  (view: { search_results_truncate: 300 })   # no render_as: html
  => m3 profile property `note` declares `view: { search_results_truncate }` without `render_as: html`;
     the truncation length is only applied to `render_as: html` catalog fields, so it has no effect here.

context_narrative  (view: { render_as: html, search_results_truncate: 300 })
  => (no warning)
```
