### PR TITLE
Tune fcrepo heap to speed up dassie CI

### DIFF
--- a/docker-compose-dassie.yml
+++ b/docker-compose-dassie.yml
@@ -126,6 +126,11 @@ services:
 
   fcrepo:
     image: ghcr.io/samvera/fcrepo4:4.7.5
+    environment:
+      # Give the (Jetty-based) fcrepo4 JVM a real heap. Untuned it relies on the
+      # JVM default, which makes the HTTP round-trips dassie specs depend on slow.
+      # Sized to stay within the CI runner's memory budget.
+      - JAVA_OPTIONS=-Xms512m -Xmx1500m
     volumes:
       - fcrepo:/data:cached
     ports:


### PR DESCRIPTION
## Summary

Try to speed up Dassie run.

## Details

Dassie's fcrepo4 ran with the JVM default heap, which on the CI runner made the Fcrepo HTTP round-trips its specs depend on slow (dassie took ~2-3x longer than the other apps). Pin the Jetty JVM to a 1500m max heap via JAVA_OPTIONS.
