### PR TITLE
Ensure iiif manifests have id attributes by forcing UTF8 encoding of request.base_url

### DIFF
--- a/app/controllers/concerns/hyrax/works_controller_behavior.rb
+++ b/app/controllers/concerns/hyrax/works_controller_behavior.rb
@@ -176,7 +176,8 @@ module Hyrax
 
     def iiif_manifest_presenter
       IiifManifestPresenter.new(search_result_document(id: params[:id])).tap do |p|
-        p.hostname = request.base_url
+        # Have to force the encoding of base_url to UTF8 because Loofah will strip out ASCII-8BIT strings in Hyrax::ManifestBuilderService#deep_sanitize
+        p.hostname = request.base_url.force_encoding('UTF-8')
         p.ability = current_ability
       end
     end

--- a/spec/features/iiif_manifest_spec.rb
+++ b/spec/features/iiif_manifest_spec.rb
@@ -18,6 +18,7 @@ RSpec.describe 'building a IIIF Manifest', :aggregate_failures do
     visit "/concern/generic_works/#{work.id}/manifest"
     manifest_json = JSON.parse(page.body)
 
+    expect(manifest_json['@id']).to match "http://.*/concern/monographs/#{work.id}/manifest"
     expect(manifest_json['label']).to eq 'Comet in Moominland'
     expect(manifest_json['description']).to eq 'a novel about moomins'
 


### PR DESCRIPTION
### Fixes

Fixes #7539 

### Summary

The issue here is that request.base_url has ASCII-8BIT encoding due to Rack's env having ASCII-8BIT strings and Loofah clears out ASCII-8BIT strings.  Instead of trying to change Loofah's or Rack's behavior this commit does the most minimal change by forcing base_url into UTF8 encoding before passing it into the iiif_manifest_presenter. Loofah being applied to all of the manifest's values including id happens in ManifestBuilderService#deep_sanitize that was added as part of 4e5536d.

### Guidance for testing, such as acceptance criteria or new user interface behaviors:
* Open the manifest for an item and ensure that the `@id` or `id` attribute is populated.
* Check that the clover iiif viewer loads

@samvera/hyrax-code-reviewers
