### PR TITLE
Apply file_set_params passed as request params

### DIFF
--- a/app/services/hyrax/work_uploads_handler.rb
+++ b/app/services/hyrax/work_uploads_handler.rb
@@ -143,12 +143,13 @@ module Hyrax
     #
     # @return [Hash{Symbol => Object}]
     def file_set_args(file, file_set_params = {})
+      extra = file_set_params.respond_to?(:to_unsafe_h) ? file_set_params.to_unsafe_h : file_set_params.to_h
       { depositor: file.user.user_key,
         creator: Array.wrap(file.user.user_key),
         date_uploaded: file.created_at,
         date_modified: Hyrax::TimeService.time_in_utc,
         label: file.uploader.filename,
-        title: Array.wrap(file.uploader.filename) }.merge(file_set_params)
+        title: Array.wrap(file.uploader.filename) }.merge(extra.symbolize_keys)
     end
 
     ##

--- a/spec/services/hyrax/work_uploads_handler_spec.rb
+++ b/spec/services/hyrax/work_uploads_handler_spec.rb
@@ -97,6 +97,24 @@ RSpec.describe Hyrax::WorkUploadsHandler, valkyrie_adapter: :test_adapter do
           end
         end
 
+        context 'that arrive as ActionController::Parameters' do
+          let(:file_set_params) do
+            [
+              ActionController::Parameters.new(alternate_ids: ['fs-1']).permit!,
+              ActionController::Parameters.new(alternate_ids: ['fs-2']).permit!,
+              ActionController::Parameters.new(alternate_ids: ['fs-3']).permit!
+            ]
+          end
+
+          it 'assigns the params to the FileSets' do
+            service.add(files: uploads, file_set_params: file_set_params)
+            service.attach
+            expect(work).to have_file_set_members(have_attributes(alternate_ids: ['fs-1']),
+                                                  have_attributes(alternate_ids: ['fs-2']),
+                                                  have_attributes(alternate_ids: ['fs-3']))
+          end
+        end
+
         context 'that are not in the schema' do
           let(:file_set_params) do
             [


### PR DESCRIPTION
## Summary
Applies per-file metadata to FileSets even when the params arrive as `ActionController::Parameters`.

## Details
- `WorkUploadsHandler#file_set_args` merged `file_set_params` onto its defaults with `Hash#merge`.
- Controllers `permit!` their per-file params, so each entry is an `ActionController::Parameters`, and `Hash#merge` does not merge a Parameters object by its keys — caller-supplied attributes (title, description, ...) were silently dropped, leaving only filename-derived defaults.
- The params are now coerced to a symbol-keyed Hash before the merge, so submitted per-file metadata is applied.
- Adds a spec covering `file_set_params` passed as `ActionController::Parameters`.
