### PR TITLE
Bug Fix: Mapping original_checksum to checksum breaks CharacterizeJob

### DIFF
--- a/app/services/hyrax/characterization/valkyrie_characterization_service.rb
+++ b/app/services/hyrax/characterization/valkyrie_characterization_service.rb
@@ -43,7 +43,9 @@ class Hyrax::Characterization::ValkyrieCharacterizationService
     metadata:,
     file:,
     characterizer: Hydra::FileCharacterization,
-    parser_mapping: Hydra::Works::Characterization.mapper,
+    # Needed to display checksum on file set show
+    # https://github.com/samvera/hyrax/commit/41b65a656b862c06f111bf8cea408d2f09213348
+    parser_mapping: Hydra::Works::Characterization.mapper.merge(original_checksum: :checksum),
     parser: Hydra::Works::Characterization::FitsDocument.new,
     ch12n_tool: :fits
   )

--- a/config/initializers/hydra_works.rb
+++ b/config/initializers/hydra_works.rb
@@ -1,3 +1,0 @@
-# frozen_string_literal: true
-
-Hydra::Works::Characterization.mapper[:original_checksum] = :checksum

--- a/spec/services/hyrax/characterization/valkyrie_characterization_service_spec.rb
+++ b/spec/services/hyrax/characterization/valkyrie_characterization_service_spec.rb
@@ -14,6 +14,7 @@ RSpec.describe Hyrax::Characterization::ValkyrieCharacterizationService do
 
     before do
       Hyrax.publisher.subscribe(listener)
+      allow(file_metadata).to receive(:checksum=).and_call_original
       described_class
         .run(metadata: file_metadata, file: file_set.original_file.file, characterizer: characterizer)
     end
@@ -31,6 +32,10 @@ RSpec.describe Hyrax::Characterization::ValkyrieCharacterizationService do
       it 'publishes metadata updated for file metadata node' do
         expect(listener.file_metadata_updated&.payload&.values&.map(&:id))
           .to include(::User.system_user.id, file_metadata.id)
+      end
+      
+      it 'maps original checksum to checksum by default' do
+        expect(file_metadata).to have_received(:checksum=)
       end
     end
   end

--- a/spec/services/hyrax/characterization/valkyrie_characterization_service_spec.rb
+++ b/spec/services/hyrax/characterization/valkyrie_characterization_service_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe Hyrax::Characterization::ValkyrieCharacterizationService do
         expect(listener.file_metadata_updated&.payload&.values&.map(&:id))
           .to include(::User.system_user.id, file_metadata.id)
       end
-      
+
       it 'maps original checksum to checksum by default' do
         expect(file_metadata).to have_received(:checksum=)
       end


### PR DESCRIPTION
### Summary

Fix NoMethodError (undefined method '+' for an instance of ActiveFedora::Checksum) raised by CharacterizeJob

### Steps to Reproduce Error
* In Dassie, attach a new file to an existing work or create a new generic work
* No thumbnail will be generated for the new work
* In the Sidekiq browser interface (`localhost:3000/sidekiq` if using Docker), there will be a failing `CharacterizeJob` in the "Retries" queue/page

### Error Backtrace

```
[ActiveJob] [CharacterizeJob] [f7c75031-bd5f-4d8c-a20b-89137207689a] Error performing CharacterizeJob (Job ID: f7c75031-bd5f-4d8c-a20b-89137207689a) from Sidekiq(default) in 1431.93ms: NoMethodError (undefined method `+' for an instance of ActiveFedora::Checksum):
/app/bundle/ruby/3.3.0/gems/hydra-works-2.3.0/lib/hydra/works/services/characterization_service.rb:107:in `append_property_value'
/app/bundle/ruby/3.3.0/gems/hydra-works-2.3.0/lib/hydra/works/services/characterization_service.rb:91:in `block (2 levels) in store_metadata'
/app/bundle/ruby/3.3.0/gems/hydra-works-2.3.0/lib/hydra/works/services/characterization_service.rb:91:in `each'
/app/bundle/ruby/3.3.0/gems/hydra-works-2.3.0/lib/hydra/works/services/characterization_service.rb:91:in `block in store_metadata'
/app/bundle/ruby/3.3.0/gems/hydra-works-2.3.0/lib/hydra/works/services/characterization_service.rb:87:in `each_pair'
/app/bundle/ruby/3.3.0/gems/hydra-works-2.3.0/lib/hydra/works/services/characterization_service.rb:87:in `store_metadata'
/app/bundle/ruby/3.3.0/gems/hydra-works-2.3.0/lib/hydra/works/services/characterization_service.rb:32:in `characterize'
/app/bundle/ruby/3.3.0/gems/hydra-works-2.3.0/lib/hydra/works/services/characterization_service.rb:11:in `run'
/app/samvera/hyrax-engine/app/jobs/characterize_job.rb:54:in `characterize'
/app/samvera/hyrax-engine/app/jobs/characterize_job.rb:34:in `perform'
```

### Type of change (for release notes)

* `notes-bugfix`

### Detailed Description

A previous commit (#7397) changed the Hydra characterization mapping from `original_checksum` to `checksum` globally. However, characterization proxies in `CharacterizeJob` still need the original mapping because they respond to `.original_checksum=` and not `.checksum=`.

This eventually raises a `NoMethodError`, and causes missing thumbnails since `CreateDerivativesJob` never runs. Testing didn't catch this error because `characterize_job_spec.rb` mocks the result of  `Hydra::Works::CharacterizationService.run`, which is where the error is raised.

### Changes proposed in this pull request

This commit moves the remapping change into `Hyrax::Characterization::ValkyrieCharacterizationService`, which runs on `Hyrax::FileMetadata` objects only. `Hydra::Pcdm::File`  (Active Fedora) objects will revert to the old mapping.

@samvera/hyrax-code-reviewers
