### PR TITLE
Fix trailing characters in citations

### DIFF
--- a/app/helpers/hyrax/citations_behaviors/publication_behavior.rb
+++ b/app/helpers/hyrax/citations_behaviors/publication_behavior.rb
@@ -23,18 +23,12 @@ module Hyrax
       end
 
       def setup_pub_info(work, include_date = false)
-        pub_info = ""
-        if (place = setup_pub_place(work))
-          pub_info += CGI.escapeHTML(place)
-        end
-        if (publisher = setup_pub_publisher(work))
-          pub_info += ": #{CGI.escapeHTML(publisher)}"
-        end
+        pub_info = [setup_pub_place(work), setup_pub_publisher(work)]
+                   .filter_map { |pub| CGI.escapeHTML(pub) if pub.present? }
+                   .join(': ')
 
         pub_date = include_date ? setup_pub_date(work) : nil
-        pub_info += ", #{pub_date}" unless pub_date.nil?
-
-        pub_info.strip.presence
+        [pub_info, pub_date].filter_map(&:presence).join(', ').strip.presence
       end
     end
   end

--- a/spec/helpers/hyrax/citations_behaviors/publication_behavior_spec.rb
+++ b/spec/helpers/hyrax/citations_behaviors/publication_behavior_spec.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+RSpec.describe Hyrax::CitationsBehaviors::PublicationBehavior do
+  subject(:behavior) { Class.new { include Hyrax::CitationsBehaviors::PublicationBehavior }.new }
+
+  let(:work) do
+    double('presenter',
+           based_near_label: Array(place),
+           publisher: Array(publisher),
+           date_created: Array(date_created))
+  end
+  let(:place)        { nil }
+  let(:publisher)    { nil }
+  let(:date_created) { nil }
+
+  describe '#setup_pub_info' do
+    context 'with a publisher and no place of publication' do
+      let(:publisher) { 'Scripps Institution of Oceanography' }
+
+      it 'returns just the publisher' do
+        expect(behavior.setup_pub_info(work)).to eq('Scripps Institution of Oceanography')
+      end
+    end
+
+    context 'with both a place and a publisher' do
+      let(:place)     { 'La Jolla' }
+      let(:publisher) { 'Scripps Institution of Oceanography' }
+
+      it 'returns the place and publisher separated by a colon' do
+        expect(behavior.setup_pub_info(work)).to eq('La Jolla: Scripps Institution of Oceanography')
+      end
+    end
+
+    context 'with a place and no publisher' do
+      let(:place) { 'La Jolla' }
+
+      it 'returns just the place' do
+        expect(behavior.setup_pub_info(work)).to eq('La Jolla')
+      end
+    end
+
+    context 'with a blank publisher' do
+      let(:publisher) { '' }
+
+      it 'returns nothing' do
+        expect(behavior.setup_pub_info(work)).to be_nil
+      end
+    end
+
+    context 'with neither a place nor a publisher' do
+      it 'returns nothing' do
+        expect(behavior.setup_pub_info(work)).to be_nil
+      end
+    end
+
+    context 'when including the date' do
+      let(:date_created) { '1960' }
+
+      context 'with a publisher' do
+        let(:publisher) { 'Scripps Institution of Oceanography' }
+
+        it 'returns the publisher and the date' do
+          expect(behavior.setup_pub_info(work, true)).to eq('Scripps Institution of Oceanography, 1960')
+        end
+      end
+
+      context 'with no place or publisher' do
+        it 'returns just the date' do
+          expect(behavior.setup_pub_info(work, true)).to eq('1960')
+        end
+      end
+
+      context 'when the date has no digits' do
+        let(:date_created) { 'circa' }
+
+        it 'returns nothing' do
+          expect(behavior.setup_pub_info(work, true)).to be_nil
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This commit will change the way we derive the MLA, APA, and Chicago citation format so in certain conditions, we don't get a trailing : or , character.  Previously, if a work had a publisher but no location set, then the citation would look something like:

"Revelle, R. (1960). Ocean Circulation. : Scripps Institution of Oceanography."

Also, for MLA, if the date is set with no publisher or location, it would produce a citation like:

"Revelle, Roger. Ocean Circulation. , 1960."
