### PR TITLE
Render compound fields on the Valkyrie FileSet edit form

### DIFF
--- a/app/views/hyrax/file_sets/_valkyrie_form.html.erb
+++ b/app/views/hyrax/file_sets/_valkyrie_form.html.erb
@@ -9,6 +9,13 @@
       <% next if [:contexts, :schema_version].include?(term) %>
       <%= render_edit_field_partial(term, f: f, curation_concern: curation_concern) %>
     <% end %>
+    <%# Primary compounds render alongside the primary scalar terms, matching
+        the work form (hyrax/base/_form_metadata) and the collection form. %>
+    <% if f.object.respond_to?(:primary_compound_terms) %>
+      <% f.object.primary_compound_terms.each do |term| %>
+        <%= render_compound_field(f, term) %>
+      <% end %>
+    <% end %>
   </div>
   <% if f.object.display_additional_fields? %>
     <%= link_to t('hyrax.collection.form.additional_fields'),
@@ -21,6 +28,11 @@
     <div id="extended-terms" class="collapse">
       <% f.object.secondary_terms.each do |term| %>
         <%= render_edit_field_partial(term, f: f, curation_concern: curation_concern) %>
+      <% end %>
+      <% if f.object.respond_to?(:secondary_compound_terms) %>
+        <% f.object.secondary_compound_terms.each do |term| %>
+          <%= render_compound_field(f, term) %>
+        <% end %>
       <% end %>
     </div>
   <% end %>

--- a/spec/views/hyrax/file_sets/_valkyrie_form.html.erb_spec.rb
+++ b/spec/views/hyrax/file_sets/_valkyrie_form.html.erb_spec.rb
@@ -19,6 +19,13 @@ RSpec.describe 'hyrax/file_sets/_valkyrie_form.html.erb', type: :view do
       [SolrDocument.new(id: "baz", title_tesim: "foo")]
     )
 
+    # Compound fields: the form responds to these (ResourceForm), but a
+    # non-flexible FileSet declares none. Stub them so we can assert the view
+    # renders compounds the same way the work and collection forms do.
+    allow(form).to receive(:primary_compound_terms).and_return([:rights])
+    allow(form).to receive(:secondary_compound_terms).and_return([:funding])
+    allow(view).to receive(:render_compound_field).and_return('<div class="compound-field"></div>'.html_safe)
+
     render partial: 'hyrax/file_sets/valkyrie_form', locals: { form_object: form }
   end
 
@@ -49,5 +56,13 @@ RSpec.describe 'hyrax/file_sets/_valkyrie_form.html.erb', type: :view do
 
   it 'renders the language form field' do
     expect(rendered).to have_selector('input[name="file_set[language][]"]')
+  end
+
+  it 'renders primary compound fields' do
+    expect(view).to have_received(:render_compound_field).with(anything, :rights)
+  end
+
+  it 'renders secondary compound fields under additional fields' do
+    expect(view).to have_received(:render_compound_field).with(anything, :funding)
   end
 end


### PR DESCRIPTION
## Summary

The Valkyrie FileSet edit form (`hyrax/file_sets/_valkyrie_form`) iterates only `primary_terms` / `secondary_terms`. Because `ResourceForm` subtracts `compound_terms` out of those lists, flexible **compound** fields never render on the FileSet edit form — even though the work form (`hyrax/base/_form_metadata`) and the collection form (`hyrax/dashboard/collections/_form`) already render them via `render_compound_field`.

The practical effect: an app that declares a compound property `available_on` `Hyrax::FileSet` under flexible metadata can persist, index, and display it, but depositors have no inputs to enter it on the FileSet edit form. Scalar flexible fields render fine; only compounds are missing.

## Change

Render `primary_compound_terms` / `secondary_compound_terms` in `_valkyrie_form`, each guarded by `respond_to?` so non-flexible and legacy forms are unaffected. This mirrors the existing work and collection forms.

## Testing

Extends `spec/views/hyrax/file_sets/_valkyrie_form.html.erb_spec.rb` to assert both primary and secondary compounds are rendered via `render_compound_field`.

Validated ERB and spec syntax locally; relying on CI for the full view-spec run.

<img width="2704" height="3224" alt="image" src="https://github.com/user-attachments/assets/037ccc0f-e8bb-4b5b-b0aa-ac144cda0085" />


🤖 Generated with [Claude Code](https://claude.com/claude-code)
