### PR TITLE
Honor view: { position: featured } in field_visible?

### DIFF
--- a/app/helpers/hyrax/attributes_helper.rb
+++ b/app/helpers/hyrax/attributes_helper.rb
@@ -91,9 +91,12 @@ module Hyrax
       view_options
     end
 
-    # Returns true when the field should render on the work show page.
-    # Honors these view options:
+    # Returns true when the field should render in the work show page's
+    # standard attribute list. Honors these view options:
     #   * `show_page: false` — suppresses the field on the show page for everyone.
+    #   * `position: featured` — the field is rendered elsewhere (e.g. near the
+    #     top of the show page), so it is omitted from the attribute list to
+    #     avoid duplicating it.
     #   * `admin_only: true` — only visible to admins.
     #   * `editor_only: true` — only visible to users the presenter reports as editors.
     # Setting both `admin_only` and `editor_only` is effectively equivalent to
@@ -101,6 +104,7 @@ module Hyrax
     # guards, but a plain editor of the record still fails the admin guard.
     def field_visible?(view_options, presenter)
       return false if view_options[:show_page] == false
+      return false if view_options[:position].to_s == 'featured'
       return false if view_options[:admin_only] && !current_user&.admin?
       return false if view_options[:editor_only] && !presenter.try(:editor?)
       true

--- a/documentation/flexible_metadata.md
+++ b/documentation/flexible_metadata.md
@@ -93,6 +93,10 @@ admin_note:
 
 Use `admin_only` in place of `editor_only` to restrict visibility to admins only.
 
+## Featured display
+
+**`view: { position: featured }`** removes a field from the standard metadata table: `field_visible?` returns false for it (the same hook that hides `admin_only`/`editor_only` fields), so it is not duplicated there. The host application's show template is responsible for rendering featured fields wherever it wants them — typically prominently at the top of the work show page.
+
 ## Related features
 
 - **URL Redirects** (`HYRAX_REDIRECTS_ENABLED`): when enabled, the redirects feature requires a `redirects` property in the m3 profile (when also Flipflop-enabled per tenant). See [`documentation/redirects.md`](redirects.md) for the full schema and gating model.

--- a/documentation/flexible_metadata.md
+++ b/documentation/flexible_metadata.md
@@ -95,7 +95,9 @@ Use `admin_only` in place of `editor_only` to restrict visibility to admins only
 
 ## Featured display
 
-**`view: { position: featured }`** removes a field from the standard metadata table: `field_visible?` returns false for it (the same hook that hides `admin_only`/`editor_only` fields), so it is not duplicated there. The host application's show template is responsible for rendering featured fields wherever it wants them — typically prominently at the top of the work show page.
+**`view: { position: featured }`** removes a field from the standard metadata table: `field_visible?` returns false for it (the same hook that hides `admin_only`/`editor_only` fields), so it is not duplicated there. The host application's show template is responsible for rendering featured fields wherever it wants them, typically prominently at the top of the work show page.
+
+Note: `position: featured` only *hides* the field from the standard table; it does not render it anywhere on its own. If your show template does not explicitly render the featured field, it will not appear at all. This is a template-integration responsibility and is not checked by m3 profile validation, since the profile cannot know what the app's templates render.
 
 ## Related features
 

--- a/spec/helpers/hyrax/attributes_helper_spec.rb
+++ b/spec/helpers/hyrax/attributes_helper_spec.rb
@@ -98,6 +98,32 @@ RSpec.describe Hyrax::AttributesHelper, type: :helper do
       end
     end
 
+    context 'when position is featured' do
+      let(:view_options) { { position: 'featured' } }
+
+      it 'is false so the field is not duplicated in the attribute list' do
+        allow(helper).to receive(:current_user).and_return(non_admin_user)
+        expect(helper.field_visible?(view_options, non_editor_presenter)).to be false
+      end
+
+      it 'is false even for admins' do
+        allow(helper).to receive(:current_user).and_return(admin_user)
+        expect(helper.field_visible?(view_options, editor_presenter)).to be false
+      end
+
+      it 'accepts a symbol value' do
+        allow(helper).to receive(:current_user).and_return(non_admin_user)
+        expect(helper.field_visible?({ position: :featured }, non_editor_presenter)).to be false
+      end
+    end
+
+    context 'when position is set to a non-featured value' do
+      it 'does not suppress the field' do
+        allow(helper).to receive(:current_user).and_return(non_admin_user)
+        expect(helper.field_visible?({ position: 'sidebar' }, non_editor_presenter)).to be true
+      end
+    end
+
     context 'when admin_only is set' do
       let(:view_options) { { admin_only: true } }
 


### PR DESCRIPTION
## Summary

Adds a `view: { position: featured }` directive for flexible/metadata fields. `field_visible?` returns false for a featured field (the same hook that hides `admin_only`/`editor_only` fields), so it is removed from the standard metadata table and not duplicated there. The host application's show template is responsible for rendering featured fields wherever it wants them, typically prominently at the top of the work show page.

<img width="2704" height="1454" alt="image" src="https://github.com/user-attachments/assets/15a84423-eae2-4d96-ab4a-a590cf32f816" />

# koppie
<img width="1238" height="866" alt="image" src="https://github.com/user-attachments/assets/867c86e4-8d05-49c2-8cb1-bc2eb0f13c0a" />


## Note on validation

`position: featured` only *hides* the field from the standard table; it does not render it anywhere on its own. If the host show template does not explicitly render the featured field, it will not appear at all. This is a template-integration responsibility, and unlike the sibling PRs it is intentionally **not** covered by an m3 profile validator: the profile cannot know what an app's templates render. This PR adds a documentation caveat instead (see `documentation/flexible_metadata.md`).

## Notes

One of three PRs split out of #7492 (which was a single 17-file PR) so each feature reviews independently:
- #7497: `rich_text` input + sanitized show-page HTML
- this PR: `view: { position: featured }`
- #7498: catalog `render_as: html` rendering + `search_results_truncate`

Ref: https://github.com/research-technologies/enact_knapsack/issues/40

🤖 Generated with [Claude Code](https://claude.com/claude-code)
