### PR TITLE
Move erb pin to gemspec

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,12 +3,6 @@ source 'https://rubygems.org'
 
 # Please see hyrax.gemspec for dependency information.
 
-# Pin erb to the 4.x line: sprockets 3.7.2 (the asset pipeline used by the
-# test apps) calls the legacy positional ERB.new(data, trim_mode, eoutvar)
-# API, which erb 6.x removed — under erb 6.x every asset/template render
-# raises "wrong number of arguments (given 3, expected 1)".
-gem 'erb', '~> 4.0'
-
 # Install gems from test app
 if ENV['RAILS_ROOT']
   test_app_gemfile_path = File.expand_path('Gemfile', ENV['RAILS_ROOT'])

--- a/hyrax.gemspec
+++ b/hyrax.gemspec
@@ -52,6 +52,7 @@ SUMMARY
   spec.add_dependency 'dry-events', '~> 1.0', '>= 1.0.1'
   spec.add_dependency 'dry-monads', '~> 1.6'
   spec.add_dependency 'dry-validation', '~> 1.10'
+  spec.add_dependency 'erb', '~> 4.0'
   spec.add_dependency 'flipflop', '~> 2.3'
   # Pin more tightly because 0.x gems are potentially unstable
   spec.add_dependency 'flot-rails', '~> 0.0.6'


### PR DESCRIPTION
### Fixes

Fixes nurax servers hitting erb ArgumentError during asset:precompile

### Summary

Pinning a gem should be done in the gemspec. Doing so in the Gemfile only affects spec runs, but not the actual application.