### PR TITLE
Don't `up` the whole stack, `run` instead.

### DIFF
--- a/.github/workflows/lint-build-test.yml
+++ b/.github/workflows/lint-build-test.yml
@@ -120,23 +120,17 @@ jobs:
         with:
           name: hyrax-dev
           path: ${{runner.temp}}
-      - name: Start containers
+      - name: Load hyrax container
         run: |
           docker load --input ${{runner.temp}}/hyrax-dev-${{ github.sha }}.tar
           docker image ls -a
-          docker compose -f docker-compose-${{ matrix.ci_test_app }}.yml up -d --quiet-pull --pull missing --no-build
       - name: RSpec
         env:
           CI_NODE_TOTAL: ${{ matrix.ci_node_total }}
           CI_NODE_INDEX: ${{ matrix.ci_node_index }}
         run: >-
-          docker compose -f docker-compose-${{ matrix.ci_test_app }}.yml exec -T -w /app/samvera/hyrax-engine web sh -c
-          "bundle install && yarn install && rspec_booster --job ${{ matrix.ci_node_index }}/${{ matrix.ci_node_total }}"
-      - name: Capture Container Logs
-        if: always()
-        uses: jwalton/gh-docker-logs@v2
-        with:
-          images: 'selenium/standalone-chromium,postgres,fcrepo/fcrepo,solr,bitnami/redis,ghcr.io/samvera/fitsservlet,ghcr.io/samvera/fcrepo4'
+          docker compose -f docker-compose-${{ matrix.ci_test_app }}.yml run -T --quiet-pull --pull missing web sh -c
+          "cd ../hyrax-engine && bundle install && yarn install && rspec_booster --job ${{ matrix.ci_node_index }}/${{ matrix.ci_node_total }}"
       - name: Move Test Files
         if: always()
         env:


### PR DESCRIPTION
Experimenting with not running unneeded services in github actions tests.