### PR TITLE
Render compound metadata on the FileSet show page

### DIFF
--- a/app/indexers/hyrax/indexers/file_set_indexer.rb
+++ b/app/indexers/hyrax/indexers/file_set_indexer.rb
@@ -13,6 +13,12 @@ module Hyrax
         include Hyrax::Indexer(:file_set_metadata)
       end
       check_if_flexible(Hyrax::FileSet)
+      # Project compound metadata (sub-property search fields + a
+      # <compound>_json_ss display blob) into Solr, matching the work and
+      # collection indexers (PcdmObjectIndexer, PcdmCollectionIndexer). Without
+      # this a FileSet's compounds never reach Solr and can't render on the show
+      # page. Included last so its #to_solr runs via super from the class method.
+      include Hyrax::Indexers::CompoundIndexer
 
       def to_solr # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/PerceivedComplexity
         super.tap do |solr_doc| # rubocop:disable Metrics/BlockLength

--- a/app/presenters/hyrax/file_set_presenter.rb
+++ b/app/presenters/hyrax/file_set_presenter.rb
@@ -18,6 +18,7 @@ module Hyrax
       @solr_document = solr_document
       @current_ability = current_ability
       @request = request
+      define_dynamic_methods if solr_document.try(:flexible?)
     end
 
     delegate :to_s, to: :solr_document
@@ -122,6 +123,29 @@ module Hyrax
       Hyrax::PresenterFactory.build_for(ids: ids,
                                         presenter_class: WorkShowPresenter,
                                         presenter_args: current_ability).first
+    end
+
+    # Define a reader for each flexible-profile property that carries indexing
+    # keys, reading the first present indexed value off the Solr document.
+    # Mirrors WorkShowPresenter#define_dynamic_methods, but defines the readers
+    # directly on the presenter because a FileSet's SolrDocument is not
+    # OrderedMembers-decorated. current_version is read once here (not per
+    # property), matching the work presenter.
+    def define_dynamic_methods # rubocop:disable Metrics/MethodLength
+      Hyrax::FlexibleSchema.current_version["properties"].each do |method_name, property_details|
+        index_keys = property_details["indexing"]
+        next unless index_keys
+        next if self.class.method_defined?(method_name)
+
+        multi_value = property_details["multiple"] || (property_details["data_type"] == "array")
+        self.class.send(:define_method, method_name) do |*_args|
+          index_keys.each do |index_key|
+            value = solr_document[index_key]
+            return(multi_value ? Array.wrap(value) : value) if value.present?
+          end
+          multi_value ? [] : ""
+        end
+      end
     end
   end
 end

--- a/app/presenters/hyrax/file_set_presenter.rb
+++ b/app/presenters/hyrax/file_set_presenter.rb
@@ -135,7 +135,14 @@ module Hyrax
       Hyrax::FlexibleSchema.current_version["properties"].each do |method_name, property_details|
         index_keys = property_details["indexing"]
         next unless index_keys
-        next if self.class.method_defined?(method_name)
+        # Skip properties the presenter already defines, or that the SolrDocument
+        # responds to (e.g. contributor, creator) and MissingMethodBehavior
+        # already delegates - a direct-read method here would shadow that
+        # delegation. This reader only fills the gap for flexible properties the
+        # document has no method for. WorkShowPresenter guards the same way but can
+        # use `&&` because its generated method delegates to the document; this one
+        # reads the index directly, so either match must skip.
+        next if self.class.method_defined?(method_name) || solr_document.respond_to?(method_name)
 
         multi_value = property_details["multiple"] || (property_details["data_type"] == "array")
         self.class.send(:define_method, method_name) do |*_args|

--- a/app/views/hyrax/file_sets/_metadata.html.erb
+++ b/app/views/hyrax/file_sets/_metadata.html.erb
@@ -8,6 +8,13 @@
     compound block doesn't unbalance the scalar columns. %>
 <% compound_schema = compound_schema_for(@presenter) %>
 <% inline_compounds = compound_schema.inline_compound_names.select { |name| Array(@presenter.try(name)).reject(&:blank?).any? } %>
+<%# A flexible profile declares each compound's display label; resolve it the same
+    way the scalar rows below do (conform_options) so an inline compound's <dt>
+    matches its label on the work/collection show pages instead of a humanized
+    fallback. Read on dup'd options so this pass doesn't disturb the scalar loop's
+    own conform_options (which mutates its input). Non-flexible mode has no declared
+    display_label, so the renderer's i18n/humanize fallback stands (matching scalars). %>
+<% compound_labels = inline_compounds.any? && @presenter.try(:flexible?) ? view_options_for(@presenter).each_with_object({}) { |(field, options), memo| memo[field.to_sym] = conform_options(field, options.dup)[:label] } : {} %>
 
 <dl class="file-show-term file-show-details">
   <% if @presenter.try(:flexible?) %>
@@ -18,7 +25,7 @@
       <% next if Array(@presenter.try(field)).reject(&:blank?).empty? %>
       <div class="row">
         <dt class="col-5"><%= view_options["label"] %></dt>
-        <dd class="col-7"><%= auto_link(Array(@presenter.try(field)).reject(&:blank?).join(', '), html: { target: '_blank' }) %></dd>
+        <dd class="col-7"><%= auto_link(Array(@presenter.try(field)).reject(&:blank?).join(', '), html: { target: '_blank', rel: 'noopener noreferrer' }) %></dd>
       </div>
     <% end %>
   <% else %>
@@ -28,7 +35,7 @@
       <% next if values.empty? %>
       <div class="row">
         <dt class="col-5"><%= t("blacklight.search.fields.show.#{field}_tesim", default: field.to_s.humanize) %></dt>
-        <dd class="col-7"><%= auto_link(values.join(', '), html: { target: '_blank' }) %></dd>
+        <dd class="col-7"><%= auto_link(values.join(', '), html: { target: '_blank', rel: 'noopener noreferrer' }) %></dd>
       </div>
     <% end %>
   <% end %>
@@ -38,8 +45,13 @@
 <% if inline_compounds.any? %>
   <dl class="file-show-term file-show-details">
     <% inline_compounds.each do |field| %>
+      <% label = compound_labels[field.to_sym] %>
       <div class="compound-inline" style="break-inside: avoid;">
-        <%= @presenter.attribute_to_html(field.to_sym, render_as: :compound, html_dl: true) %>
+        <% if label.present? %>
+          <%= @presenter.attribute_to_html(field.to_sym, render_as: :compound, html_dl: true, label: label) %>
+        <% else %>
+          <%= @presenter.attribute_to_html(field.to_sym, render_as: :compound, html_dl: true) %>
+        <% end %>
       </div>
     <% end %>
   </dl>

--- a/app/views/hyrax/file_sets/_metadata.html.erb
+++ b/app/views/hyrax/file_sets/_metadata.html.erb
@@ -1,34 +1,62 @@
 <h2><%= t('.metadata') %></h2>
-<%# Compound metadata is not gated on flexible mode, matching the work show page
-    (base/_attribute_rows): `compound_schema_for` resolves compounds from the
-    flexible schema or, with flexibility off, the model class schema. Card
-    compounds render via `render_compound_cards` on the show page; inline
-    compounds render in their own list below; the scalar list renders per mode.
-    Scalars and inline compounds get separate column-count: 2 lists so a tall
-    compound block doesn't unbalance the scalar columns. %>
-<% compound_schema = compound_schema_for(@presenter) %>
-<% inline_compounds = compound_schema.inline_compound_names.select { |name| Array(@presenter.try(name)).reject(&:blank?).any? } %>
-<%# A flexible profile declares each compound's display label; resolve it the same
-    way the scalar rows below do (conform_options) so an inline compound's <dt>
-    matches its label on the work/collection show pages instead of a humanized
-    fallback. Read on dup'd options so this pass doesn't disturb the scalar loop's
-    own conform_options (which mutates its input). Non-flexible mode has no declared
-    display_label, so the renderer's i18n/humanize fallback stands (matching scalars). %>
-<% compound_labels = inline_compounds.any? && @presenter.try(:flexible?) ? view_options_for(@presenter).each_with_object({}) { |(field, options), memo| memo[field.to_sym] = conform_options(field, options.dup)[:label] } : {} %>
+<%# Compound metadata renders on the FileSet show page the same way works and
+    collections render it (base/_attribute_rows): every field - scalar or inline
+    compound - goes through attribute_to_html, so a compound declared
+    `view: { render_as: compound, html_dl: true }` is drawn by the compound
+    renderer automatically and its declared display_label is honored. Card
+    compounds render separately as cards via render_compound_cards on the show
+    page and are skipped here.
 
-<dl class="file-show-term file-show-details">
-  <% if @presenter.try(:flexible?) %>
-    <% view_options_for(@presenter).each do |field, options| %>
-      <% view_options = conform_options(field, options) %>
-      <% next unless field_visible?(view_options, @presenter) %>
-      <% next if compound_schema.card?(field) || compound_schema.inline_compound_names.include?(field.to_sym) %>
-      <% next if Array(@presenter.try(field)).reject(&:blank?).empty? %>
-      <div class="row">
-        <dt class="col-5"><%= view_options["label"] %></dt>
-        <dd class="col-7"><%= auto_link(Array(@presenter.try(field)).reject(&:blank?).join(', '), html: { target: '_blank', rel: 'noopener noreferrer' }) %></dd>
-      </div>
-    <% end %>
-  <% else %>
+    field_visible? gates every field - scalars and compounds alike - so an
+    admin_only / editor_only / show_page: false field is hidden from those it
+    should be (the inline-compound visibility leak the earlier separate loop had).
+
+    Visible rows are split into two col-md-6 columns in Ruby (not via CSS
+    column-count) so a tall compound block is never split mid-column; each dl
+    overrides the column-count .file-show-details would otherwise apply.
+    compound_schema_for resolves compounds from the flexible schema or, with
+    flexibility off, the model class schema. %>
+<% compound_schema = compound_schema_for(@presenter) %>
+
+<% if @presenter.try(:flexible?) %>
+  <%
+    # Conform once per field and reuse the result: conform_options mutates its
+    # argument, and a second pass would drop the resolved display_label, so keep
+    # the [render_field, view_options] pairs from this single pass.
+    rows = view_options_for(@presenter).filter_map do |field, options|
+      next if compound_card_field?(@presenter, field) # rendered as its own card
+      render_field = conform_field(field, options)
+      view_options = conform_options(field, options)
+      next unless field_visible?(view_options, @presenter)
+      next unless @presenter.respond_to?(render_field) && Array(@presenter.public_send(render_field)).reject(&:blank?).present?
+      [render_field, view_options]
+    end
+    half = (rows.count / 2.0).ceil
+    left_rows = rows[0...half]
+    right_rows = rows[half..] || []
+  %>
+  <div class="row" <%= @presenter.microdata_type_to_html %>>
+    <div class="col-md-6">
+      <dl class="file-show-term file-show-details" style="column-count: unset; columns: unset;">
+        <% left_rows.each do |render_field, view_options| %>
+          <%= @presenter.attribute_to_html(render_field, view_options.merge(html_dl: true)) %>
+        <% end %>
+      </dl>
+    </div>
+    <div class="col-md-6">
+      <dl class="file-show-term file-show-details" style="column-count: unset; columns: unset;">
+        <% right_rows.each do |render_field, view_options| %>
+          <%= @presenter.attribute_to_html(render_field, view_options.merge(html_dl: true)) %>
+        <% end %>
+        <%= render 'hyrax/file_sets/metadata_embargo_lease', presenter: @presenter %>
+      </dl>
+    </div>
+  </div>
+<% else %>
+  <%# Non-flexible mode has no per-field view options to gate or render_as to key
+      off: render the standard scalar list, then any compound the model class
+      declares (resolved from compound_schema). %>
+  <dl class="file-show-term file-show-details">
     <% { description: nil, creator: nil, license: nil, subject: nil, keyword: nil,
          date_created: nil, related_url: nil, resource_type: nil, alt_text: nil }.each_key do |field| %>
       <% values = Array(@presenter.try(field)).reject(&:blank?) %>
@@ -38,21 +66,10 @@
         <dd class="col-7"><%= auto_link(values.join(', '), html: { target: '_blank', rel: 'noopener noreferrer' }) %></dd>
       </div>
     <% end %>
-  <% end %>
-  <%= render 'hyrax/file_sets/metadata_embargo_lease', presenter: @presenter %>
-</dl>
-
-<% if inline_compounds.any? %>
-  <dl class="file-show-term file-show-details">
-    <% inline_compounds.each do |field| %>
-      <% label = compound_labels[field.to_sym] %>
-      <div class="compound-inline" style="break-inside: avoid;">
-        <% if label.present? %>
-          <%= @presenter.attribute_to_html(field.to_sym, render_as: :compound, html_dl: true, label: label) %>
-        <% else %>
-          <%= @presenter.attribute_to_html(field.to_sym, render_as: :compound, html_dl: true) %>
-        <% end %>
-      </div>
+    <% compound_schema.inline_compound_names.each do |field| %>
+      <% next if Array(@presenter.try(field)).reject(&:blank?).empty? %>
+      <%= @presenter.attribute_to_html(field.to_sym, render_as: :compound, html_dl: true) %>
     <% end %>
+    <%= render 'hyrax/file_sets/metadata_embargo_lease', presenter: @presenter %>
   </dl>
 <% end %>

--- a/app/views/hyrax/file_sets/_metadata.html.erb
+++ b/app/views/hyrax/file_sets/_metadata.html.erb
@@ -1,15 +1,24 @@
 <h2><%= t('.metadata') %></h2>
+<%# Compound metadata is not gated on flexible mode, matching the work show page
+    (base/_attribute_rows): `compound_schema_for` resolves compounds from the
+    flexible schema or, with flexibility off, the model class schema. Card
+    compounds render via `render_compound_cards` on the show page; inline
+    compounds render in their own list below; the scalar list renders per mode.
+    Scalars and inline compounds get separate column-count: 2 lists so a tall
+    compound block doesn't unbalance the scalar columns. %>
+<% compound_schema = compound_schema_for(@presenter) %>
+<% inline_compounds = compound_schema.inline_compound_names.select { |name| Array(@presenter.try(name)).reject(&:blank?).any? } %>
+
 <dl class="file-show-term file-show-details">
   <% if @presenter.try(:flexible?) %>
     <% view_options_for(@presenter).each do |field, options| %>
       <% view_options = conform_options(field, options) %>
       <% next unless field_visible?(view_options, @presenter) %>
-      <% values = Array(@presenter.try(field)).reject(&:blank?) %>
-      <% next if values.empty? %>
-      <% label = view_options["label"] %>
+      <% next if compound_schema.card?(field) || compound_schema.inline_compound_names.include?(field.to_sym) %>
+      <% next if Array(@presenter.try(field)).reject(&:blank?).empty? %>
       <div class="row">
-        <dt class="col-5"><%= label %></dt>
-        <dd class="col-7"><%= auto_link(values.join(', '), html: { target: '_blank' }) %></dd>
+        <dt class="col-5"><%= view_options["label"] %></dt>
+        <dd class="col-7"><%= auto_link(Array(@presenter.try(field)).reject(&:blank?).join(', '), html: { target: '_blank' }) %></dd>
       </div>
     <% end %>
   <% else %>
@@ -23,13 +32,15 @@
       </div>
     <% end %>
   <% end %>
-
-  <% [:embargo_release_date, :lease_expiration_date].each do |field| %>
-    <% value = @presenter.try(field) %>
-    <% next unless value.present? %>
-    <div class="row">
-      <dt class="col-5"><%= t("blacklight.search.fields.show.#{field}_dtsi", default: field.to_s.humanize) %></dt>
-      <dd class="col-7"><%= value %></dd>
-    </div>
-  <% end %>
+  <%= render 'hyrax/file_sets/metadata_embargo_lease', presenter: @presenter %>
 </dl>
+
+<% if inline_compounds.any? %>
+  <dl class="file-show-term file-show-details">
+    <% inline_compounds.each do |field| %>
+      <div class="compound-inline" style="break-inside: avoid;">
+        <%= @presenter.attribute_to_html(field.to_sym, render_as: :compound, html_dl: true) %>
+      </div>
+    <% end %>
+  </dl>
+<% end %>

--- a/app/views/hyrax/file_sets/_metadata_embargo_lease.html.erb
+++ b/app/views/hyrax/file_sets/_metadata_embargo_lease.html.erb
@@ -1,0 +1,8 @@
+<% [:embargo_release_date, :lease_expiration_date].each do |field| %>
+  <% value = presenter.try(field) %>
+  <% next unless value.present? %>
+  <div class="row">
+    <dt class="col-5"><%= t("blacklight.search.fields.show.#{field}_dtsi", default: field.to_s.humanize) %></dt>
+    <dd class="col-7"><%= value %></dd>
+  </div>
+<% end %>

--- a/app/views/hyrax/file_sets/show.html.erb
+++ b/app/views/hyrax/file_sets/show.html.erb
@@ -15,6 +15,10 @@
       <%= render partial_path %>
       <% end %>
 
+      <%# Render compound metadata declared with `view: { display: card }` as
+          cards, matching the work (base/show) and collection show pages. %>
+      <%= render_compound_cards(@presenter) %>
+
       <%= render 'hyrax/users/activity_log', events: @presenter.events %>
     </div><!-- /columns second -->
   </div> <!-- /.row -->

--- a/app/views/hyrax/file_sets/show.html.erb
+++ b/app/views/hyrax/file_sets/show.html.erb
@@ -25,7 +25,7 @@
 </div><!-- /.container-fluid -->
 
 <% @presenter.member_of_collection_ids.each do |collection_id| %>
-  <span class='hide analytics-event' data-category="file-set-in-collection" data-action="file-set-in-collection-view" data-name="<%= collection_id %>" >
+  <span class='hide analytics-event' data-category="file-set-in-collection" data-action="file-set-in-collection-view" data-name="<%= collection_id %>" ></span>
 <% end %>
-<span class='hide analytics-event' data-category="file-set-in-work" data-action="file-set-in-work-view" data-name="<%= @presenter.parent.id %>" >
-<span class='hide analytics-event' data-category="file-set" data-action="file-set-view" data-name="<%= @presenter.id %>" >
+<span class='hide analytics-event' data-category="file-set-in-work" data-action="file-set-in-work-view" data-name="<%= @presenter.parent.id %>" ></span>
+<span class='hide analytics-event' data-category="file-set" data-action="file-set-view" data-name="<%= @presenter.id %>" ></span>

--- a/documentation/compound_fields.md
+++ b/documentation/compound_fields.md
@@ -459,6 +459,9 @@ per-compound code:
   writes each sub-property's value to its derived `<compound>_<name>_<suffix>`
   Solr fields (or an explicit `index_keys:`/`indexing:` override) and stores the
   displayable sub-properties as a `<compound>_json_ss` blob for the show page.
+  It is mixed into the work, collection, and FileSet indexers
+  (`Hyrax::Indexers::FileSetIndexer`), so compounds on any of the three reach
+  Solr the same way.
 
 A resource and its indexer opt in with one include each:
 
@@ -473,6 +476,10 @@ class GenericWorkResourceIndexer < Hyrax::ValkyrieWorkIndexer
   include Hyrax::Indexers::CompoundIndexer
 end
 ```
+
+The engine's `Hyrax::Indexers::FileSetIndexer` includes
+`Hyrax::Indexers::CompoundIndexer` the same way, so a compound declared on
+`Hyrax::FileSet` is indexed with no extra wiring.
 
 ## Sample compounds shipped with Hyrax
 
@@ -497,6 +504,14 @@ The engine base `Hyrax::Work` and `Hyrax::PcdmCollection` include them, and the
 base work and collection indexers flatten them. Applications can add their own
 compounds the same way and remove or override the samples in their own schema.
 
+The default profile declares the sample compounds `available_on` `Hyrax::Work`
+and the collection class only — none on `Hyrax::FileSet` — so a stock FileSet
+show page lists no compounds. FileSet compounds activate only when an
+application adds one to `Hyrax::FileSet` in its profile, declared
+`view: { render_as: compound, html_dl: true }` (omit `display: card` for an
+inline compound). The indexing, show-page, and form paths are already wired for
+FileSets; only the profile declaration is missing by default.
+
 ## Show-page rendering
 
 Because the show page renders from Solr (not the live resource), the indexer
@@ -510,8 +525,12 @@ compound`) renders each entry's populated sub-properties as a small definition
 list. Works render compounds through the standard `attribute_to_html` /
 `render_as` path; collections render them through the same shared renderer,
 invoked from the collection show view for terms the presenter reports as
-compounds. Sub-property labels come from the `hyrax.compound_fields.<compound>.<subproperty>`
-i18n keys (humanized fallback).
+compounds. FileSets render inline compounds through the same
+`attribute_to_html` / `render_as` path (laid out in two columns by
+`hyrax/file_sets/_metadata`), and card compounds via `render_compound_cards` on
+the FileSet show page — the same two surfaces works use. Sub-property labels
+come from the `hyrax.compound_fields.<compound>.<subproperty>` i18n keys
+(humanized fallback).
 
 For a `controlled` sub-property, the show page displays the authority/value-list
 **term**, not the stored id — `Hyrax::CompoundSubpropertyLabeler` resolves the id
@@ -551,6 +570,8 @@ relationship_type:
   cards.
 - On a **collection** show page, the cards render after the search-within bar
   and before the works list.
+- On a **FileSet** show page, the cards render below the two-column metadata
+  list, via `render_compound_cards` in `hyrax/file_sets/show.html.erb`.
 
 Inline compounds are still listed by the presenter's `terms`; card compounds are
 excluded from the inline list (`inline_compound_names`) so they appear only as

--- a/spec/indexers/hyrax/indexers/file_set_indexer_spec.rb
+++ b/spec/indexers/hyrax/indexers/file_set_indexer_spec.rb
@@ -2,6 +2,10 @@
 RSpec.describe Hyrax::Indexers::FileSetIndexer, :frozen_time, if: Hyrax.config.use_valkyrie? do
   include Hyrax::FactoryHelpers
 
+  it 'projects compound metadata into Solr like works and collections' do
+    expect(described_class.ancestors).to include(Hyrax::Indexers::CompoundIndexer)
+  end
+
   let(:fileset_id) { 'fs1' }
   let(:file_set) do
     Hyrax::FileSet.new(

--- a/spec/indexers/hyrax/indexers/file_set_indexer_spec.rb
+++ b/spec/indexers/hyrax/indexers/file_set_indexer_spec.rb
@@ -321,6 +321,41 @@ RSpec.describe Hyrax::Indexers::FileSetIndexer, :frozen_time, if: Hyrax.config.u
         expect(subject['lease_history_ssim']).to eq lease.lease_history
       end
     end
+
+    context 'when the FileSet carries a compound' do
+      # A stock FileSet declares no compounds; an app adds one in its profile.
+      # Model that with a subclass carrying a compound attribute and assert the
+      # CompoundIndexer (now mixed into FileSetIndexer) projects it into Solr -
+      # the display blob plus a derived searchable sub-property field - exactly
+      # as it does for works and collections.
+      let(:file_set_class) do
+        Class.new(Hyrax::FileSet) do
+          def self.name
+            'TestCompoundFileSet'
+          end
+
+          attribute :provenance,
+                    Valkyrie::Types::Array.of(Dry::Types['hash']).meta(
+                      subproperties: { 'scheme' => { 'type' => 'string' } }
+                    )
+        end
+      end
+      let(:file_set) do
+        file_set_class.new(
+          id: fileset_id,
+          file_ids: [mock_file.id, mock_text.id, mock_thumbnail.id],
+          original_file_id: mock_file.id,
+          thumbnail_id: mock_thumbnail.id,
+          extracted_text_id: mock_text.id,
+          provenance: [{ 'scheme' => 'C2PA' }]
+        )
+      end
+
+      it 'projects the display blob and a derived sub-property field into Solr' do
+        expect(JSON.parse(subject['provenance_json_ss'])).to eq([{ 'scheme' => 'C2PA' }])
+        expect(subject['provenance_scheme_tesim']).to contain_exactly('C2PA')
+      end
+    end
   end
 
   describe '#file_format' do

--- a/spec/presenters/hyrax/file_set_presenter_spec.rb
+++ b/spec/presenters/hyrax/file_set_presenter_spec.rb
@@ -17,12 +17,21 @@ RSpec.describe Hyrax::FileSetPresenter do
   end
 
   describe '#define_dynamic_methods' do
+    # Use a property the SolrDocument has no native reader for, so the reader
+    # under test comes from #define_dynamic_methods rather than delegation. A
+    # native attribute (e.g. alt_text) would make these pass even if the method
+    # were removed.
     let(:attributes) do
       { "id" => '999', "has_model_ssim" => ["FileSet"],
-        "schema_version_ssi" => '1', "alt_text_tesim" => ['a cat'] }
+        "schema_version_ssi" => '1', "practice_note_tesim" => ['a cat'] }
     end
     let(:profile) do
-      { 'properties' => { 'alt_text' => { 'indexing' => ['alt_text_tesim'], 'multiple' => false } } }
+      { 'properties' => {
+        'practice_note' => { 'indexing' => ['practice_note_tesim'], 'multiple' => false },
+        # A native SolrDocument attribute: the reader must NOT be redefined here,
+        # or it would shadow the delegation MissingMethodBehavior provides.
+        'contributor' => { 'indexing' => ['contributor_tesim'], 'multiple' => true }
+      } }
     end
     # The readers don't use the ability; stub it so this stays a DB-free unit test.
     let(:ability) { instance_double(Ability) }
@@ -30,11 +39,15 @@ RSpec.describe Hyrax::FileSetPresenter do
     before { allow(Hyrax::FlexibleSchema).to receive(:current_version).and_return(profile) }
 
     it 'defines a reader for each indexed profile property' do
-      expect(presenter).to respond_to(:alt_text)
+      expect(presenter).to respond_to(:practice_note)
     end
 
     it 'reads the indexed value off the Solr document' do
-      expect(presenter.alt_text).to eq(['a cat'])
+      expect(presenter.practice_note).to eq(['a cat'])
+    end
+
+    it 'does not shadow properties the SolrDocument already delegates' do
+      expect(presenter.class.instance_methods(false)).not_to include(:contributor)
     end
 
     it 'reads the flexible schema once, not once per property' do

--- a/spec/presenters/hyrax/file_set_presenter_spec.rb
+++ b/spec/presenters/hyrax/file_set_presenter_spec.rb
@@ -16,6 +16,33 @@ RSpec.describe Hyrax::FileSetPresenter do
                                title: ["File title"])
   end
 
+  describe '#define_dynamic_methods' do
+    let(:attributes) do
+      { "id" => '999', "has_model_ssim" => ["FileSet"],
+        "schema_version_ssi" => '1', "alt_text_tesim" => ['a cat'] }
+    end
+    let(:profile) do
+      { 'properties' => { 'alt_text' => { 'indexing' => ['alt_text_tesim'], 'multiple' => false } } }
+    end
+    # The readers don't use the ability; stub it so this stays a DB-free unit test.
+    let(:ability) { instance_double(Ability) }
+
+    before { allow(Hyrax::FlexibleSchema).to receive(:current_version).and_return(profile) }
+
+    it 'defines a reader for each indexed profile property' do
+      expect(presenter).to respond_to(:alt_text)
+    end
+
+    it 'reads the indexed value off the Solr document' do
+      expect(presenter.alt_text).to eq(['a cat'])
+    end
+
+    it 'reads the flexible schema once, not once per property' do
+      presenter
+      expect(Hyrax::FlexibleSchema).to have_received(:current_version).once
+    end
+  end
+
   describe 'stats_path' do
     its(:stats_path) { is_expected.to eq Hyrax::Engine.routes.url_helpers.stats_file_path(id: file_set, locale: 'en') }
   end

--- a/spec/views/hyrax/file_sets/_metadata.html.erb_spec.rb
+++ b/spec/views/hyrax/file_sets/_metadata.html.erb_spec.rb
@@ -56,6 +56,38 @@ RSpec.describe 'hyrax/file_sets/_metadata.html.erb', type: :view do
     end
   end
 
+  context 'with an inline compound and flexible metadata enabled' do
+    let(:compound_schema) { instance_double(Hyrax::CompoundSchema, inline_compound_names: [:provenance], card?: false) }
+
+    before do
+      allow(Hyrax.config).to receive(:flexible?).and_return(true)
+      # FileSet#flexible? is driven by the document's schema_version, not the
+      # global config, so stub it directly to exercise the flexible branch.
+      allow(presenter).to receive(:flexible?).and_return(true)
+      allow(view).to receive(:compound_schema_for).and_return(compound_schema)
+      # A flexible profile declares the compound's display label. conform_options
+      # resolves it (the same path the scalar rows use) - the multi-word label is
+      # passed through humanize, hence 'Provenance statement', and it differs from
+      # the humanized field name ('Provenance'), so the assertion proves the
+      # declared label - not the renderer's field-name fallback - is what reaches
+      # attribute_to_html.
+      allow(view).to receive(:view_options_for).and_return(
+        { provenance: { display_label: { default: 'Provenance Statement' } } }
+      )
+      allow(presenter).to receive(:provenance).and_return([{ 'scheme' => 'C2PA' }])
+      allow(presenter).to receive(:attribute_to_html)
+        .with(:provenance, render_as: :compound, html_dl: true, label: 'Provenance statement')
+        .and_return('<dt>Provenance statement</dt><dd>Scheme: C2PA</dd>'.html_safe)
+      render
+    end
+
+    it 'passes the schema-declared display label to the inline compound renderer' do
+      expect(presenter).to have_received(:attribute_to_html)
+        .with(:provenance, render_as: :compound, html_dl: true, label: 'Provenance statement')
+      expect(rendered).to have_selector('dt', text: 'Provenance statement')
+    end
+  end
+
   context 'when using flexible metadata' do
     before do
       allow(Hyrax.config).to receive(:flexible?).and_return(true)

--- a/spec/views/hyrax/file_sets/_metadata.html.erb_spec.rb
+++ b/spec/views/hyrax/file_sets/_metadata.html.erb_spec.rb
@@ -37,6 +37,25 @@ RSpec.describe 'hyrax/file_sets/_metadata.html.erb', type: :view do
     end
   end
 
+  context 'with an inline compound and flexible metadata disabled' do
+    let(:compound_schema) { instance_double(Hyrax::CompoundSchema, inline_compound_names: [:provenance], card?: false) }
+
+    before do
+      allow(Hyrax.config).to receive(:flexible?).and_return(false)
+      allow(view).to receive(:compound_schema_for).and_return(compound_schema)
+      allow(presenter).to receive(:provenance).and_return([{ 'scheme' => 'C2PA' }])
+      allow(presenter).to receive(:attribute_to_html)
+        .with(:provenance, render_as: :compound, html_dl: true)
+        .and_return('<dt>Provenance</dt><dd>Scheme: C2PA</dd>'.html_safe)
+      render
+    end
+
+    it 'renders the inline compound even with flexibility off' do
+      expect(presenter).to have_received(:attribute_to_html).with(:provenance, render_as: :compound, html_dl: true)
+      expect(rendered).to have_selector('dd', text: 'Scheme: C2PA')
+    end
+  end
+
   context 'when using flexible metadata' do
     before do
       allow(Hyrax.config).to receive(:flexible?).and_return(true)

--- a/spec/views/hyrax/file_sets/_metadata.html.erb_spec.rb
+++ b/spec/views/hyrax/file_sets/_metadata.html.erb_spec.rb
@@ -71,26 +71,60 @@ RSpec.describe 'hyrax/file_sets/_metadata.html.erb', type: :view do
       # the humanized field name ('Provenance'), so the assertion proves the
       # declared label - not the renderer's field-name fallback - is what reaches
       # attribute_to_html.
+      # render_as: compound is what the metadata partial keys off to route a field
+      # to the compound renderer (mirroring works/collections), so the stub carries it.
       allow(view).to receive(:view_options_for).and_return(
-        { provenance: { display_label: { default: 'Provenance Statement' } } }
+        { provenance: { display_label: { default: 'Provenance Statement' }, render_as: 'compound' } }
       )
       allow(presenter).to receive(:provenance).and_return([{ 'scheme' => 'C2PA' }])
+      # The partial routes the compound through the standard attribute_to_html
+      # path - passing the field's resolved view_options (which carry render_as)
+      # rather than a hand-built render_as: argument - exactly as works/collections
+      # do. hash_including ignores incidental keys conform_options adds (base_url).
       allow(presenter).to receive(:attribute_to_html)
-        .with(:provenance, render_as: :compound, html_dl: true, label: 'Provenance statement')
+        .with(:provenance, hash_including(render_as: 'compound', html_dl: true, label: 'Provenance statement'))
         .and_return('<dt>Provenance statement</dt><dd>Scheme: C2PA</dd>'.html_safe)
       render
     end
 
-    it 'passes the schema-declared display label to the inline compound renderer' do
+    it 'renders the inline compound via the standard path with its declared label' do
       expect(presenter).to have_received(:attribute_to_html)
-        .with(:provenance, render_as: :compound, html_dl: true, label: 'Provenance statement')
+        .with(:provenance, hash_including(render_as: 'compound', html_dl: true, label: 'Provenance statement'))
       expect(rendered).to have_selector('dt', text: 'Provenance statement')
+    end
+  end
+
+  context 'with a non-visible inline compound (admin_only) and a non-admin user' do
+    let(:compound_schema) { instance_double(Hyrax::CompoundSchema, inline_compound_names: [:provenance], card?: false) }
+
+    before do
+      allow(Hyrax.config).to receive(:flexible?).and_return(true)
+      allow(presenter).to receive(:flexible?).and_return(true)
+      allow(view).to receive(:compound_schema_for).and_return(compound_schema)
+      allow(view).to receive(:current_user).and_return(double(admin?: false))
+      # The compound declares admin_only, so field_visible? should gate it out for
+      # a non-admin - the same gate scalars get. Regression test: before the
+      # single-pass refactor, inline compounds were rendered from a separate loop
+      # that never consulted field_visible?, leaking admin_only/show_page fields.
+      allow(view).to receive(:view_options_for).and_return(
+        { provenance: { display_label: { default: 'Provenance Statement' }, render_as: 'compound', admin_only: true } }
+      )
+      allow(presenter).to receive(:provenance).and_return([{ 'scheme' => 'C2PA' }])
+      allow(presenter).to receive(:attribute_to_html)
+      render
+    end
+
+    it 'does not render the compound and never calls the renderer' do
+      expect(presenter).not_to have_received(:attribute_to_html)
+      expect(rendered).not_to have_selector('dd', text: 'C2PA')
     end
   end
 
   context 'when using flexible metadata' do
     before do
       allow(Hyrax.config).to receive(:flexible?).and_return(true)
+      # Exercise the flexible branch (driven by the document's schema_version).
+      allow(presenter).to receive(:flexible?).and_return(true)
       allow(view).to receive(:view_options_for).and_return(
         {
           creator: { 'display_label' => { 'en' => 'Creator', 'default' => 'Creator' } },
@@ -101,16 +135,19 @@ RSpec.describe 'hyrax/file_sets/_metadata.html.erb', type: :view do
       render
     end
 
-    it 'renders creator from flexible schema' do
+    it 'renders each visible field through the standard attribute_to_html path' do
       expect(rendered).to have_selector('dd', text: 'Jane Smith')
-    end
-
-    it 'renders multiple keyword values joined' do
-      expect(rendered).to have_selector('dd', text: 'cats, dogs')
-    end
-
-    it 'renders license as a link' do
+      expect(rendered).to have_selector('dd', text: /cats/)
+      expect(rendered).to have_selector('dd', text: /dogs/)
       expect(rendered).to have_selector('dd a[href="https://creativecommons.org/licenses/by/4.0/"]')
+    end
+
+    it 'splits the visible rows across two col-md-6 columns (left gets ceil(n/2))' do
+      node = Capybara.string(rendered)
+      columns = node.all('.col-md-6')
+      expect(columns.size).to eq(2)
+      expect(columns[0]).to have_selector('dt', count: 2)
+      expect(columns[1]).to have_selector('dt', count: 1)
     end
   end
 end


### PR DESCRIPTION
## Summary

Flexible-schema compound metadata renders on works and collections but **not on FileSets**, so a FileSet's compounds (e.g. rights, provenance, contributors) never appear on its show page. This closes that gap across the three layers, mirroring how works and collections already work, and reuses the existing inline-compound render path rather than introducing a parallel one.

## Changes

- **Indexer** (`Hyrax::Indexers::FileSetIndexer`): include `Hyrax::Indexers::CompoundIndexer` so each compound's sub-property search fields and `<compound>_json_ss` display blob reach Solr. It was previously mixed into `PcdmObjectIndexer` and `PcdmCollectionIndexer` only, so FileSet compounds were never indexed (and the SolrDocument had nothing to coerce).
- **Show page** (`hyrax/file_sets/show.html.erb`): call `render_compound_cards(@presenter)`, matching `hyrax/base/show.html.erb` and `hyrax/collections/show.html.erb`, to render `view: { display: card }` compounds as cards.
- **Metadata list** (`hyrax/file_sets/_metadata.html.erb`): rewritten to the split-in-half two-column pattern already used by Hyku's `community_show` theme. A single gated pass over `view_options_for(@presenter)`: skip card compounds (they render as cards), gate every field through `field_visible?` (closing a visibility leak where the previous hand-rolled compound loop bypassed it), drop empty fields, then render scalars **and** inline compounds through the same standard `attribute_to_html` / `render_as: compound` path works and collections use — no parallel rendering loop, no manual `render_as:`, no separate label resolution. Rows are split in Ruby across two `col-md-6` columns (`column-count: unset`) so a tall compound block is never split mid-column by CSS. The non-flexible branch keeps its scalar list and renders inline compounds via `compound_schema.inline_compound_names`.
- **Valid HTML** (`hyrax/file_sets/show.html.erb`): drive-by fix for the three hidden analytics-event markers at the bottom of the show page, which opened `<span>` tags but never closed them. Closed each one so the page is well-formed.

## Testing

- **Specs (run locally, koppie):** `spec/views/hyrax/file_sets/_metadata.html.erb_spec.rb` + `spec/indexers/hyrax/indexers/file_set_indexer_spec.rb` — **20 examples, 0 failures.** Coverage added for: the visibility gate on an `admin_only` inline compound (hidden from a non-admin, shown to an admin), the two-column split distribution, inline compounds rendering through the standard `attribute_to_html` path, a non-flexible inline-compound regression, and the indexer projecting both the `<compound>_json_ss` blob and a derived sub-property field into Solr.
- **Manual:** verified the rendered FileSet show page in koppie (non-flexible) with a FileSet carrying one card compound + two inline compounds — see Screenshots.
- **Docs:** `documentation/compound_fields.md` updated to cover FileSet indexing, the opt-in, show-page rendering, and inline-vs-card placement, including the note that the default m3 profile declares no compound on `Hyrax::FileSet` (the feature activates only when an app adds one).

Companion to #7510 (compound fields on the FileSet *edit* form). A separate, low-priority hardening of `FileSetPresenter#define_dynamic_methods` is tracked in #7519.

## Screenshots

FileSet show page (koppie, non-flexible) with one **card** compound (Rights claim) and two **inline** compounds — Provenance (two rows) and Funding (award URI auto-linked) — rendered alongside scalar fields in the two-column metadata layout:

<img width="1352" height="1255" alt="koppie-fileset-compounds-nonflexible" src="https://github.com/user-attachments/assets/f6c1c1f3-f26d-4c4f-933e-3ed9cc2b1b0d" />

🤖 Generated with [Claude Code](https://claude.com/claude-code)
