### PR TITLE
PersistDirectlyContainedOutputFileService.fileset_for_directives always uses valkyrie

### DIFF
--- a/app/services/hyrax/persist_directly_contained_output_file_service.rb
+++ b/app/services/hyrax/persist_directly_contained_output_file_service.rb
@@ -47,7 +47,7 @@ module Hyrax
                .match(/^(.*)-\w*(\.\w+)*$/) { |m| m[1] }
       raise "Could not extract fileset id from path #{path}" unless id
 
-      Hyrax.metadata_adapter.query_service.find_by(id: id)
+      Hyrax.metadata_adapter.query_service.find_by(id: id, use_valkyrie: false)
     end
     private_class_method :fileset_for_directives
 

--- a/app/services/hyrax/persist_directly_contained_output_file_service.rb
+++ b/app/services/hyrax/persist_directly_contained_output_file_service.rb
@@ -47,7 +47,7 @@ module Hyrax
                .match(/^(.*)-\w*(\.\w+)*$/) { |m| m[1] }
       raise "Could not extract fileset id from path #{path}" unless id
 
-      Hyrax.metadata_adapter.query_service.find_by(id: id, use_valkyrie: false)
+      Hyrax.query_service.find_by_alternate_identifier(alternate_identifier: id, use_valkyrie: false)
     end
     private_class_method :fileset_for_directives
 

--- a/spec/services/hyrax/persist_directly_contained_output_file_service_spec.rb
+++ b/spec/services/hyrax/persist_directly_contained_output_file_service_spec.rb
@@ -18,4 +18,19 @@ RSpec.describe Hyrax::PersistDirectlyContainedOutputFileService, :active_fedora 
     expect(resource.content).to eq("fake file content")
     expect(resource.content.encoding).to eq(Encoding::UTF_8)
   end
+
+  context "when the url is a file:// url" do
+    subject(:call) do
+      described_class.call(content,
+                           format: 'txt',
+                           url: "file://#{Hyrax::DerivativePath.derivative_path_for_reference(file_set, 'extracted_text')}",
+                           container: 'extracted_text')
+    end
+
+    it "persists the file to the specified destination on the given object" do
+      expect(call).to be true
+      expect(resource.content).to eq("fake file content")
+      expect(resource.content.encoding).to eq(Encoding::UTF_8)
+    end
+  end
 end


### PR DESCRIPTION
### Summary

Do not use valkyrie in fileset_for_directives when file URIs are supplied, otherwise it will return a valkyrie object and cause problems further down the derivative pipeline. The retrieve_file_set method for HTTP uris already specifies no valkyrie, and there was no existing file uri test to catch the issue

### Guidance for testing, such as acceptance criteria or new user interface behaviors:
PDF derivatives should be able to generate for Fedora 4/ActiveFedora instances of hyrax.

### Type of change (for release notes)

notes-bugfix
