### PR TITLE
Allow overriding label for relations rows

### DIFF
--- a/app/views/hyrax/base/_relationships_parent_row.html.erb
+++ b/app/views/hyrax/base/_relationships_parent_row.html.erb
@@ -1,4 +1,4 @@
-<dt> <%= t(".label", type: type.humanize) %> </dt>
+<dt><%= t(".#{type}_label", default: :".label", type: type.humanize) %></dt>
 <dd>
     <% if items.blank? %>
       <p><%= t('.empty', type: type.humanize) %></p>


### PR DESCRIPTION
## Summary

The `Relations` card on the work show page uses labels based on the model class name. This change allows the label to be overridden via locales, allowing a name to be displayed that is different from the model's name. 

For example, if you want to change the label for the collection model, you can add an entry in your locale file like this:
``` yaml
en:
  hyrax:
    base:
      relationships_parent_row:
        collection_label: "In User Collection:"
        label: "In %{type}:"
```
