### PR TITLE
Add find-or-create lookup to linked_record resolver

### DIFF
--- a/app/services/hyrax/compound_linked_record_resolver.rb
+++ b/app/services/hyrax/compound_linked_record_resolver.rb
@@ -27,7 +27,7 @@ module Hyrax
   # The M3 profile names the source via the sub-property's `authority:` key; see
   # documentation/compound_fields.md.
   class CompoundLinkedRecordResolver
-    Source = Struct.new(:finder, :label, :path, :search, :create, keyword_init: true)
+    Source = Struct.new(:finder, :label, :path, :search, :create, :match, keyword_init: true)
 
     class << self
       # @return [Hash{Symbol => Source}] the registered sources, by name
@@ -49,8 +49,13 @@ module Hyrax
       # @param create [#call, nil] `(attributes Hash) -> record` for the
       #   lookup-or-create flow. A scalar create-field arrives as a single value;
       #   a `group` create-field arrives as an Array of Hashes (one per row).
-      def register(source, finder:, label:, path:, search: nil, create: nil)
-        registry[source.to_sym] = Source.new(finder:, label:, path:, search:, create:)
+      # @param match [#call, nil] `(attributes Hash) -> record | nil` an exact,
+      #   single-row lookup on a natural key (e.g. a name or external id), for the
+      #   find-or-create import flow. Distinct from `search`, which is fuzzy and
+      #   multi-row for the picker — a fuzzy hit is the wrong record to reuse when
+      #   resolving an imported reference with no human to disambiguate.
+      def register(source, finder:, label:, path:, search: nil, create: nil, match: nil)
+        registry[source.to_sym] = Source.new(finder:, label:, path:, search:, create:, match:)
       end
 
       # @param source [Symbol, String]
@@ -63,6 +68,12 @@ module Hyrax
       # @return [Boolean] whether the source is registered with a `create` proc
       def creatable?(source)
         spec_for(source)&.create.present?
+      end
+
+      # @param source [Symbol, String]
+      # @return [Boolean] whether the source is registered with a `match` proc
+      def matchable?(source)
+        spec_for(source)&.match.present?
       end
 
       # @param source [Symbol, String]
@@ -92,6 +103,38 @@ module Hyrax
         return nil if spec.nil? || spec.create.nil?
 
         spec.create.call(attrs)
+      end
+
+      # Find an existing record by an exact natural key, via the source's `match`
+      # proc. The find half of the find-or-create import flow; on its own it is
+      # also the find-ONLY entry point (a caller that must not create uses this
+      # and treats nil as "no match", rather than calling {.find_or_create}).
+      #
+      # @param source [Symbol, String]
+      # @param attrs [Hash] the natural-key attributes (e.g. `display_name:`)
+      # @return [Object, nil] the single matching record, or nil when the source
+      #   is unregistered, not matchable, or nothing matches
+      def match(source, attrs)
+        spec = spec_for(source)
+        return nil if spec.nil? || spec.match.nil?
+
+        spec.match.call(attrs)
+      rescue StandardError => e
+        Hyrax.logger.debug("CompoundLinkedRecordResolver.match(#{source}): #{e.message}")
+        nil
+      end
+
+      # Find an existing record by natural key, else create one — the id-yielding
+      # entry point for importers that receive a natural key (a name) rather than
+      # a stored row id. Create-allowed by definition; a find-only caller uses
+      # {.match} instead and does not fall back to create.
+      #
+      # @param source [Symbol, String]
+      # @param attrs [Hash] attributes for both the match and (on a miss) create
+      # @return [Object, nil] the existing-or-new record, or nil when the source
+      #   can neither match nor create
+      def find_or_create(source, attrs)
+        match(source, attrs) || create(source, attrs)
       end
 
       # @param source [Symbol, String]

--- a/documentation/compound_fields.md
+++ b/documentation/compound_fields.md
@@ -649,5 +649,53 @@ compound entry a unique mapping key and `name: 'license'`. See the
 [Configuring Bulkrax wiki](https://github.com/samvera/bulkrax/wiki/Configuring-Bulkrax#reusing-a-row-key-across-objects)
 for details.
 
+### Importing `linked_record` sub-properties with Bulkrax
+
+A [`linked_record`](#linked_record-sub-properties) member stores a **row id**, but
+a CSV column naturally carries a human-readable natural key — a name. A plain
+`nested_attributes: true` mapping would store that name verbatim, and it would
+never resolve, because the source's `finder` looks records up by id. So importing
+a `linked_record` takes one extra step the host application supplies: resolving the
+cell to a row id (and, where appropriate, creating the record).
+
+Hyrax provides the resolution **verb** but not the table knowledge. Register two
+optional procs on the source alongside `finder`/`label`/`path`:
+
+```ruby
+Hyrax::CompoundLinkedRecordResolver.register(
+  :people,
+  # …finder/label/path/search/create as above…
+  # exact, single-row lookup on a natural key, for import resolution:
+  match: ->(attrs) { Person.where('LOWER(display_name) = LOWER(?)', attrs[:display_name].to_s.strip).order(:id).first }
+)
+```
+
+`match` is deliberately distinct from `search`: `search` is the fuzzy, multi-row
+query behind the picker autocomplete, where a human disambiguates; `match` is an
+exact, single-row lookup, because an importer resolving a reference has no human to
+choose among near-matches. The resolver composes them:
+
+- `Hyrax::CompoundLinkedRecordResolver.match(source, attrs)` — find an existing
+  record by its natural key, or `nil`.
+- `Hyrax::CompoundLinkedRecordResolver.find_or_create(source, attrs)` — `match`,
+  else fall back to the `create` proc. The id-yielding entry point for an importer.
+
+Where the resolution itself runs is the host's: Bulkrax has no model of
+`linked_record`, and Bulkrax is not a Hyrax dependency, so the glue lives in the
+application — typically a Bulkrax entry decorator that, after the compound's
+`_attributes` are assembled, replaces each member's natural-key cell with the
+resolved row id. (A per-cell matcher cannot do this when the resolution depends on
+sibling columns, e.g. matching on an identifier carried in a separate column.)
+
+Two policy choices the host owns:
+
+- **Find vs. find-or-create.** Drive it from the sub-property's
+  [`creatable:`](#linked_record-sub-properties) flag: a creatable member uses
+  `find_or_create` (an unmatched name is created); a find-only member uses `match`
+  alone and skips an unmatched cell rather than fabricating a record.
+- **The match key.** What counts as "the same record" — a name, an external
+  identifier, or an identifier-then-name fallback — is encoded entirely in the
+  `match` proc. The resolver never inspects it.
+
 Note: Bulkrax's controlled-URI sanitization does not currently descend into
 compound sub-properties.

--- a/spec/services/hyrax/compound_linked_record_resolver_spec.rb
+++ b/spec/services/hyrax/compound_linked_record_resolver_spec.rb
@@ -30,6 +30,14 @@ RSpec.describe Hyrax::CompoundLinkedRecordResolver do
         )
         store[rec.id] = rec
         rec
+      },
+      # Exact, single-row lookup on a natural key (display_name), distinct from
+      # the fuzzy multi-row `search`. Returns one record or nil.
+      match: lambda { |attrs|
+        name = attrs[:display_name].to_s
+        next nil if name.empty?
+
+        ([record] + store.values).find { |r| r.name.to_s.casecmp?(name) }
       }
     )
     example.run
@@ -129,6 +137,72 @@ RSpec.describe Hyrax::CompoundLinkedRecordResolver do
       expect(described_class.searchable?(:stub_people)).to be(true)
       expect(described_class.creatable?(:stub_people)).to be(true)
       expect(described_class.creatable?(:nope)).to be(false)
+    end
+  end
+
+  describe '.matchable?' do
+    it 'reports whether a source declares an exact-match proc' do
+      expect(described_class.matchable?(:stub_people)).to be(true)
+      expect(described_class.matchable?(:nope)).to be(false)
+    end
+
+    it 'is false for a source registered without a match proc' do
+      described_class.register(:matchless, finder: ->(_id) {}, label: ->(_r) {}, path: ->(_r) {})
+      expect(described_class.matchable?(:matchless)).to be(false)
+    ensure
+      described_class.registry.delete(:matchless)
+    end
+  end
+
+  describe '.match' do
+    it 'returns a single existing record for an exact natural-key hit' do
+      expect(described_class.match(:stub_people, display_name: 'Ada Lovelace')).to eq(record)
+    end
+
+    it 'is case-insensitive on the key, not a fuzzy substring like search' do
+      expect(described_class.match(:stub_people, display_name: 'ADA LOVELACE')).to eq(record)
+      expect(described_class.match(:stub_people, display_name: 'Ada')).to be_nil
+    end
+
+    it 'returns nil on a miss, an unregistered source, or a raising proc' do
+      expect(described_class.match(:stub_people, display_name: 'Nobody')).to be_nil
+      expect(described_class.match(:nope, display_name: 'Ada Lovelace')).to be_nil
+      described_class.register(:boom, finder: ->(_id) {}, label: ->(_r) {}, path: ->(_r) {},
+                                      match: ->(_attrs) { raise 'kaboom' })
+      expect(described_class.match(:boom, display_name: 'Ada Lovelace')).to be_nil
+    ensure
+      described_class.registry.delete(:boom)
+    end
+  end
+
+  describe '.find_or_create' do
+    it 'returns the existing record on a match without invoking create' do
+      created = described_class.find_or_create(:stub_people, display_name: 'Ada Lovelace')
+      expect(created).to eq(record)
+      expect(store).to be_empty # create proc was not called
+    end
+
+    it 'creates a record when the match misses' do
+      created = described_class.find_or_create(:stub_people, display_name: 'Grace Hopper')
+      expect(created.display_name).to eq('Grace Hopper')
+      expect(described_class.label_for(:stub_people, created.id)).to eq('Grace Hopper')
+    end
+
+    it 'always creates when the source has no match proc' do
+      described_class.register(:create_only, finder: ->(id) { store[id.to_s] }, label: ->(r) { r.name },
+                                             path: ->(r) { "/x/#{r.id}" },
+                                             create: ->(attrs) { store['9'] = Struct.new(:id, :name).new('9', attrs[:display_name]) })
+      created = described_class.find_or_create(:create_only, display_name: 'X')
+      expect(created.name).to eq('X')
+    ensure
+      described_class.registry.delete(:create_only)
+    end
+
+    it 'returns nil when the source can neither match nor create' do
+      described_class.register(:inert, finder: ->(_id) {}, label: ->(_r) {}, path: ->(_r) {})
+      expect(described_class.find_or_create(:inert, display_name: 'X')).to be_nil
+    ensure
+      described_class.registry.delete(:inert)
     end
   end
 


### PR DESCRIPTION
### Fixes

Adds the lookup needed for importing `linked_record` type compound metadata via Bulkrax.

### Summary

The linked_record resolver can now resolve a natural key (such as a name) to an existing record, creating one only when none matches, via a new optional match proc registered alongside finder/search/create.

A bulk importer receiving a name rather than a stored row id needs an exact, single-row lookup to reuse the right record; the existing search proc is deliberately fuzzy and multi-row for the picker, so reusing it would risk linking to the wrong record. find-only callers use match on its own and treat a miss as unresolved rather than creating.