### PR TITLE
Match identifiers predicate change in compound metadata config

### DIFF
--- a/config/metadata_profiles/m3_profile.yaml
+++ b/config/metadata_profiles/m3_profile.yaml
@@ -1018,7 +1018,7 @@ properties:
       default: Identifiers
     form:
       primary: false
-    property_uri: http://purl.org/dc/terms/identifier
+    property_uri: http://id.loc.gov/ontologies/bibframe/identifiedBy
     view:
       render_as: compound
       html_dl: true


### PR DESCRIPTION
The predicate used for identifiers in the compound metadata changed (#7546) due to conflicts with the identifier field in basic metadata leading to errors saving identifier when both fields were present (sirenia).

Related to #7544 