### PR TITLE
chore: upgrade valkyrie to 3.6.0

### DIFF
--- a/hyrax.gemspec
+++ b/hyrax.gemspec
@@ -88,7 +88,7 @@ SUMMARY
   spec.add_dependency 'retriable', '>= 2.9', '< 4.0'
   spec.add_dependency 'signet'
   spec.add_dependency 'tinymce-rails', '~> 5.10'
-  spec.add_dependency 'valkyrie', '~> 3.5'
+  spec.add_dependency 'valkyrie', '~> 3.6.0'
   spec.add_dependency 'view_component', '~> 2.74.1' # Pin until blacklight is updated with workaround for https://github.com/ViewComponent/view_component/issues/1565
   spec.add_dependency 'sprockets', '3.7.2' # 3.7.3 fails feature specs
   spec.add_dependency 'sass-rails', '~> 6.0'


### PR DESCRIPTION
## Summary
- constrain the Valkyrie dependency to the 3.6 release line
- target Valkyrie 3.6.0 for the Dassie and Koppie test applications

## Validation
- `git diff --check`
- resolved the Dassie bundle in the Hyrax development image and verified `Valkyrie::VERSION == "3.6.0"`
- resolved the Koppie bundle in the Hyrax development image and verified `Valkyrie::VERSION == "3.6.0"`

Full app specs were not run locally; the PR CI matrix covers Dassie and Koppie.
