### PR TITLE
[ActiveStorage For All] enable Active Storage in test apps and install generator

### DIFF
--- a/.dassie/db/migrate/20260716000001_create_active_storage_tables.active_storage.rb
+++ b/.dassie/db/migrate/20260716000001_create_active_storage_tables.active_storage.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+# This migration comes from active_storage (originally 20170806125915)
+class CreateActiveStorageTables < ActiveRecord::Migration[7.0]
+  def change
+    # Use Active Record's configured type for primary and foreign keys
+    primary_key_type, foreign_key_type = primary_and_foreign_key_types
+
+    create_table :active_storage_blobs, id: primary_key_type do |t|
+      t.string   :key,          null: false
+      t.string   :filename,     null: false
+      t.string   :content_type
+      t.text     :metadata
+      t.string   :service_name, null: false
+      t.bigint   :byte_size,    null: false
+      t.string   :checksum
+
+      if connection.supports_datetime_with_precision?
+        t.datetime :created_at, precision: 6, null: false
+      else
+        t.datetime :created_at, null: false
+      end
+
+      t.index [:key], unique: true
+    end
+
+    create_table :active_storage_attachments, id: primary_key_type do |t|
+      t.string     :name,     null: false
+      t.references :record,   null: false, polymorphic: true, index: false, type: foreign_key_type
+      t.references :blob,     null: false, type: foreign_key_type
+
+      if connection.supports_datetime_with_precision?
+        t.datetime :created_at, precision: 6, null: false
+      else
+        t.datetime :created_at, null: false
+      end
+
+      t.index [:record_type, :record_id, :name, :blob_id], name: :index_active_storage_attachments_uniqueness, unique: true
+      t.foreign_key :active_storage_blobs, column: :blob_id
+    end
+
+    create_table :active_storage_variant_records, id: primary_key_type do |t|
+      t.belongs_to :blob, null: false, index: false, type: foreign_key_type
+      t.string :variation_digest, null: false
+
+      t.index [:blob_id, :variation_digest], name: :index_active_storage_variant_records_uniqueness, unique: true
+      t.foreign_key :active_storage_blobs, column: :blob_id
+    end
+  end
+
+  private
+
+  def primary_and_foreign_key_types
+    config = Rails.configuration.generators
+    setting = config.options[config.orm][:primary_key_type]
+    primary_key_type = setting || :primary_key
+    foreign_key_type = setting || :bigint
+    [primary_key_type, foreign_key_type]
+  end
+end

--- a/.dassie/db/schema.rb
+++ b/.dassie/db/schema.rb
@@ -10,11 +10,39 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2026_05_21_003627) do
+ActiveRecord::Schema.define(version: 2026_07_16_000001) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "uuid-ossp"
+
+  create_table "active_storage_attachments", force: :cascade do |t|
+    t.string "name", null: false
+    t.string "record_type", null: false
+    t.bigint "record_id", null: false
+    t.bigint "blob_id", null: false
+    t.datetime "created_at", null: false
+    t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
+    t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
+  end
+
+  create_table "active_storage_blobs", force: :cascade do |t|
+    t.string "key", null: false
+    t.string "filename", null: false
+    t.string "content_type"
+    t.text "metadata"
+    t.string "service_name", null: false
+    t.bigint "byte_size", null: false
+    t.string "checksum"
+    t.datetime "created_at", null: false
+    t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
+  end
+
+  create_table "active_storage_variant_records", force: :cascade do |t|
+    t.bigint "blob_id", null: false
+    t.string "variation_digest", null: false
+    t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
+  end
 
   create_table "bookmarks", id: :serial, force: :cascade do |t|
     t.integer "user_id", null: false
@@ -753,6 +781,8 @@ ActiveRecord::Schema.define(version: 2026_05_21_003627) do
     t.index ["work_id"], name: "index_work_view_stats_on_work_id"
   end
 
+  add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "bulkrax_exporter_runs", "bulkrax_exporters", column: "exporter_id"
   add_foreign_key "bulkrax_importer_runs", "bulkrax_importers", column: "importer_id"
   add_foreign_key "bulkrax_pending_relationships", "bulkrax_importer_runs", column: "importer_run_id"

--- a/.koppie/db/migrate/20260716000001_create_active_storage_tables.active_storage.rb
+++ b/.koppie/db/migrate/20260716000001_create_active_storage_tables.active_storage.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+# This migration comes from active_storage (originally 20170806125915)
+class CreateActiveStorageTables < ActiveRecord::Migration[7.0]
+  def change
+    # Use Active Record's configured type for primary and foreign keys
+    primary_key_type, foreign_key_type = primary_and_foreign_key_types
+
+    create_table :active_storage_blobs, id: primary_key_type do |t|
+      t.string   :key,          null: false
+      t.string   :filename,     null: false
+      t.string   :content_type
+      t.text     :metadata
+      t.string   :service_name, null: false
+      t.bigint   :byte_size,    null: false
+      t.string   :checksum
+
+      if connection.supports_datetime_with_precision?
+        t.datetime :created_at, precision: 6, null: false
+      else
+        t.datetime :created_at, null: false
+      end
+
+      t.index [:key], unique: true
+    end
+
+    create_table :active_storage_attachments, id: primary_key_type do |t|
+      t.string     :name,     null: false
+      t.references :record,   null: false, polymorphic: true, index: false, type: foreign_key_type
+      t.references :blob,     null: false, type: foreign_key_type
+
+      if connection.supports_datetime_with_precision?
+        t.datetime :created_at, precision: 6, null: false
+      else
+        t.datetime :created_at, null: false
+      end
+
+      t.index [:record_type, :record_id, :name, :blob_id], name: :index_active_storage_attachments_uniqueness, unique: true
+      t.foreign_key :active_storage_blobs, column: :blob_id
+    end
+
+    create_table :active_storage_variant_records, id: primary_key_type do |t|
+      t.belongs_to :blob, null: false, index: false, type: foreign_key_type
+      t.string :variation_digest, null: false
+
+      t.index [:blob_id, :variation_digest], name: :index_active_storage_variant_records_uniqueness, unique: true
+      t.foreign_key :active_storage_blobs, column: :blob_id
+    end
+  end
+
+  private
+
+  def primary_and_foreign_key_types
+    config = Rails.configuration.generators
+    setting = config.options[config.orm][:primary_key_type]
+    primary_key_type = setting || :primary_key
+    foreign_key_type = setting || :bigint
+    [primary_key_type, foreign_key_type]
+  end
+end

--- a/.koppie/db/schema.rb
+++ b/.koppie/db/schema.rb
@@ -10,10 +10,38 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_05_21_003627) do
+ActiveRecord::Schema[7.2].define(version: 2026_07_16_000001) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "uuid-ossp"
+
+  create_table "active_storage_attachments", force: :cascade do |t|
+    t.string "name", null: false
+    t.string "record_type", null: false
+    t.bigint "record_id", null: false
+    t.bigint "blob_id", null: false
+    t.datetime "created_at", null: false
+    t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
+    t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
+  end
+
+  create_table "active_storage_blobs", force: :cascade do |t|
+    t.string "key", null: false
+    t.string "filename", null: false
+    t.string "content_type"
+    t.text "metadata"
+    t.string "service_name", null: false
+    t.bigint "byte_size", null: false
+    t.string "checksum"
+    t.datetime "created_at", null: false
+    t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
+  end
+
+  create_table "active_storage_variant_records", force: :cascade do |t|
+    t.bigint "blob_id", null: false
+    t.string "variation_digest", null: false
+    t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
+  end
 
   create_table "bookmarks", id: :serial, force: :cascade do |t|
     t.integer "user_id", null: false
@@ -744,6 +772,8 @@ ActiveRecord::Schema[7.2].define(version: 2026_05_21_003627) do
     t.index ["work_id"], name: "index_work_view_stats_on_work_id"
   end
 
+  add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "bulkrax_exporter_runs", "bulkrax_exporters", column: "exporter_id"
   add_foreign_key "bulkrax_importer_runs", "bulkrax_importers", column: "importer_id"
   add_foreign_key "bulkrax_pending_relationships", "bulkrax_importer_runs", column: "importer_run_id"

--- a/documentation/developing-your-hyrax-based-app.md
+++ b/documentation/developing-your-hyrax-based-app.md
@@ -184,6 +184,17 @@ rails db:seed
 This creates the default administrative set -- into which all works will be deposited unless assigned to other administrative sets.
 This command also makes sure that Hyrax's built-in workflows are loaded for your application and available for the default administrative set.
 
+### Active Storage
+
+Hyrax's install generator runs `active_storage:install`, so the `active_storage_*` tables are created alongside Hyrax's own migrations. [Active Storage](https://guides.rubyonrails.org/active_storage_overview.html) is the Rails file attachment framework; Hyrax uses it for its non-ActiveFedora upload and storage paths. Which storage service backs those files (local disk, Amazon S3, etc.) is controlled entirely by standard Rails configuration: declare services in `config/storage.yml` and select one via `config.active_storage.service` per environment. Switching an application from disk-backed to S3-backed storage is that one configuration change; no Hyrax-specific storage settings are involved.
+
+If you are upgrading an existing application rather than generating a new one, run:
+
+```shell
+rails active_storage:install
+rails db:migrate
+```
+
 ### Generate a work type
 
 Using Hyrax requires generating at least one type of repository object, or "work type." Hyrax allows you to generate the work types required in your application by using a Rails generator-based tool. You may generate one or more of these work types.

--- a/lib/generators/hyrax/models_generator.rb
+++ b/lib/generators/hyrax/models_generator.rb
@@ -16,6 +16,7 @@ class Hyrax::ModelsGenerator < Rails::Generators::Base
   def copy_migrations
     rake 'hyrax:install:migrations'
     rake 'valkyrie_engine:install:migrations'
+    rake 'active_storage:install'
   end
 
   # Add behaviors to the user model


### PR DESCRIPTION
## Summary

First step of a small-PR chain moving Hyrax's **non-ActiveFedora** upload/storage paths onto Rails **Active Storage** (staging uploads now; an Active Storage-backed Valkyrie storage adapter and a modern upload UI follow in stacked PRs).

This PR only enables the plumbing; **no Hyrax behavior changes**:

- Adds the canonical Rails `create_active_storage_tables` migration to the `.dassie` and `.koppie` test apps (both already ship `config/storage.yml` + `config.active_storage.service` for every environment — the tables were the missing piece) and updates their `schema.rb`.
- Teaches `hyrax:models` generator to run `active_storage:install` so new host applications get the tables alongside Hyrax's own migrations.
- Documents Active Storage setup (including the upgrade path for existing apps) in `documentation/developing-your-hyrax-based-app.md`, and that disk↔S3 is a standard `config/storage.yml` / `config.active_storage.service` change.

## Why

Upcoming PRs in this chain let `Hyrax::UploadedFile` staging and (separately) Valkyrie file storage run on Active Storage, so that switching non-AF storage between local disk and S3 is one Rails config change rather than bespoke Hyrax configuration. ActiveFedora file-set storage is explicitly **out of scope** and unchanged throughout the chain.

## Dependencies

None — safe to merge first. PRs that follow are stacked on this one.

## Tests

- `.koppie` migration run for real against dockerized Postgres (`rails db:create db:migrate`, test env) — `schema.rb` here is that regenerated output.
- `.dassie/db/schema.rb` updated with the identical dumper output (same migration, same Postgres); dassie's full stack (Fedora etc.) was not run locally — CI exercises it.
- `git diff --check` clean; RuboCop clean on touched Ruby (test-app `db/` is outside RuboCop's scan).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
