### PR TITLE
Add typeahead + multi-select opt-ins for controlled compound members

### DIFF
--- a/app/assets/javascripts/hyrax/compound_metadata.js
+++ b/app/assets/javascripts/hyrax/compound_metadata.js
@@ -84,9 +84,6 @@
                 allowClear: !$el.prop('multiple'),
                 placeholder: $el.data('placeholder') || ''
             });
-            // Tag the generated container so the styling stays scoped to these
-            // selects and off other select2 controls in the row.
-            $el.select2('container').addClass('hyrax-compound-controlled-select2');
         });
     }
 

--- a/app/assets/javascripts/hyrax/compound_metadata.js
+++ b/app/assets/javascripts/hyrax/compound_metadata.js
@@ -67,6 +67,29 @@
         });
     }
 
+    // Bind select2 to a `controlled` sub-property tagged
+    // `data-hyrax-compound-controlled` (see _compound_row.html.erb). Unlike the
+    // work_or_url / linked_record pickers, this binds a NATIVE <select> whose
+    // full option list is already in the DOM, so select2 filters client-side —
+    // no ajax. A `multiple` select becomes a tags-style multi picker; select2
+    // infers `multiple` from the element.
+    function bindControlledSelects(root) {
+        if (typeof jQuery === 'undefined' || !jQuery.fn.select2) return;
+        jQuery(root).find('[data-hyrax-compound-controlled]').each(function() {
+            var $el = jQuery(this);
+            if ($el.hasClass('select2-offscreen') || $el.data('select2')) return; // already bound
+
+            $el.select2({
+                width: '100%',
+                // A single select carries a blank option (include_blank), so
+                // allowClear gives it an "x"; a multiple has none and needs a
+                // placeholder to prompt.
+                allowClear: !$el.prop('multiple'),
+                placeholder: $el.data('placeholder') || ''
+            });
+        });
+    }
+
     // Show/hide the "Add new" trigger for a creatable linked_record when a
     // search returned no matches; stash the typed term to prefill the form.
     // `wrapEl` is the [data-hyrax-linked-record] wrapper captured at bind time.
@@ -86,7 +109,7 @@
     // Bind saved rows once the DOM is ready (at script-eval time the form
     // inputs don't exist yet, so the select2 would never attach). Covers both a
     // fresh load and Turbolinks navigation.
-    function bindAll() { bindWorkOrUrlInputs(document); }
+    function bindAll() { bindWorkOrUrlInputs(document); bindControlledSelects(document); }
     if (document.readyState === 'loading') {
         document.addEventListener('DOMContentLoaded', bindAll);
     } else {
@@ -264,8 +287,10 @@
         }
         var html = template.innerHTML.replace(/__INDEX__/g, nextIndex);
         rowsHost.insertAdjacentHTML('beforeend', html);
-        // Bind select2 on any work_or_url / linked_record inputs in the new row.
+        // Bind select2 on any work_or_url / linked_record inputs and controlled
+        // typeahead selects in the new row.
         bindWorkOrUrlInputs(rowsHost.lastElementChild || rowsHost);
+        bindControlledSelects(rowsHost.lastElementChild || rowsHost);
         section.dataset.nextIndex = String(nextIndex + 1);
     });
 })();

--- a/app/assets/javascripts/hyrax/compound_metadata.js
+++ b/app/assets/javascripts/hyrax/compound_metadata.js
@@ -67,12 +67,9 @@
         });
     }
 
-    // Bind select2 to a `controlled` sub-property tagged
-    // `data-hyrax-compound-controlled` (see _compound_row.html.erb). Unlike the
-    // work_or_url / linked_record pickers, this binds a NATIVE <select> whose
-    // full option list is already in the DOM, so select2 filters client-side —
-    // no ajax. A `multiple` select becomes a tags-style multi picker; select2
-    // infers `multiple` from the element.
+    // Unlike the work_or_url / linked_record pickers (hidden input + ajax), this
+    // binds a native <select> whose full option list is already in the DOM, so
+    // select2 filters client-side.
     function bindControlledSelects(root) {
         if (typeof jQuery === 'undefined' || !jQuery.fn.select2) return;
         jQuery(root).find('[data-hyrax-compound-controlled]').each(function() {
@@ -287,8 +284,7 @@
         }
         var html = template.innerHTML.replace(/__INDEX__/g, nextIndex);
         rowsHost.insertAdjacentHTML('beforeend', html);
-        // Bind select2 on any work_or_url / linked_record inputs and controlled
-        // typeahead selects in the new row.
+        // Cloned rows are fresh DOM, so re-run the select2 bindings.
         bindWorkOrUrlInputs(rowsHost.lastElementChild || rowsHost);
         bindControlledSelects(rowsHost.lastElementChild || rowsHost);
         section.dataset.nextIndex = String(nextIndex + 1);

--- a/app/assets/javascripts/hyrax/compound_metadata.js
+++ b/app/assets/javascripts/hyrax/compound_metadata.js
@@ -84,6 +84,9 @@
                 allowClear: !$el.prop('multiple'),
                 placeholder: $el.data('placeholder') || ''
             });
+            // Tag the generated container so the styling stays scoped to these
+            // selects and off other select2 controls in the row.
+            $el.select2('container').addClass('hyrax-compound-controlled-select2');
         });
     }
 

--- a/app/assets/javascripts/hyrax/compound_metadata.js
+++ b/app/assets/javascripts/hyrax/compound_metadata.js
@@ -67,9 +67,8 @@
         });
     }
 
-    // Unlike the work_or_url / linked_record pickers (hidden input + ajax), this
-    // binds a native <select> whose full option list is already in the DOM, so
-    // select2 filters client-side.
+    // The full option list is already in the DOM, so select2 filters
+    // client-side (no ajax, unlike the work_or_url / linked_record pickers).
     function bindControlledSelects(root) {
         if (typeof jQuery === 'undefined' || !jQuery.fn.select2) return;
         jQuery(root).find('[data-hyrax-compound-controlled]').each(function() {
@@ -78,9 +77,7 @@
 
             $el.select2({
                 width: '100%',
-                // A single select carries a blank option (include_blank), so
-                // allowClear gives it an "x"; a multiple has none and needs a
-                // placeholder to prompt.
+                // allowClear only on single-selects; a v3 multi warns without a placeholder.
                 allowClear: !$el.prop('multiple'),
                 placeholder: $el.data('placeholder') || ''
             });

--- a/app/assets/stylesheets/hyrax/_compound_metadata.scss
+++ b/app/assets/stylesheets/hyrax/_compound_metadata.scss
@@ -93,36 +93,32 @@
 // (Bootstrap border + fixed `.form-control-sm` height) while drawing its own
 // bordered inner box, so a bound control shows a "box within a box" and clips
 // its chosen pills. Flatten the inner box and let the frame grow to fit.
-.hyrax-compound-row {
-  .select2-container.form-control {
-    height: auto;
-    min-height: calc(1.5em + 0.5rem + 2px); // matches .form-control-sm
-    padding: 0;
+// (bindControlledSelects tags the container so this stays off other select2
+// controls in the row.)
+.hyrax-compound-controlled-select2.form-control {
+  height: auto;
+  min-height: calc(1.5em + 0.5rem + 2px); // matches .form-control-sm
+  padding: 0;
 
-    .select2-choices, // multi-select
-    .select2-choice {  // single-select
-      border: 0;
-      background: transparent;
-      box-shadow: none;
-      min-height: 0;
-    }
+  .select2-choice,  // single-select
+  .select2-choices { // multi-select
+    background: transparent;
+    border: 0;
+    box-shadow: none;
+    min-height: 0;
+  }
+}
+
+// Multi-select: match an empty control to a sibling .form-control-sm input so
+// fields line up, and keep pills tidy as they wrap.
+.select2-container-multi.hyrax-compound-controlled-select2 {
+  .select2-choices {
+    padding: 0 0.5rem;
   }
 
-  // Multi-select: match an empty control to a sibling .form-control-sm input so
-  // fields line up, and keep pills tidy as they wrap.
-  .select2-container-multi.form-control {
-    .select2-choices {
-      padding: 0 0.5rem;
-    }
-
-    .select2-search-field input.select2-input {
-      height: calc(1.5em + 0.5rem);
-      margin: 0;
-      line-height: 1.5;
-    }
-
-    .select2-search-choice {
-      margin: 2px 0 2px 5px;
-    }
+  .select2-search-field .select2-input {
+    height: calc(1.5em + 0.5rem);
+    line-height: 1.5;
+    margin: 0;
   }
 }

--- a/app/assets/stylesheets/hyrax/_compound_metadata.scss
+++ b/app/assets/stylesheets/hyrax/_compound_metadata.scss
@@ -88,3 +88,45 @@
     margin-top: 0.25rem;
   }
 }
+
+// A `controlled` sub-property with `form: { autocomplete: true }` binds select2
+// v3 over the native <select>. select2 copies the control's `.form-control`
+// classes onto its own container (a Bootstrap border + the fixed
+// `.form-control-sm` height) while rendering its own bordered inner box (a
+// "box within a box"), and the fixed height clips a multi-select's chosen pills.
+// Flatten the inner box so only the form-control frame shows, and let that frame
+// grow to fit the selected values instead of overflowing into the next field.
+.hyrax-compound-row {
+  .select2-container.form-control {
+    height: auto;
+    min-height: calc(1.5em + 0.5rem + 2px); // matches .form-control-sm
+    padding: 0;
+
+    .select2-choices, // multi-select
+    .select2-choice {  // single-select
+      border: 0;
+      background: transparent;
+      box-shadow: none;
+      min-height: 0;
+    }
+  }
+
+  // Multi-select: size the empty control to match a sibling .form-control-sm
+  // input (so Name and Role line up), and keep the chosen pills tidy as they
+  // wrap and grow the box.
+  .select2-container-multi.form-control {
+    .select2-choices {
+      padding: 0 0.5rem;
+    }
+
+    .select2-search-field input.select2-input {
+      height: calc(1.5em + 0.5rem);
+      margin: 0;
+      line-height: 1.5;
+    }
+
+    .select2-search-choice {
+      margin: 2px 0 2px 5px;
+    }
+  }
+}

--- a/app/assets/stylesheets/hyrax/_compound_metadata.scss
+++ b/app/assets/stylesheets/hyrax/_compound_metadata.scss
@@ -89,13 +89,12 @@
   }
 }
 
-// select2 v3 copies the <select>'s `.form-control` classes onto its container
-// (Bootstrap border + fixed `.form-control-sm` height) while drawing its own
-// bordered inner box, so a bound control shows a "box within a box" and clips
-// its chosen pills. Flatten the inner box and let the frame grow to fit.
-// (bindControlledSelects tags the container so this stays off other select2
-// controls in the row.)
-.hyrax-compound-controlled-select2.form-control {
+// select2 v3 copies the control's `.form-control` classes onto its container
+// (Bootstrap border + fixed `.form-control-sm` height) and then draws its own
+// bordered inner box, so every select2 control in a compound row shows a
+// "box within a box". Flatten the inner box so only the form-control frame
+// shows and let the frame grow to fit its contents.
+.hyrax-compound-row .select2-container.form-control {
   height: auto;
   min-height: calc(1.5em + 0.5rem + 2px); // matches .form-control-sm
   padding: 0;
@@ -107,11 +106,17 @@
     box-shadow: none;
     min-height: 0;
   }
+
+  // The single-select dropdown arrow otherwise sits in its own bordered cell.
+  .select2-arrow {
+    background: transparent;
+    border-left: 0;
+  }
 }
 
 // Multi-select: match an empty control to a sibling .form-control-sm input so
 // fields line up, and keep pills tidy as they wrap.
-.select2-container-multi.hyrax-compound-controlled-select2 {
+.hyrax-compound-row .select2-container-multi.form-control {
   .select2-choices {
     padding: 0 0.5rem;
   }

--- a/app/assets/stylesheets/hyrax/_compound_metadata.scss
+++ b/app/assets/stylesheets/hyrax/_compound_metadata.scss
@@ -89,40 +89,35 @@
   }
 }
 
-// select2 v3 copies the control's `.form-control` classes onto its container
-// (Bootstrap border + fixed `.form-control-sm` height) and then draws its own
-// bordered inner box, so every select2 control in a compound row shows a
-// "box within a box". Flatten the inner box so only the form-control frame
-// shows and let the frame grow to fit its contents.
+// select2 v3 copies the control's `.form-control` classes onto its container and
+// then draws its own bordered inner box, so a bound control renders a "box within
+// a box". Flatten the inner box so only the form-control frame shows.
 .hyrax-compound-row .select2-container.form-control {
   height: auto;
   min-height: calc(1.5em + 0.5rem + 2px); // matches .form-control-sm
   padding: 0;
 
-  .select2-choice,  // single-select
-  .select2-choices { // multi-select
+  .select2-choice,
+  .select2-choices {
     background: transparent;
     border: 0;
     box-shadow: none;
     min-height: 0;
   }
 
-  // The single-select dropdown arrow otherwise sits in its own bordered cell.
   .select2-arrow {
     background: transparent;
     border-left: 0;
   }
 }
 
-// Multi-select: match an empty control to a sibling .form-control-sm input so
-// fields line up, and keep pills tidy as they wrap.
 .hyrax-compound-row .select2-container-multi.form-control {
   .select2-choices {
     padding: 0 0.5rem;
   }
 
   .select2-search-field .select2-input {
-    height: calc(1.5em + 0.5rem);
+    height: calc(1.5em + 0.5rem); // matches .form-control-sm
     line-height: 1.5;
     margin: 0;
   }

--- a/app/assets/stylesheets/hyrax/_compound_metadata.scss
+++ b/app/assets/stylesheets/hyrax/_compound_metadata.scss
@@ -89,13 +89,10 @@
   }
 }
 
-// A `controlled` sub-property with `form: { autocomplete: true }` binds select2
-// v3 over the native <select>. select2 copies the control's `.form-control`
-// classes onto its own container (a Bootstrap border + the fixed
-// `.form-control-sm` height) while rendering its own bordered inner box (a
-// "box within a box"), and the fixed height clips a multi-select's chosen pills.
-// Flatten the inner box so only the form-control frame shows, and let that frame
-// grow to fit the selected values instead of overflowing into the next field.
+// select2 v3 copies the <select>'s `.form-control` classes onto its container
+// (Bootstrap border + fixed `.form-control-sm` height) while drawing its own
+// bordered inner box, so a bound control shows a "box within a box" and clips
+// its chosen pills. Flatten the inner box and let the frame grow to fit.
 .hyrax-compound-row {
   .select2-container.form-control {
     height: auto;
@@ -111,9 +108,8 @@
     }
   }
 
-  // Multi-select: size the empty control to match a sibling .form-control-sm
-  // input (so Name and Role line up), and keep the chosen pills tidy as they
-  // wrap and grow the box.
+  // Multi-select: match an empty control to a sibling .form-control-sm input so
+  // fields line up, and keep pills tidy as they wrap.
   .select2-container-multi.form-control {
     .select2-choices {
       padding: 0 0.5rem;

--- a/app/forms/concerns/hyrax/compound_field_behavior.rb
+++ b/app/forms/concerns/hyrax/compound_field_behavior.rb
@@ -56,34 +56,67 @@ module Hyrax
 
     # One populator serves every compound (Reform passes the property name as
     # `as:`). Builds the replacement array of plain hashes — declared
-    # sub-property keys only, dropping `_destroy` and all-blank rows.
+    # sub-property keys only, dropping `_destroy` and all-blank rows. A
+    # `multiple: true` member with several selected values fans its row out into
+    # one entry per value (see {#expand_multiple_members}).
     def compound_attributes_populator(fragment:, as:, **_options)
       name = as.to_s.delete_suffix('_attributes')
       return unless respond_to?(name)
 
-      allowed = Hyrax::CompoundSchema.for(model).subproperty_keys(name)
-      public_send(:"#{name}=", build_compound_rows(fragment, allowed))
+      definition = Hyrax::CompoundSchema.for(model).definition_for(name)
+      allowed = (definition || {}).fetch(:subproperties, {}).keys
+      multiple_keys = multiple_subproperty_keys(definition)
+      public_send(:"#{name}=", build_compound_rows(fragment, allowed, multiple_keys))
     end
 
-    def build_compound_rows(fragment, allowed_keys)
+    def build_compound_rows(fragment, allowed_keys, multiple_keys = [])
       fragment_pairs(fragment)
         .sort_by { |key, _row| key.to_i }
-        .map { |_key, row| compound_row_from(row, allowed_keys) }
+        .flat_map { |_key, row| compound_row_from(row, allowed_keys, multiple_keys) }
         .compact
     end
 
-    # Returns nil for a row marked for destruction or whose declared sub-properties
-    # are all blank, otherwise the persisted hash for that row.
-    def compound_row_from(row, allowed_keys)
+    # The sub-property keys declared `form: { multiple: true }` for this
+    # compound (empty when the definition is unavailable).
+    def multiple_subproperty_keys(definition)
+      return [] unless definition.is_a?(Hash)
+      definition.fetch(:subproperties, {}).select { |_k, spec| spec[:multiple] }.keys
+    end
+
+    # Returns nil for a row marked for destruction or whose declared
+    # sub-properties are all blank; otherwise an array of one or more persisted
+    # entry hashes — several when a `multiple` member carries multiple values.
+    def compound_row_from(row, allowed_keys, multiple_keys = [])
       row = row_hash(row)
       return nil if %w[true 1].include?(row['_destroy'].to_s)
 
-      entry = allowed_keys.each_with_object({}) do |key, memo|
-        value = row[key]
-        memo[key] = value.is_a?(String) ? value.strip : value
-      end
+      entry = allowed_keys.index_with { |key| normalize_row_value(row[key], multiple_keys.include?(key)) }
       return nil if entry.values.all?(&:blank?)
-      entry
+
+      expand_multiple_members(entry, multiple_keys)
+    end
+
+    # A `multiple` member is coerced to a compacted array of stripped, non-blank
+    # values; any other member keeps its scalar (stripped if a string).
+    def normalize_row_value(value, multiple)
+      return Array(value).map { |v| v.is_a?(String) ? v.strip : v }.reject(&:blank?) if multiple
+
+      value.is_a?(String) ? value.strip : value
+    end
+
+    # Fan `multiple` members out so each stored entry holds one scalar value per
+    # such member. With a single multiple member (the common case) this yields
+    # one entry per selected value; with several it yields their cartesian
+    # product. A multiple member with no values collapses to a single nil, so a
+    # row whose only content is its other members is still stored once.
+    def expand_multiple_members(entry, multiple_keys)
+      present = multiple_keys.select { |key| entry[key].is_a?(Array) && entry[key].any? }
+      return [entry.transform_values { |v| v.is_a?(Array) ? nil : v }] if present.empty?
+
+      value_lists = present.map { |key| entry[key] }
+      value_lists.first.product(*value_lists[1..]).map do |combo|
+        entry.merge(present.zip(combo).to_h)
+      end
     end
   end
 end

--- a/app/forms/concerns/hyrax/compound_field_behavior.rb
+++ b/app/forms/concerns/hyrax/compound_field_behavior.rb
@@ -101,11 +101,14 @@ module Hyrax
     # still stored once.
     def expand_multiple_members(entry, multiple_keys)
       present = multiple_keys.select { |key| entry[key].is_a?(Array) && entry[key].any? }
-      return [entry.transform_values { |v| v.is_a?(Array) ? nil : v }] if present.empty?
+      # Only `multiple` members are collapsed (to nil), so a non-selected one
+      # never leaks a `[]` and other members keep whatever they came in as.
+      base = entry.merge((multiple_keys - present).index_with(nil))
+      return [base] if present.empty?
 
       value_lists = present.map { |key| entry[key] }
       value_lists.first.product(*value_lists[1..]).map do |combo|
-        entry.merge(present.zip(combo).to_h)
+        base.merge(present.zip(combo).to_h)
       end
     end
   end

--- a/app/forms/concerns/hyrax/compound_field_behavior.rb
+++ b/app/forms/concerns/hyrax/compound_field_behavior.rb
@@ -55,10 +55,8 @@ module Hyrax
     end
 
     # One populator serves every compound (Reform passes the property name as
-    # `as:`). Builds the replacement array of plain hashes — declared
-    # sub-property keys only, dropping `_destroy` and all-blank rows. A
-    # `multiple: true` member with several selected values fans its row out into
-    # one entry per value (see {#expand_multiple_members}).
+    # `as:`). A `multiple: true` member fans its row out into one entry per
+    # selected value (see {#expand_multiple_members}).
     def compound_attributes_populator(fragment:, as:, **_options)
       name = as.to_s.delete_suffix('_attributes')
       return unless respond_to?(name)
@@ -76,16 +74,11 @@ module Hyrax
         .compact
     end
 
-    # The sub-property keys declared `form: { multiple: true }` for this
-    # compound (empty when the definition is unavailable).
     def multiple_subproperty_keys(definition)
       return [] unless definition.is_a?(Hash)
       definition.fetch(:subproperties, {}).select { |_k, spec| spec[:multiple] }.keys
     end
 
-    # Returns nil for a row marked for destruction or whose declared
-    # sub-properties are all blank; otherwise an array of one or more persisted
-    # entry hashes — several when a `multiple` member carries multiple values.
     def compound_row_from(row, allowed_keys, multiple_keys = [])
       row = row_hash(row)
       return nil if %w[true 1].include?(row['_destroy'].to_s)
@@ -96,19 +89,16 @@ module Hyrax
       expand_multiple_members(entry, multiple_keys)
     end
 
-    # A `multiple` member is coerced to a compacted array of stripped, non-blank
-    # values; any other member keeps its scalar (stripped if a string).
     def normalize_row_value(value, multiple)
       return Array(value).map { |v| v.is_a?(String) ? v.strip : v }.reject(&:blank?) if multiple
 
       value.is_a?(String) ? value.strip : value
     end
 
-    # Fan `multiple` members out so each stored entry holds one scalar value per
-    # such member. With a single multiple member (the common case) this yields
-    # one entry per selected value; with several it yields their cartesian
-    # product. A multiple member with no values collapses to a single nil, so a
-    # row whose only content is its other members is still stored once.
+    # Fan `multiple` members out into one entry per value (their cartesian
+    # product when a row has more than one). A `multiple` member with no values
+    # collapses to a single nil so a row carrying only its other members is
+    # still stored once.
     def expand_multiple_members(entry, multiple_keys)
       present = multiple_keys.select { |key| entry[key].is_a?(Array) && entry[key].any? }
       return [entry.transform_values { |v| v.is_a?(Array) ? nil : v }] if present.empty?

--- a/app/forms/concerns/hyrax/compound_field_behavior.rb
+++ b/app/forms/concerns/hyrax/compound_field_behavior.rb
@@ -54,9 +54,6 @@ module Hyrax
       []
     end
 
-    # One populator serves every compound (Reform passes the property name as
-    # `as:`). A `multiple: true` member fans its row out into one entry per
-    # selected value (see {#expand_multiple_members}).
     def compound_attributes_populator(fragment:, as:, **_options)
       name = as.to_s.delete_suffix('_attributes')
       return unless respond_to?(name)
@@ -95,14 +92,11 @@ module Hyrax
       value.is_a?(String) ? value.strip : value
     end
 
-    # Fan `multiple` members out into one entry per value (their cartesian
-    # product when a row has more than one). A `multiple` member with no values
-    # collapses to a single nil so a row carrying only its other members is
-    # still stored once.
+    # A `multiple` member with no selection collapses to nil, not an empty array,
+    # so a row carrying only its other members is still stored once. Only
+    # `multiple` members are touched, so other members are never clobbered.
     def expand_multiple_members(entry, multiple_keys)
       present = multiple_keys.select { |key| entry[key].is_a?(Array) && entry[key].any? }
-      # Only `multiple` members are collapsed (to nil), so a non-selected one
-      # never leaks a `[]` and other members keep whatever they came in as.
       base = entry.merge((multiple_keys - present).index_with(nil))
       return [base] if present.empty?
 

--- a/app/helpers/hyrax/compound_fields_helper.rb
+++ b/app/helpers/hyrax/compound_fields_helper.rb
@@ -3,7 +3,7 @@
 module Hyrax
   # View helpers for rendering compound (hierarchical) metadata fields on forms
   # and show pages. See documentation/compound_fields.md.
-  module CompoundFieldsHelper
+  module CompoundFieldsHelper # rubocop:disable Metrics/ModuleLength
     ##
     # Renders one compound section (a repeatable stack of sub-property rows) for the
     # given attribute via the `hyrax/compounds/*` partials.
@@ -81,6 +81,29 @@ module Hyrax
       return false if values.empty?
       base = spec[:values].presence || authority_options(spec[:authority])
       values.any? { |value| base.none? { |(_label, id)| id.to_s == value.to_s } }
+    end
+
+    # Renders the `<select>` for a `controlled` sub-property, applying the
+    # `multiple` (array name, no blank) and `autocomplete` (select2 typeahead) opt-ins.
+    def compound_controlled_select(spec, value, input_name, input_id)
+      multiple = spec[:multiple]
+      classes = ['form-control', 'form-control-sm']
+      classes << 'force-select' if compound_subproperty_forced?(spec, value)
+      select_tag(multiple ? "#{input_name}[]" : input_name,
+                 options_for_select(compound_subproperty_options(spec, value), value),
+                 id: input_id,
+                 include_blank: !multiple,
+                 multiple: multiple,
+                 data: compound_controlled_data(spec),
+                 class: classes.join(' '))
+    end
+
+    # select2 typeahead data attrs for an `autocomplete` sub-property, else empty.
+    def compound_controlled_data(spec)
+      return {} unless spec[:autocomplete]
+
+      { 'hyrax-compound-controlled' => true,
+        'placeholder' => t('hyrax.compound_fields.search', default: 'Search') }
     end
 
     ##

--- a/app/helpers/hyrax/compound_fields_helper.rb
+++ b/app/helpers/hyrax/compound_fields_helper.rb
@@ -65,11 +65,8 @@ module Hyrax
     end
 
     ##
-    # Options for a `controlled` sub-property's `<select>`: an inline `values:`
-    # list when present, otherwise the named QA authority. Any stored value not
-    # among the options is appended so it still renders. +current_value+ may be
-    # an array (a `multiple: true` member), in which case every stored value is
-    # ensured.
+    # Options for a `controlled` sub-property's `<select>`. Any stored value not
+    # among the offered options is appended so a forced/stale value still renders.
     #
     # @return [Array<Array(String, String)>] `[[label, id], ...]`
     def compound_subproperty_options(spec, current_value = nil)
@@ -78,11 +75,9 @@ module Hyrax
     end
 
     ##
-    # @return [Boolean] whether any present +current_value+ is not among the
-    #   sub-property's offered options — i.e. a forced/stale value. The select
-    #   gets the +force-select+ class in that case, matching the ordinary
-    #   controlled-field convention. Handles an array value (a `multiple: true`
-    #   member): forced when any selected value is off-list.
+    # @return [Boolean] whether any present +current_value+ is off the
+    #   sub-property's offered options. Such a value gets the +force-select+ class
+    #   so it still renders, matching the ordinary controlled-field convention.
     def compound_subproperty_forced?(spec, current_value = nil)
       values = Array(current_value).reject(&:blank?)
       return false if values.empty?

--- a/app/helpers/hyrax/compound_fields_helper.rb
+++ b/app/helpers/hyrax/compound_fields_helper.rb
@@ -66,24 +66,28 @@ module Hyrax
 
     ##
     # Options for a `controlled` sub-property's `<select>`: an inline `values:`
-    # list when present, otherwise the named QA authority. A stored value not
-    # among the options is appended so it still renders (`include_current_value`).
+    # list when present, otherwise the named QA authority. Any stored value not
+    # among the options is appended so it still renders. +current_value+ may be
+    # an array (a `multiple: true` member), in which case every stored value is
+    # ensured.
     #
     # @return [Array<Array(String, String)>] `[[label, id], ...]`
     def compound_subproperty_options(spec, current_value = nil)
       options = spec[:values].presence || authority_options(spec[:authority])
-      ensure_current_value(options, current_value)
+      Array(current_value).reject(&:blank?).reduce(options) { |opts, value| ensure_current_value(opts, value) }
     end
 
     ##
-    # @return [Boolean] whether +current_value+ is present but not among the
+    # @return [Boolean] whether any present +current_value+ is not among the
     #   sub-property's offered options — i.e. a forced/stale value. The select
     #   gets the +force-select+ class in that case, matching the ordinary
-    #   controlled-field convention.
+    #   controlled-field convention. Handles an array value (a `multiple: true`
+    #   member): forced when any selected value is off-list.
     def compound_subproperty_forced?(spec, current_value = nil)
-      return false if current_value.blank?
+      values = Array(current_value).reject(&:blank?)
+      return false if values.empty?
       base = spec[:values].presence || authority_options(spec[:authority])
-      base.none? { |(_label, id)| id.to_s == current_value.to_s }
+      values.any? { |value| base.none? { |(_label, id)| id.to_s == value.to_s } }
     end
 
     ##

--- a/app/helpers/hyrax/compound_fields_helper.rb
+++ b/app/helpers/hyrax/compound_fields_helper.rb
@@ -65,8 +65,7 @@ module Hyrax
     end
 
     ##
-    # Options for a `controlled` sub-property's `<select>`. Any stored value not
-    # among the offered options is appended so a forced/stale value still renders.
+    # Off-list stored values are appended so a forced/stale value still renders.
     #
     # @return [Array<Array(String, String)>] `[[label, id], ...]`
     def compound_subproperty_options(spec, current_value = nil)
@@ -75,9 +74,8 @@ module Hyrax
     end
 
     ##
-    # @return [Boolean] whether any present +current_value+ is off the
-    #   sub-property's offered options. Such a value gets the +force-select+ class
-    #   so it still renders, matching the ordinary controlled-field convention.
+    # @return [Boolean] whether any present value is off-list (so it gets the
+    #   +force-select+ class and still renders).
     def compound_subproperty_forced?(spec, current_value = nil)
       values = Array(current_value).reject(&:blank?)
       return false if values.empty?

--- a/app/indexers/hyrax/indexers/compound_indexer.rb
+++ b/app/indexers/hyrax/indexers/compound_indexer.rb
@@ -64,9 +64,8 @@ module Hyrax
           index_keys = solr_index_keys(compound_name, sub_property, spec)
           next if index_keys.empty?
 
-          # `flatten` so a member whose stored value is itself an array (e.g. a
-          # `multiple: true` member echoed back before fan-out) contributes each
-          # term as its own facet value rather than a nested array.
+          # A `multiple` member echoed back before fan-out arrives as an array;
+          # flat_map indexes each term as its own facet value.
           values = rows.flat_map { |row| compound_entry_value(row, sub_property) }.reject(&:blank?)
           next if values.empty?
 

--- a/app/indexers/hyrax/indexers/compound_indexer.rb
+++ b/app/indexers/hyrax/indexers/compound_indexer.rb
@@ -64,7 +64,10 @@ module Hyrax
           index_keys = solr_index_keys(compound_name, sub_property, spec)
           next if index_keys.empty?
 
-          values = rows.map { |row| compound_entry_value(row, sub_property) }.reject(&:blank?)
+          # `flatten` so a member whose stored value is itself an array (e.g. a
+          # `multiple: true` member echoed back before fan-out) contributes each
+          # term as its own facet value rather than a nested array.
+          values = rows.flat_map { |row| compound_entry_value(row, sub_property) }.reject(&:blank?)
           next if values.empty?
 
           index_keys.each { |index_key| document[index_key] = values }

--- a/app/renderers/hyrax/renderers/compound_attribute_renderer.rb
+++ b/app/renderers/hyrax/renderers/compound_attribute_renderer.rb
@@ -106,13 +106,23 @@ module Hyrax
       # stored value is itself a linkable URI (e.g. a rights-statement or license
       # URI), link the term to that URI — mirroring the ordinary rights/license
       # renderer. Non-URI controlled values (e.g. inline option ids) stay plain.
+      # An array value (a `multiple: true` member echoed back before fan-out)
+      # renders each term, comma-separated.
       def controlled_markup(sub_property, value)
+        return safe_join_terms(Array(value).map { |v| controlled_markup(sub_property, v) }) if value.is_a?(::Array)
+
         label = display_value(sub_property, value)
         if Hyrax::AuthorityRenderingHelper.linkable_uri?(value)
           %(<a href="#{ERB::Util.h(value)}" target="_blank" rel="noopener noreferrer">#{ERB::Util.h(label)}</a>).html_safe
         else
           ERB::Util.h(label)
         end
+      end
+
+      # Join already-escaped term fragments with a comma separator, preserving
+      # html_safe-ness.
+      def safe_join_terms(fragments)
+        fragments.map(&:to_s).join(', ').html_safe
       end
 
       # Link a URL or a resolvable work; render anything else as plain text so

--- a/app/renderers/hyrax/renderers/compound_attribute_renderer.rb
+++ b/app/renderers/hyrax/renderers/compound_attribute_renderer.rb
@@ -106,8 +106,7 @@ module Hyrax
       # stored value is itself a linkable URI (e.g. a rights-statement or license
       # URI), link the term to that URI — mirroring the ordinary rights/license
       # renderer. Non-URI controlled values (e.g. inline option ids) stay plain.
-      # An array value (a `multiple: true` member echoed back before fan-out)
-      # renders each term, comma-separated.
+      # An array can arrive when a `multiple` member is echoed back before fan-out.
       def controlled_markup(sub_property, value)
         return safe_join_terms(Array(value).map { |v| controlled_markup(sub_property, v) }) if value.is_a?(::Array)
 
@@ -119,8 +118,7 @@ module Hyrax
         end
       end
 
-      # Join already-escaped term fragments with a comma separator, preserving
-      # html_safe-ness.
+      # Fragments are already escaped, so joining and marking html_safe is safe.
       def safe_join_terms(fragments)
         fragments.map(&:to_s).join(', ').html_safe
       end

--- a/app/services/hyrax/compound_schema.rb
+++ b/app/services/hyrax/compound_schema.rb
@@ -263,10 +263,8 @@ module Hyrax
         group: opts['group']&.to_s,
         cols: (form['cols'] || DEFAULT_COLS).to_i,
         as: form['as']&.to_s,
-        # `controlled`-only form opt-ins: `autocomplete` binds a select2
-        # typeahead over the options; `multiple` allows several values, each
-        # fanned out into its own compound entry at submit time (see
-        # Hyrax::CompoundFieldBehavior). Both default false.
+        # `controlled`-only form opt-ins (both default false). `multiple` values
+        # fan out into one entry each at submit time (see Hyrax::CompoundFieldBehavior).
         autocomplete: truthy?(form['autocomplete']),
         multiple: truthy?(form['multiple']) }.merge(linked_record_keys(opts))
     end

--- a/app/services/hyrax/compound_schema.rb
+++ b/app/services/hyrax/compound_schema.rb
@@ -263,8 +263,6 @@ module Hyrax
         group: opts['group']&.to_s,
         cols: (form['cols'] || DEFAULT_COLS).to_i,
         as: form['as']&.to_s,
-        # `controlled`-only form opt-ins (both default false). `multiple` values
-        # fan out into one entry each at submit time (see Hyrax::CompoundFieldBehavior).
         autocomplete: truthy?(form['autocomplete']),
         multiple: truthy?(form['multiple']) }.merge(linked_record_keys(opts))
     end

--- a/app/services/hyrax/compound_schema.rb
+++ b/app/services/hyrax/compound_schema.rb
@@ -262,7 +262,13 @@ module Hyrax
         required: truthy?(opts['required']),
         group: opts['group']&.to_s,
         cols: (form['cols'] || DEFAULT_COLS).to_i,
-        as: form['as']&.to_s }.merge(linked_record_keys(opts))
+        as: form['as']&.to_s,
+        # `controlled`-only form opt-ins: `autocomplete` binds a select2
+        # typeahead over the options; `multiple` allows several values, each
+        # fanned out into its own compound entry at submit time (see
+        # Hyrax::CompoundFieldBehavior). Both default false.
+        autocomplete: truthy?(form['autocomplete']),
+        multiple: truthy?(form['multiple']) }.merge(linked_record_keys(opts))
     end
 
     # The `linked_record`-specific declarations: profile-driven lookup-or-create

--- a/app/services/hyrax/compound_subproperty_labeler.rb
+++ b/app/services/hyrax/compound_subproperty_labeler.rb
@@ -15,6 +15,7 @@ module Hyrax
     #
     # @return [String] the term to display
     def self.label_for(spec, value)
+      return Array(value).map { |v| label_for(spec, v) }.join(', ') if value.is_a?(::Array)
       return value.to_s if spec.nil? || spec[:type].to_s != 'controlled' || value.blank?
 
       if spec[:values].present?

--- a/app/views/hyrax/compounds/_compound_row.html.erb
+++ b/app/views/hyrax/compounds/_compound_row.html.erb
@@ -45,24 +45,7 @@
             <% end %>
             <% case spec[:type] %>
             <% when 'controlled' %>
-              <%# `multiple` submits an array (`[]` suffix) that fans out server-side;
-                  `autocomplete` tags the select for compound_metadata.js. %>
-              <% multiple = spec[:multiple] %>
-              <% control_name = multiple ? "#{input_name}[]" : input_name %>
-              <% select_classes = ['form-control', 'form-control-sm'] %>
-              <% select_classes << 'force-select' if compound_subproperty_forced?(spec, value) %>
-              <% control_data = {} %>
-              <% if spec[:autocomplete] %>
-                <% control_data['hyrax-compound-controlled'] = true %>
-                <% control_data['placeholder'] = t('hyrax.compound_fields.search', default: 'Search') %>
-              <% end %>
-              <%= select_tag control_name,
-                             options_for_select(compound_subproperty_options(spec, value), value),
-                             id: input_id,
-                             include_blank: !multiple,
-                             multiple: multiple,
-                             data: control_data,
-                             class: select_classes.join(' ') %>
+              <%= compound_controlled_select(spec, value, input_name, input_id) %>
             <% when 'url' %>
               <%= url_field_tag input_name, value,
                                 id: input_id,

--- a/app/views/hyrax/compounds/_compound_row.html.erb
+++ b/app/views/hyrax/compounds/_compound_row.html.erb
@@ -45,12 +45,27 @@
             <% end %>
             <% case spec[:type] %>
             <% when 'controlled' %>
+              <%# A controlled member is a single-select by default. `multiple:
+                  true` makes it a multi-select whose values submit as an array
+                  (`[]` name suffix) and fan out into one entry per value
+                  server-side. `autocomplete: true` tags the select so
+                  compound_metadata.js binds a select2 typeahead; the full option
+                  list is already in the DOM, so filtering is client-side. %>
+              <% multiple = spec[:multiple] %>
+              <% control_name = multiple ? "#{input_name}[]" : input_name %>
               <% select_classes = ['form-control', 'form-control-sm'] %>
               <% select_classes << 'force-select' if compound_subproperty_forced?(spec, value) %>
-              <%= select_tag input_name,
+              <% control_data = {} %>
+              <% if spec[:autocomplete] %>
+                <% control_data['hyrax-compound-controlled'] = true %>
+                <% control_data['placeholder'] = t('hyrax.compound_fields.search', default: 'Search') %>
+              <% end %>
+              <%= select_tag control_name,
                              options_for_select(compound_subproperty_options(spec, value), value),
                              id: input_id,
-                             include_blank: true,
+                             include_blank: !multiple,
+                             multiple: multiple,
+                             data: control_data,
                              class: select_classes.join(' ') %>
             <% when 'url' %>
               <%= url_field_tag input_name, value,

--- a/app/views/hyrax/compounds/_compound_row.html.erb
+++ b/app/views/hyrax/compounds/_compound_row.html.erb
@@ -45,9 +45,8 @@
             <% end %>
             <% case spec[:type] %>
             <% when 'controlled' %>
-              <%# `multiple` submits values as an array (`[]` suffix) that fans out
-                  into one entry per value server-side; `autocomplete` tags the
-                  select for compound_metadata.js to bind a select2 typeahead. %>
+              <%# `multiple` submits an array (`[]` suffix) that fans out server-side;
+                  `autocomplete` tags the select for compound_metadata.js. %>
               <% multiple = spec[:multiple] %>
               <% control_name = multiple ? "#{input_name}[]" : input_name %>
               <% select_classes = ['form-control', 'form-control-sm'] %>

--- a/app/views/hyrax/compounds/_compound_row.html.erb
+++ b/app/views/hyrax/compounds/_compound_row.html.erb
@@ -45,12 +45,9 @@
             <% end %>
             <% case spec[:type] %>
             <% when 'controlled' %>
-              <%# A controlled member is a single-select by default. `multiple:
-                  true` makes it a multi-select whose values submit as an array
-                  (`[]` name suffix) and fan out into one entry per value
-                  server-side. `autocomplete: true` tags the select so
-                  compound_metadata.js binds a select2 typeahead; the full option
-                  list is already in the DOM, so filtering is client-side. %>
+              <%# `multiple` submits values as an array (`[]` suffix) that fans out
+                  into one entry per value server-side; `autocomplete` tags the
+                  select for compound_metadata.js to bind a select2 typeahead. %>
               <% multiple = spec[:multiple] %>
               <% control_name = multiple ? "#{input_name}[]" : input_name %>
               <% select_classes = ['form-control', 'form-control-sm'] %>

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -930,6 +930,7 @@ en:
         default_description: A User Collection can be created by any user to organize their works.
     compound_fields:
       add_row: Add %{label}
+      search: Search
       remove_row: Remove
       remove_row_with_label: Remove %{label}
       errors:

--- a/documentation/compound_fields.md
+++ b/documentation/compound_fields.md
@@ -139,7 +139,7 @@ textarea). Supported `type:` values:
 | `url`        | url input → auto-linked on show | The stored value is rendered as a clickable `<a href>` on show pages (matching the scalar `render_as: external_link` behavior). |
 | `work_or_url` | select2 typeahead → linked on show | Searches internal works (via the `compound_works` QA authority, backed by `Hyrax::CompoundWorkPickerBuilder`) **or** accepts a typed external URL. The stored value is a work id or a URL; on show, a work id links to the work's show page with its title (resolved by `Hyrax::CompoundWorkResolver`), a URL is auto-linked. |
 | `linked_record` | select2 typeahead → linked on show | A reference to a row in a database table (a person, organization, funder, place, …). The stored value is the row id; the picker searches that table and, optionally, lets a cataloger add a new record inline. On show, the id links to the record using the resolved label. The table and its procs are registered by the host application — see [`linked_record` sub-properties](#linked_record-sub-properties) below. |
-| `controlled` | `<select>` dropdown | Options come from either an inline `values:` list or a QA local authority named by `authority:` (see below). The row's stored value is preserved even if it is no longer offered, matching the `include_current_value` convention of the ordinary controlled-field partials. |
+| `controlled` | `<select>` dropdown (optionally a select2 typeahead / multi-select) | Options come from either an inline `values:` list or a QA local authority named by `authority:` (see below). The row's stored value is preserved even if it is no longer offered, matching the `include_current_value` convention of the ordinary controlled-field partials. Two per-member `form:` opt-ins refine the input — see [Typeahead and multi-select](#typeahead-and-multi-select-for-controlled-members) below. |
 
 A `controlled` sub-property sources its options one of two ways:
 
@@ -169,6 +169,36 @@ the same `config/authorities/*.yml` files ordinary controlled fields use. When
 both are given, `values:` wins. Authority options are read through
 `Hyrax::TolerantSelectService`, so an authority file that omits the `active:`
 key behaves the same as it does for ordinary fields (terms default to active).
+
+#### Typeahead and multi-select for `controlled` members
+
+A `controlled` member is a single-select plain `<select>` by default. Two
+`form:` opt-ins, each defaulting off, refine it:
+
+```yaml
+participant_role:
+  type: controlled
+  available_on: { properties: [participants] }
+  authority: participant_role
+  form:
+    autocomplete: true   # bind a select2 typeahead over the options
+    multiple: true        # allow several values in one row
+```
+
+- **`autocomplete: true`** binds a select2 typeahead to the select so the
+  cataloger can filter the options by typing. The full option list is rendered
+  into the DOM, so filtering is client-side — no extra request. It works on both
+  single- and multi-select members.
+- **`multiple: true`** renders a multi-select (the values submit as an array).
+  At submit time each selected value **fans out into its own compound entry**,
+  sharing the row's other members — so a participant picked with three roles is
+  stored as three entries of one role each, not one entry holding an array. This
+  keeps the stored shape uniform (every member value is a scalar) and lets each
+  term index and facet independently. A row whose only multi-select member is
+  left empty is still stored once (with that member nil).
+
+Both are independent: a member may be a typeahead single-select, a plain
+multi-select, both, or neither.
 
 A `work_or_url` sub-property's work search is broader than the stock "my works"
 picker: `Hyrax::CompoundWorkPickerBuilder` matches a typed term against any

--- a/spec/forms/concerns/hyrax/compound_field_behavior_spec.rb
+++ b/spec/forms/concerns/hyrax/compound_field_behavior_spec.rb
@@ -14,6 +14,17 @@ RSpec.describe Hyrax::CompoundFieldBehavior do
                     'family_name' => { 'type' => 'string' }
                   }
                 )
+
+      # A second compound with a `multiple: true` controlled member, kept
+      # separate from `contributors` so the single-value examples above are
+      # unaffected by the extra sub-property.
+      attribute :credits,
+                Valkyrie::Types::Array.of(Dry::Types['hash']).meta(
+                  subproperties: {
+                    'name' => { 'type' => 'string' },
+                    'role' => { 'type' => 'controlled', 'form' => { 'multiple' => true } }
+                  }
+                )
     end
   end
 
@@ -23,7 +34,7 @@ RSpec.describe Hyrax::CompoundFieldBehavior do
   # and a settable compound accessor, mirroring the redirects behavior spec.
   let(:form_class) do
     Class.new do
-      attr_accessor :contributors
+      attr_accessor :contributors, :credits
 
       def self.property(*); end
 
@@ -34,7 +45,7 @@ RSpec.describe Hyrax::CompoundFieldBehavior do
       attr_reader :model
 
       def respond_to_missing?(name, *)
-        %i[contributors contributors=].include?(name) || super
+        %i[contributors contributors= credits credits=].include?(name) || super
       end
 
       def from_hash(params)
@@ -87,6 +98,39 @@ RSpec.describe Hyrax::CompoundFieldBehavior do
       form.send(:compound_attributes_populator, fragment: fragment, as: :contributors_attributes)
 
       expect(form.contributors).to eq([{ 'given_name' => 'Grace', 'family_name' => 'Hopper' }])
+    end
+
+    context 'with a multiple: true sub-property' do
+      it 'fans a row with several selected values out into one entry per value' do
+        fragment = { '0' => { 'name' => 'Ada', 'role' => %w[author editor] } }
+        form.send(:compound_attributes_populator, fragment: fragment, as: :credits_attributes)
+
+        expect(form.credits).to eq([
+                                     { 'name' => 'Ada', 'role' => 'author' },
+                                     { 'name' => 'Ada', 'role' => 'editor' }
+                                   ])
+      end
+
+      it 'collapses a single selected value to one scalar entry' do
+        fragment = { '0' => { 'name' => 'Ada', 'role' => ['author'] } }
+        form.send(:compound_attributes_populator, fragment: fragment, as: :credits_attributes)
+
+        expect(form.credits).to eq([{ 'name' => 'Ada', 'role' => 'author' }])
+      end
+
+      it 'keeps a row with only the multi member blank as one scalar-nil entry' do
+        fragment = { '0' => { 'name' => 'Ada', 'role' => [''] } }
+        form.send(:compound_attributes_populator, fragment: fragment, as: :credits_attributes)
+
+        expect(form.credits).to eq([{ 'name' => 'Ada', 'role' => nil }])
+      end
+
+      it 'drops a row where every member (including the multi) is blank' do
+        fragment = { '0' => { 'name' => '', 'role' => ['', ''] } }
+        form.send(:compound_attributes_populator, fragment: fragment, as: :credits_attributes)
+
+        expect(form.credits).to eq([])
+      end
     end
 
     it 'orders rows by their numeric key' do

--- a/spec/helpers/hyrax/compound_fields_helper_spec.rb
+++ b/spec/helpers/hyrax/compound_fields_helper_spec.rb
@@ -20,6 +20,18 @@ RSpec.describe Hyrax::CompoundFieldsHelper, type: :helper do
     it 'returns an empty list for a controlled sub-property with neither values nor authority' do
       expect(helper.compound_subproperty_options({ type: 'controlled', authority: nil, values: nil })).to eq([])
     end
+
+    context 'with an array current value (a multiple: true member)' do
+      it 'appends every stored value not among the offered options' do
+        expect(helper.compound_subproperty_options(spec, %w[ed Legacy Extra]))
+          .to eq([%w[Author Author], %w[Editor ed], %w[Legacy Legacy], %w[Extra Extra]])
+      end
+
+      it 'leaves the list unchanged when every stored value is already offered' do
+        expect(helper.compound_subproperty_options(spec, %w[Author ed]))
+          .to eq([%w[Author Author], %w[Editor ed]])
+      end
+    end
   end
 
   describe '#compound_subproperty_forced?' do
@@ -35,6 +47,20 @@ RSpec.describe Hyrax::CompoundFieldsHelper, type: :helper do
 
     it 'is true when the value is not among the offered options' do
       expect(helper.compound_subproperty_forced?(spec, 'Legacy')).to be true
+    end
+
+    context 'with an array value (a multiple: true member)' do
+      it 'is false when every selected value is offered' do
+        expect(helper.compound_subproperty_forced?(spec, ['Author'])).to be false
+      end
+
+      it 'is true when any selected value is off-list' do
+        expect(helper.compound_subproperty_forced?(spec, %w[Author Legacy])).to be true
+      end
+
+      it 'is false when the array is empty or all blank' do
+        expect(helper.compound_subproperty_forced?(spec, ['', nil])).to be false
+      end
     end
   end
 

--- a/spec/helpers/hyrax/compound_fields_helper_spec.rb
+++ b/spec/helpers/hyrax/compound_fields_helper_spec.rb
@@ -64,6 +64,44 @@ RSpec.describe Hyrax::CompoundFieldsHelper, type: :helper do
     end
   end
 
+  describe '#compound_controlled_select' do
+    let(:value) { nil }
+    let(:spec) { { type: 'controlled', authority: nil, values: [%w[Author Author], %w[Editor ed]] } }
+    subject(:node) { Capybara.string(helper.compound_controlled_select(spec, value, 'work[roles]', 'work_roles')) }
+
+    it 'renders a single-select with a blank option and no typeahead tag by default' do
+      expect(node).to have_selector("select[name='work[roles]'][id='work_roles']")
+      expect(node).not_to have_selector('select[multiple]')
+      expect(node).to have_selector("select option[value='']", visible: :all)
+      expect(node).not_to have_selector('select[data-hyrax-compound-controlled]')
+    end
+
+    context 'when multiple' do
+      let(:spec) { { type: 'controlled', authority: nil, values: [%w[Author Author]], multiple: true } }
+
+      it 'uses an array name, is multiple, and drops the blank option' do
+        expect(node).to have_selector("select[name='work[roles][]'][multiple]")
+        expect(node).not_to have_selector("select option[value='']", visible: :all)
+      end
+    end
+
+    context 'when autocomplete' do
+      let(:spec) { { type: 'controlled', authority: nil, values: [%w[Author Author]], autocomplete: true } }
+
+      it 'tags the select for the select2 typeahead with a placeholder' do
+        expect(node).to have_selector('select[data-hyrax-compound-controlled][data-placeholder]')
+      end
+    end
+
+    context 'with an off-list stored value' do
+      let(:value) { 'Legacy' }
+
+      it 'adds the force-select class' do
+        expect(node).to have_selector('select.force-select')
+      end
+    end
+  end
+
   describe '#compound_subproperty_label' do
     it 'falls back to a humanized sub-property key when no translation exists' do
       expect(helper.compound_subproperty_label(:nonexistent_compound, :some_field)).to eq('Some field')

--- a/spec/indexers/hyrax/indexers/compound_indexer_spec.rb
+++ b/spec/indexers/hyrax/indexers/compound_indexer_spec.rb
@@ -67,6 +67,19 @@ RSpec.describe Hyrax::Indexers::CompoundIndexer do
       expect(indexer.to_solr.keys.grep(/affiliation/)).to be_empty
     end
 
+    context 'when a controlled member value is itself an array' do
+      let(:resource) do
+        resource_class.new(contributors: [
+                             { 'given_name' => 'Ada', 'role_label' => %w[author editor] },
+                             { 'given_name' => 'Alan', 'role_label' => 'author' }
+                           ])
+      end
+
+      it 'flattens each term into its own facet value rather than nesting the array' do
+        expect(indexer.to_solr['contributors_role_label_sim']).to contain_exactly('author', 'editor', 'author')
+      end
+    end
+
     it 'accepts symbol-keyed entries (JSONValueMapper reload shape)' do
       resource.contributors = [{ given_name: 'Grace', family_name: 'Hopper' }]
       doc = indexer.to_solr

--- a/spec/renderers/hyrax/renderers/compound_attribute_renderer_spec.rb
+++ b/spec/renderers/hyrax/renderers/compound_attribute_renderer_spec.rb
@@ -80,6 +80,15 @@ RSpec.describe Hyrax::Renderers::CompoundAttributeRenderer do
       markup = described_class.new(:agent, values, label: 'Agent', html_dl: true).render_dl_row
       expect(markup).to include('ed')
     end
+
+    context 'when a controlled value is an array (a multiple: true member)' do
+      let(:values) { [{ 'role' => %w[author ed], 'name' => 'Ada' }] }
+
+      it 'renders every term, comma-separated, translated to its label' do
+        markup = renderer.render_dl_row
+        expect(markup).to include('Author, Editor')
+      end
+    end
   end
 
   describe 'controlled sub-property with a linkable URI value' do

--- a/spec/services/hyrax/compound_schema_spec.rb
+++ b/spec/services/hyrax/compound_schema_spec.rb
@@ -193,12 +193,31 @@ RSpec.describe Hyrax::CompoundSchema do
       expect(definition[:subproperties]['role_label'])
         .to eq(type: 'controlled', authority: 'contributor_role', values: nil, index_keys: [],
                index: true, display: false, required: false, group: 'role', cols: 6, as: nil,
+               autocomplete: false, multiple: false,
                creatable: false, create_fields: [], label_field: nil)
       expect(definition[:subproperties]['given_name'])
         .to eq(type: 'string', authority: nil, values: nil,
                index_keys: %w[contributors_given_name_sim contributors_given_name_tesim],
                index: true, display: true, required: false, group: 'identity', cols: 6, as: nil,
+               autocomplete: false, multiple: false,
                creatable: false, create_fields: [], label_field: nil)
+    end
+
+    it 'reads controlled form opt-ins (autocomplete, multiple) from the sub-property form block' do
+      klass = Class.new(Hyrax::Resource) do
+        def self.name
+          'MultiControlledResource'
+        end
+        attribute :credits,
+                  Valkyrie::Types::Array.of(Dry::Types['hash']).meta(
+                    subproperties: {
+                      'role' => { 'type' => 'controlled', 'authority' => 'roles',
+                                  'form' => { 'autocomplete' => true, 'multiple' => true } }
+                    }
+                  )
+      end
+      spec = described_class.for(klass).definition_for(:credits)[:subproperties]['role']
+      expect(spec).to include(autocomplete: true, multiple: true)
     end
 
     it 'reads per-sub-property index_keys (literal Solr field names)' do

--- a/spec/views/hyrax/compounds/_compound_row_controlled_multiple_spec.rb
+++ b/spec/views/hyrax/compounds/_compound_row_controlled_multiple_spec.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+# Renders the _compound_row partial with a `controlled` sub-property declaring
+# `multiple: true` and `autocomplete: true`, asserting it renders a multi-select
+# whose values submit as an array (`[]` name), pre-selects each stored value,
+# and carries the select2 typeahead hook. Exercises the `when 'controlled'`
+# branch's opt-in paths.
+RSpec.describe 'hyrax/compounds/_compound_row', type: :view do
+  before do
+    allow(view).to receive(:compound_subproperty_label).and_return('Role')
+    render partial: 'hyrax/compounds/compound_row',
+           locals: { f:, compound_name: :credits, definition:,
+                     row: { 'name' => 'Ada', 'role' => %w[author editor] },
+                     index: 0, row_label_singular: 'Credit' }
+  end
+
+  let(:form_object) { Struct.new(:credits).new(nil) }
+  let(:f) { ActionView::Helpers::FormBuilder.new('genericwork', form_object, view, {}) }
+
+  let(:definition) do
+    {
+      subproperties: {
+        'role' => { type: 'controlled', cols: 6, multiple: true, autocomplete: true,
+                    authority: nil, values: [%w[Author author], %w[Editor editor], %w[Reviewer reviewer]] },
+        'name' => { type: 'string', cols: 6 }
+      },
+      groups: [{ label: nil, fields: %w[role name] }]
+    }
+  end
+
+  it 'renders a multiple select whose values submit as an array' do
+    expect(rendered).to have_css("select[multiple][name='genericwork[credits_attributes][0][role][]']")
+  end
+
+  it 'tags the select for the select2 typeahead binder' do
+    expect(rendered).to have_css("select[data-hyrax-compound-controlled][name='genericwork[credits_attributes][0][role][]']")
+  end
+
+  it 'pre-selects each stored value' do
+    select = Capybara.string(rendered).find("select[name='genericwork[credits_attributes][0][role][]']")
+    selected = select.all('option[selected]').map { |o| o[:value] }
+    expect(selected).to contain_exactly('author', 'editor')
+  end
+
+  it 'offers every declared option' do
+    select = Capybara.string(rendered).find("select[name='genericwork[credits_attributes][0][role][]']")
+    expect(select.all('option').map { |o| o[:value] }).to include('author', 'editor', 'reviewer')
+  end
+
+  context 'a controlled sub-property with neither flag (backward compatible)' do
+    let(:definition) do
+      {
+        subproperties: {
+          'role' => { type: 'controlled', cols: 6, multiple: false, autocomplete: false,
+                      authority: nil, values: [%w[Author author], %w[Editor editor]] },
+          'name' => { type: 'string', cols: 6 }
+        },
+        groups: [{ label: nil, fields: %w[role name] }]
+      }
+    end
+
+    before do
+      render partial: 'hyrax/compounds/compound_row',
+             locals: { f:, compound_name: :credits, definition:,
+                       row: { 'name' => 'Ada', 'role' => 'author' },
+                       index: 0, row_label_singular: 'Credit' }
+    end
+
+    it 'renders a plain single select with the scalar name (no [] suffix, no multiple)' do
+      expect(rendered).to have_css("select[name='genericwork[credits_attributes][0][role]']")
+      expect(rendered).to have_no_css("select[multiple][name='genericwork[credits_attributes][0][role]']")
+      expect(rendered).to have_no_css('select[data-hyrax-compound-controlled]')
+    end
+  end
+end


### PR DESCRIPTION
Issue: 
- research-technologies/enact_knapsack#92
- https://github.com/research-technologies/enact_knapsack/issues/93

## Summary

Adds two opt-in, per-member `form:` flags for compound `controlled` metadata members in the M3 profile. Both default **off**, so existing controlled members render exactly as before.

- **`autocomplete: true`** — binds a select2 typeahead over the member's `<select>`. The full option list is already in the DOM, so filtering is client-side (no extra request). Works for single- and multi-select.
- **`multiple: true`** — renders a `<select multiple>`. At submit time each selected value **fans out into its own compound entry**, sharing the row's other members (cartesian product when a row has more than one `multiple` member). A contributor picked with three roles is stored as three single-role entries, not one entry holding an array.

## Screenshots

**Deposit form — Name and Role controls aligned (empty state):**
<img width="1352" height="705" alt="pr-shot-1-empty-matched" src="https://github.com/user-attachments/assets/a8f425d5-ab11-4abb-aa89-0797ffe91ff1" />



**Multi-select typeahead with several roles chosen (pills wrap in one box, no overflow):**

<img width="786" height="344" alt="image" src="https://github.com/user-attachments/assets/b01aa48b-7b68-4c94-982b-a994f0413f7b" />


**Edit round-trip — one saved row's roles reopen as separate preselected entries:**

<img width="1352" height="900" alt="pr-shot-3-edit-roundtrip-fixed" src="https://github.com/user-attachments/assets/45127052-a693-476e-ab3b-e9c59905bdad" />

**Show pg**

<img width="554" height="356" alt="image" src="https://github.com/user-attachments/assets/8ff25fcf-e22a-4020-bd22-f9f37853db81" />


** MOBILE VIEW **

<img width="390" height="844" alt="pr-shot-3-mobile" src="https://github.com/user-attachments/assets/8e32e5ae-e177-4926-8db5-b94ee286fa18" />



## Details

The key design decision is **fan-out**: the stored shape stays uniform — every member value is a scalar, whether or not the member is multi-select. Consumers never branch on array-vs-scalar, and each term indexes and facets independently. The array only exists transiently between form submit and fan-out; the indexer and show renderer were hardened to tolerate a transient array value because an invalid submission is echoed back before fan-out runs.

Changed (all form / index / render path — nothing touches persistence):

- `app/services/hyrax/compound_schema.rb` — `normalize_subproperty` reads `form.autocomplete` / `form.multiple` into the spec (default false).
- `app/forms/concerns/hyrax/compound_field_behavior.rb` — the load-bearing change: fans a multi-select row out into one entry per value.
- `app/views/hyrax/compounds/_compound_row.html.erb` — `multiple` → `<select multiple>` with `[]` name; `autocomplete` → `data-hyrax-compound-controlled` + placeholder.
- `app/assets/javascripts/hyrax/compound_metadata.js` — `bindControlledSelects` binds select2 v3 to native selects, on load and on cloned rows.
- `app/indexers/.../compound_indexer.rb`, `app/renderers/.../compound_attribute_renderer.rb`, `app/helpers/hyrax/compound_fields_helper.rb`, `app/services/hyrax/compound_subproperty_labeler.rb` — tolerate/represent an array member value.
- `config/locales/hyrax.en.yml` — new `compound_fields.search` placeholder key.
- `documentation/compound_fields.md` — new section + type-table row.

Behavior holds in both flexible and non-flexible modes (the compound list comes from the effective schema either way). The Enact profile opt-in (adding these flags to `contributor_role`) is a separate follow-up in `enact_knapsack`, not part of this PR.

## Testing

Unit/spec coverage added for: schema flag parsing, fan-out (several values → several entries; single value → one scalar; blank handling), array-tolerant indexer/renderer/helper/labeler, and a new view spec for the multi/autocomplete markup. Green on all CI test apps (koppie, dassie, allinson, sirenia).

Manual end-to-end verification in a flexible-mode deposit form (allinson), with `autocomplete: true` + `multiple: true` on a controlled compound member:

- role control renders as a select2 typeahead over a native `<select multiple>`; typing filters client-side;
- picking two roles for one participant, saving → the row **fans out** into two separate scalar entries on the show page (`Name / Role` per entry), each faceting independently;
- reopening edit → the two entries re-collapse into their rows, each preselected;
- "Add" clones a row whose select is also a searchable multi-select.

### select2 styling

select2 v3 copies the control's `.form-control` classes onto its own container (Bootstrap border + fixed `.form-control-sm` height) while rendering its own bordered inner box, producing a "box within a box" and clipping a multi-select's chosen pills. `_compound_metadata.scss` flattens the inner box so only the form-control frame shows and lets the frame grow to fit the selected values. Verified in a flexible-mode deposit form (single clean box; multiple pills wrap without overflowing into the next field).
