### PR TITLE
Expands compound metadata: builds linked record compound type

### DIFF
--- a/app/assets/javascripts/hyrax/compound_metadata.js
+++ b/app/assets/javascripts/hyrax/compound_metadata.js
@@ -1,30 +1,40 @@
 // Behavior for compound metadata fields on resource edit forms (add/remove row,
-// work_or_url select2). Event-delegated so dynamically-added rows need no
-// rebinding. The sentinel guards against the IIFE running twice (Turbolinks
-// re-evaluates module scripts on some navigation paths), which would stack
-// duplicate listeners. Mirrors hyrax/redirects.js.
+// work_or_url and linked_record select2 pickers). Event-delegated so
+// dynamically-added rows need no rebinding. The sentinel guards against the IIFE
+// running twice (Turbolinks re-evaluates module scripts on some navigation
+// paths), which would stack duplicate listeners. Mirrors hyrax/redirects.js.
 (function() {
     if (document.hyraxCompoundsBound) return;
     document.hyraxCompoundsBound = true;
 
-    // Bind select2 to a `work_or_url` sub-property. The v3 API (Hyrax bundles
-    // select2-rails 3.x) binds to a hidden input; createSearchChoice lets a
-    // typed external URL be selected as-is.
+    // Bind select2 to a `work_or_url` or `linked_record` sub-property. The v3
+    // API (Hyrax bundles select2-rails 3.x) binds to a hidden input. A
+    // work_or_url picker lets a typed external URL be selected as-is
+    // (createSearchChoice); a linked_record picker resolves only to a row id, so
+    // a typed value is not a valid selection — and an empty result set reveals
+    // its "Add new" affordance instead.
     function bindWorkOrUrlInputs(root) {
         if (typeof jQuery === 'undefined' || !jQuery.fn.select2) return;
         jQuery(root).find('[data-hyrax-compound-work-input]').each(function() {
             var $el = jQuery(this);
             if ($el.hasClass('select2-offscreen') || $el.data('select2')) return; // already bound
-            $el.select2({
+
+            var isLinkedRecord = $el.is('[data-hyrax-linked-record-input]');
+            var lastTerm = '';
+            // Capture the wrapper now, before select2 restructures the DOM around
+            // the input, so the no-results reveal doesn't depend on .closest()
+            // still resolving after binding.
+            var wrapEl = isLinkedRecord ? $el.closest('[data-hyrax-linked-record]')[0] : null;
+
+            var options = {
                 width: '100%',
                 allowClear: true,
-                placeholder: 'Search for a work or enter a URL',
+                // Per-field prompt via data-placeholder (work_or_url omits it and
+                // keeps the original text).
+                placeholder: $el.data('placeholder') || 'Search for a work or enter a URL',
                 minimumInputLength: 2,
-                // Let a typed value (e.g. an external URL) be selected as-is.
-                createSearchChoice: function(term) {
-                    return { id: term, text: term };
-                },
-                // Render the current value's label (work title or the URL) on load.
+                // Render the current value's label (work title / record label /
+                // URL) on load.
                 initSelection: function(element, callback) {
                     var val = element.val();
                     if (!val) return;
@@ -34,8 +44,11 @@
                     url: $el.data('autocomplete-url'),
                     dataType: 'json',
                     quietMillis: 250,
-                    data: function(term, page) { return { q: term }; },
+                    data: function(term, page) { lastTerm = term; return { q: term }; },
                     results: function(data, page) {
+                        // For a creatable linked_record, surface the "Add new"
+                        // trigger when the search came back empty.
+                        if (isLinkedRecord) toggleAddNew(wrapEl, data.length === 0, lastTerm);
                         return {
                             results: data.map(function(obj) {
                                 return { id: obj.id, text: [].concat(obj.label)[0] };
@@ -43,8 +56,31 @@
                         };
                     }
                 }
-            });
+            };
+
+            // Only work_or_url accepts a free-typed value as its selection.
+            if (!isLinkedRecord) {
+                options.createSearchChoice = function(term) { return { id: term, text: term }; };
+            }
+
+            $el.select2(options);
         });
+    }
+
+    // Show/hide the "Add new" trigger for a creatable linked_record when a
+    // search returned no matches; stash the typed term to prefill the form.
+    // `wrapEl` is the [data-hyrax-linked-record] wrapper captured at bind time.
+    function toggleAddNew(wrapEl, noResults, term) {
+        if (!wrapEl || wrapEl.getAttribute('data-creatable') !== 'true') return;
+        var $wrap = jQuery(wrapEl);
+        var $add = $wrap.find('[data-hyrax-linked-record-add]');
+        if (!$add.length) return;
+        $wrap.data('lastTerm', term || '');
+        if (noResults) {
+            $add.removeClass('d-none').prop('hidden', false);
+        } else {
+            $add.addClass('d-none').prop('hidden', true);
+        }
     }
 
     // Bind saved rows once the DOM is ready (at script-eval time the form
@@ -58,7 +94,73 @@
     }
     document.addEventListener('turbolinks:load', bindAll);
 
+    // Reveal the inline create form (prefilling the first text field with the
+    // typed search term), POST it to the source's create endpoint, and on
+    // success select the new record in the picker.
+    function openCreateForm(wrap) {
+        var form = wrap.querySelector('[data-hyrax-linked-record-create-form]');
+        if (!form) return;
+        form.classList.remove('d-none');
+        form.hidden = false;
+        var firstText = form.querySelector('input[data-create-field]');
+        var term = jQuery(wrap).data('lastTerm');
+        if (firstText && term && !firstText.value) firstText.value = term;
+    }
+
+    function closeCreateForm(wrap) {
+        var form = wrap.querySelector('[data-hyrax-linked-record-create-form]');
+        if (form) { form.classList.add('d-none'); form.hidden = true; }
+    }
+
+    function submitCreateForm(wrap) {
+        var url = wrap.getAttribute('data-create-url');
+        var form = wrap.querySelector('[data-hyrax-linked-record-create-form]');
+        var errors = form.querySelector('[data-hyrax-linked-record-create-errors]');
+        var record = {};
+        form.querySelectorAll('[data-create-field]').forEach(function(input) {
+            record[input.getAttribute('data-create-field')] = input.value;
+        });
+
+        var token = (document.querySelector('meta[name="csrf-token"]') || {}).content;
+        fetch(url, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json', 'X-CSRF-Token': token || '', 'Accept': 'application/json' },
+            body: JSON.stringify({ record: record })
+        }).then(function(resp) {
+            return resp.json().then(function(body) { return { ok: resp.ok, body: body }; });
+        }).then(function(result) {
+            if (result.ok) {
+                // Select the new record in the picker (select2 v3 takes {id,text}).
+                var $input = jQuery(wrap).find('[data-hyrax-linked-record-input]');
+                $input.select2('data', { id: result.body.id, text: result.body.label });
+                closeCreateForm(wrap);
+                var $add = jQuery(wrap).find('[data-hyrax-linked-record-add]');
+                $add.addClass('d-none').prop('hidden', true);
+            } else if (errors) {
+                errors.textContent = [].concat(result.body.errors || ['Could not create']).join(', ');
+                errors.classList.remove('d-none');
+            }
+        });
+    }
+
     document.addEventListener('click', function(event) {
+        // --- linked_record inline create affordance ---
+        var addTrigger = event.target.closest('[data-hyrax-linked-record-add]');
+        if (addTrigger) {
+            openCreateForm(addTrigger.closest('[data-hyrax-linked-record]'));
+            return;
+        }
+        var createSubmit = event.target.closest('[data-hyrax-linked-record-create-submit]');
+        if (createSubmit) {
+            submitCreateForm(createSubmit.closest('[data-hyrax-linked-record]'));
+            return;
+        }
+        var createCancel = event.target.closest('[data-hyrax-linked-record-create-cancel]');
+        if (createCancel) {
+            closeCreateForm(createCancel.closest('[data-hyrax-linked-record]'));
+            return;
+        }
+
         var removeButton = event.target.closest('[data-hyrax-compound-remove-row]');
         if (removeButton) {
             var row = removeButton.closest('[data-hyrax-compound-row]');
@@ -91,7 +193,7 @@
         }
         var html = template.innerHTML.replace(/__INDEX__/g, nextIndex);
         rowsHost.insertAdjacentHTML('beforeend', html);
-        // Bind select2 on any work_or_url inputs in the row just added.
+        // Bind select2 on any work_or_url / linked_record inputs in the new row.
         bindWorkOrUrlInputs(rowsHost.lastElementChild || rowsHost);
         section.dataset.nextIndex = String(nextIndex + 1);
     });

--- a/app/assets/javascripts/hyrax/compound_metadata.js
+++ b/app/assets/javascripts/hyrax/compound_metadata.js
@@ -117,8 +117,35 @@
         var form = wrap.querySelector('[data-hyrax-linked-record-create-form]');
         var errors = form.querySelector('[data-hyrax-linked-record-create-errors]');
         var record = {};
+        // Scalar create-fields: one value each. Skip inputs that live inside a
+        // group (those are collected per-row below).
         form.querySelectorAll('[data-create-field]').forEach(function(input) {
+            if (input.closest('[data-create-group]')) return;
             record[input.getAttribute('data-create-field')] = input.value;
+        });
+        // Repeatable create-fields: collected from their rows (the <template>
+        // row is inert). A group field becomes an array of {subfield: value}
+        // hashes; a repeatable scalar (data-create-scalar) becomes a plain array
+        // of strings. Blank rows are skipped.
+        form.querySelectorAll('[data-create-group]').forEach(function(group) {
+            var name = group.getAttribute('data-create-group');
+            var scalar = group.getAttribute('data-create-scalar') === 'true';
+            var rows = [];
+            group.querySelectorAll('[data-create-group-rows] [data-create-group-row]').forEach(function(rowEl) {
+                if (scalar) {
+                    var input = rowEl.querySelector('[data-create-subfield]');
+                    if (input && input.value) rows.push(input.value);
+                } else {
+                    var row = {};
+                    var any = false;
+                    rowEl.querySelectorAll('[data-create-subfield]').forEach(function(sub) {
+                        row[sub.getAttribute('data-create-subfield')] = sub.value;
+                        if (sub.value) any = true;
+                    });
+                    if (any) rows.push(row);
+                }
+            });
+            record[name] = rows;
         });
 
         var token = (document.querySelector('meta[name="csrf-token"]') || {}).content;
@@ -158,6 +185,27 @@
         var createCancel = event.target.closest('[data-hyrax-linked-record-create-cancel]');
         if (createCancel) {
             closeCreateForm(createCancel.closest('[data-hyrax-linked-record]'));
+            return;
+        }
+        // Repeatable group create-field: add a row (clone the template) / remove a row.
+        var groupAdd = event.target.closest('[data-create-group-add]');
+        if (groupAdd) {
+            var group = groupAdd.closest('[data-create-group]');
+            var template = group.querySelector('[data-create-group-row-template]');
+            var rows = group.querySelector('[data-create-group-rows]');
+            if (template && rows) rows.appendChild(template.content.cloneNode(true));
+            return;
+        }
+        var groupRemove = event.target.closest('[data-create-group-remove]');
+        if (groupRemove) {
+            var groupRows = groupRemove.closest('[data-create-group-rows]');
+            var thisRow = groupRemove.closest('[data-create-group-row]');
+            // Keep at least one row present; clear it instead of removing the last.
+            if (groupRows && groupRows.querySelectorAll('[data-create-group-row]').length > 1) {
+                thisRow.parentNode.removeChild(thisRow);
+            } else if (thisRow) {
+                thisRow.querySelectorAll('[data-create-subfield]').forEach(function(i) { i.value = ''; });
+            }
             return;
         }
 

--- a/app/assets/javascripts/hyrax/compound_metadata.js
+++ b/app/assets/javascripts/hyrax/compound_metadata.js
@@ -148,13 +148,30 @@
             record[name] = rows;
         });
 
+        // Show server-supplied messages (already localized), falling back to the
+        // localized default the partial set on `data-default-message`.
+        function showError(messages) {
+            if (!errors) return;
+            var fallback = errors.getAttribute('data-default-message') || 'Could not create';
+            var list = [].concat(messages || []).filter(Boolean);
+            errors.textContent = (list.length ? list : [fallback]).join(', ');
+            errors.classList.remove('d-none');
+        }
+
         var token = (document.querySelector('meta[name="csrf-token"]') || {}).content;
         fetch(url, {
             method: 'POST',
             headers: { 'Content-Type': 'application/json', 'X-CSRF-Token': token || '', 'Accept': 'application/json' },
             body: JSON.stringify({ record: record })
         }).then(function(resp) {
-            return resp.json().then(function(body) { return { ok: resp.ok, body: body }; });
+            // A 5xx (e.g. a DB-level failure) returns an HTML error page, not
+            // JSON; tolerate a non-JSON body so the form still surfaces a message
+            // instead of silently swallowing the parse error.
+            return resp.text().then(function(text) {
+                var body;
+                try { body = JSON.parse(text); } catch (e) { body = {}; }
+                return { ok: resp.ok, body: body };
+            });
         }).then(function(result) {
             if (result.ok) {
                 // Select the new record in the picker (select2 v3 takes {id,text}).
@@ -163,10 +180,12 @@
                 closeCreateForm(wrap);
                 var $add = jQuery(wrap).find('[data-hyrax-linked-record-add]');
                 $add.addClass('d-none').prop('hidden', true);
-            } else if (errors) {
-                errors.textContent = [].concat(result.body.errors || ['Could not create']).join(', ');
-                errors.classList.remove('d-none');
+            } else {
+                showError(result.body.errors);
             }
+        }).catch(function() {
+            // No-arg showError falls back to the localized default message.
+            showError();
         });
     }
 

--- a/app/assets/javascripts/hyrax/compound_metadata.js
+++ b/app/assets/javascripts/hyrax/compound_metadata.js
@@ -98,6 +98,7 @@
     // typed search term), POST it to the source's create endpoint, and on
     // success select the new record in the picker.
     function openCreateForm(wrap) {
+        if (!wrap) return;
         var form = wrap.querySelector('[data-hyrax-linked-record-create-form]');
         if (!form) return;
         form.classList.remove('d-none');
@@ -108,13 +109,16 @@
     }
 
     function closeCreateForm(wrap) {
+        if (!wrap) return;
         var form = wrap.querySelector('[data-hyrax-linked-record-create-form]');
         if (form) { form.classList.add('d-none'); form.hidden = true; }
     }
 
     function submitCreateForm(wrap) {
+        if (!wrap) return;
         var url = wrap.getAttribute('data-create-url');
         var form = wrap.querySelector('[data-hyrax-linked-record-create-form]');
+        if (!url || !form) return;
         var errors = form.querySelector('[data-hyrax-linked-record-create-errors]');
         var record = {};
         // Scalar create-fields: one value each. Skip inputs that live inside a

--- a/app/authorities/qa/authorities/linked_record.rb
+++ b/app/authorities/qa/authorities/linked_record.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module Qa::Authorities
+  ##
+  # @api public
+  #
+  # Autocomplete authority for the `linked_record` compound sub-property's
+  # picker, mounted at `/authorities/search/linked_record/:source`. The `:source`
+  # URL segment arrives as `params[:subauthority]` (QA's standard
+  # `/search/:vocab(/:subauthority)` route); the query is delegated to that
+  # registered {Hyrax::CompoundLinkedRecordResolver} source's `search` proc, so a
+  # single authority serves every source — no per-source authority class.
+  #
+  # Returns `{ id:, label:, value: }` rows, or `[]` when the source is missing,
+  # unregistered, or not searchable.
+  class LinkedRecord < Qa::Authorities::Base
+    def search(query, controller)
+      source = controller.params[:subauthority].to_s
+      return [] if source.empty?
+
+      Hyrax::CompoundLinkedRecordResolver.search(source, query)
+    end
+  end
+end

--- a/app/controllers/hyrax/compound_linked_records_controller.rb
+++ b/app/controllers/hyrax/compound_linked_records_controller.rb
@@ -14,6 +14,10 @@ module Hyrax
   # `create` proc owns the attribute contract (declared via the profile's
   # `create_fields`), so the submitted `record` hash is passed through as-is.
   class CompoundLinkedRecordsController < ApplicationController
+    # Server-side record creation — require a logged-in user so anonymous
+    # visitors can't create records against any registered source.
+    before_action :authenticate_user!
+
     def create
       source = params[:source].to_s
       return head(:not_found) unless Hyrax::CompoundLinkedRecordResolver.creatable?(source)
@@ -26,6 +30,11 @@ module Hyrax
       else
         render json: { errors: record_errors(record) }, status: :unprocessable_entity
       end
+    rescue StandardError => e
+      # The source's create proc may raise; return a controlled 422 (so the
+      # picker shows a message) rather than a 500 HTML page, and log the cause.
+      Hyrax.logger.error("CompoundLinkedRecordsController#create(#{params[:source]}): #{e.class}: #{e.message}")
+      render json: { errors: ['could not be created'] }, status: :unprocessable_entity
     end
 
     private
@@ -42,8 +51,14 @@ module Hyrax
       raw.to_unsafe_h.deep_symbolize_keys
     end
 
+    # A record is a success when it reports `persisted?`; for a record-like
+    # object that doesn't implement `persisted?`, require an id and (when it
+    # exposes errors) no errors — so we never 201 with a nil/invalid id.
     def record_valid?(record)
-      record.respond_to?(:persisted?) ? record.persisted? : true
+      return record.persisted? if record.respond_to?(:persisted?)
+
+      record.respond_to?(:id) && record.id.present? &&
+        (!record.respond_to?(:errors) || Array(record.errors).empty?)
     end
 
     # Messages for an invalid record. Accepts either an ActiveModel errors object

--- a/app/controllers/hyrax/compound_linked_records_controller.rb
+++ b/app/controllers/hyrax/compound_linked_records_controller.rb
@@ -32,12 +32,14 @@ module Hyrax
 
     # Pass the submitted record attributes through to the source's create proc,
     # which decides what it accepts. The source owns the field contract (declared
-    # via the profile's create_fields), so permit an open hash.
+    # via the profile's create_fields), so permit an open hash. A `group`
+    # create-field arrives as an Array of Hashes (one per row); deep-symbolize so
+    # the create proc sees symbol keys at every level, including nested rows.
     def create_attributes
       raw = params[:record]
       return {} unless raw.respond_to?(:to_unsafe_h) || raw.is_a?(ActionController::Parameters)
 
-      raw.to_unsafe_h.symbolize_keys
+      raw.to_unsafe_h.deep_symbolize_keys
     end
 
     def record_valid?(record)

--- a/app/controllers/hyrax/compound_linked_records_controller.rb
+++ b/app/controllers/hyrax/compound_linked_records_controller.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+module Hyrax
+  ##
+  # @api public
+  #
+  # Inline-create endpoint for the `linked_record` compound picker's
+  # lookup-or-create flow. Source-agnostic: `params[:source]` selects a source
+  # registered with {Hyrax::CompoundLinkedRecordResolver}, which owns how to
+  # create the record and how to derive its label.
+  #
+  # Returns `{ id:, label: }` (201) on success, the record's errors (422) when
+  # invalid, or 404 when the source is unknown or not creatable. The source's
+  # `create` proc owns the attribute contract (declared via the profile's
+  # `create_fields`), so the submitted `record` hash is passed through as-is.
+  class CompoundLinkedRecordsController < ApplicationController
+    def create
+      source = params[:source].to_s
+      return head(:not_found) unless Hyrax::CompoundLinkedRecordResolver.creatable?(source)
+
+      record = Hyrax::CompoundLinkedRecordResolver.create(source, create_attributes)
+
+      if record && record_valid?(record)
+        render json: { id: record.id, label: Hyrax::CompoundLinkedRecordResolver.label_for(source, record.id) },
+               status: :created
+      else
+        render json: { errors: record_errors(record) }, status: :unprocessable_entity
+      end
+    end
+
+    private
+
+    # Pass the submitted record attributes through to the source's create proc,
+    # which decides what it accepts. The source owns the field contract (declared
+    # via the profile's create_fields), so permit an open hash.
+    def create_attributes
+      raw = params[:record]
+      return {} unless raw.respond_to?(:to_unsafe_h) || raw.is_a?(ActionController::Parameters)
+
+      raw.to_unsafe_h.symbolize_keys
+    end
+
+    def record_valid?(record)
+      record.respond_to?(:persisted?) ? record.persisted? : true
+    end
+
+    # Messages for an invalid record. Accepts either an ActiveModel errors object
+    # (`full_messages`) or a plain array, since a source's `create` proc may
+    # return any record-like object.
+    def record_errors(record)
+      return ['could not be created'] unless record.respond_to?(:errors)
+
+      messages = record.errors.respond_to?(:full_messages) ? record.errors.full_messages : Array(record.errors)
+      messages.presence || ['could not be created']
+    end
+  end
+end

--- a/app/helpers/hyrax/compound_fields_helper.rb
+++ b/app/helpers/hyrax/compound_fields_helper.rb
@@ -100,6 +100,21 @@ module Hyrax
       [title, value.to_s]
     end
 
+    # The pre-selected `[label, value]` option for a `linked_record`
+    # sub-property's select2, or nil when empty. The stored id resolves to its
+    # label via the registered `source`; an unresolvable id falls back to the id
+    # string so the picker still shows the stored value.
+    #
+    # @param value [String] the stored row id
+    # @param source [String, Symbol] the registered source name (`authority:`)
+    # @return [Array(String, String), nil]
+    def compound_linked_record_option(value, source)
+      return nil if value.blank?
+
+      label = Hyrax::CompoundLinkedRecordResolver.label_for(source, value)
+      [label, value.to_s]
+    end
+
     # The label for a compound. A declared `display_label` is resolved through
     # the same path ordinary properties use ({Hyrax::AttributesHelper#conform_options});
     # otherwise it falls back to the `hyrax.compound_fields.<name>.label` key.

--- a/app/indexers/hyrax/indexers/compound_indexer.rb
+++ b/app/indexers/hyrax/indexers/compound_indexer.rb
@@ -50,6 +50,7 @@ module Hyrax
         'controlled' => %w[_sim],
         'url' => %w[_ssim],
         'work_or_url' => %w[_ssim],
+        'linked_record' => %w[_ssim],
         'id' => %w[_ssim],
         'date_time' => %w[_dtsi],
         'date' => %w[_dtsi]

--- a/app/renderers/hyrax/renderers/compound_attribute_renderer.rb
+++ b/app/renderers/hyrax/renderers/compound_attribute_renderer.rb
@@ -74,11 +74,28 @@ module Hyrax
           auto_link(ERB::Util.h(value.to_s))
         when 'work_or_url'
           work_or_url_markup(value)
+        when 'linked_record'
+          linked_record_markup(sub_property, value)
         when 'controlled'
           controlled_markup(sub_property, value)
         else
           ERB::Util.h(display_value(sub_property, value))
         end
+      end
+
+      # Resolve a `linked_record` reference (a row id) to the record's label,
+      # linked to its show path, via the sub-property's registered source
+      # (`spec[:authority]`). The link text prefers the profile-declared
+      # `view: { label_field: }`, else the source's registered label proc.
+      # Renders the bare id when it doesn't resolve, so the link is never broken.
+      def linked_record_markup(sub_property, value)
+        spec = subproperty_spec(sub_property)
+        label, path = Hyrax::CompoundLinkedRecordResolver.title_and_path(
+          spec&.dig(:authority), value, label_field: spec&.dig(:label_field)
+        )
+        return ERB::Util.h(value.to_s) if path.blank?
+
+        link_to(ERB::Util.h(label), path)
       end
 
       # A controlled value displays its authority/value-list term. When the

--- a/app/renderers/hyrax/renderers/compound_attribute_renderer.rb
+++ b/app/renderers/hyrax/renderers/compound_attribute_renderer.rb
@@ -93,7 +93,11 @@ module Hyrax
         label, path = Hyrax::CompoundLinkedRecordResolver.title_and_path(
           spec&.dig(:authority), value, label_field: spec&.dig(:label_field)
         )
-        return ERB::Util.h(value.to_s) if path.blank?
+        # When there's no path (record resolves but its `path:` proc returns
+        # blank, or it doesn't resolve), render the resolved label as plain text
+        # — `label` is the record's label when resolved, else the id string — so
+        # a resolved name is never discarded in favor of the bare id.
+        return ERB::Util.h(label.to_s) if path.blank?
 
         link_to(ERB::Util.h(label), path)
       end

--- a/app/services/hyrax/compound_linked_record_resolver.rb
+++ b/app/services/hyrax/compound_linked_record_resolver.rb
@@ -47,7 +47,8 @@ module Hyrax
       # @param search [#call, nil] `(query) -> Array<{id:, label:, value:}>` for
       #   the picker autocomplete
       # @param create [#call, nil] `(attributes Hash) -> record` for the
-      #   lookup-or-create flow
+      #   lookup-or-create flow. A scalar create-field arrives as a single value;
+      #   a `group` create-field arrives as an Array of Hashes (one per row).
       def register(source, finder:, label:, path:, search: nil, create: nil)
         registry[source.to_sym] = Source.new(finder:, label:, path:, search:, create:)
       end

--- a/app/services/hyrax/compound_linked_record_resolver.rb
+++ b/app/services/hyrax/compound_linked_record_resolver.rb
@@ -1,0 +1,174 @@
+# frozen_string_literal: true
+
+module Hyrax
+  ##
+  # @api public
+  #
+  # Registry and resolver for the `linked_record` compound sub-property type,
+  # whose stored value is a reference to a row in a database table. Turns that
+  # stored id into a display label and a show path — the database-backed
+  # analogue of {Hyrax::CompoundWorkResolver}, which resolves work ids via Solr.
+  #
+  # Generic by design: each linked source registers how to find a record, how to
+  # label it, how to build its show path, how to search the table (for the
+  # picker autocomplete), and — optionally — how to create one (for the
+  # profile-driven lookup-or-create flow). The resolver stays naive about which
+  # tables exist; the host application names its own sources.
+  #
+  #   Hyrax::CompoundLinkedRecordResolver.register(
+  #     :people,
+  #     finder: ->(id) { Person.find_by(id:) },
+  #     label:  ->(p)  { p.display_name },
+  #     path:   ->(p)  { Rails.application.routes.url_helpers.person_path(p) },
+  #     search: ->(q)  { Person.matching(q).limit(20).map { |p| { id: p.id.to_s, label: p.display_name, value: p.id.to_s } } },
+  #     create: ->(attrs) { Person.create(attrs.slice(:display_name, :orcid)) }
+  #   )
+  #
+  # The M3 profile names the source via the sub-property's `authority:` key; see
+  # documentation/compound_fields.md.
+  class CompoundLinkedRecordResolver
+    Source = Struct.new(:finder, :label, :path, :search, :create, keyword_init: true)
+
+    class << self
+      # @return [Hash{Symbol => Source}] the registered sources, by name
+      def registry
+        @registry ||= {}
+      end
+
+      # Register a linked source: the procs that map between a stored id and a
+      # database record. `search` and `create` are optional — omit them for a
+      # source that is resolve-only (no picker autocomplete, no inline creation).
+      #
+      # @param source [Symbol, String] the source name, matched to a
+      #   sub-property's `authority:` in the M3 profile
+      # @param finder [#call] `(id) -> record | nil`
+      # @param label  [#call] `(record) -> String` the display label
+      # @param path   [#call] `(record) -> String` the record's show path
+      # @param search [#call, nil] `(query) -> Array<{id:, label:, value:}>` for
+      #   the picker autocomplete
+      # @param create [#call, nil] `(attributes Hash) -> record` for the
+      #   lookup-or-create flow
+      def register(source, finder:, label:, path:, search: nil, create: nil)
+        registry[source.to_sym] = Source.new(finder:, label:, path:, search:, create:)
+      end
+
+      # @param source [Symbol, String]
+      # @return [Boolean] whether the source is registered with a `search` proc
+      def searchable?(source)
+        registry[source.to_sym]&.search.present?
+      end
+
+      # @param source [Symbol, String]
+      # @return [Boolean] whether the source is registered with a `create` proc
+      def creatable?(source)
+        registry[source.to_sym]&.create.present?
+      end
+
+      # @param source [Symbol, String]
+      # @param query [String] the typed search term
+      # @return [Array<Hash{Symbol => String}>] picker results
+      #   (`{ id:, label:, value: }`); `[]` when the source is unregistered or
+      #   not searchable
+      def search(source, query)
+        spec = registry[source.to_sym]
+        return [] if spec.nil? || spec.search.nil?
+
+        Array(spec.search.call(query))
+      rescue StandardError => e
+        Hyrax.logger.debug("CompoundLinkedRecordResolver.search(#{source}, #{query}): #{e.message}")
+        []
+      end
+
+      # Create a record for the source from the given attributes. The source's
+      # `create` proc owns validation; it may return a record with errors or raise.
+      #
+      # @param source [Symbol, String]
+      # @param attrs [Hash] the create-form attributes
+      # @return [Object, nil] the new record (resolvable via the same source), or
+      #   nil when the source is unregistered or not creatable
+      def create(source, attrs)
+        spec = registry[source.to_sym]
+        return nil if spec.nil? || spec.create.nil?
+
+        spec.create.call(attrs)
+      end
+
+      # @param source [Symbol, String]
+      # @param id [String] the stored row id
+      # @return [Array(String, String), nil] `[label, path]`, or nil when the
+      #   source is unregistered or the record is not found (so callers can
+      #   render a bare, unlinked value)
+      def resolve(source, id)
+        record = find(source, id)
+        return nil if record.nil?
+
+        spec = registry[source.to_sym]
+        [spec.label.call(record), spec.path.call(record)]
+      end
+
+      # @param source [Symbol, String]
+      # @param id [String] the stored row id
+      # @param label_field [String, nil] a field to read off the record (from the
+      #   profile's `view: { label_field: }`); falls back to the source's `label`
+      #   proc when absent/blank/unsupported
+      # @return [String] the record's label, or the id string when unresolved
+      def label_for(source, id, label_field: nil)
+        record = find(source, id)
+        record ? record_label(registry[source.to_sym], record, label_field) : id.to_s
+      end
+
+      # @param source [Symbol, String]
+      # @param id [String] the stored row id
+      # @return [String, nil] the record's show path, or nil when unresolved
+      def path_for(source, id)
+        record = find(source, id)
+        record ? registry[source.to_sym].path.call(record) : nil
+      end
+
+      # Label + path with id/nil fallbacks when unresolved — convenient for the
+      # form pre-fill and show-page rendering.
+      #
+      # @param source [Symbol, String]
+      # @param id [String] the stored row id
+      # @param label_field [String, nil] see {.label_for}
+      # @return [Array(String, String), Array(String, nil)] `[label, path]` when
+      #   resolved, else `[id, nil]`
+      def title_and_path(source, id, label_field: nil)
+        record = find(source, id)
+        return [id.to_s, nil] if record.nil?
+
+        spec = registry[source.to_sym]
+        [record_label(spec, record, label_field), spec.path.call(record)]
+      end
+
+      # The raw record, so callers that need fields beyond label/path (e.g. an
+      # external identifier) can read them off it.
+      #
+      # @param source [Symbol, String]
+      # @param id [String] the stored row id
+      # @return [Object, nil] the record, or nil when unregistered/blank/unfound
+      def find(source, id)
+        spec = registry[source.to_sym]
+        return nil if spec.nil? || id.blank?
+
+        spec.finder.call(id)
+      rescue StandardError => e
+        Hyrax.logger.debug("CompoundLinkedRecordResolver.find(#{source}, #{id}): #{e.message}")
+        nil
+      end
+
+      private
+
+      # Prefer the profile-declared `label_field` read off the record; fall back
+      # to the source's registered label proc (when no field is named, the field
+      # is blank, or the record doesn't expose it).
+      def record_label(spec, record, label_field)
+        if label_field.present? && record.respond_to?(label_field)
+          value = record.public_send(label_field)
+          return value.to_s if value.present?
+        end
+        spec.label.call(record)
+      end
+    end
+  end
+end

--- a/app/services/hyrax/compound_linked_record_resolver.rb
+++ b/app/services/hyrax/compound_linked_record_resolver.rb
@@ -56,13 +56,13 @@ module Hyrax
       # @param source [Symbol, String]
       # @return [Boolean] whether the source is registered with a `search` proc
       def searchable?(source)
-        registry[source.to_sym]&.search.present?
+        spec_for(source)&.search.present?
       end
 
       # @param source [Symbol, String]
       # @return [Boolean] whether the source is registered with a `create` proc
       def creatable?(source)
-        registry[source.to_sym]&.create.present?
+        spec_for(source)&.create.present?
       end
 
       # @param source [Symbol, String]
@@ -71,7 +71,7 @@ module Hyrax
       #   (`{ id:, label:, value: }`); `[]` when the source is unregistered or
       #   not searchable
       def search(source, query)
-        spec = registry[source.to_sym]
+        spec = spec_for(source)
         return [] if spec.nil? || spec.search.nil?
 
         Array(spec.search.call(query))
@@ -88,7 +88,7 @@ module Hyrax
       # @return [Object, nil] the new record (resolvable via the same source), or
       #   nil when the source is unregistered or not creatable
       def create(source, attrs)
-        spec = registry[source.to_sym]
+        spec = spec_for(source)
         return nil if spec.nil? || spec.create.nil?
 
         spec.create.call(attrs)
@@ -103,7 +103,7 @@ module Hyrax
         record = find(source, id)
         return nil if record.nil?
 
-        spec = registry[source.to_sym]
+        spec = spec_for(source)
         [spec.label.call(record), spec.path.call(record)]
       end
 
@@ -115,7 +115,7 @@ module Hyrax
       # @return [String] the record's label, or the id string when unresolved
       def label_for(source, id, label_field: nil)
         record = find(source, id)
-        record ? record_label(registry[source.to_sym], record, label_field) : id.to_s
+        record ? record_label(spec_for(source), record, label_field) : id.to_s
       end
 
       # @param source [Symbol, String]
@@ -123,7 +123,7 @@ module Hyrax
       # @return [String, nil] the record's show path, or nil when unresolved
       def path_for(source, id)
         record = find(source, id)
-        record ? registry[source.to_sym].path.call(record) : nil
+        record ? spec_for(source).path.call(record) : nil
       end
 
       # Label + path with id/nil fallbacks when unresolved — convenient for the
@@ -138,7 +138,7 @@ module Hyrax
         record = find(source, id)
         return [id.to_s, nil] if record.nil?
 
-        spec = registry[source.to_sym]
+        spec = spec_for(source)
         [record_label(spec, record, label_field), spec.path.call(record)]
       end
 
@@ -149,7 +149,7 @@ module Hyrax
       # @param id [String] the stored row id
       # @return [Object, nil] the record, or nil when unregistered/blank/unfound
       def find(source, id)
-        spec = registry[source.to_sym]
+        spec = spec_for(source)
         return nil if spec.nil? || id.blank?
 
         spec.finder.call(id)
@@ -159,6 +159,15 @@ module Hyrax
       end
 
       private
+
+      # The registered Source for a source name, or nil when the name is blank
+      # (a misconfigured/default-schema sub-property with no `authority:`) or
+      # unregistered — so callers never hit `nil.to_sym`.
+      def spec_for(source)
+        return nil if source.blank?
+
+        registry[source.to_sym]
+      end
 
       # Prefer the profile-declared `label_field` read off the record; fall back
       # to the source's registered label proc (when no field is named, the field

--- a/app/services/hyrax/compound_schema.rb
+++ b/app/services/hyrax/compound_schema.rb
@@ -277,9 +277,11 @@ module Hyrax
     end
 
     # Each create field declares its own input spec so the generic add-form can
-    # render it without model knowledge: name, input kind (`as`: string/select),
-    # whether it's required, and any select `values`. A bare string entry is
-    # treated as a name-only string field.
+    # render it without model knowledge: name, input kind (`as`:
+    # string/select/group), whether it's required, any select `values`, whether
+    # it `repeatable`s, and — for `as: group` — its nested `fields`. A group
+    # field collects a list of {sub-field => value} hashes; a bare string entry
+    # is treated as a name-only string field.
     def normalize_create_fields(fields)
       Array(fields).filter_map { |field| normalize_create_field(field) }
     end
@@ -290,11 +292,16 @@ module Hyrax
       name = field['name']
       return if name.blank?
 
+      as = field['as'].presence&.to_s || 'string'
       values = field['values'].presence
       { name: name.to_s,
-        as: field['as'].presence&.to_s || 'string',
+        as: as,
         required: truthy?(field['required']),
-        values: values && Array(values).map(&:to_s) }
+        repeatable: truthy?(field['repeatable']),
+        values: values && Array(values).map(&:to_s),
+        # A group's nested sub-fields are themselves create-fields; everything
+        # else has no sub-fields.
+        fields: as == 'group' ? normalize_create_fields(field['fields']) : nil }
     end
 
     # Whether the compound itself is required (at least one row must exist).

--- a/app/services/hyrax/compound_schema.rb
+++ b/app/services/hyrax/compound_schema.rb
@@ -262,7 +262,39 @@ module Hyrax
         required: truthy?(opts['required']),
         group: opts['group']&.to_s,
         cols: (form['cols'] || DEFAULT_COLS).to_i,
-        as: form['as']&.to_s }
+        as: form['as']&.to_s }.merge(linked_record_keys(opts))
+    end
+
+    # The `linked_record`-specific declarations: profile-driven lookup-or-create
+    # (`creatable:` + `create_fields:`) and which field of the resolved record
+    # supplies the show-page link text (`view: { label_field: }`). Inert for
+    # every other type (false/[]/nil). See documentation/compound_fields.md.
+    def linked_record_keys(opts)
+      view = opts['view'].is_a?(Hash) ? opts['view'] : {}
+      { creatable: truthy?(opts['creatable']),
+        create_fields: normalize_create_fields(opts['create_fields']),
+        label_field: view['label_field'].presence&.to_s }
+    end
+
+    # Each create field declares its own input spec so the generic add-form can
+    # render it without model knowledge: name, input kind (`as`: string/select),
+    # whether it's required, and any select `values`. A bare string entry is
+    # treated as a name-only string field.
+    def normalize_create_fields(fields)
+      Array(fields).filter_map { |field| normalize_create_field(field) }
+    end
+
+    def normalize_create_field(field)
+      field = { 'name' => field } unless field.is_a?(Hash)
+      field = field.with_indifferent_access
+      name = field['name']
+      return if name.blank?
+
+      values = field['values'].presence
+      { name: name.to_s,
+        as: field['as'].presence&.to_s || 'string',
+        required: truthy?(field['required']),
+        values: values && Array(values).map(&:to_s) }
     end
 
     # Whether the compound itself is required (at least one row must exist).

--- a/app/services/hyrax/flexible_schema_validators/compound_validator.rb
+++ b/app/services/hyrax/flexible_schema_validators/compound_validator.rb
@@ -60,10 +60,23 @@ module Hyrax
           @errors << t('unknown_parent', property: name, parent: parent_name)
         end
 
-        return unless config['type'].to_s == 'controlled'
-        return if config['authority'].present? || config['values'].present?
+        validate_option_source(name, config)
+      end
 
-        @errors << t('controlled_without_source', property: name)
+      # A type that resolves its value/options from a source is meaningless
+      # without one: catch the omission at profile-save rather than letting it
+      # produce an unresolvable picker/value at runtime.
+      def validate_option_source(name, config)
+        case config['type'].to_s
+        when 'controlled'
+          return if config['authority'].present? || config['values'].present?
+
+          @errors << t('controlled_without_source', property: name)
+        when 'linked_record'
+          return if config['authority'].present?
+
+          @errors << t('linked_record_without_source', property: name)
+        end
       end
 
       # A top-level `indexing:` on a parent would point the catalog at a

--- a/app/services/hyrax/schema_loader.rb
+++ b/app/services/hyrax/schema_loader.rb
@@ -231,7 +231,7 @@ module Hyrax
       #
       # @param [String]
       # @return [Dry::Types::Type]
-      def type_for(type)
+      def type_for(type) # rubocop:disable Metrics/MethodLength
         case type
         when 'id'
           Valkyrie::Types::ID
@@ -241,6 +241,8 @@ module Hyrax
           Valkyrie::Types::DateTime
         when 'hash'
           Dry::Types['hash']
+        when 'linked_record'
+          Valkyrie::Types::String
         else
           "Valkyrie::Types::#{type.classify}".safe_constantize ||
             raise(ArgumentError, "Unrecognized type: #{type}")

--- a/app/views/hyrax/compounds/_compound_row.html.erb
+++ b/app/views/hyrax/compounds/_compound_row.html.erb
@@ -66,8 +66,14 @@
                                    data: { 'hyrax-compound-work-input': true,
                                            'label': current_option&.first,
                                            'autocomplete-url': "#{Rails.application.routes.url_helpers.qa_path}/search/compound_works" } %>
+            <% when 'linked_record' %>
+              <%# A reference to a row in a database table: a select2 picker over
+                  the source's QA authority, plus an optional inline create form.
+                  See _linked_record_field and Hyrax::CompoundLinkedRecordResolver. %>
+              <%= render 'hyrax/compounds/linked_record_field',
+                         spec: spec, input_id: input_id, input_name: input_name, value: value %>
             <% else %>
-              <%# string (default); db_table / geocode slot in here later. %>
+              <%# string (default); geocode and other types slot in here later. %>
               <%= text_field_tag input_name, value,
                                  id: input_id,
                                  class: 'form-control form-control-sm' %>

--- a/app/views/hyrax/compounds/_linked_record_create_input.html.erb
+++ b/app/views/hyrax/compounds/_linked_record_create_input.html.erb
@@ -7,21 +7,33 @@
 
     Locals:
       field     - a normalized create-field spec (name, as, required, values)
-      input_id  - the DOM id for this input
+      input_id  - the DOM id for this input, or blank for a repeatable row
       data_attr - 'create-field' or 'create-subfield' %>
+<%# A repeatable group row passes a blank `input_id`: the row template is cloned
+    by JS, so a fixed `id`/`for` would create duplicate ids and break label
+    targeting. With no id, the label wraps the control (no `for`); a top-level
+    field keeps the standard label + `for`. The `id` attribute is only emitted
+    when present. %>
+<% label_text = t("hyrax.compound_fields.linked_record.fields.#{field[:name]}", default: field[:name].to_s.humanize) %>
+<% id_html = input_id.present? ? "id=\"#{input_id}\"".html_safe : ''.html_safe %>
 <div class="form-group mb-2">
-  <label for="<%= input_id %>" class="form-label small text-muted mb-0">
-    <%= t("hyrax.compound_fields.linked_record.fields.#{field[:name]}", default: field[:name].to_s.humanize) %><%
-      if field[:required] %><abbr title="required" class="required text-danger">*</abbr><% end %>
-  </label>
+  <% if input_id.present? %>
+    <label for="<%= input_id %>" class="form-label small text-muted mb-0">
+      <%= label_text %><% if field[:required] %><abbr title="required" class="required text-danger">*</abbr><% end %>
+    </label>
+  <% else %>
+    <label class="form-label small text-muted mb-0">
+      <%= label_text %><% if field[:required] %><abbr title="required" class="required text-danger">*</abbr><% end %>
+  <% end %>
   <% if field[:as] == 'select' %>
-    <select id="<%= input_id %>" class="form-control form-control-sm" data-<%= data_attr %>="<%= field[:name] %>">
+    <select <%= id_html %> class="form-control form-control-sm" data-<%= data_attr %>="<%= field[:name] %>">
       <option value=""></option>
       <% Array(field[:values]).each do |v| %>
         <option value="<%= v %>"><%= v.to_s.humanize %></option>
       <% end %>
     </select>
   <% else %>
-    <input type="text" id="<%= input_id %>" class="form-control form-control-sm" data-<%= data_attr %>="<%= field[:name] %>">
+    <input type="text" <%= id_html %> class="form-control form-control-sm" data-<%= data_attr %>="<%= field[:name] %>">
   <% end %>
+  <% unless input_id.present? %></label><% end %>
 </div>

--- a/app/views/hyrax/compounds/_linked_record_create_input.html.erb
+++ b/app/views/hyrax/compounds/_linked_record_create_input.html.erb
@@ -1,0 +1,27 @@
+<%# One input inside a linked_record inline create form: a text box (`as:
+    string`, the default) or a dropdown (`as: select`) over the field's
+    `values`. Used both for top-level create-fields and for a group field's
+    nested sub-fields. The input carries `data-create-field` (top-level) or
+    `data-create-subfield` (inside a group) so the JS can collect it; it has no
+    `name` (it is not part of the work form's params).
+
+    Locals:
+      field     - a normalized create-field spec (name, as, required, values)
+      input_id  - the DOM id for this input
+      data_attr - 'create-field' or 'create-subfield' %>
+<div class="form-group mb-2">
+  <label for="<%= input_id %>" class="form-label small text-muted mb-0">
+    <%= t("hyrax.compound_fields.linked_record.fields.#{field[:name]}", default: field[:name].to_s.humanize) %><%
+      if field[:required] %><abbr title="required" class="required text-danger">*</abbr><% end %>
+  </label>
+  <% if field[:as] == 'select' %>
+    <select id="<%= input_id %>" class="form-control form-control-sm" data-<%= data_attr %>="<%= field[:name] %>">
+      <option value=""></option>
+      <% Array(field[:values]).each do |v| %>
+        <option value="<%= v %>"><%= v.to_s.humanize %></option>
+      <% end %>
+    </select>
+  <% else %>
+    <input type="text" id="<%= input_id %>" class="form-control form-control-sm" data-<%= data_attr %>="<%= field[:name] %>">
+  <% end %>
+</div>

--- a/app/views/hyrax/compounds/_linked_record_field.html.erb
+++ b/app/views/hyrax/compounds/_linked_record_field.html.erb
@@ -100,7 +100,10 @@
           <%= t('hyrax.compound_fields.linked_record.cancel', default: 'Cancel') %>
         </button>
       </div>
-      <div class="text-danger small mt-1 d-none" data-hyrax-linked-record-create-errors></div>
+      <%# data-default-message: the localized fallback the JS shows when the server
+          returns no usable error body; server 422 errors take precedence. %>
+      <div class="text-danger small mt-1 d-none" data-hyrax-linked-record-create-errors
+           data-default-message="<%= t('hyrax.compound_fields.linked_record.create_failed', default: 'Could not create — please try again.') %>"></div>
     </div>
   <% end %>
 </div>

--- a/app/views/hyrax/compounds/_linked_record_field.html.erb
+++ b/app/views/hyrax/compounds/_linked_record_field.html.erb
@@ -8,25 +8,35 @@
 
     Locals: spec, input_id, input_name, value %>
 <% source = spec[:authority] %>
-<% current_option = compound_linked_record_option(value, source) %>
-<% placeholder = t("hyrax.compound_fields.linked_record.#{source}.placeholder",
-                   default: t('hyrax.compound_fields.linked_record.placeholder', default: 'Search')) %>
+<% searchable = source.present? && Hyrax::CompoundLinkedRecordResolver.searchable?(source) %>
 
-<div class="hyrax-linked-record" data-hyrax-linked-record
-     data-source="<%= source %>"
-     data-creatable="<%= spec[:creatable] ? 'true' : 'false' %>"
-     data-create-url="<%= Hyrax::Engine.routes.url_helpers.compound_linked_record_path(source: source) %>">
-  <%# The select2 picker (same hidden-input binding as work_or_url). %>
-  <%= hidden_field_tag input_name, value,
-                       id: input_id,
-                       class: 'form-control form-control-sm',
-                       data: { 'hyrax-compound-work-input': true,
-                               'hyrax-linked-record-input': true,
-                               'label': current_option&.first,
-                               'placeholder': placeholder,
-                               'autocomplete-url': "#{Rails.application.routes.url_helpers.qa_path}/search/linked_record/#{source}" } %>
+<% unless searchable %>
+  <%# No registered/searchable source: the select2 picker would have nothing to
+      search and (createSearchChoice is off for linked_record) no way to enter a
+      value, so fall back to a plain text input holding the stored reference. %>
+  <%= text_field_tag input_name, value, id: input_id, class: 'form-control form-control-sm' %>
+<% else %>
+  <% current_option = compound_linked_record_option(value, source) %>
+  <% placeholder = t("hyrax.compound_fields.linked_record.#{source}.placeholder",
+                     default: t('hyrax.compound_fields.linked_record.placeholder', default: 'Search')) %>
 
-  <% if spec[:creatable] && spec[:create_fields].present? %>
+  <div class="hyrax-linked-record" data-hyrax-linked-record
+       data-source="<%= source %>"
+       data-creatable="<%= spec[:creatable] ? 'true' : 'false' %>"
+       data-create-url="<%= Hyrax::Engine.routes.url_helpers.compound_linked_record_path(source: source) %>">
+    <%# The select2 picker (same hidden-input binding as work_or_url). %>
+    <%= hidden_field_tag input_name, value,
+                         id: input_id,
+                         class: 'form-control form-control-sm',
+                         data: { 'hyrax-compound-work-input': true,
+                                 'hyrax-linked-record-input': true,
+                                 'label': current_option&.first,
+                                 'placeholder': placeholder,
+                                 'autocomplete-url': "#{Rails.application.routes.url_helpers.qa_path}/search/linked_record/#{source}" } %>
+
+  <%# Offer inline create only when the profile asks for it AND the source
+      actually registers a `create:` proc — otherwise the endpoint would 404. %>
+  <% if spec[:creatable] && spec[:create_fields].present? && Hyrax::CompoundLinkedRecordResolver.creatable?(source) %>
     <%# Trigger shown by JS only when a search returns no results. %>
     <button type="button" class="btn btn-link btn-sm px-0 mt-1 d-none"
             data-hyrax-linked-record-add hidden>
@@ -60,9 +70,9 @@
               <div class="hyrax-linked-record-group-row d-flex align-items-end" data-create-group-row>
                 <div class="flex-grow-1">
                   <% row_fields.each do |sub| %>
+                    <%# input_id blank: rows are cloned, so no fixed id/for. %>
                     <%= render 'hyrax/compounds/linked_record_create_input',
-                               field: sub, input_id: "#{input_id}_new_#{field[:name]}_#{sub[:name]}",
-                               data_attr: 'create-subfield' %>
+                               field: sub, input_id: nil, data_attr: 'create-subfield' %>
                   <% end %>
                 </div>
                 <button type="button" class="btn btn-link btn-sm text-danger pb-3" data-create-group-remove
@@ -74,8 +84,7 @@
                 <div class="flex-grow-1">
                   <% row_fields.each do |sub| %>
                     <%= render 'hyrax/compounds/linked_record_create_input',
-                               field: sub, input_id: "#{input_id}_new_#{field[:name]}_#{sub[:name]}",
-                               data_attr: 'create-subfield' %>
+                               field: sub, input_id: nil, data_attr: 'create-subfield' %>
                   <% end %>
                 </div>
                 <button type="button" class="btn btn-link btn-sm text-danger pb-3" data-create-group-remove
@@ -106,4 +115,5 @@
            data-default-message="<%= t('hyrax.compound_fields.linked_record.create_failed', default: 'Could not create — please try again.') %>"></div>
     </div>
   <% end %>
-</div>
+  </div>
+<% end %>

--- a/app/views/hyrax/compounds/_linked_record_field.html.erb
+++ b/app/views/hyrax/compounds/_linked_record_field.html.erb
@@ -1,0 +1,74 @@
+<%# A `linked_record` sub-property field: a select2 search picker over the
+    source's QA authority (Qa::Authorities::LinkedRecord, keyed by the
+    sub-property's `authority:`), plus — when the sub-property declares
+    `creatable: true` — an inline "add new" form built from its `create_fields`.
+    Source-agnostic: everything keys off `spec[:authority]` /
+    `spec[:create_fields]`; no model knowledge here. See
+    Hyrax::CompoundLinkedRecordResolver and documentation/compound_fields.md.
+
+    Locals: spec, input_id, input_name, value %>
+<% source = spec[:authority] %>
+<% current_option = compound_linked_record_option(value, source) %>
+<% placeholder = t("hyrax.compound_fields.linked_record.#{source}.placeholder",
+                   default: t('hyrax.compound_fields.linked_record.placeholder', default: 'Search')) %>
+
+<div class="hyrax-linked-record" data-hyrax-linked-record
+     data-source="<%= source %>"
+     data-creatable="<%= spec[:creatable] ? 'true' : 'false' %>"
+     data-create-url="<%= Hyrax::Engine.routes.url_helpers.compound_linked_record_path(source: source) %>">
+  <%# The select2 picker (same hidden-input binding as work_or_url). %>
+  <%= hidden_field_tag input_name, value,
+                       id: input_id,
+                       class: 'form-control form-control-sm',
+                       data: { 'hyrax-compound-work-input': true,
+                               'hyrax-linked-record-input': true,
+                               'label': current_option&.first,
+                               'placeholder': placeholder,
+                               'autocomplete-url': "#{Rails.application.routes.url_helpers.qa_path}/search/linked_record/#{source}" } %>
+
+  <% if spec[:creatable] && spec[:create_fields].present? %>
+    <%# Trigger shown by JS only when a search returns no results. %>
+    <button type="button" class="btn btn-link btn-sm px-0 mt-1 d-none"
+            data-hyrax-linked-record-add hidden>
+      <%= t('hyrax.compound_fields.linked_record.add_new', default: '+ Add new') %>
+    </button>
+
+    <%# Inline create form (hidden until the trigger is clicked). Each field
+        renders from its declared spec: string -> text input, select -> dropdown
+        of `values`. Inputs are NOT part of the work form's params (no `name`);
+        JS reads them by data-create-field and POSTs to data-create-url. %>
+    <div class="hyrax-linked-record-create card card-body p-2 mt-1 d-none"
+         data-hyrax-linked-record-create-form hidden>
+      <% spec[:create_fields].each do |field| %>
+        <% field_id = "#{input_id}_new_#{field[:name]}" %>
+        <div class="form-group mb-2">
+          <label for="<%= field_id %>" class="form-label small text-muted mb-0">
+            <%= t("hyrax.compound_fields.linked_record.fields.#{field[:name]}", default: field[:name].to_s.humanize) %><%
+              if field[:required] %><abbr title="required" class="required text-danger">*</abbr><% end %>
+          </label>
+          <% if field[:as] == 'select' %>
+            <select id="<%= field_id %>" class="form-control form-control-sm"
+                    data-create-field="<%= field[:name] %>">
+              <option value=""></option>
+              <% Array(field[:values]).each do |v| %>
+                <option value="<%= v %>"><%= v.to_s.humanize %></option>
+              <% end %>
+            </select>
+          <% else %>
+            <input type="text" id="<%= field_id %>" class="form-control form-control-sm"
+                   data-create-field="<%= field[:name] %>">
+          <% end %>
+        </div>
+      <% end %>
+      <div class="d-flex">
+        <button type="button" class="btn btn-primary btn-sm mr-2" data-hyrax-linked-record-create-submit>
+          <%= t('hyrax.compound_fields.linked_record.create', default: 'Create') %>
+        </button>
+        <button type="button" class="btn btn-link btn-sm" data-hyrax-linked-record-create-cancel>
+          <%= t('hyrax.compound_fields.linked_record.cancel', default: 'Cancel') %>
+        </button>
+      </div>
+      <div class="text-danger small mt-1 d-none" data-hyrax-linked-record-create-errors></div>
+    </div>
+  <% end %>
+</div>

--- a/app/views/hyrax/compounds/_linked_record_field.html.erb
+++ b/app/views/hyrax/compounds/_linked_record_field.html.erb
@@ -33,32 +33,64 @@
       <%= t('hyrax.compound_fields.linked_record.add_new', default: '+ Add new') %>
     </button>
 
-    <%# Inline create form (hidden until the trigger is clicked). Each field
-        renders from its declared spec: string -> text input, select -> dropdown
-        of `values`. Inputs are NOT part of the work form's params (no `name`);
-        JS reads them by data-create-field and POSTs to data-create-url. %>
+    <%# Inline create form (hidden until the trigger is clicked). A scalar field
+        (string/select) renders one input tagged `data-create-field`; a
+        `as: group` field renders a repeatable set of rows (its sub-fields tagged
+        `data-create-subfield`) the JS collects into an array of hashes. Inputs
+        are NOT part of the work form's params (no `name`); JS reads them by the
+        data attributes and POSTs to data-create-url. %>
     <div class="hyrax-linked-record-create card card-body p-2 mt-1 d-none"
          data-hyrax-linked-record-create-form hidden>
       <% spec[:create_fields].each do |field| %>
-        <% field_id = "#{input_id}_new_#{field[:name]}" %>
-        <div class="form-group mb-2">
-          <label for="<%= field_id %>" class="form-label small text-muted mb-0">
-            <%= t("hyrax.compound_fields.linked_record.fields.#{field[:name]}", default: field[:name].to_s.humanize) %><%
-              if field[:required] %><abbr title="required" class="required text-danger">*</abbr><% end %>
-          </label>
-          <% if field[:as] == 'select' %>
-            <select id="<%= field_id %>" class="form-control form-control-sm"
-                    data-create-field="<%= field[:name] %>">
-              <option value=""></option>
-              <% Array(field[:values]).each do |v| %>
-                <option value="<%= v %>"><%= v.to_s.humanize %></option>
-              <% end %>
-            </select>
-          <% else %>
-            <input type="text" id="<%= field_id %>" class="form-control form-control-sm"
-                   data-create-field="<%= field[:name] %>">
-          <% end %>
-        </div>
+        <% if field[:repeatable] || field[:as] == 'group' %>
+          <%# Repeatable field — rendered as add/remove rows. A `group` row holds
+              its nested sub-fields (collected into a Hash); a repeatable scalar
+              (`as: string/select`, no sub-fields) holds one input (collected as a
+              plain string). `data-create-scalar` tells the JS which shape to emit.
+              The <template> row is cloned on "+ Add"; one row renders initially. %>
+          <% scalar = field[:as] != 'group' %>
+          <div class="form-group mb-2 hyrax-linked-record-group"
+               data-create-group="<%= field[:name] %>" data-repeatable="true"
+               data-create-scalar="<%= scalar ? 'true' : 'false' %>">
+            <label class="form-label small text-muted mb-1 d-block">
+              <%= t("hyrax.compound_fields.linked_record.fields.#{field[:name]}", default: field[:name].to_s.humanize) %>
+            </label>
+            <% row_fields = scalar ? [field] : Array(field[:fields]) %>
+            <template data-create-group-row-template>
+              <div class="hyrax-linked-record-group-row d-flex align-items-end" data-create-group-row>
+                <div class="flex-grow-1">
+                  <% row_fields.each do |sub| %>
+                    <%= render 'hyrax/compounds/linked_record_create_input',
+                               field: sub, input_id: "#{input_id}_new_#{field[:name]}_#{sub[:name]}",
+                               data_attr: 'create-subfield' %>
+                  <% end %>
+                </div>
+                <button type="button" class="btn btn-link btn-sm text-danger pb-3" data-create-group-remove
+                        aria-label="<%= t('hyrax.compound_fields.remove_row', default: 'Remove') %>">&times;</button>
+              </div>
+            </template>
+            <div data-create-group-rows>
+              <div class="hyrax-linked-record-group-row d-flex align-items-end" data-create-group-row>
+                <div class="flex-grow-1">
+                  <% row_fields.each do |sub| %>
+                    <%= render 'hyrax/compounds/linked_record_create_input',
+                               field: sub, input_id: "#{input_id}_new_#{field[:name]}_#{sub[:name]}",
+                               data_attr: 'create-subfield' %>
+                  <% end %>
+                </div>
+                <button type="button" class="btn btn-link btn-sm text-danger pb-3" data-create-group-remove
+                        aria-label="<%= t('hyrax.compound_fields.remove_row', default: 'Remove') %>">&times;</button>
+              </div>
+            </div>
+            <button type="button" class="btn btn-link btn-sm px-0" data-create-group-add>
+              <%= t('hyrax.compound_fields.add_row', label: field[:name].to_s.humanize, default: "+ Add #{field[:name].to_s.humanize}") %>
+            </button>
+          </div>
+        <% else %>
+          <%= render 'hyrax/compounds/linked_record_create_input',
+                     field: field, input_id: "#{input_id}_new_#{field[:name]}",
+                     data_attr: 'create-field' %>
+        <% end %>
       <% end %>
       <div class="d-flex">
         <button type="button" class="btn btn-primary btn-sm mr-2" data-hyrax-linked-record-create-submit>

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -1419,6 +1419,7 @@ en:
         errors:
           unknown_parent: "m3 profile subproperty `%{property}` declares `available_on: { properties: [%{parent}] }`, but `%{parent}` is not a declared `type: hash` compound property"
           controlled_without_source: "m3 profile compound subproperty `%{property}` is `type: controlled` but declares neither `authority` nor `values`"
+          linked_record_without_source: "m3 profile compound subproperty `%{property}` is `type: linked_record` but declares no `authority` naming a registered linked-record source"
           top_level_indexing: "m3 profile compound property `%{property}` must not declare top-level `indexing`; declare `indexing` (or `index_keys`) on each subproperty instead"
           duplicate_subproperty_name: "m3 profile compound `%{parent}` has multiple sub-properties resolving to the in-compound name `%{name}` (%{properties}); each sub-property in a compound must resolve to a unique name (set a distinct `name:`)"
       redirects_validator:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -22,6 +22,11 @@ Hyrax::Engine.routes.draw do
   get '/resourcelist' => 'resource_sync#resource_list', as: :resource_list
   get '/changelist' => 'resource_sync#change_list', as: :change_list
 
+  # Inline create endpoint for the `linked_record` compound picker's
+  # lookup-or-create flow; `:source` selects a registered
+  # Hyrax::CompoundLinkedRecordResolver source.
+  post '/linked_records/:source', to: 'compound_linked_records#create', as: :compound_linked_record
+
   delete '/uploads/:id', to: 'uploads#destroy', as: :uploaded_file
   post '/uploads', to: 'uploads#create'
   # This is a hack that is required because the rails form the uploader is on

--- a/documentation/compound_fields.md
+++ b/documentation/compound_fields.md
@@ -245,6 +245,15 @@ creator_ref:
     - { name: display_name, as: string, required: true }
     - { name: orcid, as: string }
     - { name: kind, as: select, values: [person, organization] }
+    # a repeatable scalar -> the proc receives an Array of strings:
+    - { name: affiliations, as: string, repeatable: true }
+    # a repeatable group -> the proc receives an Array of Hashes:
+    - name: identifiers
+      as: group
+      repeatable: true
+      fields:
+        - { name: value, as: string }
+        - { name: scheme, as: select, values: [ISNI, VIAF, ROR] }
 ```
 
 How the pieces fit together:
@@ -265,6 +274,12 @@ How the pieces fit together:
   the new record in the picker. Each `create_fields` entry declares its own
   input: `as: string` (text input) or `as: select` (a dropdown of `values:`),
   and `required:`.
+- **Repeatable create-fields** (see `affiliations` and `identifiers` above). Mark
+  any create-field `repeatable: true` and the "Add new" form renders add/remove
+  rows for it. A repeatable **scalar** (`as: string`/`select`, no `fields:`)
+  collects a plain **Array of strings** (`affiliations: ["A", "B"]`). A
+  repeatable **group** (`as: group` with nested `fields:`) collects an **Array of
+  Hashes**, one per non-blank row (`identifiers: [{ value: "…", scheme: "ISNI" }, …]`).
 - **Indexing & reverse lookup.** A `linked_record` indexes as a single stored
   string `<compound>_<name>_ssim` (like an id), so you can reverse-look-up "which
   works reference this record?" with a Solr query on that field.

--- a/documentation/compound_fields.md
+++ b/documentation/compound_fields.md
@@ -533,7 +533,9 @@ property; no two sub-properties of the same compound resolve to the same
 in-compound name (a `name:` alias or the property key), which would otherwise
 silently drop one when the loader folds members by that name (the same name
 reused across *different* compounds is fine); a `type: controlled` sub-property
-declares an option source (`authority:` or `values:`); and a compound parent
+declares an option source (`authority:` or `values:`); a `type: linked_record`
+sub-property declares an `authority:` naming a registered source (without one the
+picker and show-page link can't resolve); and a compound parent
 does **not** carry a top-level `indexing:` (indexing is declared per
 sub-property — a top-level `indexing:` would point the catalog at a
 `<compound>_tesim` field the indexer never writes).

--- a/documentation/compound_fields.md
+++ b/documentation/compound_fields.md
@@ -137,6 +137,7 @@ textarea). Supported `type:` values:
 | `string`     | text input          | The default when `type:` is omitted. |
 | `url`        | url input → auto-linked on show | The stored value is rendered as a clickable `<a href>` on show pages (matching the scalar `render_as: external_link` behavior). |
 | `work_or_url` | select2 typeahead → linked on show | Searches internal works (via the `compound_works` QA authority, backed by `Hyrax::CompoundWorkPickerBuilder`) **or** accepts a typed external URL. The stored value is a work id or a URL; on show, a work id links to the work's show page with its title (resolved by `Hyrax::CompoundWorkResolver`), a URL is auto-linked. |
+| `linked_record` | select2 typeahead → linked on show | A reference to a row in a database table (a person, organization, funder, place, …). The stored value is the row id; the picker searches that table and, optionally, lets a cataloger add a new record inline. On show, the id links to the record using the resolved label. The table and its procs are registered by the host application — see [`linked_record` sub-properties](#linked_record-sub-properties) below. |
 | `controlled` | `<select>` dropdown | Options come from either an inline `values:` list or a QA local authority named by `authority:` (see below). The row's stored value is preserved even if it is no longer offered, matching the `include_current_value` convention of the ordinary controlled-field partials. |
 
 A `controlled` sub-property sources its options one of two ways:
@@ -176,13 +177,97 @@ catalog's read-permission filtering is retained — a user only sees works they
 can read. The picker is mounted as the `compound_works` QA authority at
 `/authorities/search/compound_works`.
 
-`db_table` (a typeahead backed by an ActiveRecord lookup table, with
-add-new) and `geocode` (a Geonames/coordinate lookup) are planned additional
-sub-property types; the form's row partial has an explicit extension point for
-them. `geocode` generalizes the existing single-value controlled-URI location
-field — see `Hyrax::BasedNearFieldBehavior` and
+`geocode` (a Geonames/coordinate lookup) is a planned additional sub-property
+type; the form's row partial has an explicit extension point for it. `geocode`
+generalizes the existing single-value controlled-URI location field — see
+`Hyrax::BasedNearFieldBehavior` and
 [`field_behaviors.md`](field_behaviors.md), which `geocode` is intended to
 replace once it lands.
+
+### `linked_record` sub-properties
+
+A `linked_record` sub-property's value is a reference to a row in a database
+table — a person, organization, funder, place, or any other entity you want to
+record once and cite from many works, rather than retyping the same name on each
+work. The stored value is the row id; on show pages it renders as a link to that
+record using a resolved label.
+
+Hyrax provides the **mechanism**; the host application provides the **table**.
+You register a *source* — a name plus the procs that map between a stored id and
+a record — with `Hyrax::CompoundLinkedRecordResolver`, and name that source in
+the sub-property's `authority:` key. (Hyrax ships no person/organization table
+itself, so the examples below assume an application-supplied `Person` model.)
+
+```ruby
+# config/initializers/linked_records.rb
+Rails.application.config.to_prepare do
+  Hyrax::CompoundLinkedRecordResolver.register(
+    :people,
+    finder: ->(id)    { Person.find_by(id:) },
+    label:  ->(person) { person.display_name },
+    path:   ->(person) { Rails.application.routes.url_helpers.person_path(person) },
+    # optional — enables the picker autocomplete:
+    search: ->(q) { Person.where('display_name ILIKE ?', "%#{q}%").limit(20)
+                          .map { |p| { id: p.id.to_s, label: p.display_name, value: p.id.to_s } } },
+    # optional — enables inline "add new" (lookup-or-create):
+    create: ->(attrs) { Person.create(attrs.slice(:display_name, :orcid)) }
+  )
+end
+```
+
+**What the table needs.** The source can wrap any object the four procs can
+operate on — typically an `ActiveRecord` model, but nothing about the type is
+prescribed. The only contract is what the procs imply:
+
+- a stable identifier the `finder` can look up by and that is safe to persist as
+  a string (an integer or UUID primary key is fine — it is stored as its string
+  form);
+- a human-readable label (whatever `label:` / `view: { label_field: }` returns);
+- any other fields the `path:`, `search:`, or `create:` procs reference.
+
+There is **no base class to inherit, no required column names, no migration or
+schema Hyrax imposes, and no per-source authority or controller class to write** —
+the generic authority and create endpoint (below) serve every source. Registering
+the source is the whole integration.
+
+```yaml
+# the sub-property names the registered source via `authority:`
+creator_ref:
+  type: linked_record
+  name: creator
+  available_on: { properties: [creators] }
+  authority: people          # the registered source name
+  view:
+    label_field: display_name # which record field supplies the show-page link text
+  # optional inline lookup-or-create form (only when `create:` is registered):
+  creatable: true
+  create_fields:
+    - { name: display_name, as: string, required: true }
+    - { name: orcid, as: string }
+    - { name: kind, as: select, values: [person, organization] }
+```
+
+How the pieces fit together:
+
+- **Search picker.** The picker is the generic `linked_record` QA authority,
+  mounted at `/authorities/search/linked_record/:source`. The source name is the
+  sub-authority segment, so one authority serves every source — there is no
+  per-source authority class. It delegates the query to the source's `search:`
+  proc. A source registered without `search:` renders a plain text input.
+- **Show-page link.** `Hyrax::CompoundLinkedRecordResolver` resolves the stored
+  id to `[label, path]`. The link text is the record field named by
+  `view: { label_field: }` when present, otherwise the source's `label:` proc.
+  An id that no longer resolves renders as bare text, never a broken link.
+- **Inline lookup-or-create.** When the sub-property declares `creatable: true`
+  and the source registers a `create:` proc, a search that returns no matches
+  offers an "Add new" form built from `create_fields`. Submitting it POSTs to
+  `/linked_records/:source`, which calls the source's `create:` proc and selects
+  the new record in the picker. Each `create_fields` entry declares its own
+  input: `as: string` (text input) or `as: select` (a dropdown of `values:`),
+  and `required:`.
+- **Indexing & reverse lookup.** A `linked_record` indexes as a single stored
+  string `<compound>_<name>_ssim` (like an id), so you can reverse-look-up "which
+  works reference this record?" with a Solr query on that field.
 
 ### Grouping (`group:` + `groups:`, optional)
 
@@ -222,7 +307,7 @@ chosen by its `type:`:
 |--------------------------|------------------|------|
 | `string`                 | `_sim`, `_tesim` | facetable **and** full-text searchable |
 | `controlled`             | `_sim`           | facetable only (a closed vocabulary needs no full-text) |
-| `url`, `work_or_url`, `id` | `_ssim`        | stored exact-match string |
+| `url`, `work_or_url`, `linked_record`, `id` | `_ssim` | stored exact-match string (reverse-lookup id) |
 | `date_time`, `date`      | `_dtsi`          | date |
 
 So `participants` with a `name`-aliased `title` (type `string`) is indexed to

--- a/documentation/flexible_metadata.md
+++ b/documentation/flexible_metadata.md
@@ -60,6 +60,15 @@ Restricted fields (declared with either `admin_only` or `editor_only`) are **not
 
 Visibility for restricted fields is enforced on show pages by the `field_visible?` view helper.
 
+### `view:`-driven visibility (show page and catalog separately)
+
+Beyond the role flags, a property's `view:` block controls show-page and catalog visibility independently:
+
+- **Show page is opt-in via `view:`.** A property renders on the show page only when it declares a meaningful `view:` block (e.g. `html_dl: true`); a property with no `view:` block is not enrolled in show-page rendering at all (the `display_label` / `admin_only` / `editor_only` keys alone don't count). Within a rendered field, `view: { show_page: false }` hides it from the show page for everyone (the value is still stored and indexed).
+- **`view: { search_results: false }`** drops the property's column from catalog search results, while leaving it on the show page. It suppresses only the search-results column — the property can still be **facetable** (declare `facetable` in `indexing:`).
+
+These combine with the role flags: `admin_only` / `editor_only` remove a property from the catalog entirely (column *and* facet) at registration time, whereas `search_results: false` removes only the column.
+
 ### Declaring the flags
 
 In a YAML schema (HYRAX_FLEXIBLE=false), declare the flag at the top level of the property:
@@ -95,6 +104,7 @@ Use `admin_only` in place of `editor_only` to restrict visibility to admins only
 
 ## Related features
 
+- **Compound (hierarchical) metadata**: an m3 profile (or YAML schema) can declare a `type: hash` property whose members are separate properties naming it via `available_on: { properties: [...] }` — repeatable groups of sub-fields such as `contributors`, `titles`, or `relationships`. Member sub-property types include `string`, `controlled`, `url`, `work_or_url`, and `linked_record` (a reference to a row in a database table, with an inline search-or-create picker). See [`documentation/compound_fields.md`](compound_fields.md) for declaring compounds, the supported sub-property types, indexing, and show-page rendering.
 - **URL Redirects** (`HYRAX_REDIRECTS_ENABLED`): when enabled, the redirects feature requires a `redirects` property in the m3 profile (when also Flipflop-enabled per tenant). See [`documentation/redirects.md`](redirects.md) for the full schema and gating model.
 - **Copy permalink button** (Flipflop `copy_permalink_button`): a show-page button that copies the record's canonical UUID-based URL. See [`documentation/copy_permalink.md`](copy_permalink.md).
 

--- a/spec/authorities/qa/authorities/linked_record_spec.rb
+++ b/spec/authorities/qa/authorities/linked_record_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+# The generic autocomplete authority for the `linked_record` compound picker,
+# mounted at `/authorities/search/linked_record/:source`. The `:source` URL
+# segment arrives as `params[:subauthority]`; the authority delegates the query
+# to that registered Hyrax::CompoundLinkedRecordResolver source's `search` proc,
+# so no per-source authority class is needed. Returns `{ id:, label:, value: }`
+# rows (or [] for an unregistered / non-searchable source).
+RSpec.describe Qa::Authorities::LinkedRecord do
+  let(:service) { described_class.new }
+  let(:controller) { instance_double(Qa::TermsController, params:) }
+  let(:params) { ActionController::Parameters.new(q: 'ada', subauthority: 'stub_people') }
+
+  before do
+    Hyrax::CompoundLinkedRecordResolver.register(
+      :stub_people,
+      finder: ->(_id) {},
+      label: ->(r) { r[:label] },
+      path: ->(r) { "/stub_people/#{r[:id]}" },
+      search: lambda { |q|
+        [{ id: '7', label: 'Ada Lovelace', value: '7' }, { id: '8', label: 'Alan Turing', value: '8' }]
+          .select { |row| row[:label].downcase.include?(q.to_s.downcase) }
+      }
+    )
+  end
+
+  after { Hyrax::CompoundLinkedRecordResolver.registry.delete(:stub_people) }
+
+  describe '#search' do
+    subject(:results) { service.search('ada', controller) }
+
+    it 'delegates to the source named by params[:subauthority]' do
+      expect(results).to contain_exactly(a_hash_including(id: '7', label: 'Ada Lovelace', value: '7'))
+    end
+
+    context 'when the source is unregistered' do
+      let(:params) { ActionController::Parameters.new(q: 'ada', subauthority: 'nope') }
+
+      it 'returns an empty list' do
+        expect(results).to eq([])
+      end
+    end
+
+    context 'when no source (subauthority) is given' do
+      let(:params) { ActionController::Parameters.new(q: 'ada') }
+
+      it 'returns an empty list' do
+        expect(results).to eq([])
+      end
+    end
+  end
+end

--- a/spec/helpers/hyrax/compound_fields_helper_spec.rb
+++ b/spec/helpers/hyrax/compound_fields_helper_spec.rb
@@ -129,4 +129,46 @@ RSpec.describe Hyrax::CompoundFieldsHelper, type: :helper do
       end
     end
   end
+
+  describe '#compound_work_or_url_option' do
+    it 'is nil for a blank value' do
+      expect(helper.compound_work_or_url_option('')).to be_nil
+    end
+
+    it 'shows an external URL as-is (label and value both the URL)' do
+      expect(helper.compound_work_or_url_option('https://example.com/a'))
+        .to eq(['https://example.com/a', 'https://example.com/a'])
+    end
+
+    it 'resolves an internal work id to its title, keeping the id as the value' do
+      allow(Hyrax::CompoundWorkResolver).to receive(:title_and_path)
+        .with('work-1').and_return(['A Work', '/concern/works/work-1'])
+      expect(helper.compound_work_or_url_option('work-1')).to eq(['A Work', 'work-1'])
+    end
+  end
+
+  describe '#compound_linked_record_option' do
+    before do
+      Hyrax::CompoundLinkedRecordResolver.register(
+        :stub_people,
+        finder: ->(id) { id.to_s == '7' ? { id: 7 } : nil },
+        label: ->(_r) { 'Ada Lovelace' },
+        path: ->(_r) { '/people/7' }
+      )
+    end
+
+    after { Hyrax::CompoundLinkedRecordResolver.registry.delete(:stub_people) }
+
+    it 'returns [label, value] for pre-seeding the picker' do
+      expect(helper.compound_linked_record_option('7', 'stub_people')).to eq(['Ada Lovelace', '7'])
+    end
+
+    it 'is nil for a blank value' do
+      expect(helper.compound_linked_record_option('', 'stub_people')).to be_nil
+    end
+
+    it 'falls back to the id label when the value does not resolve' do
+      expect(helper.compound_linked_record_option('999', 'stub_people')).to eq(['999', '999'])
+    end
+  end
 end

--- a/spec/indexers/hyrax/indexers/compound_linked_record_indexing_spec.rb
+++ b/spec/indexers/hyrax/indexers/compound_linked_record_indexing_spec.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+# A `linked_record` sub-property references a row in a database table. It indexes
+# like an id/reference: a single stored-string field `<compound>_<name>_ssim`,
+# for reverse lookup ("which works name this record?"). This mirrors how
+# `work_or_url` derives `_ssim`; without the suffix mapping an unknown type
+# falls back to the default `_tesim`.
+RSpec.describe 'linked_record compound indexing' do
+  let(:resource_class) do
+    Class.new(Hyrax::Resource) do
+      def self.name
+        'TestLinkedRecordIndexingResource'
+      end
+
+      attribute :people,
+                Valkyrie::Types::Array.of(Dry::Types['hash']).meta(
+                  subproperties: {
+                    # the linked-record reference (a row id/key)
+                    'person' => { 'type' => 'linked_record' },
+                    # a plain string sub-field alongside it, to confirm normal
+                    # derivation is untouched
+                    'role' => { 'type' => 'string' }
+                  }
+                )
+    end
+  end
+
+  let(:host_indexer_class) do
+    Class.new(Hyrax::Indexers::ResourceIndexer) do
+      include Hyrax::Indexers::CompoundIndexer
+    end
+  end
+
+  let(:indexer) { host_indexer_class.new(resource:) }
+  let(:resource) do
+    resource_class.new(people: [
+                         { 'person' => 'p-123', 'role' => 'Author' },
+                         { 'person' => 'p-456', 'role' => 'Editor' }
+                       ])
+  end
+
+  it 'derives a single stored-string field <compound>_<name>_ssim for the linked_record' do
+    doc = indexer.to_solr
+    expect(doc['people_person_ssim']).to contain_exactly('p-123', 'p-456')
+  end
+
+  it 'does not derive text/facet fields for the linked_record reference' do
+    doc = indexer.to_solr
+    expect(doc.keys).not_to include('people_person_tesim')
+    expect(doc.keys).not_to include('people_person_sim')
+  end
+
+  it 'leaves sibling string sub-properties deriving normally (_sim + _tesim)' do
+    doc = indexer.to_solr
+    expect(doc['people_role_sim']).to contain_exactly('Author', 'Editor')
+    expect(doc['people_role_tesim']).to contain_exactly('Author', 'Editor')
+  end
+end

--- a/spec/renderers/hyrax/renderers/compound_attribute_renderer_linked_record_spec.rb
+++ b/spec/renderers/hyrax/renderers/compound_attribute_renderer_linked_record_spec.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+# Show-page rendering for a `linked_record` sub-property: the stored value (a row
+# id) renders as the record's label LINKED to its show path, resolved via
+# Hyrax::CompoundLinkedRecordResolver. Mirrors the `work_or_url` branch. The link
+# text uses the profile's `view: { label_field: }` when present, else the
+# source's registered label proc. Falls back to the bare id when unresolvable, so
+# it never emits a broken link.
+RSpec.describe Hyrax::Renderers::CompoundAttributeRenderer do
+  let(:record) { Struct.new(:id, :full_name, :display_name).new(7, 'PROC NAME', 'Ada Lovelace') }
+
+  around do |example|
+    Hyrax::CompoundLinkedRecordResolver.register(
+      :stub_people,
+      finder: ->(id) { id.to_s == '7' ? record : nil },
+      label: ->(r) { r.full_name },
+      path: ->(r) { "/people/#{r.id}" }
+    )
+    example.run
+  ensure
+    Hyrax::CompoundLinkedRecordResolver.registry.delete(:stub_people)
+  end
+
+  context 'when the value resolves and view.label_field names a record field' do
+    let(:subproperties) do
+      { 'person' => { type: 'linked_record', authority: 'stub_people', label_field: 'display_name', values: nil } }
+    end
+    let(:values) { [{ 'person' => '7' }] }
+    let(:renderer) { described_class.new(:people, values, label: 'People', html_dl: true, subproperties:) }
+
+    it 'links the label_field value (not the registry proc) to the show path' do
+      markup = renderer.render_dl_row
+      expect(markup).to include('Ada Lovelace')
+      expect(markup).not_to include('PROC NAME')
+      expect(markup).to include('href="/people/7"')
+    end
+  end
+
+  context 'when no label_field is declared' do
+    let(:subproperties) do
+      { 'person' => { type: 'linked_record', authority: 'stub_people', label_field: nil, values: nil } }
+    end
+    let(:values) { [{ 'person' => '7' }] }
+    let(:renderer) { described_class.new(:people, values, label: 'People', html_dl: true, subproperties:) }
+
+    it 'falls back to the registry label proc' do
+      markup = renderer.render_dl_row
+      expect(markup).to include('PROC NAME')
+      expect(markup).to include('href="/people/7"')
+    end
+  end
+
+  context 'when the value does not resolve' do
+    let(:subproperties) do
+      { 'person' => { type: 'linked_record', authority: 'stub_people', label_field: 'display_name', values: nil } }
+    end
+    let(:values) { [{ 'person' => '999' }] }
+    let(:renderer) { described_class.new(:people, values, label: 'People', html_dl: true, subproperties:) }
+
+    it 'renders the bare id, not a broken link' do
+      markup = renderer.render_dl_row
+      expect(markup).to include('999')
+      expect(markup).not_to include('href="/people/999"')
+    end
+  end
+end

--- a/spec/renderers/hyrax/renderers/compound_attribute_renderer_linked_record_spec.rb
+++ b/spec/renderers/hyrax/renderers/compound_attribute_renderer_linked_record_spec.rb
@@ -63,4 +63,31 @@ RSpec.describe Hyrax::Renderers::CompoundAttributeRenderer do
       expect(markup).not_to include('href="/people/999"')
     end
   end
+
+  context 'when the record resolves but its path is blank' do
+    # A source whose `path:` proc returns blank: the resolved label must still
+    # render as text (the bare id should never replace a resolved name).
+    around do |example|
+      Hyrax::CompoundLinkedRecordResolver.register(
+        :pathless, finder: ->(id) { id.to_s == '7' ? record : nil },
+        label: ->(r) { r.display_name }, path: ->(_r) { '' }
+      )
+      example.run
+    ensure
+      Hyrax::CompoundLinkedRecordResolver.registry.delete(:pathless)
+    end
+
+    let(:subproperties) do
+      { 'person' => { type: 'linked_record', authority: 'pathless', label_field: 'display_name', values: nil } }
+    end
+    let(:values) { [{ 'person' => '7' }] }
+    let(:renderer) { described_class.new(:people, values, label: 'People', html_dl: true, subproperties:) }
+
+    it 'renders the resolved label as text, not the id, and no link' do
+      markup = renderer.render_dl_row
+      expect(markup).to include('Ada Lovelace')
+      expect(markup).not_to include('href=')
+      expect(markup).not_to match(/>\s*7\s*</) # not the bare id
+    end
+  end
 end

--- a/spec/requests/hyrax/compound_linked_records_spec.rb
+++ b/spec/requests/hyrax/compound_linked_records_spec.rb
@@ -11,8 +11,10 @@ RSpec.describe 'Hyrax linked_record create endpoint', type: :request do
   # captures a `group` create-field so a test can assert its shape.
   let(:store) { {} }
   let(:record_class) { Struct.new(:id, :display_name, :ids, :affiliations, :persisted?, :errors, keyword_init: true) }
+  let(:user) { create(:user) }
 
   before do
+    login_as user # the endpoint requires an authenticated user
     s = store
     rc = record_class
     Hyrax::CompoundLinkedRecordResolver.register(
@@ -84,6 +86,31 @@ RSpec.describe 'Hyrax linked_record create endpoint', type: :request do
       expect(response).to have_http_status(:created)
       created = store[response.parsed_body['id'].to_s]
       expect(created.affiliations).to eq(['US Navy', 'Vassar College'])
+    end
+
+    it 'returns a controlled 422 (not a 500) when the create proc raises' do
+      Hyrax::CompoundLinkedRecordResolver.registry.delete(:stub_people)
+      Hyrax::CompoundLinkedRecordResolver.register(
+        :stub_people, finder: ->(_i) {}, label: ->(_r) {}, path: ->(_r) {},
+        create: ->(_attrs) { raise 'boom' }
+      )
+      post hyrax.compound_linked_record_path(source: 'stub_people'),
+           params: { record: { display_name: 'Grace Hopper' } }
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(response.parsed_body['errors']).to be_present
+    end
+  end
+
+  describe 'without an authenticated user' do
+    before { logout }
+
+    it 'does not allow anonymous creation' do
+      post hyrax.compound_linked_record_path(source: 'stub_people'),
+           params: { record: { display_name: 'Grace Hopper' } }
+
+      expect(response).not_to have_http_status(:created)
+      expect(store).to be_empty
     end
   end
 end

--- a/spec/requests/hyrax/compound_linked_records_spec.rb
+++ b/spec/requests/hyrax/compound_linked_records_spec.rb
@@ -7,9 +7,10 @@
 # routes by the :source segment to whatever Hyrax::CompoundLinkedRecordResolver
 # has registered. Driven here through an in-memory stub source.
 RSpec.describe 'Hyrax linked_record create endpoint', type: :request do
-  # A minimal in-memory record + store the stub source creates into.
+  # A minimal in-memory record + store the stub source creates into. `ids`
+  # captures a `group` create-field so a test can assert its shape.
   let(:store) { {} }
-  let(:record_class) { Struct.new(:id, :display_name, :persisted?, :errors, keyword_init: true) }
+  let(:record_class) { Struct.new(:id, :display_name, :ids, :affiliations, :persisted?, :errors, keyword_init: true) }
 
   before do
     s = store
@@ -22,10 +23,10 @@ RSpec.describe 'Hyrax linked_record create endpoint', type: :request do
       create: lambda { |attrs|
         name = attrs[:display_name].to_s
         if name.empty?
-          rc.new(id: nil, display_name: name, persisted?: false, errors: ['Display name is required'])
+          rc.new(id: nil, display_name: name, ids: nil, affiliations: nil, persisted?: false, errors: ['Display name is required'])
         else
           id = (s.size + 1).to_s
-          rec = rc.new(id:, display_name: name, persisted?: true, errors: [])
+          rec = rc.new(id:, display_name: name, ids: attrs[:ids], affiliations: attrs[:affiliations], persisted?: true, errors: [])
           s[id] = rec
           rec
         end
@@ -59,6 +60,30 @@ RSpec.describe 'Hyrax linked_record create endpoint', type: :request do
            params: { record: { display_name: 'X' } }
 
       expect(response).to have_http_status(:not_found)
+    end
+
+    it 'passes a group create-field through to the proc as a deep-symbolized array of hashes' do
+      post hyrax.compound_linked_record_path(source: 'stub_people'),
+           params: { record: { display_name: 'Grace Hopper',
+                               ids: [{ value: '0000000121032683', scheme: 'ISNI' },
+                                     { value: 'https://ror.org/02mhbdp94', scheme: 'ROR' }] } }
+
+      expect(response).to have_http_status(:created)
+      created = store[response.parsed_body['id'].to_s]
+      expect(created.ids).to eq(
+        [{ value: '0000000121032683', scheme: 'ISNI' },
+         { value: 'https://ror.org/02mhbdp94', scheme: 'ROR' }]
+      )
+    end
+
+    it 'passes a repeatable scalar create-field through as a plain array of strings' do
+      post hyrax.compound_linked_record_path(source: 'stub_people'),
+           params: { record: { display_name: 'Grace Hopper',
+                               affiliations: ['US Navy', 'Vassar College'] } }
+
+      expect(response).to have_http_status(:created)
+      created = store[response.parsed_body['id'].to_s]
+      expect(created.affiliations).to eq(['US Navy', 'Vassar College'])
     end
   end
 end

--- a/spec/requests/hyrax/compound_linked_records_spec.rb
+++ b/spec/requests/hyrax/compound_linked_records_spec.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+# The generic inline-create endpoint for a `linked_record` picker's
+# lookup-or-create flow: POST /linked_records/:source creates a record via the
+# registered source and returns { id:, label: } JSON (201), the record's errors
+# (422), or 404 when the source is unknown / not creatable. Source-agnostic — it
+# routes by the :source segment to whatever Hyrax::CompoundLinkedRecordResolver
+# has registered. Driven here through an in-memory stub source.
+RSpec.describe 'Hyrax linked_record create endpoint', type: :request do
+  # A minimal in-memory record + store the stub source creates into.
+  let(:store) { {} }
+  let(:record_class) { Struct.new(:id, :display_name, :persisted?, :errors, keyword_init: true) }
+
+  before do
+    s = store
+    rc = record_class
+    Hyrax::CompoundLinkedRecordResolver.register(
+      :stub_people,
+      finder: ->(id) { s[id.to_s] },
+      label: ->(r) { r.display_name },
+      path: ->(r) { "/stub_people/#{r.id}" },
+      create: lambda { |attrs|
+        name = attrs[:display_name].to_s
+        if name.empty?
+          rc.new(id: nil, display_name: name, persisted?: false, errors: ['Display name is required'])
+        else
+          id = (s.size + 1).to_s
+          rec = rc.new(id:, display_name: name, persisted?: true, errors: [])
+          s[id] = rec
+          rec
+        end
+      }
+    )
+  end
+
+  after { Hyrax::CompoundLinkedRecordResolver.registry.delete(:stub_people) }
+
+  describe 'POST /linked_records/:source' do
+    it 'creates a record and returns { id, label } as 201' do
+      post hyrax.compound_linked_record_path(source: 'stub_people'),
+           params: { record: { display_name: 'Grace Hopper' } }
+
+      expect(response).to have_http_status(:created)
+      body = response.parsed_body
+      expect(body['label']).to eq('Grace Hopper')
+      expect(store[body['id'].to_s].display_name).to eq('Grace Hopper')
+    end
+
+    it 'returns 422 with errors when creation is invalid' do
+      post hyrax.compound_linked_record_path(source: 'stub_people'),
+           params: { record: { display_name: '' } }
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(response.parsed_body['errors']).to be_present
+    end
+
+    it 'returns 404 for an unknown / non-creatable source' do
+      post hyrax.compound_linked_record_path(source: 'nonexistent'),
+           params: { record: { display_name: 'X' } }
+
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+end

--- a/spec/services/hyrax/compound_linked_record_resolver_spec.rb
+++ b/spec/services/hyrax/compound_linked_record_resolver_spec.rb
@@ -144,4 +144,26 @@ RSpec.describe Hyrax::CompoundLinkedRecordResolver do
       expect(described_class.create(:nope, display_name: 'X')).to be_nil
     end
   end
+
+  # A misconfigured profile (or the default schema) can leave a linked_record
+  # sub-property with no `authority:`, so the lookups receive a nil/blank source.
+  # These must degrade gracefully rather than raise NoMethodError on `nil.to_sym`.
+  describe 'with a nil or blank source' do
+    it 'reports not searchable / not creatable' do
+      expect(described_class.searchable?(nil)).to be(false)
+      expect(described_class.creatable?('')).to be(false)
+    end
+
+    it 'returns safe empties from search/create' do
+      expect(described_class.search(nil, 'q')).to eq([])
+      expect(described_class.create('', display_name: 'X')).to be_nil
+    end
+
+    it 'falls back to the id string / nils for label and path lookups' do
+      expect(described_class.label_for(nil, '7')).to eq('7')
+      expect(described_class.path_for('', '7')).to be_nil
+      expect(described_class.title_and_path(nil, '7')).to eq(['7', nil])
+      expect(described_class.find(nil, '7')).to be_nil
+    end
+  end
 end

--- a/spec/services/hyrax/compound_linked_record_resolver_spec.rb
+++ b/spec/services/hyrax/compound_linked_record_resolver_spec.rb
@@ -1,0 +1,147 @@
+# frozen_string_literal: true
+
+# The registry/resolver for the `linked_record` compound sub-property type. A
+# `linked_record` value is a reference to a row in a database table; the resolver
+# turns that stored id into a display label and a show path, the database-backed
+# analogue of {Hyrax::CompoundWorkResolver} (which resolves work ids via Solr).
+#
+# Generic by design: a source registers a finder, a label proc, a path proc, an
+# optional search proc (for the picker autocomplete), and an optional create proc
+# (for inline lookup-or-create). The resolver stays naive about which tables
+# exist.
+RSpec.describe Hyrax::CompoundLinkedRecordResolver do
+  let(:record) { Struct.new(:id, :name).new(7, 'Ada Lovelace') }
+  let(:store) { {} }
+
+  around do |example|
+    described_class.register(
+      :stub_people,
+      finder: ->(id) { id.to_s == '7' ? record : store[id.to_s] },
+      label: ->(r) { r.name },
+      path: ->(r) { "/stub_people/#{r.id}" },
+      search: lambda { |q|
+        ([record] + store.values)
+          .select { |r| r.name.to_s.downcase.include?(q.to_s.downcase) }
+          .map { |r| { id: r.id.to_s, label: r.name, value: r.id.to_s } }
+      },
+      create: lambda { |attrs|
+        rec = Struct.new(:id, :name, :display_name, :errors).new(
+          (store.size + 100).to_s, attrs[:display_name], attrs[:display_name], []
+        )
+        store[rec.id] = rec
+        rec
+      }
+    )
+    example.run
+  ensure
+    described_class.registry.delete(:stub_people)
+  end
+
+  describe '.resolve' do
+    it 'returns [label, path] for a found record' do
+      expect(described_class.resolve(:stub_people, '7')).to eq(['Ada Lovelace', '/stub_people/7'])
+    end
+
+    it 'returns nil when the record is not found' do
+      expect(described_class.resolve(:stub_people, '999')).to be_nil
+    end
+
+    it 'returns nil for an unregistered source' do
+      expect(described_class.resolve(:nope, '7')).to be_nil
+    end
+  end
+
+  describe '.label_for' do
+    it 'returns the label for a found record' do
+      expect(described_class.label_for(:stub_people, '7')).to eq('Ada Lovelace')
+    end
+
+    it 'falls back to the id string when not found' do
+      expect(described_class.label_for(:stub_people, '999')).to eq('999')
+    end
+
+    context 'with a label_field naming a record attribute' do
+      let(:record) { Struct.new(:id, :name, :display_name).new(7, 'PROC NAME', 'Ada Lovelace') }
+
+      it 'reads the label_field off the record in preference to the label proc' do
+        expect(described_class.label_for(:stub_people, '7', label_field: 'display_name'))
+          .to eq('Ada Lovelace')
+      end
+
+      it 'falls back to the label proc when the field is blank/absent' do
+        expect(described_class.label_for(:stub_people, '7', label_field: 'nope'))
+          .to eq('PROC NAME')
+      end
+    end
+  end
+
+  describe '.path_for' do
+    it 'returns the path for a found record' do
+      expect(described_class.path_for(:stub_people, '7')).to eq('/stub_people/7')
+    end
+
+    it 'returns nil when not found' do
+      expect(described_class.path_for(:stub_people, '999')).to be_nil
+    end
+  end
+
+  describe '.title_and_path' do
+    it 'returns label + path when found' do
+      expect(described_class.title_and_path(:stub_people, '7')).to eq(['Ada Lovelace', '/stub_people/7'])
+    end
+
+    it 'falls back to [id, nil] when not found' do
+      expect(described_class.title_and_path(:stub_people, '999')).to eq(['999', nil])
+    end
+  end
+
+  describe '.find' do
+    it 'returns the raw record so callers can read fields beyond label/path' do
+      expect(described_class.find(:stub_people, '7')).to eq(record)
+    end
+
+    it 'returns nil for an unregistered source or blank id' do
+      expect(described_class.find(:nope, '7')).to be_nil
+      expect(described_class.find(:stub_people, '')).to be_nil
+    end
+  end
+
+  describe '.search' do
+    it 'returns picker results from the source search proc' do
+      results = described_class.search(:stub_people, 'ada')
+      expect(results).to contain_exactly(a_hash_including(id: '7', label: 'Ada Lovelace'))
+    end
+
+    it 'returns [] for a source registered without a search proc' do
+      described_class.register(:searchless, finder: ->(_id) {}, label: ->(_r) {}, path: ->(_r) {})
+      expect(described_class.search(:searchless, 'x')).to eq([])
+    ensure
+      described_class.registry.delete(:searchless)
+    end
+
+    it 'returns [] for an unregistered source' do
+      expect(described_class.search(:nope, 'x')).to eq([])
+    end
+  end
+
+  describe '.searchable? and .creatable?' do
+    it 'reports the optional capabilities a source declares' do
+      expect(described_class.searchable?(:stub_people)).to be(true)
+      expect(described_class.creatable?(:stub_people)).to be(true)
+      expect(described_class.creatable?(:nope)).to be(false)
+    end
+  end
+
+  describe '.create' do
+    it 'creates a record via the source, resolvable through the same source' do
+      created = described_class.create(:stub_people, display_name: 'Grace Hopper')
+      expect(created).not_to be_nil
+      expect(described_class.label_for(:stub_people, created.id)).to eq('Grace Hopper')
+      expect(described_class.path_for(:stub_people, created.id)).to eq("/stub_people/#{created.id}")
+    end
+
+    it 'returns nil for an unregistered or non-creatable source' do
+      expect(described_class.create(:nope, display_name: 'X')).to be_nil
+    end
+  end
+end

--- a/spec/services/hyrax/compound_schema_linked_record_spec.rb
+++ b/spec/services/hyrax/compound_schema_linked_record_spec.rb
@@ -25,7 +25,12 @@ RSpec.describe Hyrax::CompoundSchema do
                       'create_fields' => [
                         { 'name' => 'display_name', 'as' => 'string', 'required' => true },
                         { 'name' => 'orcid', 'as' => 'string' },
-                        { 'name' => 'kind', 'as' => 'select', 'values' => %w[person organization] }
+                        { 'name' => 'kind', 'as' => 'select', 'values' => %w[person organization] },
+                        { 'name' => 'identifiers', 'as' => 'group', 'repeatable' => true,
+                          'fields' => [
+                            { 'name' => 'value', 'as' => 'string' },
+                            { 'name' => 'scheme', 'as' => 'select', 'values' => %w[ISNI ROR] }
+                          ] }
                       ]
                     },
                     'role' => { 'type' => 'controlled' }
@@ -48,12 +53,24 @@ RSpec.describe Hyrax::CompoundSchema do
     expect(spec[:creatable]).to be(true)
   end
 
-  it 'normalizes create_fields with name/as/values/required' do
-    expect(spec[:create_fields]).to eq(
+  it 'normalizes scalar create_fields with name/as/required/repeatable/values/fields' do
+    scalar = spec[:create_fields].reject { |f| f[:as] == 'group' }
+    expect(scalar).to eq(
       [
-        { name: 'display_name', as: 'string', required: true, values: nil },
-        { name: 'orcid', as: 'string', required: false, values: nil },
-        { name: 'kind', as: 'select', required: false, values: %w[person organization] }
+        { name: 'display_name', as: 'string', required: true, repeatable: false, values: nil, fields: nil },
+        { name: 'orcid', as: 'string', required: false, repeatable: false, values: nil, fields: nil },
+        { name: 'kind', as: 'select', required: false, repeatable: false, values: %w[person organization], fields: nil }
+      ]
+    )
+  end
+
+  it 'normalizes a repeatable group create-field with nested sub-fields' do
+    group = spec[:create_fields].find { |f| f[:name] == 'identifiers' }
+    expect(group).to include(name: 'identifiers', as: 'group', repeatable: true, values: nil)
+    expect(group[:fields]).to eq(
+      [
+        { name: 'value', as: 'string', required: false, repeatable: false, values: nil, fields: nil },
+        { name: 'scheme', as: 'select', required: false, repeatable: false, values: %w[ISNI ROR], fields: nil }
       ]
     )
   end

--- a/spec/services/hyrax/compound_schema_linked_record_spec.rb
+++ b/spec/services/hyrax/compound_schema_linked_record_spec.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+# A `linked_record` sub-property can declare profile-driven lookup-or-create:
+# `creatable: true` plus `create_fields` describing the inline add-form, and
+# `view: { label_field: }` naming which field of the resolved record supplies
+# the show-page link text. `normalize_subproperty` returns a fixed key set and
+# drops unknown keys, so these must be threaded through explicitly.
+RSpec.describe Hyrax::CompoundSchema do
+  let(:resource_class) do
+    Class.new(Hyrax::Resource) do
+      def self.name
+        'TestLinkedRecordCompoundResource'
+      end
+
+      # A compound whose linked_record sub-property declares creatability, the
+      # inline create-form field specs, and a label_field under `view:`.
+      attribute :people,
+                Valkyrie::Types::Array.of(Dry::Types['hash']).meta(
+                  subproperties: {
+                    'person' => {
+                      'type' => 'linked_record',
+                      'authority' => 'people',
+                      'view' => { 'label_field' => 'display_name' },
+                      'creatable' => true,
+                      'create_fields' => [
+                        { 'name' => 'display_name', 'as' => 'string', 'required' => true },
+                        { 'name' => 'orcid', 'as' => 'string' },
+                        { 'name' => 'kind', 'as' => 'select', 'values' => %w[person organization] }
+                      ]
+                    },
+                    'role' => { 'type' => 'controlled' }
+                  }
+                )
+
+      # A second compound with a plain sub-property, to assert non-creatable defaults.
+      attribute :titles,
+                Valkyrie::Types::Array.of(Dry::Types['hash']).meta(
+                  subproperties: { 'main' => { 'type' => 'string' } }
+                )
+    end
+  end
+
+  subject(:compound_schema) { described_class.for(resource_class) }
+
+  let(:spec) { compound_schema.definition_for(:people)[:subproperties]['person'] }
+
+  it 'carries creatable into the sub-property spec' do
+    expect(spec[:creatable]).to be(true)
+  end
+
+  it 'normalizes create_fields with name/as/values/required' do
+    expect(spec[:create_fields]).to eq(
+      [
+        { name: 'display_name', as: 'string', required: true, values: nil },
+        { name: 'orcid', as: 'string', required: false, values: nil },
+        { name: 'kind', as: 'select', required: false, values: %w[person organization] }
+      ]
+    )
+  end
+
+  it 'carries view.label_field into the sub-property spec' do
+    expect(spec[:label_field]).to eq('display_name')
+  end
+
+  it 'defaults creatable to false, create_fields to [], label_field to nil when not declared' do
+    s = compound_schema.definition_for(:titles)[:subproperties]['main']
+    expect(s[:creatable]).to be(false)
+    expect(s[:create_fields]).to eq([])
+    expect(s[:label_field]).to be_nil
+  end
+end

--- a/spec/services/hyrax/compound_schema_spec.rb
+++ b/spec/services/hyrax/compound_schema_spec.rb
@@ -192,11 +192,13 @@ RSpec.describe Hyrax::CompoundSchema do
       definition = schema.definition_for(:contributors)
       expect(definition[:subproperties]['role_label'])
         .to eq(type: 'controlled', authority: 'contributor_role', values: nil, index_keys: [],
-               index: true, display: false, required: false, group: 'role', cols: 6, as: nil)
+               index: true, display: false, required: false, group: 'role', cols: 6, as: nil,
+               creatable: false, create_fields: [], label_field: nil)
       expect(definition[:subproperties]['given_name'])
         .to eq(type: 'string', authority: nil, values: nil,
                index_keys: %w[contributors_given_name_sim contributors_given_name_tesim],
-               index: true, display: true, required: false, group: 'identity', cols: 6, as: nil)
+               index: true, display: true, required: false, group: 'identity', cols: 6, as: nil,
+               creatable: false, create_fields: [], label_field: nil)
     end
 
     it 'reads per-sub-property index_keys (literal Solr field names)' do

--- a/spec/services/hyrax/flexible_schema_validators/compound_validator_spec.rb
+++ b/spec/services/hyrax/flexible_schema_validators/compound_validator_spec.rb
@@ -65,6 +65,38 @@ RSpec.describe Hyrax::FlexibleSchemaValidators::CompoundValidator do
       end
     end
 
+    context 'with a linked_record subproperty that declares an authority (source)' do
+      let(:profile) do
+        {
+          'properties' => {
+            'creators' => { 'type' => 'hash' },
+            'creator_ref' => { 'type' => 'linked_record', **member_of('creators'), 'authority' => 'people' }
+          }
+        }
+      end
+
+      it 'is valid (authority names the registered source)' do
+        validator.validate!
+        expect(errors).to be_empty
+      end
+    end
+
+    context 'with a linked_record subproperty that declares no authority' do
+      let(:profile) do
+        {
+          'properties' => {
+            'creators' => { 'type' => 'hash' },
+            'creator_ref' => { 'type' => 'linked_record', **member_of('creators') }
+          }
+        }
+      end
+
+      it 'records an error keyed on the subproperty' do
+        validator.validate!
+        expect(errors).to include(t('linked_record_without_source', property: 'creator_ref'))
+      end
+    end
+
     context 'with a top-level indexing declaration on the compound parent' do
       let(:profile) do
         {

--- a/spec/services/hyrax/schema_loader_linked_record_spec.rb
+++ b/spec/services/hyrax/schema_loader_linked_record_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+# A `linked_record` compound sub-property stores its reference (a row id/key) as
+# a plain string at the Valkyrie layer — the same as `string`, and the same way
+# `work_or_url` is effectively a string. The schema loader's type resolution
+# must recognize `linked_record` and resolve it to the string member type;
+# without the case it falls through to the classify branch and raises
+# ArgumentError ("Unrecognized type: linked_record").
+RSpec.describe Hyrax::SchemaLoader::AttributeDefinition do
+  let(:string_member_type) do
+    described_class.new('ref', { 'type' => 'string' }).send(:type_for, 'string')
+  end
+
+  describe '#type_for with a linked_record type' do
+    subject(:linked_record_type) do
+      described_class.new('ref', { 'type' => 'linked_record' }).send(:type_for, 'linked_record')
+    end
+
+    it 'does not raise' do
+      expect { linked_record_type }.not_to raise_error
+    end
+
+    it 'resolves to the same member type as a string (stored as a string reference)' do
+      expect(linked_record_type).to eq(string_member_type)
+    end
+  end
+
+  describe '#type for a linked_record attribute' do
+    it 'builds without raising' do
+      definition = described_class.new('ref', { 'type' => 'linked_record' })
+      expect { definition.type }.not_to raise_error
+    end
+  end
+end

--- a/spec/views/hyrax/compounds/_compound_row_linked_record_spec.rb
+++ b/spec/views/hyrax/compounds/_compound_row_linked_record_spec.rb
@@ -33,9 +33,15 @@ RSpec.describe 'hyrax/compounds/_compound_row', type: :view do
         'person' => { type: 'linked_record', authority: 'people', cols: 6,
                       creatable: true,
                       create_fields: [
-                        { name: 'display_name', as: 'string', required: true, values: nil },
-                        { name: 'orcid', as: 'string', required: false, values: nil },
-                        { name: 'kind', as: 'select', required: false, values: %w[person organization] }
+                        { name: 'display_name', as: 'string', required: true, repeatable: false, values: nil, fields: nil },
+                        { name: 'orcid', as: 'string', required: false, repeatable: false, values: nil, fields: nil },
+                        { name: 'kind', as: 'select', required: false, repeatable: false, values: %w[person organization], fields: nil },
+                        { name: 'identifiers', as: 'group', required: false, repeatable: true, values: nil,
+                          fields: [
+                            { name: 'value', as: 'string', required: false, repeatable: false, values: nil, fields: nil },
+                            { name: 'scheme', as: 'select', required: false, repeatable: false, values: %w[ISNI ROR], fields: nil }
+                          ] },
+                        { name: 'affiliations', as: 'string', required: false, repeatable: true, values: nil, fields: nil }
                       ] },
         'role' => { type: 'string', cols: 6 }
       },
@@ -82,6 +88,30 @@ RSpec.describe 'hyrax/compounds/_compound_row', type: :view do
     it 'renders the select options from the field values' do
       expect(rendered).to have_css('select[data-create-field="kind"] option[value="person"]', visible: false)
       expect(rendered).to have_css('select[data-create-field="kind"] option[value="organization"]', visible: false)
+    end
+
+    describe 'a repeatable group create-field' do
+      it 'renders a group container marked repeatable with an Add button' do
+        expect(rendered).to have_css('[data-create-group="identifiers"][data-repeatable="true"]', visible: false)
+        expect(rendered).to have_css('[data-create-group="identifiers"] button[data-create-group-add]', visible: false)
+      end
+
+      it 'renders an initial row with the sub-field inputs tagged data-create-subfield' do
+        expect(rendered).to have_css('[data-create-group-rows] [data-create-group-row] input[data-create-subfield="value"]', visible: false)
+        expect(rendered).to have_css('[data-create-group-rows] [data-create-group-row] select[data-create-subfield="scheme"]', visible: false)
+      end
+
+      it 'provides a row <template> for JS to clone' do
+        expect(rendered).to have_css('[data-create-group="identifiers"] template[data-create-group-row-template]', visible: false)
+      end
+    end
+
+    describe 'a repeatable scalar create-field' do
+      it 'renders as add/remove rows marked data-create-scalar with one input per row' do
+        expect(rendered).to have_css('[data-create-group="affiliations"][data-create-scalar="true"]', visible: false)
+        expect(rendered).to have_css('[data-create-group="affiliations"] button[data-create-group-add]', visible: false)
+        expect(rendered).to have_css('[data-create-group="affiliations"] [data-create-group-rows] input[data-create-subfield="affiliations"]', visible: false)
+      end
     end
   end
 

--- a/spec/views/hyrax/compounds/_compound_row_linked_record_spec.rb
+++ b/spec/views/hyrax/compounds/_compound_row_linked_record_spec.rb
@@ -6,13 +6,21 @@
 # lookup-or-create affordance built from `create_fields`. Exercises the
 # `when 'linked_record'` branch and the _linked_record_field partial.
 RSpec.describe 'hyrax/compounds/_compound_row', type: :view do
-  before do
-    Hyrax::CompoundLinkedRecordResolver.register(
-      :people,
-      finder: ->(id) { id.to_s == '7' ? { id: 7 } : nil },
+  # The source registration args the shared render uses. The default is a
+  # fully-featured source (search + create) so the picker and inline
+  # lookup-or-create UI render — matching the runtime contract a real source
+  # provides. A context overrides `people_source` to register it differently
+  # (e.g. without `search:`) before the shared render runs.
+  let(:people_source) do
+    { finder: ->(id) { id.to_s == '7' ? { id: 7 } : nil },
       label: ->(_r) { 'Ada Lovelace' },
-      path: ->(_r) { '/people/7' }
-    )
+      path: ->(_r) { '/people/7' },
+      search: ->(_q) { [{ id: '7', label: 'Ada Lovelace', value: '7' }] },
+      create: ->(attrs) { { id: 8, display_name: attrs[:display_name] } } }
+  end
+
+  before do
+    Hyrax::CompoundLinkedRecordResolver.register(:people, **people_source)
     allow(view).to receive(:compound_subproperty_label).and_return('Person')
     render partial: 'hyrax/compounds/compound_row',
            locals: { f:, compound_name: :people, definition:,
@@ -101,6 +109,10 @@ RSpec.describe 'hyrax/compounds/_compound_row', type: :view do
         expect(rendered).to have_css('[data-create-group-rows] [data-create-group-row] select[data-create-subfield="scheme"]', visible: false)
       end
 
+      it 'gives repeatable-row sub-field inputs no id (cloned rows must not collide on id)' do
+        expect(rendered).to have_no_css('[data-create-group="identifiers"] [data-create-subfield][id]', visible: false)
+      end
+
       it 'provides a row <template> for JS to clone' do
         expect(rendered).to have_css('[data-create-group="identifiers"] template[data-create-group-row-template]', visible: false)
       end
@@ -126,6 +138,30 @@ RSpec.describe 'hyrax/compounds/_compound_row', type: :view do
     it 'renders no add-new trigger or create form' do
       expect(rendered).to have_no_css('[data-hyrax-linked-record-add]')
       expect(rendered).to have_no_css('[data-hyrax-linked-record-create-form]')
+    end
+  end
+
+  context 'when the source is not registered as searchable' do
+    let(:definition) do
+      {
+        subproperties: { 'person' => { type: 'linked_record', authority: 'people', cols: 6, creatable: false, create_fields: [] } },
+        groups: [{ label: nil, fields: %w[person] }]
+      }
+    end
+
+    # Register `:people` without a `search:` proc (overriding the default) so the
+    # shared render uses it. Without search the select2 picker has nothing to
+    # query and (createSearchChoice is off) no way to enter a value, so the field
+    # must fall back to a plain text input.
+    let(:people_source) do
+      { finder: ->(_id) {}, label: ->(_r) { '' }, path: ->(_r) { '' } }
+    end
+
+    it 'renders a plain text input and no select2 picker' do
+      expect(rendered).to have_no_css('[data-hyrax-linked-record-input]')
+      expect(rendered).to have_no_css('[data-hyrax-linked-record]')
+      input = Capybara.string(rendered).find("input[name='genericwork[people_attributes][0][person]']", visible: :all)
+      expect(input[:type]).to eq('text')
     end
   end
 end

--- a/spec/views/hyrax/compounds/_compound_row_linked_record_spec.rb
+++ b/spec/views/hyrax/compounds/_compound_row_linked_record_spec.rb
@@ -1,0 +1,101 @@
+# frozen_string_literal: true
+
+# Renders the _compound_row partial with a `linked_record` sub-property and
+# asserts the picker hidden input points at the generic QA authority (keyed by
+# the source) and is pre-seeded with the resolved label, plus the inline
+# lookup-or-create affordance built from `create_fields`. Exercises the
+# `when 'linked_record'` branch and the _linked_record_field partial.
+RSpec.describe 'hyrax/compounds/_compound_row', type: :view do
+  before do
+    Hyrax::CompoundLinkedRecordResolver.register(
+      :people,
+      finder: ->(id) { id.to_s == '7' ? { id: 7 } : nil },
+      label: ->(_r) { 'Ada Lovelace' },
+      path: ->(_r) { '/people/7' }
+    )
+    allow(view).to receive(:compound_subproperty_label).and_return('Person')
+    render partial: 'hyrax/compounds/compound_row',
+           locals: { f:, compound_name: :people, definition:,
+                     row: { 'person' => '7', 'role' => 'Author' },
+                     index: 0, row_label_singular: 'Person' }
+  end
+
+  after { Hyrax::CompoundLinkedRecordResolver.registry.delete(:people) }
+
+  # Minimal form builder against a throwaway object; the partial only uses
+  # f.object_name for input names.
+  let(:form_object) { Struct.new(:people).new(nil) }
+  let(:f) { ActionView::Helpers::FormBuilder.new('genericwork', form_object, view, {}) }
+
+  let(:definition) do
+    {
+      subproperties: {
+        'person' => { type: 'linked_record', authority: 'people', cols: 6,
+                      creatable: true,
+                      create_fields: [
+                        { name: 'display_name', as: 'string', required: true, values: nil },
+                        { name: 'orcid', as: 'string', required: false, values: nil },
+                        { name: 'kind', as: 'select', required: false, values: %w[person organization] }
+                      ] },
+        'role' => { type: 'string', cols: 6 }
+      },
+      groups: [{ label: nil, fields: %w[person role] }]
+    }
+  end
+
+  it 'renders the linked_record value as a hidden picker input' do
+    expect(rendered).to have_css(
+      "input[type=hidden][name='genericwork[people_attributes][0][person]']", visible: false
+    )
+  end
+
+  it 'points the picker autocomplete at the generic QA authority keyed by source' do
+    expect(rendered).to match(%r{data-autocomplete-url="[^"]*/authorities/search/linked_record/people"})
+  end
+
+  it 'pre-seeds the picker label with the resolved record label' do
+    expect(rendered).to match(/data-label="Ada Lovelace"/)
+  end
+
+  it 'still renders sibling string sub-properties as text inputs' do
+    expect(rendered).to have_css("input[type=text][name='genericwork[people_attributes][0][role]']")
+  end
+
+  describe 'the inline create (lookup-or-create) affordance' do
+    it 'renders the linked-record wrapper with source + create-url data' do
+      expect(rendered).to have_css(
+        'div[data-hyrax-linked-record][data-source="people"][data-creatable="true"]'
+      )
+      expect(rendered).to match(%r{data-create-url="[^"]*/linked_records/people"})
+    end
+
+    it 'renders the (hidden) Add new trigger' do
+      expect(rendered).to have_css('button[data-hyrax-linked-record-add]', text: '+ Add new', visible: false)
+    end
+
+    it 'renders the create form fields from create_fields (string inputs + a select)' do
+      expect(rendered).to have_css('[data-hyrax-linked-record-create-form] input[data-create-field="display_name"]', visible: false)
+      expect(rendered).to have_css('[data-hyrax-linked-record-create-form] input[data-create-field="orcid"]', visible: false)
+      expect(rendered).to have_css('[data-hyrax-linked-record-create-form] select[data-create-field="kind"]', visible: false)
+    end
+
+    it 'renders the select options from the field values' do
+      expect(rendered).to have_css('select[data-create-field="kind"] option[value="person"]', visible: false)
+      expect(rendered).to have_css('select[data-create-field="kind"] option[value="organization"]', visible: false)
+    end
+  end
+
+  context 'when the sub-property is not creatable' do
+    let(:definition) do
+      {
+        subproperties: { 'person' => { type: 'linked_record', authority: 'people', cols: 6, creatable: false, create_fields: [] } },
+        groups: [{ label: nil, fields: %w[person] }]
+      }
+    end
+
+    it 'renders no add-new trigger or create form' do
+      expect(rendered).to have_no_css('[data-hyrax-linked-record-add]')
+      expect(rendered).to have_no_css('[data-hyrax-linked-record-create-form]')
+    end
+  end
+end


### PR DESCRIPTION
## Summary
Adds a new `linked_record` compound sub-property type: a metadata field whose value points at a row in a database table (a person, organization, funder, place, …) instead of free text, shown as a link on the work page.

## Details
- An application registers a *source* (a name plus finder/label/path procs, with optional search/create) with `Hyrax::CompoundLinkedRecordResolver`, and names it in a sub-property's `authority:` key. No base class, required columns, migration, or per-source authority/controller class — registering the source is the whole integration.
- One generic QA authority serves every source (the source is the sub-authority segment of `/authorities/search/linked_record/:source`); one create endpoint (`POST /linked_records/:source`) handles the optional inline "add new" flow.
- Stores the row id, indexes it as `<compound>_<name>_ssim` for reverse lookup, and renders it on show pages as a link using `view: { label_field: }` (falling back to the source's label proc); an unresolved id renders as bare text, never a broken link.
- Builds on the existing compound-metadata machinery and verified under both flex modes (default schema and m3 profile-driven). Documented with a worked example in `documentation/compound_fields.md`.

## Testing
- In a host app, register a source against any table (e.g. `Hyrax::CompoundLinkedRecordResolver.register(:people, finder:/label:/path:/search:/create:)`) and add a `type: linked_record` sub-property naming that source.
- Edit a work: the field shows a search picker; typing queries the table and selecting a record stores it.
- With `creatable: true` + a registered `create:` proc, a search with no matches offers "Add new"; submitting creates the record and selects it without leaving the form.
- View the work: the value renders as a link to the record using the resolved label.
- Confirm both with `HYRAX_FLEXIBLE=false` and `HYRAX_FLEXIBLE=true`.

## Screenshots

<details>
<summary>In use in PRI Enact</summary>

 ### Catalog search view
<img width="511" height="216" alt="Screenshot 2026-06-23 at 9 44 46 AM" src="https://github.com/user-attachments/assets/f267f575-dda7-4873-80d5-843cba578506" />

### Existing data on form
<img width="879" height="273" alt="Screenshot 2026-06-23 at 9 45 06 AM" src="https://github.com/user-attachments/assets/3a97f1dd-a1f9-4f28-8868-ff99d143cfd1" />

### Empty form segment
<img width="879" height="243" alt="Screenshot 2026-06-23 at 9 45 13 AM" src="https://github.com/user-attachments/assets/96704bdc-8c73-4765-9036-fca493f883ca" />

### Searching but not found
<img width="852" height="299" alt="Screenshot 2026-06-23 at 9 45 20 AM" src="https://github.com/user-attachments/assets/1ebccc63-6b59-4fcf-a84f-2213d040dc34" />

### Add new appears after search not found
<img width="725" height="273" alt="Screenshot 2026-06-23 at 9 45 29 AM" src="https://github.com/user-attachments/assets/b9387e55-fba7-41a4-8df0-0ec4daf8d3fa" />

### Form to add new record
<img width="466" height="595" alt="Screenshot 2026-06-23 at 9 45 40 AM" src="https://github.com/user-attachments/assets/ebf37eb4-b204-44e8-b822-d7061364150a" />

</details>
