### PR TITLE
Find child works by partial title in the picker

### DIFF
--- a/app/search_builders/hyrax/compound_work_picker_builder.rb
+++ b/app/search_builders/hyrax/compound_work_picker_builder.rb
@@ -12,6 +12,7 @@ module Hyrax
   # default type filter admits both.
   class CompoundWorkPickerBuilder < Hyrax::SearchBuilder
     include Hyrax::FilterByType
+    include Hyrax::PartialTitleQuery
 
     self.default_processor_chain += [:filter_on_any_term_or_partial_title]
 
@@ -25,38 +26,8 @@ module Hyrax
     def filter_on_any_term_or_partial_title(solr_parameters)
       return if @q.blank?
 
-      term = @q.to_s.strip
-      solr_parameters[:q] = "#{multi_field_clause(term)} OR #{prefix_title_clause(term)}"
+      solr_parameters[:q] = partial_title_query(@q.to_s.strip)
       solr_parameters[:defType] = 'lucene'
-    end
-
-    private
-
-    def multi_field_clause(term)
-      escaped = escape(term)
-      QUERY_FIELDS.map { |field| "#{field}:(#{escaped})" }.join(' OR ')
-    end
-
-    # Prefix-wildcard on each whitespace-separated token of the title, e.g.
-    # "jour stud" -> title_tesim:(jour* AND stud*).
-    def prefix_title_clause(term)
-      tokens = term.split(/\s+/).reject(&:empty?).map { |t| "#{escape_token(t)}*" }
-      return '' if tokens.empty?
-      "title_tesim:(#{tokens.join(' AND ')})"
-    end
-
-    QUERY_FIELDS = %w[title_tesim description_tesim creator_tesim keyword_tesim].freeze
-
-    # Escape Solr/Lucene special characters in a phrase (wildcards included —
-    # the multi-field clause is not a prefix search).
-    def escape(value)
-      value.to_s.gsub(%r{([+\-&|!(){}\[\]^"~*?:\\/])}, '\\\\\1')
-    end
-
-    # Escape special characters in a single token but keep it usable as a
-    # prefix (the trailing `*` is added by the caller, not escaped here).
-    def escape_token(value)
-      value.to_s.gsub(%r{([+\-&|!(){}\[\]^"~?:\\/])}, '\\\\\1')
     end
   end
 end

--- a/app/search_builders/hyrax/my/find_works_search_builder.rb
+++ b/app/search_builders/hyrax/my/find_works_search_builder.rb
@@ -2,6 +2,7 @@
 # Search for possible works that user can edit and could be a work's child or parent.
 class Hyrax::My::FindWorksSearchBuilder < Hyrax::My::SearchBuilder
   include Hyrax::FilterByType
+  include Hyrax::PartialTitleQuery
 
   self.default_processor_chain += [:filter_on_title, :show_only_other_works, :show_only_works_not_child, :show_only_works_not_parent]
 
@@ -13,9 +14,15 @@ class Hyrax::My::FindWorksSearchBuilder < Hyrax::My::SearchBuilder
     @q = context.params[:q]
   end
 
+  # Match works by a partial/prefix term so the child/parent-work picker finds
+  # works as the user types, rather than only on a complete title. Sets the
+  # query directly (lucene `q`); the exclusion processors below still add their
+  # own `fq` filters.
   def filter_on_title(solr_parameters)
-    solr_parameters[:fq] ||= []
-    solr_parameters[:fq] += [Hyrax::SolrQueryBuilderService.construct_query(title_tesim: @q)]
+    return if @q.blank?
+
+    solr_parameters[:q] = partial_title_query(@q.to_s.strip)
+    solr_parameters[:defType] = 'lucene'
   end
 
   def show_only_other_works(solr_parameters)

--- a/app/search_builders/hyrax/partial_title_query.rb
+++ b/app/search_builders/hyrax/partial_title_query.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+module Hyrax
+  ##
+  # Builds the Solr query a work picker uses for partial, as-you-type matching:
+  # an indexed term match across a few fields OR a prefix-wildcard title match,
+  # so a partial word ("repel", "jour stud") finds works before the full title is
+  # typed. Shared by the pickers that need it ({Hyrax::CompoundWorkPickerBuilder}
+  # and {Hyrax::My::FindWorksSearchBuilder}); set it on `solr_parameters[:q]` with
+  # `defType: 'lucene'`.
+  module PartialTitleQuery
+    extend ActiveSupport::Concern
+
+    QUERY_FIELDS = %w[title_tesim description_tesim creator_tesim keyword_tesim].freeze
+
+    protected
+
+    # @param term [String] the typed search term
+    # @return [String] a lucene query: the term matched across {QUERY_FIELDS} OR a
+    #   prefix-wildcard match on each title token.
+    def partial_title_query(term)
+      "#{multi_field_clause(term)} OR #{prefix_title_clause(term)}"
+    end
+
+    private
+
+    def multi_field_clause(term)
+      escaped = escape(term)
+      QUERY_FIELDS.map { |field| "#{field}:(#{escaped})" }.join(' OR ')
+    end
+
+    # Prefix-wildcard on each whitespace-separated title token, e.g.
+    # "jour stud" -> title_tesim:(jour* AND stud*).
+    def prefix_title_clause(term)
+      tokens = term.split(/\s+/).reject(&:empty?).map { |t| "#{escape_token(t)}*" }
+      return '' if tokens.empty?
+
+      "title_tesim:(#{tokens.join(' AND ')})"
+    end
+
+    # Escape Solr/Lucene special characters in a phrase (wildcards included — the
+    # multi-field clause is not a prefix search).
+    def escape(value)
+      value.to_s.gsub(%r{([+\-&|!(){}\[\]^"~*?:\\/])}, '\\\\\1')
+    end
+
+    # Escape special characters in a single token but keep it usable as a prefix
+    # (the trailing `*` is added by the caller, not escaped here).
+    def escape_token(value)
+      value.to_s.gsub(%r{([+\-&|!(){}\[\]^"~?:\\/])}, '\\\\\1')
+    end
+  end
+end

--- a/spec/search_builders/hyrax/my/find_works_search_builder_spec.rb
+++ b/spec/search_builders/hyrax/my/find_works_search_builder_spec.rb
@@ -19,9 +19,24 @@ RSpec.describe Hyrax::My::FindWorksSearchBuilder do
   describe "#filter_on_title" do
     subject { builder.filter_on_title(solr_params) }
 
-    it "is successful" do
+    it "finds works whose title contains or starts with the typed term" do
       subject
-      expect(solr_params[:fq]).to eq [Hyrax::SolrQueryBuilderService.construct_query(title_tesim: q)]
+      expect(solr_params[:q]).to include('title_tesim:(foo)').and include('title_tesim:(foo*)')
+      expect(solr_params[:defType]).to eq 'lucene'
+    end
+
+    it "does not require an exact whole-title match" do
+      subject
+      expect(solr_params[:fq]).to be_blank
+    end
+
+    context "when no search term is given" do
+      let(:q) { '' }
+
+      it "applies no title filter" do
+        subject
+        expect(solr_params[:q]).to be_blank
+      end
     end
   end
 

--- a/spec/search_builders/hyrax/partial_title_query_spec.rb
+++ b/spec/search_builders/hyrax/partial_title_query_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+RSpec.describe Hyrax::PartialTitleQuery do
+  let(:includer) do
+    Class.new do
+      include Hyrax::PartialTitleQuery
+      public :partial_title_query # expose the protected helper for testing
+    end.new
+  end
+
+  describe '#partial_title_query' do
+    it 'searches the term across title, description, creator, and keyword' do
+      query = includer.partial_title_query('repel')
+      expect(query).to include('title_tesim:(repel)')
+        .and include('description_tesim:(repel)')
+        .and include('creator_tesim:(repel)')
+        .and include('keyword_tesim:(repel)')
+    end
+
+    it 'also matches a title that starts with the term (partial typing)' do
+      query = includer.partial_title_query('repel')
+      expect(query).to include('title_tesim:(repel*)')
+    end
+
+    it 'matches a title beginning with every typed word' do
+      query = includer.partial_title_query('repel ani')
+      expect(query).to include('title_tesim:(repel* AND ani*)')
+    end
+
+    it 'treats Solr special characters as literal text, not query syntax' do
+      query = includer.partial_title_query('a:b*')
+      expect(query).to include('title_tesim:(a\\:b\\*)')
+    end
+
+    it 'escapes special characters in a word while still matching it as a prefix' do
+      query = includer.partial_title_query('a:b')
+      expect(query).to include('title_tesim:(a\\:b*)')
+    end
+  end
+end


### PR DESCRIPTION
## Summary
The "find a child work" picker now finds works as you type a partial title, instead of matching only when the complete title is entered.

## Details
- The child/parent-work picker (`/qa/search/find_works`, backed by `Hyrax::My::FindWorksSearchBuilder`) filtered titles with a whole-field exact match; combined with the default query, partial input returned no results.
- `filter_on_title` now builds a partial/prefix title query (term across title/description/creator/keyword, OR a prefix-wildcard title match) and sets it as a lucene `q`. The chain's permission, type, and self/child/parent exclusion filters are unchanged.
- The query logic is extracted into a shared `Hyrax::PartialTitleQuery` concern, also adopted by `Hyrax::CompoundWorkPickerBuilder` (which already did this matching), removing the duplicate implementation.
- Picker search results change from exact-title to partial/prefix matching — a user-visible behavior change, but no public API change (`filter_on_title` has no callers outside the search builder).

## Testing
- [ ] On a work's edit form, open the Relationships tab and use "find a child work": type a **partial** title (a leading word or two) and confirm matching works appear in the dropdown.
- [ ] Confirm a work cannot select **itself**, an existing **child**, or an existing **parent** as a relationship (the exclusion filters still apply).
- [ ] Confirm the picker only offers works the current user is permitted to edit.