### PR TITLE
Allows ActiveFedora objects to be passed to Job calls in Hyrax::PermissionsController.

### DIFF
--- a/app/controllers/hyrax/permissions_controller.rb
+++ b/app/controllers/hyrax/permissions_controller.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 module Hyrax
   class PermissionsController < ApplicationController
-    load_resource class: Hyrax::Resource, instance_name: :curation_concern
+    resource_klass = Hyrax.config.use_valkyrie? ? Hyrax::Resource : ActiveFedora::Base
+    load_resource class: resource_klass, instance_name: :curation_concern
 
     attr_reader :curation_concern
     helper_method :curation_concern


### PR DESCRIPTION
### Fixes

https://github.com/samvera/hyrax/issues/7507

### Summary

Allows either `Hyrax::Resource` or `ActiveFedora::Base` objects to pass to `VisibilityCopyJob` or `InheritPermissionsJob` based upon whether the application is configured to work with Valkyrie (`Hyrax.config.use_valkyrie?`).

### Guidance for testing, such as acceptance criteria or new user interface behaviors:

1.     Update an ActiveFedora Work containing FileSets
2.     Choose to inherit FileSet permissions from the Work
3.     The Sidekiq Job VisibilityCopyJob should not fail

### Type of change (for release notes)

- `notes-minor` New Features that are backward compatible
- `notes-bugfix` Bug Fixes
- `notes-valkyrie` Valkyrie Progress

### Changes proposed in this pull request:
* Adds switching element to `load_resource`.

@samvera/hyrax-code-reviewers
