### PR TITLE
Attempt to get CI working

### DIFF
--- a/.github/workflows/lint-build-test.yml
+++ b/.github/workflows/lint-build-test.yml
@@ -133,9 +133,16 @@ jobs:
         # rather than every service in the compose file, reducing CI memory use.
         # Let the container's default entrypoint run in the webapp dir (it does
         # db:prepare/migrate), then cd into the engine for the specs.
+        #
+        # GIT_CONFIG_* marks every repo path as a git safe.directory before the
+        # entrypoint runs. The checkout is owned by a different uid than the
+        # container user, so without this git aborts (dubious ownership) while
+        # the entrypoint and bundler touch the engine and git-sourced gems.
         run: >-
-          docker compose -f docker-compose-${{ matrix.ci_test_app }}.yml run -T --quiet-pull --pull missing web sh -c
-          "git config --global --add safe.directory /app/samvera/hyrax-engine && cd ../hyrax-engine && bundle install && yarn install && rspec_booster --job ${{ matrix.ci_node_index }}/${{ matrix.ci_node_total }}"
+          docker compose -f docker-compose-${{ matrix.ci_test_app }}.yml run -T --quiet-pull --pull missing
+          -e GIT_CONFIG_COUNT=1 -e GIT_CONFIG_KEY_0=safe.directory -e GIT_CONFIG_VALUE_0='*'
+          web sh -c
+          "cd ../hyrax-engine && bundle install && yarn install && rspec_booster --job ${{ matrix.ci_node_index }}/${{ matrix.ci_node_total }}"
       - name: Move Test Files
         if: always()
         env:

--- a/.github/workflows/lint-build-test.yml
+++ b/.github/workflows/lint-build-test.yml
@@ -120,23 +120,22 @@ jobs:
         with:
           name: hyrax-dev
           path: ${{runner.temp}}
-      - name: Start containers
+      - name: Load hyrax image
         run: |
           docker load --input ${{runner.temp}}/hyrax-dev-${{ github.sha }}.tar
           docker image ls -a
-          docker compose -f docker-compose-${{ matrix.ci_test_app }}.yml up -d --quiet-pull --pull missing --no-build
       - name: RSpec
         env:
           CI_NODE_TOTAL: ${{ matrix.ci_node_total }}
           CI_NODE_INDEX: ${{ matrix.ci_node_index }}
+        # Use `run` instead of `up`: this starts only the web service and the
+        # services it depends_on (web's depends_on excludes the sidekiq worker),
+        # rather than every service in the compose file, reducing CI memory use.
+        # Let the container's default entrypoint run in the webapp dir (it does
+        # db:prepare/migrate), then cd into the engine for the specs.
         run: >-
-          docker compose -f docker-compose-${{ matrix.ci_test_app }}.yml exec -T -w /app/samvera/hyrax-engine web sh -c
-          "git config --global --add safe.directory /app/samvera/hyrax-engine && bundle install && yarn install && rspec_booster --job ${{ matrix.ci_node_index }}/${{ matrix.ci_node_total }}"
-      - name: Capture Container Logs
-        if: always()
-        uses: jwalton/gh-docker-logs@v2
-        with:
-          images: 'selenium/standalone-chromium,postgres,fcrepo/fcrepo,solr,bitnami/redis,ghcr.io/samvera/fitsservlet,ghcr.io/samvera/fcrepo4'
+          docker compose -f docker-compose-${{ matrix.ci_test_app }}.yml run -T --quiet-pull --pull missing web sh -c
+          "git config --global --add safe.directory /app/samvera/hyrax-engine && cd ../hyrax-engine && bundle install && yarn install && rspec_booster --job ${{ matrix.ci_node_index }}/${{ matrix.ci_node_total }}"
       - name: Move Test Files
         if: always()
         env:

--- a/.github/workflows/lint-build-test.yml
+++ b/.github/workflows/lint-build-test.yml
@@ -131,17 +131,21 @@ jobs:
         # Use `run` instead of `up`: this starts only the web service and the
         # services it depends_on (web's depends_on excludes the sidekiq worker),
         # rather than every service in the compose file, reducing CI memory use.
-        # Let the container's default entrypoint run in the webapp dir (it does
-        # db:prepare/migrate), then cd into the engine for the specs.
         #
-        # GIT_CONFIG_* marks every repo path as a git safe.directory before the
-        # entrypoint runs. The checkout is owned by a different uid than the
-        # container user, so without this git aborts (dubious ownership) while
-        # the entrypoint and bundler touch the engine and git-sourced gems.
+        # --entrypoint sh skips the image's dev entrypoint (db:prepare/migrate/seed
+        # + service waits). The specs don't need it: spec_helper.rb creates and
+        # migrates its own test database. Skipping it also avoids running db:seed,
+        # which isn't needed for specs.
+        #
+        # GIT_CONFIG_* marks every repo path as a git safe.directory. The checkout
+        # is owned by a different uid than the container user, so without this git
+        # aborts (dubious ownership) while bundler touches the engine and
+        # git-sourced gems.
         run: >-
           docker compose -f docker-compose-${{ matrix.ci_test_app }}.yml run -T --quiet-pull --pull missing
+          --entrypoint sh
           -e GIT_CONFIG_COUNT=1 -e GIT_CONFIG_KEY_0=safe.directory -e GIT_CONFIG_VALUE_0='*'
-          web sh -c
+          web -c
           "cd ../hyrax-engine && bundle install && yarn install && rspec_booster --job ${{ matrix.ci_node_index }}/${{ matrix.ci_node_total }}"
       - name: Move Test Files
         if: always()

--- a/.github/workflows/lint-build-test.yml
+++ b/.github/workflows/lint-build-test.yml
@@ -141,9 +141,14 @@ jobs:
         # is owned by a different uid than the container user, so without this git
         # aborts (dubious ownership) while bundler touches the engine and
         # git-sourced gems.
+        #
+        # --use-aliases gives the run container the web service's network aliases,
+        # so the remote browser can reach the karma server at http://web:9876
+        # (the jasmine spec). Without it `run` omits the alias and the browser
+        # fails with net::ERR_NAME_NOT_RESOLVED.
         run: >-
           docker compose -f docker-compose-${{ matrix.ci_test_app }}.yml run -T --quiet-pull --pull missing
-          --entrypoint sh
+          --use-aliases --entrypoint sh
           -e GIT_CONFIG_COUNT=1 -e GIT_CONFIG_KEY_0=safe.directory -e GIT_CONFIG_VALUE_0='*'
           web -c
           "cd ../hyrax-engine && bundle install && yarn install && rspec_booster --job ${{ matrix.ci_node_index }}/${{ matrix.ci_node_total }}"

--- a/.github/workflows/lint-build-test.yml
+++ b/.github/workflows/lint-build-test.yml
@@ -131,7 +131,7 @@ jobs:
           CI_NODE_INDEX: ${{ matrix.ci_node_index }}
         run: >-
           docker compose -f docker-compose-${{ matrix.ci_test_app }}.yml exec -T -w /app/samvera/hyrax-engine web sh -c
-          "bundle install && yarn install && rspec_booster --job ${{ matrix.ci_node_index }}/${{ matrix.ci_node_total }}"
+          "git config --global --add safe.directory /app/samvera/hyrax-engine && bundle install && yarn install && rspec_booster --job ${{ matrix.ci_node_index }}/${{ matrix.ci_node_total }}"
       - name: Capture Container Logs
         if: always()
         uses: jwalton/gh-docker-logs@v2

--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,13 @@
 source 'https://rubygems.org'
 
 # Please see hyrax.gemspec for dependency information.
+
+# Pin erb to the 4.x line: sprockets 3.7.2 (the asset pipeline used by the
+# test apps) calls the legacy positional ERB.new(data, trim_mode, eoutvar)
+# API, which erb 6.x removed — under erb 6.x every asset/template render
+# raises "wrong number of arguments (given 3, expected 1)".
+gem 'erb', '~> 4.0'
+
 # Install gems from test app
 if ENV['RAILS_ROOT']
   test_app_gemfile_path = File.expand_path('Gemfile', ENV['RAILS_ROOT'])

--- a/docker-compose-allinson.yml
+++ b/docker-compose-allinson.yml
@@ -22,8 +22,9 @@ services:
       - HYRAX_FLEXIBLE_CLASSES=Hyrax::AdministrativeSet,CollectionResource,FileSet,GenericWork,Monograph
       - HYRAX_DISABLE_INCLUDE_METADATA=true
     depends_on:
-      worker:
-        condition: service_started
+      # worker (sidekiq) is intentionally omitted: the test suite uses the
+      # ActiveJob :test adapter (see spec/spec_helper.rb), so jobs run
+      # in-process and a live sidekiq container only wastes memory in CI.
       chrome:
         condition: service_started
       fits:

--- a/docker-compose-allinson.yml
+++ b/docker-compose-allinson.yml
@@ -139,6 +139,11 @@ services:
     image: solr:9.9
     env_file:
       - .koppie/.env
+    environment:
+      # Cap the Solr heap so it doesn't auto-size off host RAM and starve the
+      # rest of the stack on memory-constrained CI runners. The test index is
+      # tiny; 512m is ample.
+      - SOLR_JAVA_MEM=-Xms512m -Xmx512m
     ports:
       - 8986:8983
     command:

--- a/docker-compose-allinson.yml
+++ b/docker-compose-allinson.yml
@@ -22,13 +22,20 @@ services:
       - HYRAX_FLEXIBLE_CLASSES=Hyrax::AdministrativeSet,CollectionResource,FileSet,GenericWork,Monograph
       - HYRAX_DISABLE_INCLUDE_METADATA=true
     depends_on:
-      - worker
-      - chrome
-      - fits
-      - memcached
-      - postgres
-      - redis
-      - solr
+      worker:
+        condition: service_started
+      chrome:
+        condition: service_started
+      fits:
+        condition: service_healthy
+      memcached:
+        condition: service_started
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+      solr:
+        condition: service_healthy
     ports:
       - 3003:3000
       - 9879:9876
@@ -61,11 +68,16 @@ services:
       - HYRAX_FLEXIBLE_CLASSES=Hyrax::AdministrativeSet,CollectionResource,FileSet,GenericWork,Monograph
       - HYRAX_DISABLE_INCLUDE_METADATA=true
     depends_on:
-      - fits
-      - memcached
-      - postgres
-      - redis
-      - solr
+      fits:
+        condition: service_healthy
+      memcached:
+        condition: service_started
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+      solr:
+        condition: service_healthy
     volumes:
       - ./bin:/app/samvera
       - .koppie:/app/samvera/hyrax-webapp
@@ -109,6 +121,11 @@ services:
       - "5435:5432"
     volumes:
       - db:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U \"$$POSTGRES_USER\""]
+      interval: 5s
+      timeout: 5s
+      retries: 20
     networks:
       - allinson
 
@@ -116,6 +133,11 @@ services:
     image: ghcr.io/samvera/fitsservlet:1.6.0
     ports:
       - 8080
+    healthcheck:
+      test: ["CMD-SHELL", "curl -sf http://localhost:8080/fits/version || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 20
     networks:
       - allinson
 
@@ -132,6 +154,11 @@ services:
       - .koppie/.env
     volumes:
       - redis:/bitnamilegacy/redis/data
+    healthcheck:
+      test: ["CMD-SHELL", "redis-cli -a \"$$REDIS_PASSWORD\" ping | grep -q PONG"]
+      interval: 5s
+      timeout: 5s
+      retries: 20
     networks:
       - allinson
 
@@ -157,6 +184,11 @@ services:
       nofile:
         soft: 65536
         hard: 524288
+    healthcheck:
+      test: ["CMD-SHELL", "curl -sf 'http://localhost:8983/solr/admin/cores?action=STATUS' || exit 1"]
+      interval: 5s
+      timeout: 5s
+      retries: 30
     networks:
       - allinson
 

--- a/docker-compose-dassie.yml
+++ b/docker-compose-dassie.yml
@@ -19,14 +19,22 @@ services:
       - HYRAX_FLEXIBLE_CLASSES=
       - HYRAX_DISABLE_INCLUDE_METADATA=false
     depends_on:
-      - worker
-      - chrome
-      - fcrepo
-      - fits
-      - memcached
-      - postgres
-      - redis
-      - solr
+      worker:
+        condition: service_started
+      chrome:
+        condition: service_started
+      fcrepo:
+        condition: service_healthy
+      fits:
+        condition: service_healthy
+      memcached:
+        condition: service_started
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+      solr:
+        condition: service_healthy
     ports:
       - 3000:3000
       - 9876:9876
@@ -51,12 +59,18 @@ services:
     env_file:
       - .dassie/.env
     depends_on:
-      - fcrepo
-      - fits
-      - memcached
-      - postgres
-      - redis
-      - solr
+      fcrepo:
+        condition: service_healthy
+      fits:
+        condition: service_healthy
+      memcached:
+        condition: service_started
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+      solr:
+        condition: service_healthy
     volumes:
       - ./bin:/app/samvera
       - .dassie:/app/samvera/hyrax-webapp
@@ -101,6 +115,11 @@ services:
       - "5432:5432"
     volumes:
       - db:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U \"$$POSTGRES_USER\""]
+      interval: 5s
+      timeout: 5s
+      retries: 20
     networks:
       - hyrax
 
@@ -110,6 +129,11 @@ services:
       - fcrepo:/data:cached
     ports:
       - 8080:8080
+    healthcheck:
+      test: ["CMD-SHELL", "curl -sf http://localhost:8080/rest/ || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 30
     networks:
       - hyrax
 
@@ -117,6 +141,11 @@ services:
     image: ghcr.io/samvera/fitsservlet:1.6.0
     ports:
       - 8080
+    healthcheck:
+      test: ["CMD-SHELL", "curl -sf http://localhost:8080/fits/version || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 20
     networks:
       - hyrax
 
@@ -133,6 +162,11 @@ services:
       - .dassie/.env
     volumes:
       - redis:/bitnamilegacy/redis/data
+    healthcheck:
+      test: ["CMD-SHELL", "redis-cli -a \"$$REDIS_PASSWORD\" ping | grep -q PONG"]
+      interval: 5s
+      timeout: 5s
+      retries: 20
     networks:
       - hyrax
 
@@ -158,6 +192,11 @@ services:
       nofile:
         soft: 65536
         hard: 524288
+    healthcheck:
+      test: ["CMD-SHELL", "curl -sf 'http://localhost:8983/solr/admin/cores?action=STATUS' || exit 1"]
+      interval: 5s
+      timeout: 5s
+      retries: 30
     networks:
       - hyrax
 

--- a/docker-compose-dassie.yml
+++ b/docker-compose-dassie.yml
@@ -140,6 +140,11 @@ services:
     image: solr:9.9
     env_file:
       - .dassie/.env
+    environment:
+      # Cap the Solr heap so it doesn't auto-size off host RAM and starve the
+      # rest of the stack on memory-constrained CI runners. The test index is
+      # tiny; 512m is ample.
+      - SOLR_JAVA_MEM=-Xms512m -Xmx512m
     ports:
       - 8983:8983
     command:

--- a/docker-compose-dassie.yml
+++ b/docker-compose-dassie.yml
@@ -19,8 +19,9 @@ services:
       - HYRAX_FLEXIBLE_CLASSES=
       - HYRAX_DISABLE_INCLUDE_METADATA=false
     depends_on:
-      worker:
-        condition: service_started
+      # worker (sidekiq) is intentionally omitted: the test suite uses the
+      # ActiveJob :test adapter (see spec/spec_helper.rb), so jobs run
+      # in-process and a live sidekiq container only wastes memory in CI.
       chrome:
         condition: service_started
       fcrepo:

--- a/docker-compose-koppie.yml
+++ b/docker-compose-koppie.yml
@@ -21,13 +21,20 @@ services:
       - HYRAX_FLEXIBLE_CLASSES=
       - HYRAX_DISABLE_INCLUDE_METADATA=false
     depends_on:
-      - worker
-      - chrome
-      - fits
-      - memcached
-      - postgres
-      - redis
-      - solr
+      worker:
+        condition: service_started
+      chrome:
+        condition: service_started
+      fits:
+        condition: service_healthy
+      memcached:
+        condition: service_started
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+      solr:
+        condition: service_healthy
     ports:
       - 3001:3000
       - 9877:9876
@@ -54,11 +61,16 @@ services:
     env_file:
       - .koppie/.env
     depends_on:
-      - fits
-      - memcached
-      - postgres
-      - redis
-      - solr
+      fits:
+        condition: service_healthy
+      memcached:
+        condition: service_started
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+      solr:
+        condition: service_healthy
     volumes:
       - ./bin:/app/samvera
       - .koppie:/app/samvera/hyrax-webapp
@@ -102,6 +114,11 @@ services:
       - "5433:5432"
     volumes:
       - db:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U \"$$POSTGRES_USER\""]
+      interval: 5s
+      timeout: 5s
+      retries: 20
     networks:
       - koppie
 
@@ -109,6 +126,11 @@ services:
     image: ghcr.io/samvera/fitsservlet:1.6.0
     ports:
       - 8080
+    healthcheck:
+      test: ["CMD-SHELL", "curl -sf http://localhost:8080/fits/version || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 20
     networks:
       - koppie
 
@@ -125,6 +147,11 @@ services:
       - .koppie/.env
     volumes:
       - redis:/bitnamilegacy/redis/data
+    healthcheck:
+      test: ["CMD-SHELL", "redis-cli -a \"$$REDIS_PASSWORD\" ping | grep -q PONG"]
+      interval: 5s
+      timeout: 5s
+      retries: 20
     networks:
       - koppie
 
@@ -150,6 +177,11 @@ services:
       nofile:
         soft: 65536
         hard: 524288
+    healthcheck:
+      test: ["CMD-SHELL", "curl -sf 'http://localhost:8983/solr/admin/cores?action=STATUS' || exit 1"]
+      interval: 5s
+      timeout: 5s
+      retries: 30
     networks:
       - koppie
 

--- a/docker-compose-koppie.yml
+++ b/docker-compose-koppie.yml
@@ -21,8 +21,9 @@ services:
       - HYRAX_FLEXIBLE_CLASSES=
       - HYRAX_DISABLE_INCLUDE_METADATA=false
     depends_on:
-      worker:
-        condition: service_started
+      # worker (sidekiq) is intentionally omitted: the test suite uses the
+      # ActiveJob :test adapter (see spec/spec_helper.rb), so jobs run
+      # in-process and a live sidekiq container only wastes memory in CI.
       chrome:
         condition: service_started
       fits:

--- a/docker-compose-koppie.yml
+++ b/docker-compose-koppie.yml
@@ -132,6 +132,11 @@ services:
     image: solr:9.9
     env_file:
       - .koppie/.env
+    environment:
+      # Cap the Solr heap so it doesn't auto-size off host RAM and starve the
+      # rest of the stack on memory-constrained CI runners. The test index is
+      # tiny; 512m is ample.
+      - SOLR_JAVA_MEM=-Xms512m -Xmx512m
     ports:
       - 8984:8983
     command:

--- a/docker-compose-sirenia.yml
+++ b/docker-compose-sirenia.yml
@@ -21,8 +21,9 @@ services:
       - VALKYRIE_METADATA_ADAPTER=fedora_metadata
       - VALKYRIE_STORAGE_ADAPTER=fedora_storage
     depends_on:
-      worker:
-        condition: service_started
+      # worker (sidekiq) is intentionally omitted: the test suite uses the
+      # ActiveJob :test adapter (see spec/spec_helper.rb), so jobs run
+      # in-process and a live sidekiq container only wastes memory in CI.
       chrome:
         condition: service_started
       fcrepo:

--- a/docker-compose-sirenia.yml
+++ b/docker-compose-sirenia.yml
@@ -160,6 +160,11 @@ services:
     image: solr:9.9
     env_file:
       - .koppie/.env
+    environment:
+      # Cap the Solr heap so it doesn't auto-size off host RAM and starve the
+      # rest of the stack on memory-constrained CI runners. The test index is
+      # tiny; 512m is ample.
+      - SOLR_JAVA_MEM=-Xms512m -Xmx512m
     ports:
       - 8985:8983
     command:

--- a/docker-compose-sirenia.yml
+++ b/docker-compose-sirenia.yml
@@ -21,14 +21,22 @@ services:
       - VALKYRIE_METADATA_ADAPTER=fedora_metadata
       - VALKYRIE_STORAGE_ADAPTER=fedora_storage
     depends_on:
-      - worker
-      - chrome
-      - fcrepo
-      - fits
-      - memcached
-      - postgres
-      - redis
-      - solr
+      worker:
+        condition: service_started
+      chrome:
+        condition: service_started
+      fcrepo:
+        condition: service_healthy
+      fits:
+        condition: service_healthy
+      memcached:
+        condition: service_started
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+      solr:
+        condition: service_healthy
     ports:
       - 3002:3000
       - 9878:9876
@@ -63,12 +71,18 @@ services:
       - HYRAX_FLEXIBLE_CLASSES=
       - HYRAX_DISABLE_INCLUDE_METADATA=false
     depends_on:
-      - fcrepo
-      - fits
-      - memcached
-      - postgres
-      - redis
-      - solr
+      fcrepo:
+        condition: service_healthy
+      fits:
+        condition: service_healthy
+      memcached:
+        condition: service_started
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+      solr:
+        condition: service_healthy
     volumes:
       - ./bin:/app/samvera
       - .koppie:/app/samvera/hyrax-webapp
@@ -112,6 +126,11 @@ services:
       - "5434:5432"
     volumes:
       - db:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U \"$$POSTGRES_USER\""]
+      interval: 5s
+      timeout: 5s
+      retries: 20
     networks:
       - sirenia
 
@@ -130,6 +149,13 @@ services:
       - fcrepo:/fcrepo-home
     ports:
       - 8081:8080
+    healthcheck:
+      # fcrepo6 returns 401 (auth required) on /fcrepo/rest/ once the webapp is
+      # serving; treat 200 or 401 as healthy, anything else as not-yet-ready.
+      test: ["CMD-SHELL", "c=$$(curl -s -o /dev/null -w '%{http_code}' http://localhost:8080/fcrepo/rest/); [ \"$$c\" = 200 ] || [ \"$$c\" = 401 ]"]
+      interval: 10s
+      timeout: 5s
+      retries: 30
     networks:
       - sirenia
 
@@ -137,6 +163,11 @@ services:
     image: ghcr.io/samvera/fitsservlet:1.6.0
     ports:
       - 9082:8080
+    healthcheck:
+      test: ["CMD-SHELL", "curl -sf http://localhost:8080/fits/version || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 20
     networks:
       - sirenia
 
@@ -153,6 +184,11 @@ services:
       - .koppie/.env
     volumes:
       - redis:/bitnamilegacy/redis/data
+    healthcheck:
+      test: ["CMD-SHELL", "redis-cli -a \"$$REDIS_PASSWORD\" ping | grep -q PONG"]
+      interval: 5s
+      timeout: 5s
+      retries: 20
     networks:
       - sirenia
 
@@ -178,6 +214,11 @@ services:
       nofile:
         soft: 65536
         hard: 524288
+    healthcheck:
+      test: ["CMD-SHELL", "curl -sf 'http://localhost:8983/solr/admin/cores?action=STATUS' || exit 1"]
+      interval: 5s
+      timeout: 5s
+      retries: 30
     networks:
       - sirenia
 


### PR DESCRIPTION
## What this fixes

CI's `Lint Build Test` matrix was failing all test jobs. Three distinct problems were involved; this branch addresses all three.

## Problem 1 — OOM (exit 137)

Every test job was being SIGKILL'd by the out-of-memory killer. Each job ran the entire docker-compose stack (web + worker, Solr, Postgres, fcrepo, Chromium, FITS, redis, memcached) **plus** RSpec on a single ~7GB `ubuntu-latest` runner — sitting at the memory ceiling and tipping over under variable load (which is why it was intermittent on `main`).

Addressed by reducing the running footprint rather than enlarging the runner:

- Capped the Solr heap so it doesn't auto-size off host RAM.
- Health-gated the backing services (web waits for `service_healthy`).
- Switched the test step from `docker compose up` to `docker compose run web`, and dropped the sidekiq `worker` from web's `depends_on` — the suite uses the ActiveJob `:test` adapter, so a live worker is never exercised.
- Skipped the dev entrypoint (`--entrypoint sh`); specs create/migrate their own DB in `spec_helper`, so `db:prepare`/`db:seed` aren't needed.

Result: jobs now run the full suite to completion (~1300–1800 examples) instead of dying at ~46 seconds.

## Problem 2 — `wrong number of arguments (given 3, expected 1)`

Once the suite ran, hundreds of specs failed with this `ArgumentError`, and seeding crashed with the same error.

Root cause: `sprockets 3.7.2` calls the legacy positional `ERB.new(data, trim_mode, eoutvar)` API, which **`erb 6.x` removed** — so every asset/template render raised the arity error. Because `Gemfile*.lock` is gitignored, CI re-resolves gems to latest on every run, so this broke all branches at once the moment `erb 6.x` was published upstream (unrelated to any merge).

Fixed by pinning `gem 'erb', '~> 4.0'`.

## Problem 3 — jasmine spec (`net::ERR_NAME_NOT_RESOLVED`)

After the above, the only remaining failure was `spec/javascripts/jasmine_spec.rb`, where the remote browser couldn't reach the karma server at `http://web:9876`. The switch to `docker compose run` had dropped the `web` service's network alias, so the hostname no longer resolved.

Fixed by passing `--use-aliases` so the run container keeps the `web` network alias.

## Also added

- Marked the checkout as a git `safe.directory` (via `GIT_CONFIG_*`) so git doesn't abort with a dubious-ownership error under `docker compose run`.

## Possible Follow-up Work

### Prevent gem release breakage:

`Gemfile*.lock` being gitignored makes CI non-deterministic — any bad upstream gem release breaks every branch simultaneously (as `erb 6.x` did here). Committing the lockfiles for the test apps would make CI reproducible and prevent recurrence.

