### PR TITLE
Revert #7508 to diagnose main CI failures (OOM)

### DIFF
--- a/app/controllers/hyrax/permissions_controller.rb
+++ b/app/controllers/hyrax/permissions_controller.rb
@@ -1,8 +1,7 @@
 # frozen_string_literal: true
 module Hyrax
   class PermissionsController < ApplicationController
-    resource_klass = Hyrax.config.use_valkyrie? ? Hyrax::Resource : ActiveFedora::Base
-    load_resource class: resource_klass, instance_name: :curation_concern
+    load_resource class: Hyrax::Resource, instance_name: :curation_concern
 
     attr_reader :curation_concern
     helper_method :curation_concern


### PR DESCRIPTION
**Diagnostic revert** of #7508 (`ca85349`) to check whether it's behind the current CI failures on `main`.

`main` has been red since #7508 and #7512 landed — last green run was `5b5a470` (Jun 24); current HEAD `1f130133b` is failing. The failures are an **OOM/crash, not assertions**: every shard exits `137`, the Postgres logs show `unexpected EOF on client connection`, and the `spec-reports-*` artifacts are ~152 bytes (empty), i.e. rspec is killed before writing any results.

This PR isolates #7508 (a 2-line change to `Hyrax::PermissionsController`) by reverting it on top of current `main`:
- if CI here is **green**, #7508 is implicated and we can dig into why;
- if it's **still red**, #7508 is exonerated and the cause is elsewhere (#7512, or CI/runner memory pressure).

Not meant to merge as-is — purely to get a clean signal. If it goes green, worth a re-run to rule out flaky OOM. cc @bwatson78 @dlpierce

_Surfaced while #7513's CI went red purely from the Update-branch merge pulling in current `main`._
