### PR TITLE
Honor top-level admin_only/editor_only in SimpleSchemaLoader (flex-false)

### DIFF
--- a/app/services/hyrax/simple_schema_loader.rb
+++ b/app/services/hyrax/simple_schema_loader.rb
@@ -10,8 +10,18 @@ module Hyrax
   class SimpleSchemaLoader < Hyrax::SchemaLoader
     def view_definitions_for(schema:, version: 1, contexts: nil) # rubocop:disable Lint/UnusedMethodArgument
       schema.each_with_object({}) do |property, metadata|
-        view_options = property.meta['view']
-        metadata[property.name.to_s] = view_options.with_indifferent_access unless view_options.nil?
+        config = property.meta || {}
+        view_options = config['view']
+        # Promote top-level `admin_only` / `editor_only` (and their `indexing:`
+        # sentinel form) into the view options, so non-flexible mode honors them
+        # the same way the M3 (flexible) loader does via AttributeDefinition.
+        # A nested `view: { admin_only: true }` continues to work; without this a
+        # top-level flag was silently dropped here and the field rendered to
+        # everyone. A top-level flag wins over a nested one, matching M3.
+        gating = visibility_gating_for(config)
+        next if view_options.nil? && gating.empty?
+
+        metadata[property.name.to_s] = (view_options || {}).merge(gating).with_indifferent_access
       end
     end # rubocop:enable Lint/UnusedMethodArgument
 
@@ -22,6 +32,22 @@ module Hyrax
     end
 
     private
+
+    ##
+    # Mirrors {SchemaLoader::AttributeDefinition#admin_only?} / `#editor_only?`:
+    # a visibility flag is on when set truthy at the top level of the property
+    # config OR listed in its `indexing:` array. Returns only the flags that are
+    # actually set, so unset flags don't clobber a nested `view:` value.
+    #
+    # @param [Hash] config the property's metadata config
+    # @return [Hash{String => true}]
+    def visibility_gating_for(config)
+      indexing = Array(config['indexing'])
+      {}.tap do |opts|
+        opts['admin_only'] = true if config['admin_only'] || indexing.include?('admin_only')
+        opts['editor_only'] = true if config['editor_only'] || indexing.include?('editor_only')
+      end
+    end
 
     ##
     # @param [#to_s] schema_name

--- a/spec/services/hyrax/simple_schema_loader_spec.rb
+++ b/spec/services/hyrax/simple_schema_loader_spec.rb
@@ -125,6 +125,50 @@ RSpec.describe Hyrax::SimpleSchemaLoader do
       end
     end
 
+    context 'with top-level visibility flags (admin_only / editor_only)' do
+      it 'promotes a top-level admin_only into the view options alongside the view block' do
+        prop = double('Property', name: :admin_field, meta: { 'admin_only' => true, 'view' => { 'html_dl' => true } })
+        result = schema_loader.view_definitions_for(schema: [prop])
+        expect(result['admin_field']).to include('admin_only' => true, 'html_dl' => true)
+      end
+
+      it 'promotes a top-level editor_only into the view options' do
+        prop = double('Property', name: :editor_field, meta: { 'editor_only' => true, 'view' => { 'html_dl' => true } })
+        result = schema_loader.view_definitions_for(schema: [prop])
+        expect(result['editor_field']).to include('editor_only' => true)
+      end
+
+      it 'honors the indexing: sentinel form (admin_only listed in indexing)' do
+        prop = double('Property', name: :idx_field, meta: { 'indexing' => ['idx_field_tesim', 'admin_only'], 'view' => { 'html_dl' => true } })
+        result = schema_loader.view_definitions_for(schema: [prop])
+        expect(result['idx_field']).to include('admin_only' => true)
+      end
+
+      it 'includes a field gated only by a top-level flag with no view block' do
+        prop = double('Property', name: :bare_admin, meta: { 'admin_only' => true })
+        result = schema_loader.view_definitions_for(schema: [prop])
+        expect(result['bare_admin']).to include('admin_only' => true)
+      end
+
+      it 'lets a top-level flag win over a conflicting nested one (matching M3)' do
+        prop = double('Property', name: :both, meta: { 'editor_only' => true, 'view' => { 'editor_only' => false } })
+        result = schema_loader.view_definitions_for(schema: [prop])
+        expect(result['both']).to include('editor_only' => true)
+      end
+
+      it 'preserves a nested flag when no top-level flag is set' do
+        prop = double('Property', name: :nested_only, meta: { 'view' => { 'admin_only' => true } })
+        result = schema_loader.view_definitions_for(schema: [prop])
+        expect(result['nested_only']).to include('admin_only' => true)
+      end
+
+      it 'still excludes a field with neither view options nor visibility flags' do
+        prop = double('Property', name: :plain, meta: { 'predicate' => 'http://example.com/x' })
+        result = schema_loader.view_definitions_for(schema: [prop])
+        expect(result).not_to have_key('plain')
+      end
+    end
+
     context 'with version and contexts parameters' do
       it 'ignores version and contexts parameters as documented' do
         mock_property = double('Property', name: :title, meta: {})


### PR DESCRIPTION
## Problem

`Hyrax::AttributesHelper#field_visible?` honors both `admin_only` and `editor_only`, but **where the flag must be declared differs by schema loader**, and neither placement works in both modes:

- **M3 / flexible loader** — `SchemaLoader::AttributeDefinition#view_options` reads `admin_only`/`editor_only` from the **top level** of the property config (or its `indexing:` array) and always injects them into `view_options`.
- **Simple / non-flexible loader** — `SimpleSchemaLoader#view_definitions_for` built `view_options` from the nested `view:` block **only**. A *top-level* `admin_only`/`editor_only` was silently dropped, so the field rendered to everyone.

So an author has to put the flag at the top level for flexible mode and nested under `view:` for non-flexible mode, and a single declaration can't cover both. This bit samvera/hyku#3103 / samvera/hyku#3112: moving `admin_note` to a top-level `editor_only` un-gated it under flex-false.

## Fix

Make `SimpleSchemaLoader#view_definitions_for` promote top-level `admin_only`/`editor_only` (and their `indexing:` sentinel form) into `view_options`, mirroring what `AttributeDefinition#view_options` already does for M3:

- A **top-level** `admin_only: true` / `editor_only: true` now works under flex-false.
- A **nested** `view: { admin_only: true }` continues to work (unchanged).
- When both are present, the **top-level** flag wins, matching M3.
- A field gated only by a top-level flag (no `view:` block) is now included in the view definitions so `field_visible?` can act on it; fields with neither view options nor a visibility flag are still excluded.

After this, a property can declare `admin_only`/`editor_only` once, at the top level, and have it honored identically in both modes.

## Tests

Added `#view_definitions_for` specs covering: top-level `admin_only`/`editor_only` promotion, the `indexing:` sentinel form, top-level-wins-over-nested, nested-only preserved, a bare top-level flag with no `view:` block, and the unchanged "no view options → excluded" case.

## Downstream

Lets host apps (e.g. Hyku, samvera/hyku#3112) drop custom `_attribute_rows` overrides that special-case `admin_note`, and gate it declaratively in the metadata profile instead.
