### PR TITLE
Improve performance of dashboard/works page

### DIFF
--- a/app/helpers/hyrax/hyrax_helper_behavior.rb
+++ b/app/helpers/hyrax/hyrax_helper_behavior.rb
@@ -52,11 +52,13 @@ module Hyrax
       indexed_ids = admin_sets_list.map(&:last)
       missing_ids = source_ids.map(&:to_s) - indexed_ids
 
-      admin_sets_list.concat(
-        Hyrax.query_service.find_many_by_ids(ids: missing_ids).map do |source|
-          [source.title.first, source.id.to_s]
-        end
-      )
+      if missing_ids.present?
+        admin_sets_list.concat(
+          Hyrax.query_service.find_many_by_ids(ids: missing_ids).map do |source|
+            [source.title.first, source.id.to_s]
+          end
+        )
+      end
 
       # Sorts the default admin set to be first, then the rest by title.
       admin_sets_list.sort do |a, b|

--- a/app/helpers/hyrax/hyrax_helper_behavior.rb
+++ b/app/helpers/hyrax/hyrax_helper_behavior.rb
@@ -32,10 +32,21 @@ module Hyrax
       return [] unless ability
 
       source_ids = Hyrax::Collections::PermissionsService.source_ids_for_deposit(ability:, source_type: 'admin_set')
+      return [] if source_ids.blank?
 
-      admin_sets_list = Hyrax.query_service.find_many_by_ids(ids: source_ids).map do |source|
-        [source.title.first, source.id]
-      end
+      # This helper only needs indexed display data. Using Solr here avoids per-id repository fetches.
+      admin_sets_list = Hyrax::SolrQueryService.new
+                              .with_ids(ids: source_ids)
+                              .with_field_pairs(
+                                field_pairs: {
+                                  has_model_ssim: Hyrax::ModelRegistry.admin_set_rdf_representations.join(',')
+                                },
+                                type: 'terms'
+                              )
+                              .solr_documents(rows: source_ids.length, fl: 'id,title_tesim')
+                              .map do |doc|
+                                [Array(doc['title_tesim']).first.to_s, doc['id']]
+                              end
 
       # Sorts the default admin set to be first, then the rest by title.
       admin_sets_list.sort do |a, b|

--- a/app/helpers/hyrax/hyrax_helper_behavior.rb
+++ b/app/helpers/hyrax/hyrax_helper_behavior.rb
@@ -34,7 +34,8 @@ module Hyrax
       source_ids = Hyrax::Collections::PermissionsService.source_ids_for_deposit(ability:, source_type: 'admin_set')
       return [] if source_ids.blank?
 
-      # This helper only needs indexed display data. Using Solr here avoids per-id repository fetches.
+      # This helper only needs indexed display data. Use Solr first to avoid per-id repository fetches,
+      # but fall back for admin sets that have not been indexed yet.
       admin_sets_list = Hyrax::SolrQueryService.new
                               .with_ids(ids: source_ids)
                               .with_field_pairs(
@@ -47,6 +48,15 @@ module Hyrax
                               .map do |doc|
                                 [Array(doc['title_tesim']).first.to_s, doc['id']]
                               end
+
+      indexed_ids = admin_sets_list.map(&:last)
+      missing_ids = source_ids.map(&:to_s) - indexed_ids
+
+      admin_sets_list.concat(
+        Hyrax.query_service.find_many_by_ids(ids: missing_ids).map do |source|
+          [source.title.first, source.id.to_s]
+        end
+      )
 
       # Sorts the default admin set to be first, then the rest by title.
       admin_sets_list.sort do |a, b|

--- a/spec/helpers/hyrax_helper_spec.rb
+++ b/spec/helpers/hyrax_helper_spec.rb
@@ -142,6 +142,56 @@ RSpec.describe HyraxHelper, type: :helper do
         expect(helper.available_admin_sets_for_creating_works(ability:)).to eq([])
       end
     end
+
+    context 'when some depositable admin sets are missing from Solr' do
+      let(:source_ids) { [Hyrax::AdminSetCreateService::DEFAULT_ID, 'missing-admin-set'] }
+      let(:solr_query_service) { instance_double(Hyrax::SolrQueryService) }
+      let(:missing_admin_set) { instance_double('resource', title: ['Set B'], id: 'missing-admin-set') }
+      let(:solr_documents) do
+        [
+          { 'id' => Hyrax::AdminSetCreateService::DEFAULT_ID, 'title_tesim' => ['Default Admin Set'] }
+        ]
+      end
+
+      before do
+        allow(Hyrax::Collections::PermissionsService)
+          .to receive(:source_ids_for_deposit)
+          .with(ability:, source_type: 'admin_set')
+          .and_return(source_ids)
+        allow(Hyrax::AdminSetCreateService)
+          .to receive(:default_admin_set?) do |id:|
+            id == Hyrax::AdminSetCreateService::DEFAULT_ID
+          end
+        allow(Hyrax::SolrQueryService).to receive(:new).and_return(solr_query_service)
+        allow(solr_query_service).to receive(:with_ids).with(ids: source_ids).and_return(solr_query_service)
+        allow(solr_query_service)
+          .to receive(:with_field_pairs)
+          .with(
+            field_pairs: {
+              has_model_ssim: Hyrax::ModelRegistry.admin_set_rdf_representations.join(',')
+            },
+            type: 'terms'
+          )
+          .and_return(solr_query_service)
+        allow(solr_query_service)
+          .to receive(:solr_documents)
+          .with(rows: source_ids.length, fl: 'id,title_tesim')
+          .and_return(solr_documents)
+        allow(query_service)
+          .to receive(:find_many_by_ids)
+          .with(ids: ['missing-admin-set'])
+          .and_return([missing_admin_set])
+      end
+
+      it 'falls back to repository objects for admin sets that are not indexed yet' do
+        expect(helper.available_admin_sets_for_creating_works(ability:)).to eq(
+          [
+            ['Default Admin Set', Hyrax::AdminSetCreateService::DEFAULT_ID],
+            ['Set B', 'missing-admin-set']
+          ]
+        )
+      end
+    end
   end
 
   context 'link helpers' do

--- a/spec/helpers/hyrax_helper_spec.rb
+++ b/spec/helpers/hyrax_helper_spec.rb
@@ -68,6 +68,82 @@ RSpec.describe HyraxHelper, type: :helper do
     end
   end
 
+  describe '#available_admin_sets_for_creating_works' do
+    let(:ability) { instance_double(Ability) }
+    let(:query_service) { instance_double('query_service') }
+
+    before do
+      allow(Flipflop).to receive(:assign_admin_set?).and_return(true)
+      allow(Hyrax).to receive(:query_service).and_return(query_service)
+    end
+
+    context 'when depositable admin sets are available' do
+      let(:source_ids) { ['z-admin-set', Hyrax::AdminSetCreateService::DEFAULT_ID, 'a-admin-set'] }
+      let(:solr_query_service) { instance_double(Hyrax::SolrQueryService) }
+      let(:solr_documents) do
+        [
+          { 'id' => 'z-admin-set', 'title_tesim' => ['Zeta Admin Set'] },
+          { 'id' => Hyrax::AdminSetCreateService::DEFAULT_ID, 'title_tesim' => ['Default Admin Set'] },
+          { 'id' => 'a-admin-set', 'title_tesim' => ['Alpha Admin Set'] }
+        ]
+      end
+
+      before do
+        allow(Hyrax::Collections::PermissionsService)
+          .to receive(:source_ids_for_deposit)
+          .with(ability:, source_type: 'admin_set')
+          .and_return(source_ids)
+        allow(Hyrax::AdminSetCreateService)
+          .to receive(:default_admin_set?) do |id:|
+            id == Hyrax::AdminSetCreateService::DEFAULT_ID
+          end
+        allow(Hyrax::SolrQueryService).to receive(:new).and_return(solr_query_service)
+        allow(solr_query_service).to receive(:with_ids).with(ids: source_ids).and_return(solr_query_service)
+        allow(solr_query_service)
+          .to receive(:with_field_pairs)
+          .with(
+            field_pairs: {
+              has_model_ssim: Hyrax::ModelRegistry.admin_set_rdf_representations.join(',')
+            },
+            type: 'terms'
+          )
+          .and_return(solr_query_service)
+        allow(solr_query_service)
+          .to receive(:solr_documents)
+          .with(rows: source_ids.length, fl: 'id,title_tesim')
+          .and_return(solr_documents)
+      end
+
+      it 'builds admin set options from Solr without loading repository objects by id' do
+        expect(query_service).not_to receive(:find_many_by_ids)
+
+        expect(helper.available_admin_sets_for_creating_works(ability:)).to eq(
+          [
+            ['Default Admin Set', Hyrax::AdminSetCreateService::DEFAULT_ID],
+            ['Alpha Admin Set', 'a-admin-set'],
+            ['Zeta Admin Set', 'z-admin-set']
+          ]
+        )
+      end
+    end
+
+    context 'when there are no depositable admin sets' do
+      before do
+        allow(Hyrax::Collections::PermissionsService)
+          .to receive(:source_ids_for_deposit)
+          .with(ability:, source_type: 'admin_set')
+          .and_return([])
+      end
+
+      it 'returns an empty list without querying Solr' do
+        expect(Hyrax::SolrQueryService).not_to receive(:new)
+        expect(query_service).not_to receive(:find_many_by_ids)
+
+        expect(helper.available_admin_sets_for_creating_works(ability:)).to eq([])
+      end
+    end
+  end
+
   context 'link helpers' do
     before do
       allow(helper).to receive(:search_action_path) do |*args|


### PR DESCRIPTION
### Summary

Pull list of depositable admin sets from solr rather than from repository, otherwise for wings or valkyrie/fedora it retrieves the record for every admin set when all we need is info stored in solr. Our dashboard/works page was taking 25 seconds to load in hyrax 5, which was new.

### Type of change (for release notes)

notes-bugfix

### Detailed Description

We observed that the dashboard/works page was taking 25 seconds to load in our QA environment after upgrading from hyrax 4 to 5, but it was only taking 1-2 seconds in our Hyrax 4 instance with identical data. We are using Wings at this point, before we start looking at migrating to Fedora 7. 

It turns out that it was populating the list of admin sets by querying activefedora for each admin set, and our repository contains 30 of them. This was a new behavior in Hyrax 5, since it was now using the queryService.find_many_by_ids method, but that retrieves far more information than is needed for populating this UI component.

This PR switches to pulling the list directly from solr, which gets performance back to the Hyrax 4 level. I have the behavior change for both Wings and Valkyrie, since it looks like the Valkyrie/fedora behavior will have the same problem, but I have not tested there yet.

### Changes proposed in this pull request:
* Using solr directly for retrieving admin sets info for dashboard/works facet filter.

@samvera/hyrax-code-reviewers
