### PR TITLE
Collection terminology i18n

### DIFF
--- a/app/views/catalog/_index_list_default.html.erb
+++ b/app/views/catalog/_index_list_default.html.erb
@@ -18,10 +18,10 @@
 <div class="col-md-12 col-lg-3">
   <div class="collection-counts-wrapper">
     <div class="collection-counts-item">
-      <span><%= collection_presenter.total_viewable_collections %></span>Collections
+      <span><%= collection_presenter.total_viewable_collections %></span><%= t('hyrax.collections.collection_counts.collections') %>
     </div>
     <div class="collection-counts-item">
-      <span><%= collection_presenter.total_viewable_works %></span>Works
+      <span><%= collection_presenter.total_viewable_works %></span><%= t('hyrax.collections.collection_counts.works') %>
     </div>
   </div>
 </div>

--- a/app/views/hyrax/base/_member_of_collections.html.erb
+++ b/app/views/hyrax/base/_member_of_collections.html.erb
@@ -1,5 +1,5 @@
 <tr>
-  <td>Member of Collections</td>
+  <td><%= t('hyrax.base.member_of_collections.header') %></td>
   <td>
     <ul class="member_of_collections">
       <% presenter.member_of_collection_presenters.each do |p| %>

--- a/config/locales/hyrax.de.yml
+++ b/config/locales/hyrax.de.yml
@@ -693,6 +693,8 @@ de:
         title: Titel
         unauthorized: Es gibt keine öffentlich verfügbaren Elemente in diesem %{type}.
         visibility: Sichtbarkeit
+      member_of_collections:
+        header: Mitglied von Sammlungen
       relationships:
         empty: Diese %{type} ist derzeit noch keiner Sammlung zugeordnet.
         header: Beziehungen
@@ -844,6 +846,9 @@ de:
         admin_set_description: Eine Sammlung von Arbeiten, die bei der administrativen Kontrolle helfen sollen. Admin-Sets bieten eine Möglichkeit, Verhaltensweisen und Richtlinien für eine Reihe von Arbeiten zu definieren.
         default_description: Eine Benutzer-Sammlung kann von jedem Benutzer erstellt werden, um ihre Arbeiten zu organisieren.
     collections:
+      collection_counts:
+        collections: Sammlungen
+        works: Arbeiten
       search_form:
         button_label: Suche
         label: Suche Sammlung %{title}

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -687,6 +687,8 @@ en:
         title: Title
         unauthorized: There are no publicly available items in this %{type}.
         visibility: Visibility
+      member_of_collections:
+        header: Member of Collections
       relationships:
         empty: This %{type} is not currently in any collections.
         header: Relationships
@@ -831,6 +833,9 @@ en:
         title: Add to collection
         update: Save changes
     collections:
+      collection_counts:
+        collections: Collections
+        works: Works
       search_form:
         button_label: Go
         label: Search Collection %{title}

--- a/config/locales/hyrax.es.yml
+++ b/config/locales/hyrax.es.yml
@@ -699,6 +699,8 @@ es:
         title: Título
         unauthorized: No hay elementos disponibles públicamente en este %{type}.
         visibility: Visibilidad
+      member_of_collections:
+        header: Miembro de colecciones
       relationships:
         empty: Este %{type} no está actualmente disponible en ninguna colección.
         header: Relaciones
@@ -850,6 +852,9 @@ es:
         admin_set_description: Una agregación de trabajos que está destinada a ayudar con el control administrativo. Los conjuntos de administración proporcionan una forma de definir comportamientos y políticas en torno a un conjunto de trabajos.
         default_description: Un usuario puede crear una Colección de usuarios para organizar sus trabajos.
     collections:
+      collection_counts:
+        collections: Colecciones
+        works: Trabajos
       search_form:
         button_label: Ir
         label: Buscar Colección %{title}

--- a/config/locales/hyrax.fr.yml
+++ b/config/locales/hyrax.fr.yml
@@ -700,6 +700,8 @@ fr:
         title: Titre
         unauthorized: Il n'y a pas d'objets disponibles publiquement dans ce %{type}.
         visibility: Visibilité
+      member_of_collections:
+        header: Membre de collections
       relationships:
         empty: Ce %{type} ne se trouve actuellement dans aucune collection.
         header: Des relations
@@ -851,6 +853,9 @@ fr:
         admin_set_description: Une agrégation de travaux destinée à faciliter le contrôle administratif. Les ensembles d'administration permettent de définir des comportements et des stratégies autour d'un ensemble de travaux.
         default_description: Une collection d'utilisateurs peut être créée par n'importe quel utilisateur pour organiser leurs travaux.
     collections:
+      collection_counts:
+        collections: Collections
+        works: Travaux
       search_form:
         button_label: Aller
         label: Rechercher Collection %{title}

--- a/config/locales/hyrax.it.yml
+++ b/config/locales/hyrax.it.yml
@@ -699,6 +699,8 @@ it:
         title: Titolo
         unauthorized: Non ci sono articoli disponibili pubblicamente in questo %{type}.
         visibility: Visibilità
+      member_of_collections:
+        header: Membro di collezioni
       relationships:
         empty: Questo %{type} non è in una raccolta.
         header: Le relazioni
@@ -850,6 +852,9 @@ it:
         admin_set_description: Un'aggregazione di opere che ha lo scopo di aiutare con il controllo amministrativo. I set di amministratori forniscono un modo per definire comportamenti e politiche attorno a un insieme di opere.
         default_description: Una User Collection può essere creata da qualsiasi utente per organizzare i propri lavori.
     collections:
+      collection_counts:
+        collections: Collezioni
+        works: Lavori
       search_form:
         button_label: Partire
         label: Cerca la raccolta %{title}

--- a/config/locales/hyrax.pt-BR.yml
+++ b/config/locales/hyrax.pt-BR.yml
@@ -692,6 +692,8 @@ pt-BR:
         title: Título
         unauthorized: Não há itens publicados neste %{type}.
         visibility: Acesso
+      member_of_collections:
+        header: Membro de coleções
       relationships:
         empty: Este %{type} atualmente não está em nenhuma coleção.
         header: Relações
@@ -843,6 +845,9 @@ pt-BR:
         admin_set_description: Um agregado de obras destinado a ajudar no controle administrativo. Os conjuntos administrativos fornecem uma maneira de definir comportamentos e regras para um conjunto de obras.
         default_description: Uma Coleção de Usuário pode ser criada por qualquer usuário para organizar suas obras.
     collections:
+      collection_counts:
+        collections: Coleções
+        works: Obras
       search_form:
         button_label: Ir
         label: Pesquisar Coleção %{title}

--- a/config/locales/hyrax.zh.yml
+++ b/config/locales/hyrax.zh.yml
@@ -697,6 +697,8 @@ zh:
         title: 标题
         unauthorized: 这个%{type}中没有公开可用的项目。
         visibility: 公开度
+      member_of_collections:
+        header: 所属采集
       relationships:
         empty: 该 %{type} 目前未纳入任何收藏集内。
         header: 关联
@@ -848,6 +850,9 @@ zh:
         admin_set_description: 旨在帮助行政控制的作品集合。管理员集合提供了定义一组作品周围的行为和策略的方法。
         default_description: 用户集合可由任何用户创建以组织他们的作品。
     collections:
+      collection_counts:
+        collections: 采集
+        works: 作品
       search_form:
         button_label: 去
         label: 搜索收藏集 %{title}


### PR DESCRIPTION
### Fixes

Adds internationalization to a few collection related terms

These affect:
- collection badges on the catalog index view
- single use work show link