### PR TITLE
Move up iiif viewer javascript loading

### DIFF
--- a/app/views/layouts/_head_tag_content.html.erb
+++ b/app/views/layouts/_head_tag_content.html.erb
@@ -22,11 +22,15 @@ signed in %>
 
 <title><%= content_for?(:page_title) ? yield(:page_title) : default_page_title %></title>
 
+<% if @presenter.respond_to?(:iiif_viewer?) && @presenter.iiif_viewer? %>
+  <link rel="preload" href="<%= iiif_viewer_base_url(@presenter.iiif_viewer) %>" as="document" />
+<% end %>
+
 <!-- application css -->
 <%= stylesheet_link_tag 'application' %>
 
 <!-- application js -->
-<%= javascript_include_tag 'application' %>
+<%= javascript_include_tag 'application', defer: true %>
 
 <%= render 'shared/appearance_styles' %>
 


### PR DESCRIPTION
IIIF viewer javascript is pre-loaded on work show pages, and no longer waits to start fetching it until after the javascript is fully executed

### Fixes
There is a general perception that Hyrax and Hyku are slow, and some of this comes from IIIF viewers taking awhile to show images. By default, the viewers are "above the fold" on work pages, so if they take a long time to render an image, the impression it gives is that the overall application is slow, not just that the viewer is slow.

This frontloads getting the iiif viewer javascript, and not waiting for the whole application javascript to execute prior to trying to fetch the viewer javascript. 

Tested on a staging environment for a Hyku knapsack and shaved 3 seconds off of loading time. 

### Summary

Present tense short summary (50 characters or less)

### Guidance for testing, such as acceptance criteria or new user interface behaviors:
* For a deployment using Universal Viewer, the uv.html will start loading before the application javascript has finished executing. 
*
*

### Type of change (for release notes)

Choose from:
- `notes-bugfix` Bug Fixes

### Changes proposed in this pull request:
* Pre-load iiif viewer on work show pages when available
* The browser does not have to load and evaluate the scripts before continuing to parse

@samvera/hyrax-code-reviewers
