### PR TITLE
Clean up linked_record create form

### DIFF
--- a/app/assets/stylesheets/hyrax/_compound_metadata.scss
+++ b/app/assets/stylesheets/hyrax/_compound_metadata.scss
@@ -50,11 +50,41 @@
 }
 
 .hyrax-linked-record-create {
+  .form-group {
+    margin-bottom: 0.5rem;
+
+    &:last-child {
+      margin-bottom: 0;
+    }
+  }
+
   .form-group > label,
   .hyrax-linked-record-group > label {
     display: block;
     margin-bottom: 0.25rem;
     text-align: left;
     width: 100%;
+  }
+
+  .hyrax-linked-record-group-row {
+    align-items: flex-start;
+    background: $gray-100;
+    border: 1px solid $gray-200;
+    border-radius: 0.25rem;
+    margin-bottom: 0.5rem;
+    padding: 0.5rem;
+
+    [data-create-group-remove] {
+      padding-bottom: 0;
+      padding-top: 0;
+    }
+  }
+
+  [data-create-group-rows] .hyrax-linked-record-group-row:last-child {
+    margin-bottom: 0;
+  }
+
+  [data-create-group-add] {
+    margin-top: 0.25rem;
   }
 }

--- a/app/assets/stylesheets/hyrax/_compound_metadata.scss
+++ b/app/assets/stylesheets/hyrax/_compound_metadata.scss
@@ -48,3 +48,13 @@
     margin-right: 0.25rem;
   }
 }
+
+.hyrax-linked-record-create {
+  .form-group > label,
+  .hyrax-linked-record-group > label {
+    display: block;
+    margin-bottom: 0.25rem;
+    text-align: left;
+    width: 100%;
+  }
+}

--- a/app/views/hyrax/compounds/_linked_record_create_input.html.erb
+++ b/app/views/hyrax/compounds/_linked_record_create_input.html.erb
@@ -6,18 +6,24 @@
     `name` (it is not part of the work form's params).
 
     Locals:
-      field     - a normalized create-field spec (name, as, required, values)
-      input_id  - the DOM id for this input, or blank for a repeatable row
-      data_attr - 'create-field' or 'create-subfield' %>
+      field       - a normalized create-field spec (name, as, required, values)
+      input_id    - the DOM id for this input, or blank for a repeatable row
+      data_attr   - 'create-field' or 'create-subfield'
+      hide_label  - omit this input's own label (the group heading names it)
+      placeholder - show the field label as the input's placeholder %>
 <%# A repeatable group row passes a blank `input_id`: the row template is cloned
     by JS, so a fixed `id`/`for` would create duplicate ids and break label
     targeting. With no id, the label wraps the control (no `for`); a top-level
     field keeps the standard label + `for`. The `id` attribute is only emitted
     when present. %>
+<% hide_label = local_assigns.fetch(:hide_label, false) %>
+<% placeholder = local_assigns.fetch(:placeholder, false) %>
 <% label_text = t("hyrax.compound_fields.linked_record.fields.#{field[:name]}", default: field[:name].to_s.humanize) %>
+<% placeholder_html = placeholder ? "placeholder=\"#{ERB::Util.h(label_text)}\"".html_safe : ''.html_safe %>
 <% id_html = input_id.present? ? "id=\"#{input_id}\"".html_safe : ''.html_safe %>
-<div class="form-group mb-2">
-  <% if input_id.present? %>
+<div class="form-group">
+  <% if hide_label %>
+  <% elsif input_id.present? %>
     <label for="<%= input_id %>" class="form-label small text-muted mb-0">
       <%= label_text %><% if field[:required] %><abbr title="required" class="required text-danger">*</abbr><% end %>
     </label>
@@ -27,13 +33,13 @@
   <% end %>
   <% if field[:as] == 'select' %>
     <select <%= id_html %> class="form-control form-control-sm" data-<%= data_attr %>="<%= field[:name] %>">
-      <option value=""></option>
+      <option value=""><%= placeholder ? label_text : '' %></option>
       <% Array(field[:values]).each do |v| %>
         <option value="<%= v %>"><%= v.to_s.humanize %></option>
       <% end %>
     </select>
   <% else %>
-    <input type="text" <%= id_html %> class="form-control form-control-sm" data-<%= data_attr %>="<%= field[:name] %>">
+    <input type="text" <%= id_html %> <%= placeholder_html %> class="form-control form-control-sm" data-<%= data_attr %>="<%= field[:name] %>">
   <% end %>
-  <% unless input_id.present? %></label><% end %>
+  <% if !hide_label && input_id.blank? %></label><% end %>
 </div>

--- a/app/views/hyrax/compounds/_linked_record_field.html.erb
+++ b/app/views/hyrax/compounds/_linked_record_field.html.erb
@@ -19,29 +19,42 @@
   <% current_option = compound_linked_record_option(value, source) %>
   <% placeholder = t("hyrax.compound_fields.linked_record.#{source}.placeholder",
                      default: t('hyrax.compound_fields.linked_record.placeholder', default: 'Search')) %>
+  <%# The add buttons' noun; override per source via item_label.<source>. %>
+  <% record_item_label = t("hyrax.compound_fields.linked_record.item_label.#{source}",
+                           default: source.to_s.singularize.humanize.downcase) %>
 
   <div class="hyrax-linked-record" data-hyrax-linked-record
        data-source="<%= source %>"
        data-creatable="<%= spec[:creatable] ? 'true' : 'false' %>"
        data-create-url="<%= Hyrax::Engine.routes.url_helpers.compound_linked_record_path(source: source) %>">
-    <%# The select2 picker (same hidden-input binding as work_or_url). %>
-    <%= hidden_field_tag input_name, value,
-                         id: input_id,
-                         class: 'form-control form-control-sm',
-                         data: { 'hyrax-compound-work-input': true,
-                                 'hyrax-linked-record-input': true,
-                                 'label': current_option&.first,
-                                 'placeholder': placeholder,
-                                 'autocomplete-url': "#{Rails.application.routes.url_helpers.qa_path}/search/linked_record/#{source}" } %>
+    <%# Picker + "add new" trigger on one row, so the add button sits beside the
+        search field rather than below it (where the select2 "no results"
+        dropdown would cover it). %>
+    <% creatable = spec[:creatable] && spec[:create_fields].present? && Hyrax::CompoundLinkedRecordResolver.creatable?(source) %>
+    <div class="d-flex align-items-start">
+      <div class="flex-grow-1">
+        <%# The select2 picker (same hidden-input binding as work_or_url). %>
+        <%= hidden_field_tag input_name, value,
+                             id: input_id,
+                             class: 'form-control form-control-sm',
+                             data: { 'hyrax-compound-work-input': true,
+                                     'hyrax-linked-record-input': true,
+                                     'label': current_option&.first,
+                                     'placeholder': placeholder,
+                                     'autocomplete-url': "#{Rails.application.routes.url_helpers.qa_path}/search/linked_record/#{source}" } %>
+      </div>
+      <% if creatable %>
+        <%# Shown by JS only when a search returns no results. %>
+        <button type="button" class="btn btn-link btn-sm text-nowrap ml-2 d-none"
+                data-hyrax-linked-record-add hidden>
+          <span class="fa fa-plus"></span>
+          <%= t('hyrax.compound_fields.linked_record.add_new', item: record_item_label, default: 'Add new') %>
+        </button>
+      <% end %>
+    </div>
 
-  <%# Offer inline create only when the profile asks for it AND the source
-      actually registers a `create:` proc — otherwise the endpoint would 404. %>
-  <% if spec[:creatable] && spec[:create_fields].present? && Hyrax::CompoundLinkedRecordResolver.creatable?(source) %>
-    <%# Trigger shown by JS only when a search returns no results. %>
-    <button type="button" class="btn btn-link btn-sm px-0 mt-1 d-none"
-            data-hyrax-linked-record-add hidden>
-      <%= t('hyrax.compound_fields.linked_record.add_new', default: '+ Add new') %>
-    </button>
+  <%# Offer the inline create FORM only when the source is creatable. %>
+  <% if creatable %>
 
     <%# Inline create form (hidden until the trigger is clicked). A scalar field
         (string/select) renders one input tagged `data-create-field`; a
@@ -59,6 +72,10 @@
               plain string). `data-create-scalar` tells the JS which shape to emit.
               The <template> row is cloned on "+ Add"; one row renders initially. %>
           <% scalar = field[:as] != 'group' %>
+          <%# The add-row button's noun; override per field via item_label.<name>. %>
+          <% field_item_label = t("hyrax.compound_fields.linked_record.item_label.#{field[:name]}",
+                                  default: t("hyrax.compound_fields.linked_record.fields.#{field[:name]}",
+                                             default: field[:name].to_s.humanize)) %>
           <div class="form-group mb-2 hyrax-linked-record-group"
                data-create-group="<%= field[:name] %>" data-repeatable="true"
                data-create-scalar="<%= scalar ? 'true' : 'false' %>">
@@ -67,32 +84,36 @@
             </label>
             <% row_fields = scalar ? [field] : Array(field[:fields]) %>
             <template data-create-group-row-template>
-              <div class="hyrax-linked-record-group-row d-flex align-items-end" data-create-group-row>
+              <div class="hyrax-linked-record-group-row d-flex" data-create-group-row>
                 <div class="flex-grow-1">
                   <% row_fields.each do |sub| %>
-                    <%# input_id blank: rows are cloned, so no fixed id/for. %>
+                    <%# input_id blank: rows are cloned, so no fixed id/for. Labels
+                        are hidden; a multi-field group names sub-fields via placeholder. %>
                     <%= render 'hyrax/compounds/linked_record_create_input',
-                               field: sub, input_id: nil, data_attr: 'create-subfield' %>
+                               field: sub, input_id: nil, data_attr: 'create-subfield',
+                               hide_label: true, placeholder: !scalar %>
                   <% end %>
                 </div>
-                <button type="button" class="btn btn-link btn-sm text-danger pb-3" data-create-group-remove
-                        aria-label="<%= t('hyrax.compound_fields.remove_row', default: 'Remove') %>">&times;</button>
+                <button type="button" class="btn btn-link text-danger hyrax-linked-record-group-remove" data-create-group-remove
+                        aria-label="<%= t('hyrax.compound_fields.remove_row', default: 'Remove') %>"><span class="fa fa-times"></span></button>
               </div>
             </template>
             <div data-create-group-rows>
-              <div class="hyrax-linked-record-group-row d-flex align-items-end" data-create-group-row>
+              <div class="hyrax-linked-record-group-row d-flex" data-create-group-row>
                 <div class="flex-grow-1">
                   <% row_fields.each do |sub| %>
                     <%= render 'hyrax/compounds/linked_record_create_input',
-                               field: sub, input_id: nil, data_attr: 'create-subfield' %>
+                               field: sub, input_id: nil, data_attr: 'create-subfield',
+                               hide_label: true, placeholder: !scalar %>
                   <% end %>
                 </div>
-                <button type="button" class="btn btn-link btn-sm text-danger pb-3" data-create-group-remove
-                        aria-label="<%= t('hyrax.compound_fields.remove_row', default: 'Remove') %>">&times;</button>
+                <button type="button" class="btn btn-link text-danger hyrax-linked-record-group-remove" data-create-group-remove
+                        aria-label="<%= t('hyrax.compound_fields.remove_row', default: 'Remove') %>"><span class="fa fa-times"></span></button>
               </div>
             </div>
             <button type="button" class="btn btn-link btn-sm px-0" data-create-group-add>
-              <%= t('hyrax.compound_fields.add_row', label: field[:name].to_s.humanize, default: "+ Add #{field[:name].to_s.humanize}") %>
+              <span class="fa fa-plus"></span>
+              <%= t('hyrax.compound_fields.linked_record.add_row', item: field_item_label, default: "Add another #{field_item_label}") %>
             </button>
           </div>
         <% else %>

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -870,6 +870,9 @@ en:
       errors:
         required_but_empty: "%{compound} requires at least one entry"
         missing_required_subproperties: "Each %{compound} entry requires: %{fields}"
+      linked_record:
+        add_new: Add a %{item}
+        add_row: Add another %{item}
       participants:
         label: Participants
         title: Title

--- a/documentation/compound_fields.md
+++ b/documentation/compound_fields.md
@@ -284,6 +284,42 @@ How the pieces fit together:
   string `<compound>_<name>_ssim` (like an id), so you can reverse-look-up "which
   works reference this record?" with a Solr query on that field.
 
+#### Labelling the create form (i18n)
+
+Every label and button in the inline create form reads from i18n, so a host app
+can name things without touching the partial. All keys live under
+`hyrax.compound_fields.linked_record` and fall back to a humanized default when
+unset.
+
+| Key | Controls | Default when unset |
+|-----|----------|--------------------|
+| `fields.<field_name>` | the label above a create-field input, and the heading above a repeatable field's rows. For a multi-field `group`, the sub-field labels are dropped and each `fields.<subfield_name>` is shown as the input's placeholder instead. | humanized field name |
+| `item_label.<source>` | the noun in the **"Add new"** trigger (e.g. `contributor`), keyed by the sub-property's `authority:` | the source name, singularized + downcased |
+| `item_label.<field_name>` | the noun in a repeatable field's **"add another row"** button | that field's `fields.<field_name>` label |
+| `add_new` | the **"Add new"** trigger wording; interpolates `%{item}` from `item_label.<source>`. A `fa-plus` icon precedes it. | `Add new` |
+| `add_row` | the **"add another row"** button wording; interpolates `%{item}` from `item_label.<field_name>`. A `fa-plus` icon precedes it. | `Add another <field>` |
+
+```yaml
+# config/locales/<app>.en.yml
+en:
+  hyrax:
+    compound_fields:
+      linked_record:
+        add_new: Add a %{item}              # → "＋ Add a contributor"
+        add_row: Add another %{item}        # → "＋ Add another affiliation"
+        item_label:
+          contributors: contributor         # the source (authority:)
+          affiliations: affiliation         # a repeatable create-field
+        fields:
+          display_name: Name
+          name_identifiers: Name identifiers
+```
+
+`item_label` is the single noun reused by both add buttons, so changing it keeps
+the trigger and the row button consistent. It is independent of `fields.<name>`
+(the heading/placeholder), so relabeling a field's heading does not change its
+button noun unless you also set `item_label`.
+
 ### Grouping (`group:` + `groups:`, optional)
 
 Sub-properties can be clustered into labeled groups within each entry's card.

--- a/spec/views/hyrax/compounds/_compound_row_linked_record_spec.rb
+++ b/spec/views/hyrax/compounds/_compound_row_linked_record_spec.rb
@@ -83,8 +83,8 @@ RSpec.describe 'hyrax/compounds/_compound_row', type: :view do
       expect(rendered).to match(%r{data-create-url="[^"]*/linked_records/people"})
     end
 
-    it 'renders the (hidden) Add new trigger' do
-      expect(rendered).to have_css('button[data-hyrax-linked-record-add]', text: '+ Add new', visible: false)
+    it 'renders the (hidden) Add new trigger naming the source item' do
+      expect(rendered).to have_css('button[data-hyrax-linked-record-add]', text: 'Add a person', visible: false)
     end
 
     it 'renders the create form fields from create_fields (string inputs + a select)' do


### PR DESCRIPTION
## Summary

Makes the default custom metadata `linked_record` create form look and work better.

## Details

- Updated the compound metadata's `linked_record` create form CSS to left-align the labels. (Left aligned form labels are customary.)
- Moved the "Add new" trigger so the select2 "no results" dropdown doesn't hide it.
- Made add/remove buttons use standard icons
- Visually grouped repeatable rows within the form
- Made the add-button wording i18n-driven and overridable

## Screenshot

<details>
<summary>Sample from a consuming application</summary>

<img width="509" height="620" alt="Screenshot 2026-06-25 at 6 57 33 PM" src="https://github.com/user-attachments/assets/6c06815a-b5af-480f-8d8a-85a41b32bbd2" />

</details>
