### PR TITLE
Update `identifiers` predicate

### DIFF
--- a/.koppie/config/metadata_profiles/m3_profile.yaml
+++ b/.koppie/config/metadata_profiles/m3_profile.yaml
@@ -994,7 +994,7 @@ properties:
       default: Identifiers
     form:
       primary: false
-    property_uri: http://purl.org/dc/terms/identifier
+    property_uri: http://id.loc.gov/ontologies/bibframe/identifiedBy
     view:
       render_as: compound
       html_dl: true

--- a/config/metadata_profiles/m3_profile.yaml
+++ b/config/metadata_profiles/m3_profile.yaml
@@ -1018,7 +1018,7 @@ properties:
       default: Identifiers
     form:
       primary: false
-    property_uri: http://purl.org/dc/terms/identifier
+    property_uri: http://id.loc.gov/ontologies/bibframe/identifiedBy
     view:
       render_as: compound
       html_dl: true


### PR DESCRIPTION
This is a follow up to a previous change in the `identifiers` predicate to fix CI issues.  The m3 profiles that have the same property should also be updated.

Ref:
- https://github.com/samvera/hyrax/pull/7546/changes/387817e4
