### PR TITLE
Fix intermittent sirenia (Fedora) spec flakes

### DIFF
--- a/config/metadata/compound_metadata.yaml
+++ b/config/metadata/compound_metadata.yaml
@@ -77,7 +77,7 @@ attributes:
   identifiers:
     type: hash
     multiple: true
-    predicate: http://purl.org/dc/terms/identifier
+    predicate: http://id.loc.gov/ontologies/bibframe/identifiedBy
     form:
       primary: false
     view:

--- a/spec/features/dashboard/collection_spec.rb
+++ b/spec/features/dashboard/collection_spec.rb
@@ -727,6 +727,10 @@ RSpec.describe 'collection', type: :feature, clean_repo: true do
 
         click_on('Save')
 
+        # Wait for the deposit to land on the work show page before re-querying the
+        # collection; otherwise the listing races the still-in-flight save/index.
+        expect(page).to have_content("New Work for Collection")
+
         # verify new work was added to collection1
         visit "/dashboard/collections/#{collection1.id}"
         expect(page).to have_link("New Work for Collection")


### PR DESCRIPTION
Two intermittent sirenia (Fedora) spec flakes, bundled here so CI can validate both green together, independent of the feature branch (#7540) where they were surfacing.

## Fixes

1. **`identifiers` compound predicate collision** (cherry-picked from Kirk Wang's `942d8d403`). The compound `identifiers` declared the same predicate (`dcterms:identifier`) as the scalar `identifier`. On Fedora the read path resolves a predicate to whichever attribute was registered first, which depends on filesystem enumeration order of the metadata YAMLs, so a scalar value intermittently got coerced into the compound and raised `Dry::Types::ConstraintError`. Gives the compound a distinct `bf:identifiedBy` predicate.

2. **`spec/features/dashboard/collection_spec.rb:701` deposit-through-collection race.** Under the js (Selenium) driver, `click_on('Save')` returns before the deposit request finishes, so the immediate `visit` of the collection re-queried its member listing while the save/index was still in flight and intermittently missed the new work (`expected to find link "New Work for Collection" but there were no matches`). Waits for the work show page to render before navigating.

## Notes

- Fix (1) also lives on `configurable-file-set-derivatives` (Kirk's branch); coordinate so it isn't merged twice.
- Both are test/CI-only reliability fixes; no user-facing behavior change.
