### PR TITLE
Scope redirects form property to works and collections

### DIFF
--- a/app/forms/hyrax/forms/pcdm_collection_form.rb
+++ b/app/forms/hyrax/forms/pcdm_collection_form.rb
@@ -13,6 +13,17 @@ module Hyrax
          Hyrax::PcdmCollection.ancestors.detect { |k| k.inspect == "Hyrax::Schema(compound_metadata)" }
         include Hyrax::FormFields(:compound_metadata)
       end
+
+      # redirects is wired here (and on PcdmObjectForm), not on the shared
+      # ResourceForm; see ResourceForm for why FileSetForm must not inherit it.
+      include RedirectsFieldBehavior
+      include Hyrax::FormFields(:redirects) if Hyrax.config.redirects_enabled? && Hyrax.config.collection_include_metadata?
+      if Hyrax.config.redirects_enabled?
+        validation(name: :default, inherit: true) do
+          validates_with Hyrax::RedirectValidator, attributes: [:redirects]
+        end
+      end
+
       check_if_flexible(Hyrax::PcdmCollection)
 
       BannerInfoPrepopulator = lambda do |**_options|

--- a/app/forms/hyrax/forms/pcdm_object_form.rb
+++ b/app/forms/hyrax/forms/pcdm_object_form.rb
@@ -14,6 +14,16 @@ module Hyrax
       include Hyrax::LeaseabilityBehavior
       include Hyrax::PermissionBehavior
 
+      # redirects is wired here (and on PcdmCollectionForm), not on the shared
+      # ResourceForm; see ResourceForm for why FileSetForm must not inherit it.
+      include RedirectsFieldBehavior
+      include Hyrax::FormFields(:redirects) if Hyrax.config.redirects_enabled? && Hyrax.config.work_include_metadata?
+      if Hyrax.config.redirects_enabled?
+        validation(name: :default, inherit: true) do
+          validates_with Hyrax::RedirectValidator, attributes: [:redirects]
+        end
+      end
+
       property :on_behalf_of
       property :proxy_depositor
 

--- a/app/forms/hyrax/forms/resource_form.rb
+++ b/app/forms/hyrax/forms/resource_form.rb
@@ -27,9 +27,13 @@ module Hyrax
       end
 
       include BasedNearFieldBehavior
-      include RedirectsFieldBehavior
       include CompoundFieldBehavior
-      include Hyrax::FormFields(:redirects) if Hyrax.config.redirects_enabled? && Hyrax.config.work_include_metadata?
+      # Do NOT wire redirects here. Its property, behavior, and validator live on
+      # PcdmObjectForm and PcdmCollectionForm instead. Declaring the `redirects`
+      # property on this shared base makes Reform read `redirects` off every model
+      # when building the form twin, and FileSet (whose form also inherits
+      # ResourceForm) has no such attribute — so it raises NoMethodError on
+      # edit/validate in non-flexible mode.
       class_attribute :model_class
 
       property :human_readable_type, writable: false
@@ -58,11 +62,6 @@ module Hyrax
       # the literal options hash on every replay so each subclass gets its own
       # clean copy. This pattern applies to *any* `validates_with` that takes
       # an `attributes:` keyword.
-      if Hyrax.config.redirects_enabled?
-        validation(name: :default, inherit: true) do
-          validates_with Hyrax::RedirectValidator, attributes: [:redirects]
-        end
-      end
 
       # Required-compound / required-sub-property validation. Wired through a
       # `validation { ... }` block (not a bare `validates_with`) because these

--- a/app/forms/hyrax/forms/resource_form.rb
+++ b/app/forms/hyrax/forms/resource_form.rb
@@ -28,12 +28,6 @@ module Hyrax
 
       include BasedNearFieldBehavior
       include CompoundFieldBehavior
-      # Do NOT wire redirects here. Its property, behavior, and validator live on
-      # PcdmObjectForm and PcdmCollectionForm instead. Declaring the `redirects`
-      # property on this shared base makes Reform read `redirects` off every model
-      # when building the form twin, and FileSet (whose form also inherits
-      # ResourceForm) has no such attribute — so it raises NoMethodError on
-      # edit/validate in non-flexible mode.
       class_attribute :model_class
 
       property :human_readable_type, writable: false

--- a/spec/forms/hyrax/forms/file_set_form_spec.rb
+++ b/spec/forms/hyrax/forms/file_set_form_spec.rb
@@ -57,6 +57,23 @@ RSpec.describe Hyrax::Forms::FileSetForm do
     end
   end
 
+  # redirects is a Work/Collection concern; FileSets have no `redirects`
+  # attribute. The redirects form property must therefore not be declared on the
+  # FileSet form — otherwise Reform reads `redirects` off the FileSet model while
+  # building the form twin (on validate/prepopulate) and raises NoMethodError.
+  # This regressed when the redirects property was declared on the base
+  # ResourceForm (which FileSetForm inherits) rather than on the work/collection
+  # forms. Requires HYRAX_REDIRECTS_ENABLED=true at load so the wiring is active.
+  context 'when the redirects feature is enabled', if: Hyrax.config.redirects_enabled? do
+    it 'does not declare a redirects property on the FileSet form' do
+      expect(described_class.definitions.keys).not_to include('redirects')
+    end
+
+    it 'validates without reading a redirects attribute off the FileSet' do
+      expect { form.validate(title: ['A file']) }.not_to raise_error
+    end
+  end
+
   describe '#visibility_after_embargo' do
     context 'without an embargo' do
       it 'is nil' do

--- a/spec/forms/hyrax/forms/resource_form_spec.rb
+++ b/spec/forms/hyrax/forms/resource_form_spec.rb
@@ -9,6 +9,30 @@ RSpec.describe Hyrax::Forms::ResourceForm do
   let(:default_admin_set) { instance_double(Hyrax::AdministrativeSet, title: "DEFAULT_ADMINSET", id: "DEFAULT_ADMINSET_ID") }
   before { allow(Hyrax::AdminSetCreateService).to receive(:find_or_create_default_admin_set).and_return(default_admin_set) }
 
+  # Redirects is a Work/Collection concern, never a FileSet one. The FileSet
+  # form must not declare the property (its model has no `redirects` attribute) —
+  # guarding the regression where declaring redirects on the shared base
+  # ResourceForm leaked it onto FileSetForm. True in both flex modes.
+  # Requires HYRAX_REDIRECTS_ENABLED=true at load.
+  context 'redirects property placement', if: Hyrax.config.redirects_enabled? do
+    it 'is not declared on the FileSet form' do
+      expect(Hyrax::Forms::FileSetForm.definitions.keys).not_to include('redirects')
+    end
+
+    # In non-flexible mode the property is installed via FormFields(:redirects)
+    # on the work/collection forms. In flexible mode it comes from the m3 profile
+    # instead (adopters declare it there), so this positive check is flex-false.
+    context 'in non-flexible mode', unless: Hyrax.config.flexible? do
+      it 'is declared on a work form' do
+        expect(described_class.for(Hyrax::Work.new).class.definitions.keys).to include('redirects')
+      end
+
+      it 'is declared on a collection form' do
+        expect(Hyrax::Forms::PcdmCollectionForm.definitions.keys).to include('redirects')
+      end
+    end
+  end
+
   describe '.required_fields=' do
     subject(:form) { form_class.new(work) }
 


### PR DESCRIPTION
## Summary

Fixes a crash when editing a FileSet in non-flexible mode with the redirects feature enabled.

<img width="802" height="701" alt="Screenshot 2026-07-07 at 9 03 54 PM" src="https://github.com/user-attachments/assets/2bb038ef-39d1-4dc5-8c86-5060357b3ebc" />

## Details

- The `redirects` form property was declared on the shared `ResourceForm`, which `FileSetForm` inherits.
- With redirects enabled in non-flexible mode, Reform reads every declared property off the model while building the form twin; `Hyrax::FileSet` has no `redirects` attribute, so this raised `NoMethodError` on FileSet edit/validate.
- Redirects is a work/collection concern, so its property, behavior, and validator now live on `PcdmObjectForm` and `PcdmCollectionForm` instead of the shared base.
- In flexible mode the property comes from the m3 profile, so only non-flexible installations were affected.

## Note

The specs that were added captured the failure when run locally using the redirects property. 