### PR TITLE
Linked record picker enhancements

### DIFF
--- a/app/assets/javascripts/hyrax/compound_metadata.js
+++ b/app/assets/javascripts/hyrax/compound_metadata.js
@@ -46,12 +46,16 @@
                     quietMillis: 250,
                     data: function(term, page) { lastTerm = term; return { q: term }; },
                     results: function(data, page) {
-                        // For a creatable linked_record, surface the "Add new"
-                        // trigger when the search came back empty.
+                        // Keep the creatable linked_record's "Add new" term stashed
+                        // for the create-form prefill (the affordance is always
+                        // visible; see toggleAddNew).
                         if (isLinkedRecord) toggleAddNew(wrapEl, data.length === 0, lastTerm);
                         return {
                             results: data.map(function(obj) {
-                                return { id: obj.id, text: [].concat(obj.label)[0] };
+                                // `detail` is an optional per-row string a source may
+                                // supply; formatResult renders it as a muted second
+                                // line. A source that omits it renders the plain label.
+                                return { id: obj.id, text: [].concat(obj.label)[0], detail: obj.detail };
                             })
                         };
                     }
@@ -61,6 +65,12 @@
             // Only work_or_url accepts a free-typed value as its selection.
             if (!isLinkedRecord) {
                 options.createSearchChoice = function(term) { return { id: term, text: term }; };
+            } else {
+                // A linked_record row may carry an optional `detail` we render as
+                // HTML (a muted second line); disable select2's own escaping and
+                // escape every value ourselves in formatLinkedRecordResult.
+                options.formatResult = formatLinkedRecordResult;
+                options.escapeMarkup = function(m) { return m; };
             }
 
             $el.select2(options);
@@ -84,20 +94,33 @@
         });
     }
 
-    // Show/hide the "Add new" trigger for a creatable linked_record when a
-    // search returned no matches; stash the typed term to prefill the form.
-    // `wrapEl` is the [data-hyrax-linked-record] wrapper captured at bind time.
-    function toggleAddNew(wrapEl, noResults, term) {
+    // Keep the "Add new" trigger available for a creatable linked_record whether
+    // or not the search matched, so results and create coexist (the partial
+    // renders the button visible from the start); this only refreshes the stashed
+    // typed term used to prefill the create form. `wrapEl` is the
+    // [data-hyrax-linked-record] wrapper captured at bind time.
+    function toggleAddNew(wrapEl, _noResults, term) {
         if (!wrapEl || wrapEl.getAttribute('data-creatable') !== 'true') return;
-        var $wrap = jQuery(wrapEl);
-        var $add = $wrap.find('[data-hyrax-linked-record-add]');
-        if (!$add.length) return;
-        $wrap.data('lastTerm', term || '');
-        if (noResults) {
-            $add.removeClass('d-none').prop('hidden', false);
-        } else {
-            $add.addClass('d-none').prop('hidden', true);
-        }
+        jQuery(wrapEl).data('lastTerm', term || '');
+    }
+
+    // HTML-escape a value for interpolation into a formatResult template (select2's
+    // default escaping is off once we supply escapeMarkup).
+    function escapeHtml(value) {
+        return String(value == null ? '' : value)
+            .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+            .replace(/"/g, '&quot;').replace(/'/g, '&#39;');
+    }
+
+    // Render a linked_record result row: the label on the first line, and a muted
+    // second line from the row's optional `detail` string. Falls back to the plain
+    // label when a source supplies no detail, so this stays source-agnostic.
+    function formatLinkedRecordResult(item) {
+        var label = escapeHtml(item.text);
+        if (item.detail == null || String(item.detail).trim() === '') return label;
+        return '<div class="linked-record-option">' + label +
+               '<div class="linked-record-option-detail text-muted small">' +
+               escapeHtml(item.detail) + '</div></div>';
     }
 
     // Bind saved rows once the DOM is ready (at script-eval time the form
@@ -128,15 +151,18 @@
     function closeCreateForm(wrap) {
         if (!wrap) return;
         var form = wrap.querySelector('[data-hyrax-linked-record-create-form]');
-        if (form) { form.classList.add('d-none'); form.hidden = true; }
+        if (form) {
+            form.classList.add('d-none'); form.hidden = true;
+            // Reset the duplicate-check state so a later open starts clean.
+            var panel = form.querySelector('[data-hyrax-linked-record-similar]');
+            if (panel) { panel.classList.add('d-none'); panel.hidden = true; }
+        }
+        jQuery(wrap).data('createConfirmed', false);
     }
 
-    function submitCreateForm(wrap) {
-        if (!wrap) return;
-        var url = wrap.getAttribute('data-create-url');
-        var form = wrap.querySelector('[data-hyrax-linked-record-create-form]');
-        if (!url || !form) return;
-        var errors = form.querySelector('[data-hyrax-linked-record-create-errors]');
+    // Collect the create form's inputs into the {record} payload the create
+    // endpoint expects.
+    function collectCreateRecord(form) {
         var record = {};
         // Scalar create-fields: one value each. Skip inputs that live inside a
         // group (those are collected per-row below).
@@ -168,6 +194,101 @@
             });
             record[name] = rows;
         });
+        return record;
+    }
+
+    // The typed name for the duplicate check: the first scalar create-field (the
+    // create form's leading text input).
+    function createFormName(form) {
+        var first = form.querySelector('input[data-create-field]');
+        return first ? first.value : '';
+    }
+
+    // Select a record (existing or newly-created) in the picker and clear the
+    // create-confirm latch so a later create re-runs the duplicate check.
+    function selectRecord(wrap, id, label) {
+        jQuery(wrap).find('[data-hyrax-linked-record-input]')
+            .select2('data', { id: id, text: label });
+        jQuery(wrap).data('createConfirmed', false);
+    }
+
+    // Create submit: when the source offers a duplicate check (data-similar-url)
+    // and the entered name has similar existing records, show them and hold. A
+    // second press (createConfirmed latch) or a source with no similar-url creates
+    // immediately.
+    function submitCreateForm(wrap) {
+        if (!wrap) return;
+        var form = wrap.querySelector('[data-hyrax-linked-record-create-form]');
+        if (!form) return;
+
+        var similarUrl = wrap.getAttribute('data-similar-url');
+        if (similarUrl && !jQuery(wrap).data('createConfirmed')) {
+            checkSimilarThenCreate(wrap, form, similarUrl);
+            return;
+        }
+        postCreate(wrap, form);
+    }
+
+    // Fetch similar records for the typed name; if any, render the warning panel
+    // and hold. If none (or the check fails), fall through to creating.
+    function checkSimilarThenCreate(wrap, form, similarUrl) {
+        var name = createFormName(form).trim();
+        if (!name) { postCreate(wrap, form); return; }
+
+        var sep = similarUrl.indexOf('?') === -1 ? '?' : '&';
+        fetch(similarUrl + sep + 'q=' + encodeURIComponent(name), {
+            headers: { 'Accept': 'application/json' }, credentials: 'same-origin'
+        }).then(function(resp) {
+            return resp.ok ? resp.json() : [];
+        }).catch(function() {
+            return [];
+        }).then(function(candidates) {
+            if (candidates && candidates.length) {
+                showSimilar(wrap, form, candidates);
+            } else {
+                postCreate(wrap, form);
+            }
+        });
+    }
+
+    // Render the fuzzy-match warning panel: one "Use this" row per candidate.
+    // Selecting a candidate reuses the existing record; the primary "Create"
+    // button becomes the override — set the latch so the next press creates.
+    // Editing the name clears the latch (see the create-form input listener).
+    function showSimilar(wrap, form, candidates) {
+        var panel = form.querySelector('[data-hyrax-linked-record-similar]');
+        var list = form.querySelector('[data-hyrax-linked-record-similar-list]');
+        if (!panel || !list) { postCreate(wrap, form); return; }
+
+        list.innerHTML = '';
+        candidates.forEach(function(c) {
+            var li = document.createElement('li');
+            li.className = 'd-flex align-items-center justify-content-between mb-1';
+            li.innerHTML = '<span>' + escapeHtml(c.label) +
+                (c.detail ? ' <span class="text-muted small">' + escapeHtml(c.detail) + '</span>' : '') + '</span>';
+            var btn = document.createElement('button');
+            btn.type = 'button';
+            btn.className = 'btn btn-link btn-sm p-0 ml-2 text-nowrap';
+            btn.setAttribute('data-hyrax-linked-record-use', '');
+            btn.setAttribute('data-id', c.id);
+            btn.setAttribute('data-label', c.label);
+            btn.textContent = list.getAttribute('data-use-label') || 'Use this';
+            li.appendChild(btn);
+            list.appendChild(li);
+        });
+        panel.classList.remove('d-none');
+        panel.hidden = false;
+        // Warned once: the next "Create" press proceeds instead of re-checking.
+        jQuery(wrap).data('createConfirmed', true);
+    }
+
+    // POST the collected record to the create endpoint; on success select the new
+    // record in the picker.
+    function postCreate(wrap, form) {
+        var url = wrap.getAttribute('data-create-url');
+        if (!url) return;
+        var errors = form.querySelector('[data-hyrax-linked-record-create-errors]');
+        var record = collectCreateRecord(form);
 
         // Show server-supplied messages (already localized), falling back to the
         // localized default the partial set on `data-default-message`.
@@ -195,12 +316,8 @@
             });
         }).then(function(result) {
             if (result.ok) {
-                // Select the new record in the picker (select2 v3 takes {id,text}).
-                var $input = jQuery(wrap).find('[data-hyrax-linked-record-input]');
-                $input.select2('data', { id: result.body.id, text: result.body.label });
+                selectRecord(wrap, result.body.id, result.body.label);
                 closeCreateForm(wrap);
-                var $add = jQuery(wrap).find('[data-hyrax-linked-record-add]');
-                $add.addClass('d-none').prop('hidden', true);
             } else {
                 showError(result.body.errors);
             }
@@ -209,6 +326,18 @@
             showError();
         });
     }
+
+    // Editing any create-form field after a duplicate warning clears the "warned"
+    // latch and hides the panel, so the next "Create" re-checks the (possibly
+    // changed) name rather than creating straight through.
+    document.addEventListener('input', function(event) {
+        if (!event.target.closest('[data-hyrax-linked-record-create-form]')) return;
+        var wrap = event.target.closest('[data-hyrax-linked-record]');
+        if (!wrap || !jQuery(wrap).data('createConfirmed')) return;
+        jQuery(wrap).data('createConfirmed', false);
+        var panel = wrap.querySelector('[data-hyrax-linked-record-similar]');
+        if (panel) { panel.classList.add('d-none'); panel.hidden = true; }
+    });
 
     document.addEventListener('click', function(event) {
         // --- linked_record inline create affordance ---
@@ -220,6 +349,15 @@
         var createSubmit = event.target.closest('[data-hyrax-linked-record-create-submit]');
         if (createSubmit) {
             submitCreateForm(createSubmit.closest('[data-hyrax-linked-record]'));
+            return;
+        }
+        // "Use this" on a fuzzy-match candidate: reuse the existing record instead
+        // of creating a duplicate.
+        var useTrigger = event.target.closest('[data-hyrax-linked-record-use]');
+        if (useTrigger) {
+            var useWrap = useTrigger.closest('[data-hyrax-linked-record]');
+            selectRecord(useWrap, useTrigger.getAttribute('data-id'), useTrigger.getAttribute('data-label'));
+            closeCreateForm(useWrap);
             return;
         }
         var createCancel = event.target.closest('[data-hyrax-linked-record-create-cancel]');

--- a/app/assets/javascripts/hyrax/compound_metadata.js
+++ b/app/assets/javascripts/hyrax/compound_metadata.js
@@ -71,6 +71,11 @@
                 // escape every value ourselves in formatLinkedRecordResult.
                 options.formatResult = formatLinkedRecordResult;
                 options.escapeMarkup = function(m) { return m; };
+                // escapeMarkup is now a no-op for BOTH the dropdown and the
+                // selected value. formatResult escapes the dropdown; provide an
+                // explicit formatSelection so the selected label is escaped too —
+                // otherwise a label containing HTML would render unescaped (XSS).
+                options.formatSelection = function(data) { return escapeHtml(data && data.text); };
             }
 
             $el.select2(options);
@@ -107,7 +112,8 @@
     // HTML-escape a value for interpolation into a formatResult template (select2's
     // default escaping is off once we supply escapeMarkup).
     function escapeHtml(value) {
-        return String(value == null ? '' : value)
+        var str = (value === null || value === undefined) ? '' : value;
+        return String(str)
             .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
             .replace(/"/g, '&quot;').replace(/'/g, '&#39;');
     }
@@ -117,7 +123,7 @@
     // label when a source supplies no detail, so this stays source-agnostic.
     function formatLinkedRecordResult(item) {
         var label = escapeHtml(item.text);
-        if (item.detail == null || String(item.detail).trim() === '') return label;
+        if (item.detail === null || item.detail === undefined || String(item.detail).trim() === '') return label;
         return '<div class="linked-record-option">' + label +
                '<div class="linked-record-option-detail text-muted small">' +
                escapeHtml(item.detail) + '</div></div>';

--- a/app/authorities/qa/authorities/linked_record_similar.rb
+++ b/app/authorities/qa/authorities/linked_record_similar.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module Qa::Authorities
+  ##
+  # @api public
+  #
+  # "Did you mean" authority for the `linked_record` compound picker's create-form
+  # duplicate check, mounted at `/authorities/search/linked_record_similar/:source`.
+  # Sibling of {Qa::Authorities::LinkedRecord} (the typeahead authority): the
+  # `:source` URL segment arrives as `params[:subauthority]` (QA's standard
+  # `/search/:vocab(/:subauthority)` route), and the typed name is delegated to
+  # that registered {Hyrax::CompoundLinkedRecordResolver} source's `similar` proc,
+  # so a single authority serves every source.
+  #
+  # Returns `{ id:, label:, value: }` rows (the same shape as the typeahead), or
+  # `[]` when the source is missing, unregistered, or declares no `similar` proc.
+  class LinkedRecordSimilar < Qa::Authorities::Base
+    def search(query, controller)
+      source = controller.params[:subauthority].to_s
+      return [] if source.empty?
+
+      Hyrax::CompoundLinkedRecordResolver.similar(source, query)
+    end
+  end
+end

--- a/app/services/hyrax/compound_linked_record_resolver.rb
+++ b/app/services/hyrax/compound_linked_record_resolver.rb
@@ -27,7 +27,7 @@ module Hyrax
   # The M3 profile names the source via the sub-property's `authority:` key; see
   # documentation/compound_fields.md.
   class CompoundLinkedRecordResolver
-    Source = Struct.new(:finder, :label, :path, :search, :create, :match, keyword_init: true)
+    Source = Struct.new(:finder, :label, :path, :search, :create, :match, :similar, keyword_init: true)
 
     class << self
       # @return [Hash{Symbol => Source}] the registered sources, by name
@@ -54,8 +54,13 @@ module Hyrax
       #   find-or-create import flow. Distinct from `search`, which is fuzzy and
       #   multi-row for the picker — a fuzzy hit is the wrong record to reuse when
       #   resolving an imported reference with no human to disambiguate.
-      def register(source, finder:, label:, path:, search: nil, create: nil, match: nil)
-        registry[source.to_sym] = Source.new(finder:, label:, path:, search:, create:, match:)
+      # @param similar [#call, nil] `(query) -> Array<{id:, label:, value:}>` a
+      #   fuzzy, multi-row "did you mean" lookup on a typed name, for the create
+      #   form's duplicate check. Unlike `match` (exact, single-row, for headless
+      #   import) it is human-facing: the curator picks from the results. Same row
+      #   shape as `search`; omit it for a source with no duplicate check.
+      def register(source, finder:, label:, path:, search: nil, create: nil, match: nil, similar: nil)
+        registry[source.to_sym] = Source.new(finder:, label:, path:, search:, create:, match:, similar:)
       end
 
       # @param source [Symbol, String]
@@ -77,6 +82,13 @@ module Hyrax
       end
 
       # @param source [Symbol, String]
+      # @return [Boolean] whether the source is registered with a `similar` proc
+      #   (i.e. offers a fuzzy "did you mean" duplicate check before create)
+      def similar?(source)
+        spec_for(source)&.similar.present?
+      end
+
+      # @param source [Symbol, String]
       # @param query [String] the typed search term
       # @return [Array<Hash{Symbol => String}>] picker results
       #   (`{ id:, label:, value: }`); `[]` when the source is unregistered or
@@ -88,6 +100,24 @@ module Hyrax
         Array(spec.search.call(query))
       rescue StandardError => e
         Hyrax.logger.debug("CompoundLinkedRecordResolver.search(#{source}, #{query}): #{e.message}")
+        []
+      end
+
+      # Fuzzy "did you mean" lookup for the picker's create-form duplicate check.
+      # Same contract as {.search} (multi-row, `{id:, label:, value:}`), but
+      # semantically the human-facing near-match check rather than the typeahead.
+      #
+      # @param source [Symbol, String]
+      # @param query [String] the typed name
+      # @return [Array<Hash{Symbol => String}>] candidate rows; `[]` when the
+      #   source is unregistered or declares no `similar` proc
+      def similar(source, query)
+        spec = spec_for(source)
+        return [] if spec.nil? || spec.similar.nil?
+
+        Array(spec.similar.call(query))
+      rescue StandardError => e
+        Hyrax.logger.debug("CompoundLinkedRecordResolver.similar(#{source}, #{query}): #{e.message}")
         []
       end
 

--- a/app/views/hyrax/compounds/_linked_record_field.html.erb
+++ b/app/views/hyrax/compounds/_linked_record_field.html.erb
@@ -23,10 +23,17 @@
   <% record_item_label = t("hyrax.compound_fields.linked_record.item_label.#{source}",
                            default: source.to_s.singularize.humanize.downcase) %>
 
+  <%# data-similar-url (optional): when the source declares a `similar` proc, the
+      JS calls this before an inline create and shows near-matches so a curator
+      doesn't create a duplicate. Built from the QA `linked_record_similar`
+      authority, mirroring the autocomplete URL; a source with no `similar` proc
+      emits no attribute and the JS skips the check. %>
+  <% similar_url = Hyrax::CompoundLinkedRecordResolver.similar?(source) ? "#{Rails.application.routes.url_helpers.qa_path}/search/linked_record_similar/#{source}" : nil %>
   <div class="hyrax-linked-record" data-hyrax-linked-record
        data-source="<%= source %>"
        data-creatable="<%= spec[:creatable] ? 'true' : 'false' %>"
-       data-create-url="<%= Hyrax::Engine.routes.url_helpers.compound_linked_record_path(source: source) %>">
+       data-create-url="<%= Hyrax::Engine.routes.url_helpers.compound_linked_record_path(source: source) %>"
+       <% if similar_url %>data-similar-url="<%= similar_url %>"<% end %>>
     <%# Picker + "add new" trigger on one row, so the add button sits beside the
         search field rather than below it (where the select2 "no results"
         dropdown would cover it). %>
@@ -44,9 +51,11 @@
                                      'autocomplete-url': "#{Rails.application.routes.url_helpers.qa_path}/search/linked_record/#{source}" } %>
       </div>
       <% if creatable %>
-        <%# Shown by JS only when a search returns no results. %>
-        <button type="button" class="btn btn-link btn-sm text-nowrap ml-2 d-none"
-                data-hyrax-linked-record-add hidden>
+        <%# Always available beside the picker so results and create coexist — a
+            curator seeing partial/wrong matches can still create, and the result
+            rows' detail lines do the disambiguation. %>
+        <button type="button" class="btn btn-link btn-sm text-nowrap ml-2"
+                data-hyrax-linked-record-add>
           <span class="fa fa-plus"></span>
           <%= t('hyrax.compound_fields.linked_record.add_new', item: record_item_label, default: 'Add new') %>
         </button>
@@ -121,6 +130,23 @@
                      field: field, input_id: "#{input_id}_new_#{field[:name]}",
                      data_attr: 'create-field' %>
         <% end %>
+      <% end %>
+      <%# Fuzzy "did you mean" panel (populated by JS from data-similar-url when
+          Create is clicked and near-matches exist). Each row offers "Use this" to
+          select an existing record instead of creating a duplicate. Once shown,
+          pressing "Create" again proceeds with the new record (the primary button
+          is the override); editing the name re-checks. Hidden until matches are
+          found; only rendered when the source declares a `similar` proc. %>
+      <% if similar_url %>
+        <div class="hyrax-linked-record-similar alert alert-warning p-2 mt-1 mb-2 d-none"
+             data-hyrax-linked-record-similar hidden>
+          <div class="small font-weight-bold mb-1">
+            <%= t('hyrax.compound_fields.linked_record.similar_heading', default: 'Similar records already exist:') %>
+          </div>
+          <ul class="list-unstyled mb-1" data-hyrax-linked-record-similar-list
+              data-use-label="<%= t('hyrax.compound_fields.linked_record.use_existing', default: 'Use this') %>"></ul>
+          <div class="small text-muted"><%= t('hyrax.compound_fields.linked_record.create_again_hint', default: 'Press Create again to add as a new record.') %></div>
+        </div>
       <% end %>
       <div class="d-flex">
         <button type="button" class="btn btn-primary btn-sm mr-2" data-hyrax-linked-record-create-submit>

--- a/config/locales/hyrax.de.yml
+++ b/config/locales/hyrax.de.yml
@@ -893,6 +893,13 @@ de:
         featured_researcher: Ausgewählter Forscher
         marketing_text: Marketing Text
       updated: Inhaltsblöcke aktualisiert.
+    compound_fields:
+      linked_record:
+        add_new: "%{item} hinzufügen"
+        add_row: "Weitere(n) %{item} hinzufügen"
+        create_again_hint: "Erneut auf „Erstellen“ klicken, um als neuen Datensatz hinzuzufügen."
+        similar_heading: "Ähnliche Datensätze existieren bereits:"
+        use_existing: "Diesen verwenden"
     controls:
       about: Impressum
       contact: Kontakt

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -939,6 +939,9 @@ en:
       linked_record:
         add_new: Add a %{item}
         add_row: Add another %{item}
+        create_again_hint: Press Create again to add as a new record.
+        similar_heading: "Similar records already exist:"
+        use_existing: Use this
       participants:
         label: Participants
         title: Title

--- a/config/locales/hyrax.es.yml
+++ b/config/locales/hyrax.es.yml
@@ -899,6 +899,13 @@ es:
         featured_researcher: Investigador Destacado
         marketing_text: Texto de Marketing
       updated: Bloques de contenido actualizados.
+    compound_fields:
+      linked_record:
+        add_new: "Añadir %{item}"
+        add_row: "Añadir otro %{item}"
+        create_again_hint: "Pulse Crear de nuevo para añadirlo como un registro nuevo."
+        similar_heading: "Ya existen registros similares:"
+        use_existing: "Usar este"
     controls:
       about: Acerca de
       contact: Contacto

--- a/config/locales/hyrax.fr.yml
+++ b/config/locales/hyrax.fr.yml
@@ -900,6 +900,13 @@ fr:
         featured_researcher: Chercheur en vedette
         marketing_text: Texte de marketing
       updated: Les blocs de contenu sont mis à jour.
+    compound_fields:
+      linked_record:
+        add_new: "Ajouter un %{item}"
+        add_row: "Ajouter un autre %{item}"
+        create_again_hint: "Cliquez à nouveau sur Créer pour ajouter comme nouvel enregistrement."
+        similar_heading: "Des enregistrements similaires existent déjà :"
+        use_existing: "Utiliser celui-ci"
     controls:
       about: Sur
       contact: Contact

--- a/config/locales/hyrax.it.yml
+++ b/config/locales/hyrax.it.yml
@@ -899,6 +899,13 @@ it:
         featured_researcher: Ricercatore in primo piano
         marketing_text: Testo di marketing
       updated: Blocchi di contenuto aggiornati.
+    compound_fields:
+      linked_record:
+        add_new: "Aggiungi %{item}"
+        add_row: "Aggiungi un altro %{item}"
+        create_again_hint: "Premi di nuovo Crea per aggiungere come nuovo record."
+        similar_heading: "Esistono già record simili:"
+        use_existing: "Usa questo"
     controls:
       about: Di
       contact: contatto

--- a/config/locales/hyrax.pt-BR.yml
+++ b/config/locales/hyrax.pt-BR.yml
@@ -892,6 +892,13 @@ pt-BR:
         featured_researcher: Pesquisador em destaque
         marketing_text: Texto de marketing
       updated: Blocos de conteúdo atualizados.
+    compound_fields:
+      linked_record:
+        add_new: "Adicionar %{item}"
+        add_row: "Adicionar outro %{item}"
+        create_again_hint: "Pressione Criar novamente para adicionar como um novo registro."
+        similar_heading: "Já existem registros semelhantes:"
+        use_existing: "Usar este"
     controls:
       about: Sobre
       contact: Contato

--- a/config/locales/hyrax.zh.yml
+++ b/config/locales/hyrax.zh.yml
@@ -897,6 +897,13 @@ zh:
         featured_researcher: 特色研究员
         marketing_text: 营销文字
       updated: 内容块已更新。
+    compound_fields:
+      linked_record:
+        add_new: "添加%{item}"
+        add_row: "再添加一个%{item}"
+        create_again_hint: "再次点击“创建”以添加为新记录。"
+        similar_heading: "已存在相似的记录："
+        use_existing: "使用此项"
     controls:
       about: 关于
       contact: 联系

--- a/documentation/compound_fields.md
+++ b/documentation/compound_fields.md
@@ -237,24 +237,34 @@ Rails.application.config.to_prepare do
     finder: ->(id)    { Person.find_by(id:) },
     label:  ->(person) { person.display_name },
     path:   ->(person) { Rails.application.routes.url_helpers.person_path(person) },
-    # optional — enables the picker autocomplete:
+    # optional — enables the picker autocomplete. Each row may carry an optional
+    # `detail:` string, rendered as a muted second line under the label so
+    # same-named records are distinguishable:
     search: ->(q) { Person.where('display_name ILIKE ?', "%#{q}%").limit(20)
-                          .map { |p| { id: p.id.to_s, label: p.display_name, value: p.id.to_s } } },
+                          .map { |p| { id: p.id.to_s, label: p.display_name, value: p.id.to_s,
+                                       detail: p.orcid } } },
     # optional — enables inline "add new" (lookup-or-create):
-    create: ->(attrs) { Person.create(attrs.slice(:display_name, :orcid)) }
+    create: ->(attrs) { Person.create(attrs.slice(:display_name, :orcid)) },
+    # optional — enables the create form's fuzzy "did you mean" duplicate check.
+    # Same row shape as `search` (fuzzy, multi-row); the cataloger picks a match
+    # or creates anyway. Omit for a source with no duplicate check:
+    similar: ->(q) { Person.fuzzy_by_name(q).limit(10)
+                           .map { |p| { id: p.id.to_s, label: p.display_name, value: p.id.to_s,
+                                        detail: p.orcid } } }
   )
 end
 ```
 
-**What the table needs.** The source can wrap any object the four procs can
-operate on — typically an `ActiveRecord` model, but nothing about the type is
-prescribed. The only contract is what the procs imply:
+**What the table needs.** The source can wrap any object its procs can operate on
+— typically an `ActiveRecord` model, but nothing about the type is prescribed.
+The only contract is what the procs imply:
 
 - a stable identifier the `finder` can look up by and that is safe to persist as
   a string (an integer or UUID primary key is fine — it is stored as its string
   form);
 - a human-readable label (whatever `label:` / `view: { label_field: }` returns);
-- any other fields the `path:`, `search:`, or `create:` procs reference.
+- any other fields the `path:`, `search:`, `create:`, `similar:`, or `match:`
+  procs reference.
 
 There is **no base class to inherit, no required column names, no migration or
 schema Hyrax imposes, and no per-source authority or controller class to write** —
@@ -299,12 +309,20 @@ How the pieces fit together:
   `view: { label_field: }` when present, otherwise the source's `label:` proc.
   An id that no longer resolves renders as bare text, never a broken link.
 - **Inline lookup-or-create.** When the sub-property declares `creatable: true`
-  and the source registers a `create:` proc, a search that returns no matches
-  offers an "Add new" form built from `create_fields`. Submitting it POSTs to
+  and the source registers a `create:` proc, an "Add new" form built from
+  `create_fields` is available beside the picker (visible whether or not a search
+  matched, so results and create coexist). Submitting it POSTs to
   `/linked_records/:source`, which calls the source's `create:` proc and selects
   the new record in the picker. Each `create_fields` entry declares its own
   input: `as: string` (text input) or `as: select` (a dropdown of `values:`),
   and `required:`.
+- **Duplicate check ("did you mean").** When the source registers a `similar:`
+  proc, clicking Create first runs a fuzzy lookup on the typed name (via the
+  generic `linked_record_similar` QA authority) and, if near-matches exist, shows
+  them with a "Use this" action so the cataloger can reuse an existing record
+  instead of creating a duplicate. The primary Create button is the override:
+  press it again to create the new record anyway; editing the name re-checks. A
+  source without `similar:` skips the check and creates directly.
 - **Repeatable create-fields** (see `affiliations` and `identifiers` above). Mark
   any create-field `repeatable: true` and the "Add new" form renders add/remove
   rows for it. A repeatable **scalar** (`as: string`/`select`, no `fields:`)
@@ -753,7 +771,7 @@ optional procs on the source alongside `finder`/`label`/`path`:
 ```ruby
 Hyrax::CompoundLinkedRecordResolver.register(
   :people,
-  # …finder/label/path/search/create as above…
+  # …finder/label/path and the picker procs (search/create/similar) as above…
   # exact, single-row lookup on a natural key, for import resolution:
   match: ->(attrs) { Person.where('LOWER(display_name) = LOWER(?)', attrs[:display_name].to_s.strip).order(:id).first }
 )

--- a/hyrax.gemspec
+++ b/hyrax.gemspec
@@ -88,7 +88,7 @@ SUMMARY
   spec.add_dependency 'retriable', '>= 2.9', '< 4.0'
   spec.add_dependency 'signet'
   spec.add_dependency 'tinymce-rails', '~> 5.10'
-  spec.add_dependency 'valkyrie', '~> 3.5'
+  spec.add_dependency 'valkyrie', '~> 3.5', '!= 3.6.0' # 3.6.0's Fedora streaming read returns UTF-8 not binary (samvera/valkyrie encoding regression); exclude until fixed
   spec.add_dependency 'view_component', '~> 2.74.1' # Pin until blacklight is updated with workaround for https://github.com/ViewComponent/view_component/issues/1565
   spec.add_dependency 'sprockets', '3.7.2' # 3.7.3 fails feature specs
   spec.add_dependency 'sass-rails', '~> 6.0'

--- a/spec/authorities/qa/authorities/linked_record_similar_spec.rb
+++ b/spec/authorities/qa/authorities/linked_record_similar_spec.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+# The generic "did you mean" authority for the `linked_record` compound picker's
+# create-form duplicate check, mounted at
+# `/authorities/search/linked_record_similar/:source`. The `:source` URL segment
+# arrives as `params[:subauthority]`; the authority delegates the typed name to
+# that registered Hyrax::CompoundLinkedRecordResolver source's `similar` proc, so
+# no per-source authority class is needed. Returns `{ id:, label:, value: }` rows
+# (or [] for an unregistered source or one with no similar proc). Sibling of
+# Qa::Authorities::LinkedRecord (the typeahead authority).
+RSpec.describe Qa::Authorities::LinkedRecordSimilar do
+  let(:service) { described_class.new }
+  let(:controller) { instance_double(Qa::TermsController, params:) }
+  let(:params) { ActionController::Parameters.new(q: 'Ada Byron', subauthority: 'stub_people') }
+
+  before do
+    Hyrax::CompoundLinkedRecordResolver.register(
+      :stub_people,
+      finder: ->(_id) {},
+      label: ->(r) { r[:label] },
+      path: ->(r) { "/stub_people/#{r[:id]}" },
+      # Fuzzy stub: match on a shared first token so "Ada Byron" surfaces "Ada Lovelace".
+      similar: lambda { |q|
+        token = q.to_s.downcase.split.first.to_s
+        [{ id: '7', label: 'Ada Lovelace', value: '7' }, { id: '8', label: 'Alan Turing', value: '8' }]
+          .select { |row| row[:label].downcase.include?(token) }
+      }
+    )
+  end
+
+  after { Hyrax::CompoundLinkedRecordResolver.registry.delete(:stub_people) }
+
+  describe '#search' do
+    subject(:results) { service.search('Ada Byron', controller) }
+
+    it 'delegates to the source named by params[:subauthority]' do
+      expect(results).to contain_exactly(a_hash_including(id: '7', label: 'Ada Lovelace', value: '7'))
+    end
+
+    context 'when the source is unregistered' do
+      let(:params) { ActionController::Parameters.new(q: 'Ada Byron', subauthority: 'nope') }
+
+      it 'returns an empty list' do
+        expect(results).to eq([])
+      end
+    end
+
+    context 'when the source declares no similar proc' do
+      before do
+        Hyrax::CompoundLinkedRecordResolver.register(
+          :searchonly, finder: ->(_id) {}, label: ->(_r) {}, path: ->(_r) {}, search: ->(_q) { [] }
+        )
+      end
+
+      after { Hyrax::CompoundLinkedRecordResolver.registry.delete(:searchonly) }
+
+      let(:params) { ActionController::Parameters.new(q: 'Ada Byron', subauthority: 'searchonly') }
+
+      it 'returns an empty list' do
+        expect(results).to eq([])
+      end
+    end
+
+    context 'when no source (subauthority) is given' do
+      let(:params) { ActionController::Parameters.new(q: 'Ada Byron') }
+
+      it 'returns an empty list' do
+        expect(results).to eq([])
+      end
+    end
+  end
+end

--- a/spec/services/hyrax/compound_linked_record_resolver_spec.rb
+++ b/spec/services/hyrax/compound_linked_record_resolver_spec.rb
@@ -38,6 +38,17 @@ RSpec.describe Hyrax::CompoundLinkedRecordResolver do
         next nil if name.empty?
 
         ([record] + store.values).find { |r| r.name.to_s.casecmp?(name) }
+      },
+      # Fuzzy, multi-row "did you mean" lookup on a typed name, for the create
+      # form's duplicate check. Same row shape as `search`. Here a naive stub:
+      # match on a shared first token (so "Ada Byron" surfaces "Ada Lovelace").
+      similar: lambda { |q|
+        token = q.to_s.downcase.split.first.to_s
+        next [] if token.empty?
+
+        ([record] + store.values)
+          .select { |r| r.name.to_s.downcase.include?(token) }
+          .map { |r| { id: r.id.to_s, label: r.name, value: r.id.to_s } }
       }
     )
     example.run
@@ -130,6 +141,16 @@ RSpec.describe Hyrax::CompoundLinkedRecordResolver do
     it 'returns [] for an unregistered source' do
       expect(described_class.search(:nope, 'x')).to eq([])
     end
+
+    it 'passes optional row keys (e.g. detail) through unchanged' do
+      # The picker renders an optional `detail` line from whatever the source
+      # supplies; the resolver treats rows as opaque, so any extra key survives.
+      described_class.register(:detailed, finder: ->(_id) {}, label: ->(_r) {}, path: ->(_r) {},
+                                          search: ->(_q) { [{ id: '1', label: 'A', value: '1', detail: 'x · y' }] })
+      expect(described_class.search(:detailed, 'a')).to contain_exactly(a_hash_including(detail: 'x · y'))
+    ensure
+      described_class.registry.delete(:detailed)
+    end
   end
 
   describe '.searchable? and .creatable?' do
@@ -170,6 +191,46 @@ RSpec.describe Hyrax::CompoundLinkedRecordResolver do
       described_class.register(:boom, finder: ->(_id) {}, label: ->(_r) {}, path: ->(_r) {},
                                       match: ->(_attrs) { raise 'kaboom' })
       expect(described_class.match(:boom, display_name: 'Ada Lovelace')).to be_nil
+    ensure
+      described_class.registry.delete(:boom)
+    end
+  end
+
+  describe '.similar?' do
+    it 'reports whether a source declares a similar proc' do
+      expect(described_class.similar?(:stub_people)).to be(true)
+      expect(described_class.similar?(:nope)).to be(false)
+    end
+
+    it 'is false for a source registered without a similar proc' do
+      described_class.register(:similarless, finder: ->(_id) {}, label: ->(_r) {}, path: ->(_r) {})
+      expect(described_class.similar?(:similarless)).to be(false)
+    ensure
+      described_class.registry.delete(:similarless)
+    end
+  end
+
+  describe '.similar' do
+    it 'returns fuzzy "did you mean" rows from the source similar proc' do
+      results = described_class.similar(:stub_people, 'Ada Byron')
+      expect(results).to contain_exactly(a_hash_including(id: '7', label: 'Ada Lovelace'))
+    end
+
+    it 'returns [] for a source registered without a similar proc' do
+      described_class.register(:similarless, finder: ->(_id) {}, label: ->(_r) {}, path: ->(_r) {})
+      expect(described_class.similar(:similarless, 'x')).to eq([])
+    ensure
+      described_class.registry.delete(:similarless)
+    end
+
+    it 'returns [] for an unregistered source' do
+      expect(described_class.similar(:nope, 'x')).to eq([])
+    end
+
+    it 'returns [] when the similar proc raises' do
+      described_class.register(:boom, finder: ->(_id) {}, label: ->(_r) {}, path: ->(_r) {},
+                                      similar: ->(_q) { raise 'kaboom' })
+      expect(described_class.similar(:boom, 'x')).to eq([])
     ensure
       described_class.registry.delete(:boom)
     end

--- a/spec/views/hyrax/compounds/_compound_row_linked_record_spec.rb
+++ b/spec/views/hyrax/compounds/_compound_row_linked_record_spec.rb
@@ -83,8 +83,8 @@ RSpec.describe 'hyrax/compounds/_compound_row', type: :view do
       expect(rendered).to match(%r{data-create-url="[^"]*/linked_records/people"})
     end
 
-    it 'renders the (hidden) Add new trigger naming the source item' do
-      expect(rendered).to have_css('button[data-hyrax-linked-record-add]', text: 'Add a person', visible: false)
+    it 'renders the Add new trigger (always visible) naming the source item' do
+      expect(rendered).to have_css('button[data-hyrax-linked-record-add]', text: 'Add a person', visible: :visible)
     end
 
     it 'renders the create form fields from create_fields (string inputs + a select)' do
@@ -123,6 +123,28 @@ RSpec.describe 'hyrax/compounds/_compound_row', type: :view do
         expect(rendered).to have_css('[data-create-group="affiliations"][data-create-scalar="true"]', visible: false)
         expect(rendered).to have_css('[data-create-group="affiliations"] button[data-create-group-add]', visible: false)
         expect(rendered).to have_css('[data-create-group="affiliations"] [data-create-group-rows] input[data-create-subfield="affiliations"]', visible: false)
+      end
+    end
+
+    describe 'the "did you mean" duplicate check' do
+      it 'omits data-similar-url and the warning panel when the source has no similar proc' do
+        # The default people_source registers no `similar:`.
+        expect(rendered).to have_no_css('[data-hyrax-linked-record][data-similar-url]')
+        expect(rendered).to have_no_css('[data-hyrax-linked-record-similar]')
+      end
+
+      context 'when the source declares a similar proc' do
+        let(:people_source) do
+          super().merge(similar: ->(_q) { [{ id: '7', label: 'Ada Lovelace', value: '7' }] })
+        end
+
+        it 'renders data-similar-url pointing at the linked_record_similar authority' do
+          expect(rendered).to match(%r{data-similar-url="[^"]*/authorities/search/linked_record_similar/people"})
+        end
+
+        it 'renders the (hidden) warning panel with a similar-list and a use-label' do
+          expect(rendered).to have_css('[data-hyrax-linked-record-similar] [data-hyrax-linked-record-similar-list][data-use-label="Use this"]', visible: false)
+        end
       end
     end
   end


### PR DESCRIPTION
## Summary
Strengthens the `linked_record` compound picker so a cataloger can recognize and reuse an existing record instead of creating a duplicate, and reaches the create form without hunting for it.
https://github.com/research-technologies/enact_knapsack/issues/138

## Details
Supports two behaviors a downstream picker needs to avoid duplicate records, expressed entirely in the generic `linked_record` layer:

- **Tighten matching before create.** Adds `similar`, a new optional source capability on `Hyrax::CompoundLinkedRecordResolver` alongside `search`/`create`/`match` — a fuzzy, multi-row "did you mean" lookup exposed through a generic `linked_record_similar` QA authority (one authority per every source; no per-source class). When a source registers it, clicking Create first surfaces near-matches with a "Use this" action; the primary Create button is the override (press again to create anyway, editing the name re-checks). This is what lets a picker catch a near-duplicate the exact/substring search would miss.
- **Distinguish results.** Picker result rows may carry an optional `detail:` string, rendered as a muted second line, so records that share a label are told apart at a glance. Sources that omit it render the plain label unchanged.
- **Reach create without an empty search.** The "Add new" affordance is now always visible for a creatable source, so the create form is reachable alongside results rather than only after a search returns nothing.

A source that registers no `similar:` proc keeps today's behavior end to end. The always-visible "Add new" is a behavior change, but no Hyrax-bundled profile uses a creatable `linked_record`, so nothing shipped changes — flagged for maintainer review of the default.

<details>
<summary>Screenshot from consuming application</summary>
<img width="829" height="818" alt="Screenshot 2026-07-28 at 6 28 07 PM" src="https://github.com/user-attachments/assets/a8c400fa-6db8-4f74-88a4-9164c3b13aa0" />
</details>

## Notes

I locked down valkyrie's version to get the specs to pass until Valkyrie is fixed. See https://samvera.slack.com/archives/C5F0P8K0X/p1782316745553639

