### PR TITLE
Let engines add action buttons to a work's show page

### DIFF
--- a/app/helpers/hyrax/works_helper.rb
+++ b/app/helpers/hyrax/works_helper.rb
@@ -17,8 +17,8 @@ module Hyrax
     #
     # @example with an additional action
     #  Override this helper and ensure that it loads after Hyrax's helpers.
-    #  module WorksHelper
-    #    def show_actions_for(*)
+    #  module Hyrax::WorksHelper
+    #    def show_actions_for(presenter:)
     #      super + ["my_new_action"]
     #    end
     #  end

--- a/app/helpers/hyrax/works_helper.rb
+++ b/app/helpers/hyrax/works_helper.rb
@@ -10,5 +10,26 @@ module Hyrax
 
       all_collections.reject { |col| work.member_of_collection_ids.include?(col.id) }
     end
+
+    ##
+    # This helper allows downstream applications and engines to add additional actions to be
+    # rendered in the button row at the top of a work's show page.
+    #
+    # @example with an additional action
+    #  Override this helper and ensure that it loads after Hyrax's helpers.
+    #  module WorksHelper
+    #    def show_actions_for(*)
+    #      super + ["my_new_action"]
+    #    end
+    #  end
+    #  Add the new action partial at app/views/hyrax/base/_show_action_my_new_action.html.erb
+    #
+    # Each partial receives the presenter as a local and is responsible for deciding
+    # whether it renders anything, including any permission check its action requires.
+    #
+    # @return [Array<String>] the names of additional actions to render
+    def show_actions_for(*)
+      []
+    end
   end
 end

--- a/app/views/hyrax/base/_show_actions.html.erb
+++ b/app/views/hyrax/base/_show_actions.html.erb
@@ -22,6 +22,9 @@
       <% # analytics graph will not show unless the page is refreshed. %>
       <%= link_to t('.analytics'), presenter.stats_path, id: 'stats', class: 'btn btn-secondary', data: { turbolinks: false } %>
     <% end %>
+    <% show_actions_for(presenter: presenter).each do |action| %>
+      <%= render "show_action_#{action}", presenter: presenter %>
+    <% end %>
   </div>
 
   <div class="col-sm-6 text-right">

--- a/spec/helpers/hyrax/works_helper_spec.rb
+++ b/spec/helpers/hyrax/works_helper_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+RSpec.describe Hyrax::WorksHelper, type: :helper do
+  describe '#show_actions_for' do
+    let(:presenter) { Hyrax::WorkShowPresenter.new(SolrDocument.new(id: 'abc123'), nil) }
+
+    it 'contributes no actions of its own' do
+      expect(helper.show_actions_for(presenter: presenter)).to eq []
+    end
+
+    it 'lets a downstream override add to the list' do
+      helper.singleton_class.prepend(Module.new do
+        def show_actions_for(presenter:)
+          super + ['my_new_action']
+        end
+      end)
+
+      expect(helper.show_actions_for(presenter: presenter)).to eq ['my_new_action']
+    end
+  end
+end

--- a/spec/views/hyrax/base/_show_actions.html.erb_spec.rb
+++ b/spec/views/hyrax/base/_show_actions.html.erb_spec.rb
@@ -93,6 +93,29 @@ RSpec.describe 'hyrax/base/_show_actions.html.erb', type: :view do
     end
   end
 
+  describe "additional actions contributed by an engine" do
+    before do
+      allow(presenter).to receive(:show_deposit_for?).with(anything).and_return(false)
+      allow(presenter).to receive(:editor?).and_return(false)
+    end
+
+    it "renders nothing extra by default" do
+      render 'hyrax/base/show_actions', presenter: presenter
+
+      expect(rendered).not_to have_button 'Mint DOI'
+    end
+
+    it "renders a contributed action's partial, passing the presenter" do
+      stub_template 'hyrax/base/_show_action_mint_doi.html.erb' =>
+        '<button><%= presenter.id %></button>'
+      allow(view).to receive(:show_actions_for).with(presenter: presenter).and_return(['mint_doi'])
+
+      render 'hyrax/base/show_actions', presenter: presenter
+
+      expect(rendered).to have_button presenter.id
+    end
+  end
+
   context "when user CAN deposit to at least one collection" do
     before do
       allow(presenter).to receive(:show_deposit_for?).with(anything).and_return(true)


### PR DESCRIPTION
## Summary

Adds show_actions_for, a helper returning the names of extra action partials to render in the button row, defaulting to none. Mirrors `form_progress_sections_for`.

## Rationale

Engines wanting a button there previously had to override `_show_actions.html.erb` and keep a copy of Hyrax's markup in sync with it.

