### PR TITLE
feat: optional Active Storage backend for staged uploads

### DIFF
--- a/.dassie/db/migrate/20260716000001_create_active_storage_tables.active_storage.rb
+++ b/.dassie/db/migrate/20260716000001_create_active_storage_tables.active_storage.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+# This migration comes from active_storage (originally 20170806125915)
+class CreateActiveStorageTables < ActiveRecord::Migration[7.0]
+  def change
+    # Use Active Record's configured type for primary and foreign keys
+    primary_key_type, foreign_key_type = primary_and_foreign_key_types
+
+    create_table :active_storage_blobs, id: primary_key_type do |t|
+      t.string   :key,          null: false
+      t.string   :filename,     null: false
+      t.string   :content_type
+      t.text     :metadata
+      t.string   :service_name, null: false
+      t.bigint   :byte_size,    null: false
+      t.string   :checksum
+
+      if connection.supports_datetime_with_precision?
+        t.datetime :created_at, precision: 6, null: false
+      else
+        t.datetime :created_at, null: false
+      end
+
+      t.index [:key], unique: true
+    end
+
+    create_table :active_storage_attachments, id: primary_key_type do |t|
+      t.string     :name,     null: false
+      t.references :record,   null: false, polymorphic: true, index: false, type: foreign_key_type
+      t.references :blob,     null: false, type: foreign_key_type
+
+      if connection.supports_datetime_with_precision?
+        t.datetime :created_at, precision: 6, null: false
+      else
+        t.datetime :created_at, null: false
+      end
+
+      t.index [:record_type, :record_id, :name, :blob_id], name: :index_active_storage_attachments_uniqueness, unique: true
+      t.foreign_key :active_storage_blobs, column: :blob_id
+    end
+
+    create_table :active_storage_variant_records, id: primary_key_type do |t|
+      t.belongs_to :blob, null: false, index: false, type: foreign_key_type
+      t.string :variation_digest, null: false
+
+      t.index [:blob_id, :variation_digest], name: :index_active_storage_variant_records_uniqueness, unique: true
+      t.foreign_key :active_storage_blobs, column: :blob_id
+    end
+  end
+
+  private
+
+  def primary_and_foreign_key_types
+    config = Rails.configuration.generators
+    setting = config.options[config.orm][:primary_key_type]
+    primary_key_type = setting || :primary_key
+    foreign_key_type = setting || :bigint
+    [primary_key_type, foreign_key_type]
+  end
+end

--- a/.dassie/db/schema.rb
+++ b/.dassie/db/schema.rb
@@ -10,11 +10,39 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2026_05_21_003627) do
+ActiveRecord::Schema.define(version: 2026_07_16_000001) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "uuid-ossp"
+
+  create_table "active_storage_attachments", force: :cascade do |t|
+    t.string "name", null: false
+    t.string "record_type", null: false
+    t.bigint "record_id", null: false
+    t.bigint "blob_id", null: false
+    t.datetime "created_at", null: false
+    t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
+    t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
+  end
+
+  create_table "active_storage_blobs", force: :cascade do |t|
+    t.string "key", null: false
+    t.string "filename", null: false
+    t.string "content_type"
+    t.text "metadata"
+    t.string "service_name", null: false
+    t.bigint "byte_size", null: false
+    t.string "checksum"
+    t.datetime "created_at", null: false
+    t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
+  end
+
+  create_table "active_storage_variant_records", force: :cascade do |t|
+    t.bigint "blob_id", null: false
+    t.string "variation_digest", null: false
+    t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
+  end
 
   create_table "bookmarks", id: :serial, force: :cascade do |t|
     t.integer "user_id", null: false
@@ -753,6 +781,8 @@ ActiveRecord::Schema.define(version: 2026_05_21_003627) do
     t.index ["work_id"], name: "index_work_view_stats_on_work_id"
   end
 
+  add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "bulkrax_exporter_runs", "bulkrax_exporters", column: "exporter_id"
   add_foreign_key "bulkrax_importer_runs", "bulkrax_importers", column: "importer_id"
   add_foreign_key "bulkrax_pending_relationships", "bulkrax_importer_runs", column: "importer_run_id"

--- a/.koppie/db/migrate/20260716000001_create_active_storage_tables.active_storage.rb
+++ b/.koppie/db/migrate/20260716000001_create_active_storage_tables.active_storage.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+# This migration comes from active_storage (originally 20170806125915)
+class CreateActiveStorageTables < ActiveRecord::Migration[7.0]
+  def change
+    # Use Active Record's configured type for primary and foreign keys
+    primary_key_type, foreign_key_type = primary_and_foreign_key_types
+
+    create_table :active_storage_blobs, id: primary_key_type do |t|
+      t.string   :key,          null: false
+      t.string   :filename,     null: false
+      t.string   :content_type
+      t.text     :metadata
+      t.string   :service_name, null: false
+      t.bigint   :byte_size,    null: false
+      t.string   :checksum
+
+      if connection.supports_datetime_with_precision?
+        t.datetime :created_at, precision: 6, null: false
+      else
+        t.datetime :created_at, null: false
+      end
+
+      t.index [:key], unique: true
+    end
+
+    create_table :active_storage_attachments, id: primary_key_type do |t|
+      t.string     :name,     null: false
+      t.references :record,   null: false, polymorphic: true, index: false, type: foreign_key_type
+      t.references :blob,     null: false, type: foreign_key_type
+
+      if connection.supports_datetime_with_precision?
+        t.datetime :created_at, precision: 6, null: false
+      else
+        t.datetime :created_at, null: false
+      end
+
+      t.index [:record_type, :record_id, :name, :blob_id], name: :index_active_storage_attachments_uniqueness, unique: true
+      t.foreign_key :active_storage_blobs, column: :blob_id
+    end
+
+    create_table :active_storage_variant_records, id: primary_key_type do |t|
+      t.belongs_to :blob, null: false, index: false, type: foreign_key_type
+      t.string :variation_digest, null: false
+
+      t.index [:blob_id, :variation_digest], name: :index_active_storage_variant_records_uniqueness, unique: true
+      t.foreign_key :active_storage_blobs, column: :blob_id
+    end
+  end
+
+  private
+
+  def primary_and_foreign_key_types
+    config = Rails.configuration.generators
+    setting = config.options[config.orm][:primary_key_type]
+    primary_key_type = setting || :primary_key
+    foreign_key_type = setting || :bigint
+    [primary_key_type, foreign_key_type]
+  end
+end

--- a/.koppie/db/schema.rb
+++ b/.koppie/db/schema.rb
@@ -10,10 +10,38 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_05_21_003627) do
+ActiveRecord::Schema[7.2].define(version: 2026_07_16_000001) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "uuid-ossp"
+
+  create_table "active_storage_attachments", force: :cascade do |t|
+    t.string "name", null: false
+    t.string "record_type", null: false
+    t.bigint "record_id", null: false
+    t.bigint "blob_id", null: false
+    t.datetime "created_at", null: false
+    t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
+    t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
+  end
+
+  create_table "active_storage_blobs", force: :cascade do |t|
+    t.string "key", null: false
+    t.string "filename", null: false
+    t.string "content_type"
+    t.text "metadata"
+    t.string "service_name", null: false
+    t.bigint "byte_size", null: false
+    t.string "checksum"
+    t.datetime "created_at", null: false
+    t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
+  end
+
+  create_table "active_storage_variant_records", force: :cascade do |t|
+    t.bigint "blob_id", null: false
+    t.string "variation_digest", null: false
+    t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
+  end
 
   create_table "bookmarks", id: :serial, force: :cascade do |t|
     t.integer "user_id", null: false
@@ -744,6 +772,8 @@ ActiveRecord::Schema[7.2].define(version: 2026_05_21_003627) do
     t.index ["work_id"], name: "index_work_view_stats_on_work_id"
   end
 
+  add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "bulkrax_exporter_runs", "bulkrax_exporters", column: "exporter_id"
   add_foreign_key "bulkrax_importer_runs", "bulkrax_importers", column: "importer_id"
   add_foreign_key "bulkrax_pending_relationships", "bulkrax_importer_runs", column: "importer_run_id"

--- a/app/controllers/hyrax/dashboard/collections_controller.rb
+++ b/app/controllers/hyrax/dashboard/collections_controller.rb
@@ -322,14 +322,16 @@ module Hyrax
 
       def add_new_banner(uploaded_file_ids)
         f = uploaded_files(uploaded_file_ids).first
-        banner_info = CollectionBrandingInfo.new(
-          collection_id: @collection.id,
-          filename: File.split(f.file_url).last,
-          role: "banner",
-          alt_txt: "",
-          target_url: ""
-        )
-        banner_info.save f.file_url
+        f.with_local_path do |path|
+          banner_info = CollectionBrandingInfo.new(
+            collection_id: @collection.id,
+            filename: File.basename(path),
+            role: "banner",
+            alt_txt: "",
+            target_url: ""
+          )
+          banner_info.save path
+        end
       end
 
       def remove_banner
@@ -347,15 +349,17 @@ module Hyrax
 
       def create_logo_info(uploaded_file_id, alttext, linkurl)
         file = uploaded_files(uploaded_file_id)
-        logo_info = CollectionBrandingInfo.new(
-          collection_id: @collection.id,
-          filename: File.split(file.file_url).last,
-          role: "logo",
-          alt_txt: alttext,
-          target_url: linkurl
-        )
-        logo_info.save file.file_url
-        logo_info
+        file.with_local_path do |path|
+          logo_info = CollectionBrandingInfo.new(
+            collection_id: @collection.id,
+            filename: File.basename(path),
+            role: "logo",
+            alt_txt: alttext,
+            target_url: linkurl
+          )
+          logo_info.save path
+          logo_info
+        end
       end
 
       def remove_redundant_files(public_files)

--- a/app/controllers/hyrax/file_sets_controller.rb
+++ b/app/controllers/hyrax/file_sets_controller.rb
@@ -241,8 +241,10 @@ module Hyrax
     end
 
     def uploaded_file_from_path
-      uploaded_file = CarrierWave::SanitizedFile.new(params[:file_set][:files].first)
-      Hyrax::UploadedFile.create(user_id: current_user.id, file: uploaded_file, file_set_uri: @file_set.id.to_s)
+      # both storage backends accept the raw multipart upload object
+      Hyrax::UploadedFile.create(user_id: current_user.id,
+                                 file: params[:file_set][:files].first,
+                                 file_set_uri: @file_set.id.to_s)
     end
 
     def after_update_response

--- a/app/controllers/hyrax/uploads_controller.rb
+++ b/app/controllers/hyrax/uploads_controller.rb
@@ -1,5 +1,31 @@
 # frozen_string_literal: true
 module Hyrax
+  ##
+  # Receives uploads from the file upload widget, creating and updating
+  # {Hyrax::UploadedFile} staging records.
+  #
+  # The client protocol is two-step: an initial +POST+ carrying only the
+  # filename creates the record, then the binary content arrives in one or
+  # more requests carrying the record +id+. Requests with a +CONTENT-RANGE+
+  # header (+bytes <first>-<last>/<total>+) are chunks of a larger file,
+  # uploaded serially, which this controller reassembles server side; that
+  # keeps individual requests small enough to pass proxies that cap request
+  # size (e.g. Cloudflare's 100 MB limit).
+  #
+  # How the assembled content is stored depends on
+  # {Hyrax::Configuration#uploaded_file_storage_backend}:
+  #
+  # - +:carrierwave+ appends chunks directly to the CarrierWave-stored file
+  #   (the historical behavior; requires local, appendable storage).
+  # - +:active_storage+ assembles chunks in a local staging file under
+  #   {Hyrax::Configuration#cache_path} and attaches the completed file to
+  #   the record's Active Storage attachment when the final chunk arrives,
+  #   at which point the configured Active Storage service (local disk, S3,
+  #   ...) receives the bytes.
+  #
+  # @note chunk assembly assumes sequential chunks handled by one node (or
+  #   nodes sharing the staging/upload path), the same constraint the
+  #   CarrierWave append behavior has always had.
   class UploadsController < ApplicationController
     load_and_authorize_resource class: Hyrax::UploadedFile
 
@@ -22,6 +48,15 @@ module Hyrax
 
     def upload_with_chunking
       @upload = Hyrax::UploadedFile.find(params[:id])
+      return upload_with_chunking_active_storage if Hyrax.config.active_storage_uploads?
+
+      upload_with_chunking_carrierwave
+    end
+
+    ##
+    # @!group CarrierWave backend
+
+    def upload_with_chunking_carrierwave
       unpersisted_upload = Hyrax::UploadedFile.new(file: params[:files].first, user: current_user)
       content_range = request.headers['CONTENT-RANGE']
 
@@ -48,5 +83,59 @@ module Hyrax
         @upload.file = chunk
       end
     end
+    # @!endgroup
+
+    ##
+    # @!group Active Storage backend
+
+    def upload_with_chunking_active_storage
+      chunk = params[:files].first
+      content_range = request.headers['CONTENT-RANGE']
+      return @upload.store_file(chunk) if content_range.blank?
+
+      handle_chunk_active_storage(content_range, chunk)
+    end
+
+    # Chunks are assembled in a local staging file; when the range header
+    # shows the final chunk has arrived the assembled file is attached, which
+    # uploads it to the configured Active Storage service. A chunk that does
+    # not continue the pending assembly restarts assembly with that chunk,
+    # mirroring the replacement behavior of the CarrierWave backend.
+    def handle_chunk_active_storage(content_range, chunk)
+      begin_of_chunk = content_range[/\ (.*?)-/, 1].to_i
+      end_of_chunk = content_range[/-(\d+)/, 1].to_i
+      total = content_range[%r{/(\d+)}, 1].to_i
+
+      path = staging_path
+      current_size = File.exist?(path) ? File.size(path) : 0
+
+      if begin_of_chunk == current_size && current_size.positive?
+        File.open(path, 'ab') { |f| append_chunk(f, chunk) }
+      else
+        FileUtils.mkdir_p(File.dirname(path))
+        File.open(path, 'wb') { |f| append_chunk(f, chunk) }
+      end
+
+      finalize_staged_file(path) if end_of_chunk + 1 >= total
+    end
+
+    def append_chunk(file, chunk)
+      file.write(chunk.read)
+      file.fsync
+    end
+
+    def finalize_staged_file(path)
+      File.open(path, 'rb') do |io|
+        @upload.store_file(io, filename: @upload.filename)
+      end
+      File.delete(path)
+    end
+
+    ##
+    # @return [String] local path where this record's chunks are assembled
+    def staging_path
+      File.join(Hyrax.config.cache_path.call.to_s, 'chunked_uploads', "#{@upload.id}.part")
+    end
+    # @!endgroup
   end
 end

--- a/app/jobs/valkyrie_ingest_job.rb
+++ b/app/jobs/valkyrie_ingest_job.rb
@@ -43,17 +43,14 @@ class ValkyrieIngestJob < Hyrax::ApplicationJob
   #
   # @return [Hyrax::FileMetadata] the metadata representing the uploaded file
   def upload_file(file:, file_set:, pcdm_use:, user: nil)
-    carrier_wave_sanitized_file = file.uploader.file
-    # Pull file, since carrierwave files don't respond to a proper IO #read. See
-    # https://github.com/carrierwaveuploader/carrierwave/issues/1959
-    file_io = carrier_wave_sanitized_file.to_file
-
-    ::Hyrax::ValkyrieUpload.file(
-      io: file_io,
-      filename: carrier_wave_sanitized_file.original_filename,
-      file_set: file_set,
-      use: pcdm_use,
-      user: user
-    )
+    file.with_io do |io|
+      ::Hyrax::ValkyrieUpload.file(
+        io: io,
+        filename: file.filename,
+        file_set: file_set,
+        use: pcdm_use,
+        user: user
+      )
+    end
   end
 end

--- a/app/models/hyrax/uploaded_file.rb
+++ b/app/models/hyrax/uploaded_file.rb
@@ -4,10 +4,19 @@ module Hyrax
   # Store a file uploaded by a user.
   #
   # Eventually these files get attached to {FileSet}s and pushed into Fedora.
+  #
+  # Staged content is written to one of two storage backends, selected by
+  # {Hyrax::Configuration#uploaded_file_storage_backend}: CarrierWave on the
+  # local file system (the historical default) or Active Storage, where the
+  # configured Active Storage service determines whether bytes land on local
+  # disk, S3, etc. Reads through the storage-neutral API below dispatch on
+  # what a record actually carries, so records created under either backend
+  # remain readable after the configuration changes.
   class UploadedFile < ActiveRecord::Base
     self.table_name = 'uploaded_files'
     mount_uploader :file, UploadedFileUploader
     alias uploader file
+    has_one_attached :file_attachment if respond_to?(:has_one_attached)
     has_many :job_io_wrappers,
              inverse_of: 'uploaded_file',
              class_name: 'JobIoWrapper',
@@ -32,6 +41,23 @@ module Hyrax
     end
 
     ##
+    # Store content, routing it to the backend configured in
+    # {Hyrax::Configuration#uploaded_file_storage_backend}.
+    #
+    # @param [IO, ActionDispatch::Http::UploadedFile, Rack::Test::UploadedFile] io
+    # @param [String, nil] filename used when +io+ carries no filename of its
+    #   own (plain +File+/+Tempfile+ objects under Active Storage)
+    # @return [void]
+    def store_file(io, filename: nil)
+      if Hyrax.config.active_storage_uploads?
+        file_attachment.attach(active_storage_attachable(io, filename))
+      else
+        # the CarrierWave mount handles ActionDispatch/Rack uploads and IOs
+        self.file = io
+      end
+    end
+
+    ##
     # @!group Storage-neutral file API
     #
     # The methods in this group are the storage-backend-neutral interface for
@@ -42,27 +68,31 @@ module Hyrax
 
     ##
     # @return [String, nil] filename of the staged file; nil when no file
-    #   content has been stored yet
+    #   content has been stored yet. Under Active Storage a filename recorded
+    #   before content arrives (chunked uploads) is returned until then.
     def filename
-      uploader.file&.filename
+      return file_attachment.filename.to_s if active_storage_backed?
+      uploader.file&.filename || self[:file].presence
     end
 
     ##
     # @return [String, nil] MIME type of the staged file
     def content_type
-      uploader.file&.content_type
+      return file_attachment.content_type if active_storage_backed?
+      uploader.file&.content_type if stored?
     end
 
     ##
     # @return [Integer, nil] size of the staged file in bytes
     def byte_size
-      uploader.file&.size
+      return file_attachment.byte_size if active_storage_backed?
+      uploader.file&.size if stored?
     end
 
     ##
     # @return [Boolean] whether file content has been stored for this record
     def stored?
-      uploader.file.present?
+      active_storage_backed? || uploader.file.present?
     end
 
     ##
@@ -91,15 +121,79 @@ module Hyrax
     # @see #stored? callers should ensure content is stored first
     def with_local_path
       raise ArgumentError, "expected a block" unless block_given?
+      return file_attachment.blob.open { |tempfile| yield tempfile.path } if
+        active_storage_backed?
       yield uploader.path
     end
     # @!endgroup
 
+    ##
+    # @return [Boolean] whether this record's content lives in Active Storage
+    def active_storage_backed?
+      respond_to?(:file_attachment) && file_attachment.attached?
+    end
+
+    ##
+    # Under the Active Storage backend, route content assignment (including
+    # the mass-assignment entry points used by the uploads controller and
+    # legacy callers) to the attachment. A bare String records the intended
+    # filename ahead of content, which the chunked upload protocol sends
+    # before any bytes.
+    def file=(new_file)
+      return super unless Hyrax.config.active_storage_uploads?
+
+      case new_file
+      when String
+        self[:file] = new_file
+      when nil
+        nil
+      else
+        store_file(new_file)
+      end
+    end
+
     private
 
+    def active_storage_attachable(io, filename)
+      return io if native_attachable?(io)
+
+      name = filename ||
+             (io.respond_to?(:original_filename) && io.original_filename) ||
+             (io.respond_to?(:path) && io.path && File.basename(io.path)) ||
+             self[:file].presence
+      { io: io, filename: name }
+    end
+
+    # things Active Storage understands without an { io:, filename: } wrapper
+    def native_attachable?(io)
+      io.is_a?(::ActiveStorage::Blob) ||
+        io.is_a?(ActionDispatch::Http::UploadedFile) ||
+        (defined?(Rack::Test::UploadedFile) && io.is_a?(Rack::Test::UploadedFile))
+    end
+
     def virus_scan
-      errors.add(:file, I18n.t('hyrax.virus_scanner.virus_detected', filename: file.path)) if
-        file.path && Hyrax::VirusScanner.infected?(file.path)
+      path = path_for_virus_scan
+      errors.add(:file, I18n.t('hyrax.virus_scanner.virus_detected', filename: path)) if
+        path && Hyrax::VirusScanner.infected?(path)
+    end
+
+    # For CarrierWave the stored/cached file is scanned on every save (its
+    # historical behavior). For Active Storage only newly attached content is
+    # scanned, from the local source it is being attached from; already
+    # uploaded blobs are immutable and were scanned when they arrived.
+    def path_for_virus_scan
+      return file.path unless Hyrax.config.active_storage_uploads?
+
+      attachable = attachment_changes['file_attachment']&.attachable
+      case attachable
+      when Hash
+        io = attachable[:io]
+        io.respond_to?(:path) ? io.path : nil
+      when nil
+        nil
+      else
+        attachable.respond_to?(:path) ? attachable.path : nil
+      end
     end
   end
 end

--- a/app/models/hyrax/uploaded_file.rb
+++ b/app/models/hyrax/uploaded_file.rb
@@ -31,6 +31,70 @@ module Hyrax
       update!(file_set_uri: uri)
     end
 
+    ##
+    # @!group Storage-neutral file API
+    #
+    # The methods in this group are the storage-backend-neutral interface for
+    # reading staged upload content and metadata. Hyrax internals outside the
+    # ActiveFedora-specific code paths should prefer these over the
+    # CarrierWave-specific {#uploader} interface, so the storage backing
+    # {UploadedFile} can change without touching every consumer.
+
+    ##
+    # @return [String, nil] filename of the staged file; nil when no file
+    #   content has been stored yet
+    def filename
+      uploader.file&.filename
+    end
+
+    ##
+    # @return [String, nil] MIME type of the staged file
+    def content_type
+      uploader.file&.content_type
+    end
+
+    ##
+    # @return [Integer, nil] size of the staged file in bytes
+    def byte_size
+      uploader.file&.size
+    end
+
+    ##
+    # @return [Boolean] whether file content has been stored for this record
+    def stored?
+      uploader.file.present?
+    end
+
+    ##
+    # Yields a rewound, binary mode IO for the staged content. The IO responds
+    # to +#path+ with a local filesystem path, as expected by Valkyrie storage
+    # adapters that move files by path. The IO is closed when the block
+    # returns.
+    #
+    # @yieldparam [IO] io readable IO positioned at the start of the file
+    # @return [Object] the return value of the block
+    # @see #stored? callers should ensure content is stored first
+    def with_io(&block)
+      raise ArgumentError, "expected a block" unless block_given?
+      with_local_path { |path| File.open(path, 'rb', &block) }
+    end
+
+    ##
+    # Yields a local filesystem path for the staged content.
+    #
+    # @note the path may be a temporary materialization depending on the
+    #   storage backend; consumers must not assume it remains valid after the
+    #   block returns.
+    #
+    # @yieldparam [String] path
+    # @return [Object] the return value of the block
+    # @see #stored? callers should ensure content is stored first
+    def with_local_path
+      raise ArgumentError, "expected a block" unless block_given?
+      yield uploader.path
+    end
+    # @!endgroup
+
     private
 
     def virus_scan

--- a/app/services/hyrax/work_uploads_handler.rb
+++ b/app/services/hyrax/work_uploads_handler.rb
@@ -148,8 +148,8 @@ module Hyrax
         creator: Array.wrap(file.user.user_key),
         date_uploaded: file.created_at,
         date_modified: Hyrax::TimeService.time_in_utc,
-        label: file.uploader.filename,
-        title: Array.wrap(file.uploader.filename) }.merge(extra.symbolize_keys)
+        label: file.filename,
+        title: Array.wrap(file.filename) }.merge(extra.symbolize_keys)
     end
 
     ##

--- a/app/views/hyrax/uploads/create.json.jbuilder
+++ b/app/views/hyrax/uploads/create.json.jbuilder
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 json.files [@upload] do |uploaded_file|
   json.id uploaded_file.id
-  json.name uploaded_file.file&.file&.filename
-  json.size uploaded_file.file&.file&.size
+  json.name uploaded_file.filename
+  json.size uploaded_file.byte_size
   # TODO: implement these
   # json.url  "/uploads/#{uploaded_file.id}"
   # json.thumbnail_url uploaded_file.id

--- a/documentation/developing-your-hyrax-based-app.md
+++ b/documentation/developing-your-hyrax-based-app.md
@@ -184,6 +184,17 @@ rails db:seed
 This creates the default administrative set -- into which all works will be deposited unless assigned to other administrative sets.
 This command also makes sure that Hyrax's built-in workflows are loaded for your application and available for the default administrative set.
 
+### Active Storage
+
+Hyrax's install generator runs `active_storage:install`, so the `active_storage_*` tables are created alongside Hyrax's own migrations. [Active Storage](https://guides.rubyonrails.org/active_storage_overview.html) is the Rails file attachment framework; Hyrax uses it for its non-ActiveFedora upload and storage paths. Which storage service backs those files (local disk, Amazon S3, etc.) is controlled entirely by standard Rails configuration: declare services in `config/storage.yml` and select one via `config.active_storage.service` per environment. Switching an application from disk-backed to S3-backed storage is that one configuration change; no Hyrax-specific storage settings are involved.
+
+If you are upgrading an existing application rather than generating a new one, run:
+
+```shell
+rails active_storage:install
+rails db:migrate
+```
+
 ### Generate a work type
 
 Using Hyrax requires generating at least one type of repository object, or "work type." Hyrax allows you to generate the work types required in your application by using a Rails generator-based tool. You may generate one or more of these work types.

--- a/lib/generators/hyrax/models_generator.rb
+++ b/lib/generators/hyrax/models_generator.rb
@@ -16,6 +16,7 @@ class Hyrax::ModelsGenerator < Rails::Generators::Base
   def copy_migrations
     rake 'hyrax:install:migrations'
     rake 'valkyrie_engine:install:migrations'
+    rake 'active_storage:install'
   end
 
   # Add behaviors to the user model

--- a/lib/generators/hyrax/templates/config/initializers/hyrax.rb
+++ b/lib/generators/hyrax/templates/config/initializers/hyrax.rb
@@ -44,6 +44,18 @@ Hyrax.config do |config|
   #   maxFileSize: 500.megabytes
   # }
 
+  # Where staged user uploads (Hyrax::UploadedFile) are stored.
+  #
+  # :carrierwave (the default) stores staged files on the local file system
+  # under config.upload_path. :active_storage stores them through Rails
+  # Active Storage, so your config/storage.yml service selection (local disk,
+  # S3, ...) controls where they live.
+  #
+  # NOTE: applications using ActiveFedora file sets should stay on
+  # :carrierwave; the ActiveFedora ingest path reads staged files through
+  # CarrierWave.
+  # config.uploaded_file_storage_backend = :active_storage
+
   # Enables a link to the citations page for a work
   # Default is false
   # config.citations = false

--- a/lib/hyrax/configuration.rb
+++ b/lib/hyrax/configuration.rb
@@ -652,6 +652,51 @@ module Hyrax
       @upload_path ||= ->() { Pathname.new(ENV.fetch('HYRAX_UPLOAD_PATH') { Rails.root.join('tmp', 'uploads') }) }
     end
 
+    ##
+    # Storage backend for staged user uploads ({Hyrax::UploadedFile}).
+    #
+    # +:carrierwave+ (default) stores staged files on the local file system
+    # under {#upload_path} via CarrierWave. +:active_storage+ stores them
+    # through Rails Active Storage, so the configured Active Storage service
+    # (+config.active_storage.service+ / +config/storage.yml+) determines
+    # where staged bytes live; switching that service between local disk and
+    # S3 is a Rails configuration change only.
+    #
+    # @note reads are backend-agnostic: records carrying an Active Storage
+    #   attachment are read through Active Storage and records carrying a
+    #   CarrierWave file are read through CarrierWave, whatever this setting
+    #   is. The setting controls where newly uploaded content is written.
+    #
+    # @note the ActiveFedora ingest path reads staged files through the
+    #   CarrierWave interface; applications using ActiveFedora file sets
+    #   should stay on +:carrierwave+.
+    #
+    # @return [Symbol] +:carrierwave+ or +:active_storage+
+    def uploaded_file_storage_backend
+      @uploaded_file_storage_backend ||= :carrierwave
+    end
+
+    UPLOADED_FILE_STORAGE_BACKENDS = %i[carrierwave active_storage].freeze
+
+    def uploaded_file_storage_backend=(backend)
+      backend = backend.to_sym
+      unless UPLOADED_FILE_STORAGE_BACKENDS.include?(backend)
+        raise ArgumentError,
+              "unknown uploaded_file_storage_backend #{backend.inspect}; " \
+              "expected one of #{UPLOADED_FILE_STORAGE_BACKENDS.inspect}"
+      end
+      raise ArgumentError, "uploaded_file_storage_backend :active_storage requires the Active Storage framework to be loaded" if
+        backend == :active_storage && !defined?(::ActiveStorage)
+      @uploaded_file_storage_backend = backend
+    end
+
+    ##
+    # @return [Boolean] whether new staged uploads are written to Active
+    #   Storage
+    def active_storage_uploads?
+      uploaded_file_storage_backend == :active_storage
+    end
+
     attr_writer :cache_path
     def cache_path
       @cache_path ||= ->() { Pathname.new(ENV.fetch('HYRAX_CACHE_PATH') { Rails.root.join('tmp', 'cache') }) }

--- a/lib/hyrax/transactions/steps/save_collection_banner.rb
+++ b/lib/hyrax/transactions/steps/save_collection_banner.rb
@@ -39,14 +39,16 @@ module Hyrax
 
         def add_new_banner(collection_id:, uploaded_file_ids:)
           f = uploaded_files(uploaded_file_ids).first
-          banner_info = CollectionBrandingInfo.new(
-            collection_id: collection_id,
-            filename: File.split(f.file_url).last,
-            role: "banner",
-            alt_txt: "",
-            target_url: ""
-          )
-          banner_info.save f.file_url
+          f.with_local_path do |path|
+            banner_info = CollectionBrandingInfo.new(
+              collection_id: collection_id,
+              filename: File.basename(path),
+              role: "banner",
+              alt_txt: "",
+              target_url: ""
+            )
+            banner_info.save path
+          end
         end
 
         def uploaded_files(uploaded_file_ids)

--- a/lib/hyrax/transactions/steps/save_collection_logo.rb
+++ b/lib/hyrax/transactions/steps/save_collection_logo.rb
@@ -69,15 +69,17 @@ module Hyrax
 
         def create_logo_info(collection_id:, uploaded_file_id:, alttext:, linkurl:)
           file = uploaded_files(uploaded_file_id)
-          logo_info = CollectionBrandingInfo.new(
-            collection_id: collection_id,
-            filename: File.split(file.file_url).last,
-            role: "logo",
-            alt_txt: alttext,
-            target_url: linkurl
-          )
-          logo_info.save file.file_url
-          logo_info
+          file.with_local_path do |path|
+            logo_info = CollectionBrandingInfo.new(
+              collection_id: collection_id,
+              filename: File.basename(path),
+              role: "logo",
+              alt_txt: alttext,
+              target_url: linkurl
+            )
+            logo_info.save path
+            logo_info
+          end
         end
 
         def uploaded_files(uploaded_file_ids)

--- a/spec/controllers/hyrax/uploads_controller_spec.rb
+++ b/spec/controllers/hyrax/uploads_controller_spec.rb
@@ -97,6 +97,99 @@ RSpec.describe Hyrax::UploadsController do
         expect(response.status).to eq 401
       end
     end
+
+    context "with the :active_storage backend" do
+      render_views
+
+      around do |example|
+        original = Hyrax.config.uploaded_file_storage_backend
+        Hyrax.config.uploaded_file_storage_backend = :active_storage
+        example.run
+        Hyrax.config.uploaded_file_storage_backend = original
+      end
+
+      before { sign_in user }
+
+      let(:fixture_bytes) { File.binread(fixture_path + '/world.png') }
+
+      def precreate_upload(name = 'world.png')
+        post :create, params: { files: [name], format: 'json' }
+        assigns(:upload)
+      end
+
+      def chunk_upload(upload, bytes, first_byte, total)
+        chunk_path = File.join(Dir.mktmpdir, 'chunk')
+        File.binwrite(chunk_path, bytes)
+        request.headers['CONTENT-RANGE'] = "bytes #{first_byte}-#{first_byte + bytes.bytesize - 1}/#{total}"
+        post :create,
+             params: { files: [Rack::Test::UploadedFile.new(chunk_path, 'image/png')],
+                       id: upload.id, format: 'json' }
+      end
+
+      it "creates a record from a filename ahead of the content" do
+        upload = precreate_upload
+
+        expect(response).to be_successful
+        expect(upload).to be_persisted
+        expect(upload.filename).to eq 'world.png'
+        expect(upload).not_to be_stored
+        expect(JSON.parse(response.body)['files'].first['name']).to eq 'world.png'
+      end
+
+      it "attaches content sent in a single request" do
+        upload = precreate_upload
+
+        post :create, params: { files: [fixture_file_upload('/world.png', 'image/png')],
+                                id: upload.id, format: 'json' }
+
+        expect(response).to be_successful
+        upload.reload
+        expect(upload).to be_stored
+        expect(upload.byte_size).to eq fixture_bytes.bytesize
+        expect(upload.with_io(&:read)).to eq fixture_bytes
+      end
+
+      it "assembles sequential chunks and attaches the completed file" do
+        upload = precreate_upload
+        midpoint = fixture_bytes.bytesize / 2
+        total = fixture_bytes.bytesize
+
+        chunk_upload(upload, fixture_bytes[0...midpoint], 0, total)
+        expect(response).to be_successful
+        expect(upload.reload).not_to be_stored
+
+        chunk_upload(upload, fixture_bytes[midpoint..], midpoint, total)
+        expect(response).to be_successful
+
+        upload.reload
+        expect(upload).to be_stored
+        expect(upload.filename).to eq 'world.png'
+        expect(upload.with_io(&:read)).to eq fixture_bytes
+      end
+
+      it "removes the assembly staging file after attaching" do
+        upload = precreate_upload
+        staging_file = File.join(Hyrax.config.cache_path.call.to_s, 'chunked_uploads', "#{upload.id}.part")
+
+        chunk_upload(upload, fixture_bytes, 0, fixture_bytes.bytesize)
+
+        expect(upload.reload).to be_stored
+        expect(File).not_to exist(staging_file)
+      end
+
+      it "restarts assembly when a chunk does not continue the pending data" do
+        upload = precreate_upload
+        total = fixture_bytes.bytesize + 1000
+
+        chunk_upload(upload, fixture_bytes[0...100], 0, total)
+        # out-of-order chunk: restarts the assembly rather than appending
+        chunk_upload(upload, fixture_bytes[0...50], 500, total)
+
+        staging_file = File.join(Hyrax.config.cache_path.call.to_s, 'chunked_uploads', "#{upload.id}.part")
+        expect(File.size(staging_file)).to eq 50
+        expect(upload.reload).not_to be_stored
+      end
+    end
   end
 
   describe "#destroy" do
@@ -129,6 +222,26 @@ RSpec.describe Hyrax::UploadsController do
       it "is redirected to sign in" do
         delete :destroy, params: { id: uploaded_file }
         expect(response).to redirect_to main_app.new_user_session_path(locale: 'en')
+      end
+    end
+
+    context "with the :active_storage backend" do
+      around do |example|
+        original = Hyrax.config.uploaded_file_storage_backend
+        Hyrax.config.uploaded_file_storage_backend = :active_storage
+        example.run
+        Hyrax.config.uploaded_file_storage_backend = original
+      end
+
+      before { sign_in user }
+
+      it "destroys the record and purges the attachment" do
+        uploaded_file = Hyrax::UploadedFile.create(file: file, user: user)
+
+        expect { delete :destroy, params: { id: uploaded_file } }
+          .to have_enqueued_job(ActiveStorage::PurgeJob)
+        expect(response.status).to eq 204
+        expect(assigns[:upload]).to be_destroyed
       end
     end
   end

--- a/spec/lib/hyrax/configuration_spec.rb
+++ b/spec/lib/hyrax/configuration_spec.rb
@@ -16,6 +16,30 @@ RSpec.describe Hyrax::Configuration do
     it { is_expected.to eq('default') }
   end
 
+  describe '#uploaded_file_storage_backend' do
+    it 'defaults to :carrierwave' do
+      expect(configuration.uploaded_file_storage_backend).to eq :carrierwave
+    end
+
+    it 'accepts :active_storage' do
+      expect { configuration.uploaded_file_storage_backend = :active_storage }
+        .to change { configuration.active_storage_uploads? }
+        .from(false)
+        .to(true)
+    end
+
+    it 'accepts a string' do
+      configuration.uploaded_file_storage_backend = 'active_storage'
+
+      expect(configuration.uploaded_file_storage_backend).to eq :active_storage
+    end
+
+    it 'rejects unknown backends' do
+      expect { configuration.uploaded_file_storage_backend = :shrine }
+        .to raise_error(ArgumentError, /uploaded_file_storage_backend/)
+    end
+  end
+
   it { is_expected.to respond_to(:active_deposit_agreement_acceptance=) }
   it { is_expected.to respond_to(:active_deposit_agreement_acceptance?) }
   it { is_expected.to respond_to(:activity_to_show_default_seconds_since_now) }

--- a/spec/models/hyrax/uploaded_file_spec.rb
+++ b/spec/models/hyrax/uploaded_file_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 RSpec.describe Hyrax::UploadedFile do
   let(:file1) { File.open(fixture_path + '/world.png') }
+  let(:user) { create(:user) }
 
   subject { described_class.create(file: file1) }
 
@@ -14,10 +15,10 @@ RSpec.describe Hyrax::UploadedFile do
     expect(subject.errors[:file]).to include(/Virus detected/)
   end
 
-  describe 'the storage-neutral file API' do
+  shared_examples 'a storage-neutral staged upload' do
     describe '#filename' do
       it 'returns the name of the stored file' do
-        expect(subject.filename).to eq 'world.png'
+        expect(upload.filename).to eq 'world.png'
       end
 
       it 'is nil when no file is stored' do
@@ -27,19 +28,19 @@ RSpec.describe Hyrax::UploadedFile do
 
     describe '#content_type' do
       it 'returns the MIME type of the stored file' do
-        expect(subject.content_type).to eq 'image/png'
+        expect(upload.content_type).to eq 'image/png'
       end
     end
 
     describe '#byte_size' do
       it 'returns the size of the stored file' do
-        expect(subject.byte_size).to eq File.size(fixture_path + '/world.png')
+        expect(upload.byte_size).to eq File.size(fixture_path + '/world.png')
       end
     end
 
     describe '#stored?' do
       it 'is true when a file is stored' do
-        expect(subject).to be_stored
+        expect(upload).to be_stored
       end
 
       it 'is false when no file is stored' do
@@ -49,46 +50,127 @@ RSpec.describe Hyrax::UploadedFile do
 
     describe '#with_io' do
       it 'yields a readable IO positioned at the start of the content' do
-        content = subject.with_io(&:read)
+        content = upload.with_io(&:read)
 
         expect(content).to eq File.binread(fixture_path + '/world.png')
       end
 
       it 'yields an IO with a local filesystem path' do
-        subject.with_io do |io|
+        upload.with_io do |io|
           expect(File).to exist(io.path)
         end
       end
 
       it 'closes the IO after the block returns' do
-        leaked = subject.with_io { |io| io }
+        leaked = upload.with_io { |io| io }
 
         expect(leaked).to be_closed
       end
 
       it 'returns the value of the block' do
-        expect(subject.with_io { :result }).to eq :result
+        expect(upload.with_io { :result }).to eq :result
       end
 
       it 'raises ArgumentError without a block' do
-        expect { subject.with_io }.to raise_error ArgumentError
+        expect { upload.with_io }.to raise_error ArgumentError
       end
     end
 
     describe '#with_local_path' do
       it 'yields a path to the stored content' do
-        subject.with_local_path do |path|
+        upload.with_local_path do |path|
           expect(File.binread(path)).to eq File.binread(fixture_path + '/world.png')
         end
       end
 
       it 'returns the value of the block' do
-        expect(subject.with_local_path { :result }).to eq :result
+        expect(upload.with_local_path { :result }).to eq :result
       end
 
       it 'raises ArgumentError without a block' do
-        expect { subject.with_local_path }.to raise_error ArgumentError
+        expect { upload.with_local_path }.to raise_error ArgumentError
       end
+    end
+  end
+
+  describe 'with the :carrierwave storage backend' do
+    let(:upload) { described_class.create(file: file1, user: user) }
+
+    it_behaves_like 'a storage-neutral staged upload'
+
+    it 'does not use Active Storage' do
+      expect(upload).not_to be_active_storage_backed
+    end
+  end
+
+  describe 'with the :active_storage storage backend' do
+    around do |example|
+      original = Hyrax.config.uploaded_file_storage_backend
+      Hyrax.config.uploaded_file_storage_backend = :active_storage
+      example.run
+      Hyrax.config.uploaded_file_storage_backend = original
+    end
+
+    let(:upload) { described_class.create(file: file1, user: user) }
+
+    it_behaves_like 'a storage-neutral staged upload'
+
+    it 'stores content through Active Storage' do
+      expect(upload).to be_active_storage_backed
+      expect(upload.file_attachment).to be_attached
+    end
+
+    it 'leaves the CarrierWave uploader empty' do
+      expect(upload.uploader.file).to be_nil
+    end
+
+    it 'records an intended filename ahead of content' do
+      pending_upload = described_class.create(file: 'incoming.png', user: user)
+
+      expect(pending_upload.filename).to eq 'incoming.png'
+      expect(pending_upload).not_to be_stored
+      expect(pending_upload.byte_size).to be_nil
+    end
+
+    describe '#store_file' do
+      it 'attaches an IO under the given filename' do
+        upload = described_class.create(file: 'incoming.png', user: user)
+        File.open(fixture_path + '/world.png', 'rb') do |io|
+          upload.store_file(io, filename: upload.filename)
+        end
+
+        expect(upload.reload.filename).to eq 'incoming.png'
+        expect(upload.byte_size).to eq File.size(fixture_path + '/world.png')
+        expect(upload.with_io(&:read)).to eq File.binread(fixture_path + '/world.png')
+      end
+
+      it 'accepts an upload object carrying its own filename' do
+        upload = described_class.create(user: user)
+        upload.store_file(Rack::Test::UploadedFile.new(File.join(fixture_path, 'world.png'), 'image/png'))
+
+        expect(upload.reload.filename).to eq 'world.png'
+      end
+    end
+
+    it 'scans new content for viruses' do
+      allow(Hyrax::VirusScanner).to receive(:infected?).and_return(true)
+      upload = described_class.create(file: file1, user: user)
+
+      expect(upload.errors[:file]).to include(/Virus detected/)
+      expect(upload).not_to be_persisted
+    end
+
+    it 'does not rescan unchanged content on later saves' do
+      upload = described_class.create(file: file1, user: user)
+
+      expect(Hyrax::VirusScanner).not_to receive(:infected?)
+      upload.update!(file_set_uri: 'test:fs')
+    end
+
+    it 'purges the attachment when destroyed' do
+      upload # create before the expectation
+
+      expect { upload.destroy }.to have_enqueued_job(ActiveStorage::PurgeJob)
     end
   end
 end

--- a/spec/models/hyrax/uploaded_file_spec.rb
+++ b/spec/models/hyrax/uploaded_file_spec.rb
@@ -13,4 +13,82 @@ RSpec.describe Hyrax::UploadedFile do
     allow(Hyrax::VirusScanner).to receive(:infected?).and_return(true)
     expect(subject.errors[:file]).to include(/Virus detected/)
   end
+
+  describe 'the storage-neutral file API' do
+    describe '#filename' do
+      it 'returns the name of the stored file' do
+        expect(subject.filename).to eq 'world.png'
+      end
+
+      it 'is nil when no file is stored' do
+        expect(described_class.new.filename).to be_nil
+      end
+    end
+
+    describe '#content_type' do
+      it 'returns the MIME type of the stored file' do
+        expect(subject.content_type).to eq 'image/png'
+      end
+    end
+
+    describe '#byte_size' do
+      it 'returns the size of the stored file' do
+        expect(subject.byte_size).to eq File.size(fixture_path + '/world.png')
+      end
+    end
+
+    describe '#stored?' do
+      it 'is true when a file is stored' do
+        expect(subject).to be_stored
+      end
+
+      it 'is false when no file is stored' do
+        expect(described_class.new).not_to be_stored
+      end
+    end
+
+    describe '#with_io' do
+      it 'yields a readable IO positioned at the start of the content' do
+        content = subject.with_io(&:read)
+
+        expect(content).to eq File.binread(fixture_path + '/world.png')
+      end
+
+      it 'yields an IO with a local filesystem path' do
+        subject.with_io do |io|
+          expect(File).to exist(io.path)
+        end
+      end
+
+      it 'closes the IO after the block returns' do
+        leaked = subject.with_io { |io| io }
+
+        expect(leaked).to be_closed
+      end
+
+      it 'returns the value of the block' do
+        expect(subject.with_io { :result }).to eq :result
+      end
+
+      it 'raises ArgumentError without a block' do
+        expect { subject.with_io }.to raise_error ArgumentError
+      end
+    end
+
+    describe '#with_local_path' do
+      it 'yields a path to the stored content' do
+        subject.with_local_path do |path|
+          expect(File.binread(path)).to eq File.binread(fixture_path + '/world.png')
+        end
+      end
+
+      it 'returns the value of the block' do
+        expect(subject.with_local_path { :result }).to eq :result
+      end
+
+      it 'raises ArgumentError without a block' do
+        expect { subject.with_local_path }.to raise_error ArgumentError
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Summary

Adds an **opt-in Active Storage backend for staged uploads** (`Hyrax::UploadedFile`), preserving the existing chunked upload protocol. Part of the non-AF → Active Storage chain; **stacked on #7547 and #7548** (their commits appear in this diff until they merge).

New config:

```ruby
config.uploaded_file_storage_backend = :active_storage # default :carrierwave
```

- **`:carrierwave`** (default): byte-for-byte the existing behavior. ActiveFedora apps should stay here — the AF ingest path reads staged files through CarrierWave (documented in the generated initializer).
- **`:active_storage`**: staged bytes are written through Rails Active Storage, so `config/storage.yml` / `config.active_storage.service` decide where they live — **switching staging from local disk to S3 becomes that one Rails config change.**

Design points:

- `Hyrax::UploadedFile` gains `has_one_attached :file_attachment`. **Reads dispatch per record** (attachment present → Active Storage; CarrierWave file → CarrierWave), so records created under either backend remain readable whatever the setting — no migration required to flip.
- The **client chunk protocol is unchanged** (two-step create, serial `CONTENT-RANGE` chunks, Cloudflare-size-safe requests; the blueimp widget needs no changes). Under Active Storage, `Hyrax::UploadsController` assembles chunks in a local staging file under `config.cache_path` and attaches the completed file when the final chunk arrives (`last byte + 1 == total`); a chunk that doesn't continue the pending assembly restarts it, mirroring the CarrierWave replacement behavior. Assembly assumes sequential chunks on one node or a shared staging path — the same constraint CarrierWave append has always had.
- A bare String assignment (`file = "name.png"`, the protocol's pre-create step) records the **intended filename** ahead of content.
- **Virus scanning** runs once per newly attached content from its local source, instead of CarrierWave's rescan-of-the-growing-file on every chunk append. Unchanged-content saves don't rescan.
- Destroying an upload **purges** its attachment (`ActiveStorage::PurgeJob`).
- `FileSetsController#uploaded_file_from_path` passes the raw multipart upload straight through (both backends accept it; the `CarrierWave::SanitizedFile` wrap was redundant).

## Dependencies

- #7547 (Active Storage tables in test apps / installer)
- #7548 (storage-neutral read API this backend implements)

## Tests

Run locally against the koppie (Valkyrie) test app — dockerized Postgres/Solr/Redis:

- `spec/models/hyrax/uploaded_file_spec.rb`: the storage-neutral API examples now run as **shared examples against both backends**, plus AS-specific coverage (intended filename, `store_file`, virus scan on attach, no rescan on unchanged saves, purge on destroy) — 39 examples, 0 failures
- `spec/controllers/hyrax/uploads_controller_spec.rb`: legacy CarrierWave examples untouched and passing; new AS context covers pre-create, single-shot attach, **sequential chunk assembly + finalize with content verification**, staging-file cleanup, mismatched-chunk restart, purge on destroy — with the existing chunk examples, 140 examples total, 0 failures
- `spec/lib/hyrax/configuration_spec.rb` (backend validation), `spec/controllers/hyrax/file_sets_controller_spec.rb`, `spec/jobs/valkyrie_ingest_job_spec.rb`, `spec/services/hyrax/work_uploads_handler_spec.rb` — green

AF-side (dassie) suite portions not run locally; CI covers them. RuboCop clean on touched files.

## Notes for reviewers

- Attaching staged files enqueues Active Storage's `AnalyzeJob` (image metadata); harmless for staging records, called out for awareness.
- Uploads-controller chunk-append authorization (any signed-in user can PATCH any upload id) is a **pre-existing** gap left as-is here for parity; a follow-up PR adds ownership enforcement at the attach seam.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
