### PR TITLE
🎁 Add `datepicker` sub-property type

### DIFF
--- a/app/indexers/hyrax/indexers/compound_indexer.rb
+++ b/app/indexers/hyrax/indexers/compound_indexer.rb
@@ -41,12 +41,14 @@ module Hyrax
 
       # Solr suffix set per sub-property `type:`, following the field-role
       # conventions: a `string` (open text) is both facetable (`_sim`) and
-      # full-text searchable (`_tesim`); a `controlled` value is a closed
-      # vocabulary, so it is facetable only (`_sim`) — full-text tokenization
-      # adds nothing for fixed terms; ids/URIs get a single stored string
-      # (`_ssim`); dates a date field (`_dtsi`).
+      # full-text searchable (`_tesim`), as is a `datepicker` (its ISO date is
+      # text, not a `_dtsi` field); a `controlled` value is a closed vocabulary,
+      # so it is facetable only (`_sim`) — full-text tokenization adds nothing
+      # for fixed terms; ids/URIs get a single stored string (`_ssim`); dates a
+      # date field (`_dtsi`).
       DERIVED_SUFFIXES = {
         'string' => %w[_sim _tesim],
+        'datepicker' => %w[_sim _tesim],
         'controlled' => %w[_sim],
         'url' => %w[_ssim],
         'work_or_url' => %w[_ssim],

--- a/app/views/hyrax/compounds/_compound_row.html.erb
+++ b/app/views/hyrax/compounds/_compound_row.html.erb
@@ -72,6 +72,10 @@
                   See _linked_record_field and Hyrax::CompoundLinkedRecordResolver. %>
               <%= render 'hyrax/compounds/linked_record_field',
                          spec: spec, input_id: input_id, input_name: input_name, value: value %>
+            <% when 'datepicker' %>
+              <%= date_field_tag input_name, value,
+                                 id: input_id,
+                                 class: 'datepicker form-control form-control-sm' %>
             <% else %>
               <%# string (default); geocode and other types slot in here later. %>
               <%= text_field_tag input_name, value,

--- a/documentation/compound_fields.md
+++ b/documentation/compound_fields.md
@@ -135,6 +135,7 @@ textarea). Supported `type:` values:
 | `type:`      | Renders as          | Notes |
 |--------------|---------------------|-------|
 | `string`     | text input          | The default when `type:` is omitted. |
+| `datepicker` | native date picker (`<input type="date">`) | HTML5 date input. **Displays** in the user's locale (dd/mm/yyyy, mm/dd/yyyy) but always **stores** ISO-8601 `YYYY-MM-DD`, so the value is locale-independent. Stored as a plain string, **not** a `date`/`_dtsi` Solr field. |
 | `url`        | url input → auto-linked on show | The stored value is rendered as a clickable `<a href>` on show pages (matching the scalar `render_as: external_link` behavior). |
 | `work_or_url` | select2 typeahead → linked on show | Searches internal works (via the `compound_works` QA authority, backed by `Hyrax::CompoundWorkPickerBuilder`) **or** accepts a typed external URL. The stored value is a work id or a URL; on show, a work id links to the work's show page with its title (resolved by `Hyrax::CompoundWorkResolver`), a URL is auto-linked. |
 | `linked_record` | select2 typeahead → linked on show | A reference to a row in a database table (a person, organization, funder, place, …). The stored value is the row id; the picker searches that table and, optionally, lets a cataloger add a new record inline. On show, the id links to the record using the resolved label. The table and its procs are registered by the host application — see [`linked_record` sub-properties](#linked_record-sub-properties) below. |
@@ -357,9 +358,10 @@ chosen by its `type:`:
 | `type:`                  | Derived suffixes | Role |
 |--------------------------|------------------|------|
 | `string`                 | `_sim`, `_tesim` | facetable **and** full-text searchable |
+| `datepicker`             | `_sim`, `_tesim` | like a string; the ISO `YYYY-MM-DD` is text, **not** a `_dtsi` date field |
 | `controlled`             | `_sim`           | facetable only (a closed vocabulary needs no full-text) |
 | `url`, `work_or_url`, `linked_record`, `id` | `_ssim` | stored exact-match string (reverse-lookup id) |
-| `date_time`, `date`      | `_dtsi`          | date |
+| `date_time`, `date`      | `_dtsi`          | Solr date field; requires a full ISO-8601 datetime, so for a date input prefer `datepicker` |
 
 So `participants` with a `name`-aliased `title` (type `string`) is indexed to
 `participants_title_sim` and `participants_title_tesim` with no `indexing:`

--- a/spec/indexers/hyrax/indexers/compound_indexer_spec.rb
+++ b/spec/indexers/hyrax/indexers/compound_indexer_spec.rb
@@ -129,4 +129,30 @@ RSpec.describe Hyrax::Indexers::CompoundIndexer do
       expect(doc['relationships_title_tesim']).to contain_exactly('Sequel')
     end
   end
+
+  context 'with a datepicker sub-property' do
+    # A datepicker stores an ISO YYYY-MM-DD string and indexes like a string
+    # (facetable _sim plus full-text _tesim), never as a _dtsi date field, which
+    # would reject the date-only value.
+    let(:date_class) do
+      Class.new(Hyrax::Resource) do
+        def self.name
+          'TestDatepickerCompoundResource'
+        end
+        attribute :dates,
+                  Valkyrie::Types::Array.of(Dry::Types['hash']).meta(
+                    subproperties: { 'start_date' => { 'type' => 'datepicker' } }
+                  )
+      end
+    end
+    let(:resource) { date_class.new(dates: [{ 'start_date' => '2025-03-01' }]) }
+    let(:indexer) { host_indexer_class.new(resource: resource) }
+
+    it 'derives _sim and _tesim for a datepicker, not a _dtsi date field' do
+      doc = indexer.to_solr
+      expect(doc['dates_start_date_sim']).to contain_exactly('2025-03-01')
+      expect(doc['dates_start_date_tesim']).to contain_exactly('2025-03-01')
+      expect(doc.keys).not_to include('dates_start_date_dtsi')
+    end
+  end
 end

--- a/spec/views/hyrax/compounds/_compound_row_datepicker_spec.rb
+++ b/spec/views/hyrax/compounds/_compound_row_datepicker_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+# Renders the _compound_row partial with a `datepicker` sub-property and asserts
+# it renders the native HTML5 date input (`<input type="date">`) pre-seeded with
+# the stored ISO value. Exercises the `when 'datepicker'` branch.
+RSpec.describe 'hyrax/compounds/_compound_row', type: :view do
+  before do
+    allow(view).to receive(:compound_subproperty_label).and_return('Start date')
+    render partial: 'hyrax/compounds/compound_row',
+           locals: { f:, compound_name: :dates, definition:,
+                     row: { 'start_date' => '2025-03-01', 'note' => 'accepted' },
+                     index: 0, row_label_singular: 'Date' }
+  end
+
+  # Minimal form builder against a throwaway object; the partial only uses
+  # f.object_name for input names.
+  let(:form_object) { Struct.new(:dates).new(nil) }
+  let(:f) { ActionView::Helpers::FormBuilder.new('genericwork', form_object, view, {}) }
+
+  let(:definition) do
+    {
+      subproperties: {
+        'start_date' => { type: 'datepicker', cols: 6 },
+        'note' => { type: 'string', cols: 6 }
+      },
+      groups: [{ label: nil, fields: %w[start_date note] }]
+    }
+  end
+
+  it 'renders the datepicker sub-property as a native date input' do
+    expect(rendered).to have_css("input[type=date][name='genericwork[dates_attributes][0][start_date]']")
+  end
+
+  it 'pre-seeds the date input with the stored ISO value' do
+    input = Capybara.string(rendered).find("input[name='genericwork[dates_attributes][0][start_date]']")
+    expect(input[:value]).to eq('2025-03-01')
+  end
+
+  it 'still renders sibling string sub-properties as text inputs' do
+    expect(rendered).to have_css("input[type=text][name='genericwork[dates_attributes][0][note]']")
+  end
+end


### PR DESCRIPTION
This commit will render a compound sub-property as a native HTML5 date input (`<input type="date">`) when declared `type: datepicker`.  The value is displayed in the user's locale but always stored as an ISO `YYYY-MM-DD` string, and it is indexed like a string (`_sim` + `_tesim`) rather than a Solr `_dtsi` date field, which would reject the date-only value.

<img width="955" height="308" alt="image" src="https://github.com/user-attachments/assets/8a09dfe1-c6b8-4b9d-b431-cf53c9efb259" />

The above screenshot was created with this example yml entry:
```yml
  dates:
    available_on:
      class:
      - GenericWorkResource
    cardinality:
      minimum: 0
    data_type: array
    type: hash
    display_label:
      default: Dates
    form:
      primary: false
    mappings:
      simple_dc_pmh: dc:date
    property_uri: http://purl.org/dc/elements/1.1/date
    range: https://prvoices.org/types#hash
    view:
      render_as: compound
      html_dl: true
  date_start:
    type: datepicker
    name: start_date
    available_on:
      properties:
      - dates
    required: true
  date_end:
    type: datepicker
    name: end_date
    available_on:
      properties:
      - dates
  date_type:
    type: controlled
    name: type
    available_on:
      properties:
      - dates
    values:
    - Accepted
    - Available
    - Copyrighted
    - Collected
    - Created
    - Issued
    - Submitted
    - Updated
    - Valid
    - Withdrawn
    - Other
  date_information:
    type: string
    name: information
    available_on:
      properties:
      - dates
```