### PR TITLE
Support authorized connections in Fedora storage adapters

### DIFF
--- a/lib/hyrax/configuration.rb
+++ b/lib/hyrax/configuration.rb
@@ -793,6 +793,14 @@ module Hyrax
           f.request :multipart
           f.request :url_encoded
           f.adapter Faraday.default_adapter
+
+          user = ENV['FEDORA_USER'] || 'fedoraAdmin'
+          password = ENV['FEDORA_PASSWORD'] || 'fedoraAdmin'
+          if Gem::Version.new(Faraday::VERSION) < Gem::Version.new('2')
+            f.request :basic_auth, user, password
+          else
+            f.request :authorization, :basic, user, password
+          end
         end
       }
     end

--- a/lib/wings/valkyrie/storage.rb
+++ b/lib/wings/valkyrie/storage.rb
@@ -21,7 +21,7 @@ module Wings
       DEFAULT_CTYPE = 'application/octet-stream'
       FILES_PATH = 'files'
 
-      def initialize(connection: Ldp::Client.new(ActiveFedora.fedora.host), base_path: ActiveFedora.fedora.base_path, fedora_version: 4)
+      def initialize(connection: ActiveFedora.fedora.build_connection, base_path: ActiveFedora.fedora.base_path, fedora_version: 4)
         super
       end
 


### PR DESCRIPTION
### Summary

Support authorized connections in Fedora storage adapters

### Type of change (for release notes)
- `notes-minor` 

### Detailed Description

The Wings storage adapter uses `Ldp::Client.new(ActiveFedora.fedora.host)` in order to connect to Fedora 4, which raised a 401 Unauthorized error if an app used a different user and password than the default user/password. Using `ActiveFedora.fedora.build_connection` instead fixes this issue, and adds other options (e.g. request options) that might have been specified in `config/fedora.yml`.

This commit also adds support for authorization for Fedora 6 connections via env variables. Previously, user and password have always been hardcoded strings.

```ruby
    # A HTTP connection to use for Valkyrie Fedora requests
    #
    # @return [#call] lambda/proc that generates a Faraday connection
    def fedora_connection_builder
      @fedora_connection_builder ||= lambda { |url|
        Faraday.new(url) do |f|
          f.request :multipart
          f.request :url_encoded
          f.adapter Faraday.default_adapter

          user = ENV['FEDORA_USER'] || 'fedoraAdmin'
          password = ENV['FEDORA_PASSWORD'] || 'fedoraAdmin'
          if Gem::Version.new(Faraday::VERSION) < Gem::Version.new('2')
            f.request :basic_auth, user, password
          else
            f.request :authorization, :basic, user, password
          end
        end
      }
    end
```

@samvera/hyrax-code-reviewers
