### PR TITLE
Render license labels under flexible metadata

### DIFF
--- a/.dassie/config/metadata_profiles/m3_profile.yaml
+++ b/.dassie/config/metadata_profiles/m3_profile.yaml
@@ -228,7 +228,7 @@ properties:
     sample_values:
       - http://creativecommons.org/licenses/by/3.0/us/
     view:
-      render_as: external_link
+      render_as: license
       html_dl: true
   abstract:
     available_on:

--- a/.koppie/config/metadata_profiles/m3_profile.yaml
+++ b/.koppie/config/metadata_profiles/m3_profile.yaml
@@ -228,7 +228,7 @@ properties:
     sample_values:
       - http://creativecommons.org/licenses/by/3.0/us/
     view:
-      render_as: external_link
+      render_as: license
       html_dl: true
   abstract:
     available_on:

--- a/app/helpers/hyrax/attributes_helper.rb
+++ b/app/helpers/hyrax/attributes_helper.rb
@@ -63,6 +63,16 @@ module Hyrax
       options_hash&.with_indifferent_access&.fetch('render_term', nil) || field_name
     end
 
+    # Authority-backed fields whose values are URIs with human-readable
+    # labels. Their semantic renderers always win over a profile-supplied
+    # render_as: the label still links to the URI, so rendering the bare
+    # URI (e.g. as an external_link) is strictly worse, and profiles
+    # already stored in existing flexible schemas carry the old setting.
+    SEMANTIC_RENDERERS = {
+      license: :license,
+      rights_statement: :rights_statement
+    }.freeze
+
     # @param [String] field name
     # @param [Hash<Hash>] a nested hash of view options...
     #        {:label=>{"en"=>"Title", "es"=>"Título"}, :html_dl=>true}
@@ -88,6 +98,8 @@ module Hyrax
         )
       end
       view_options[:base_url] = request.base_url if respond_to?(:request) && request.respond_to?(:base_url)
+      semantic_renderer = SEMANTIC_RENDERERS[field_name.to_sym]
+      view_options[:render_as] = semantic_renderer if semantic_renderer
       view_options
     end
 

--- a/app/helpers/hyrax/attributes_helper.rb
+++ b/app/helpers/hyrax/attributes_helper.rb
@@ -63,15 +63,15 @@ module Hyrax
       options_hash&.with_indifferent_access&.fetch('render_term', nil) || field_name
     end
 
-    # Authority-backed fields whose values are URIs with human-readable
-    # labels. Their semantic renderers always win over a profile-supplied
-    # render_as: the label still links to the URI, so rendering the bare
-    # URI (e.g. as an external_link) is strictly worse, and profiles
-    # already stored in existing flexible schemas carry the old setting.
-    SEMANTIC_RENDERERS = {
-      license: :license,
-      rights_statement: :rights_statement
-    }.freeze
+    # These override any stored render_as: the semantic label still links
+    # to the URI, so a bare external_link rendering is strictly worse.
+    # @return [Hash{Symbol => Symbol}] field name mapped to its renderer
+    def semantic_renderers
+      {
+        license: :license,
+        rights_statement: :rights_statement
+      }
+    end
 
     # @param [String] field name
     # @param [Hash<Hash>] a nested hash of view options...
@@ -98,7 +98,7 @@ module Hyrax
         )
       end
       view_options[:base_url] = request.base_url if respond_to?(:request) && request.respond_to?(:base_url)
-      semantic_renderer = SEMANTIC_RENDERERS[field_name.to_sym]
+      semantic_renderer = semantic_renderers[field_name.to_sym]
       view_options[:render_as] = semantic_renderer if semantic_renderer
       view_options
     end

--- a/config/metadata_profiles/m3_profile.yaml
+++ b/config/metadata_profiles/m3_profile.yaml
@@ -231,7 +231,7 @@ properties:
     sample_values:
       - http://creativecommons.org/licenses/by/3.0/us/
     view:
-      render_as: external_link
+      render_as: license
       html_dl: true
   abstract:
     available_on:

--- a/spec/helpers/hyrax/attributes_helper_spec.rb
+++ b/spec/helpers/hyrax/attributes_helper_spec.rb
@@ -61,6 +61,11 @@ RSpec.describe Hyrax::AttributesHelper, type: :helper do
       expect(result[:render_as]).to eq(:license)
     end
 
+    it 'overrides a stored external_link for rights_statement' do
+      result = helper.conform_options(:rights_statement, { render_as: 'external_link' }.with_indifferent_access)
+      expect(result[:render_as]).to eq(:rights_statement)
+    end
+
     it 'leaves fields without a semantic renderer alone' do
       result = helper.conform_options(:related_url, { render_as: 'external_link' }.with_indifferent_access)
       expect(result[:render_as]).to eq('external_link')

--- a/spec/helpers/hyrax/attributes_helper_spec.rb
+++ b/spec/helpers/hyrax/attributes_helper_spec.rb
@@ -42,6 +42,29 @@ RSpec.describe Hyrax::AttributesHelper, type: :helper do
       result = helper.conform_options(:date_created, {}.with_indifferent_access)
       expect(result[:label]).to eq('Date created')
     end
+
+    it 'applies the semantic renderer for license' do
+      result = helper.conform_options(:license, {}.with_indifferent_access)
+      expect(result[:render_as]).to eq(:license)
+    end
+
+    it 'applies the semantic renderer for rights_statement' do
+      result = helper.conform_options(:rights_statement, {}.with_indifferent_access)
+      expect(result[:render_as]).to eq(:rights_statement)
+    end
+
+    it 'overrides a stored external_link for license' do
+      # Flexible schemas seeded from earlier profiles carry
+      # render_as: external_link for license; the authority label must win
+      # anyway - it still links to the URI, and a bare URI is strictly worse.
+      result = helper.conform_options(:license, { render_as: 'external_link' }.with_indifferent_access)
+      expect(result[:render_as]).to eq(:license)
+    end
+
+    it 'leaves fields without a semantic renderer alone' do
+      result = helper.conform_options(:related_url, { render_as: 'external_link' }.with_indifferent_access)
+      expect(result[:render_as]).to eq('external_link')
+    end
   end
 
   describe '#schema' do


### PR DESCRIPTION
### What

On flexible-metadata apps, a work's license renders as a bare auto-linked URI ("https://creativecommons.org/licenses/by/4.0/") instead of its authority label ("Creative Commons BY Attribution 4.0 International").

### Why

Attribute rendering under flexible metadata follows the m3 profile's view options, and the profiles Hyrax ships (engine default, koppie, dassie) mark license as `render_as: external_link`. Every app seeded from those profiles also carries the setting in its stored flexible schema, so fixing the profiles alone would not heal existing apps.

### Fix

* `AttributesHelper#conform_options` applies the semantic renderer for the two authority-backed fields (`license` -> `:license`, `rights_statement` -> `:rights_statement`), overriding a profile-supplied `render_as`. The semantic renderer's label still links out to the URI, so an `external_link` rendering is strictly worse than the label - which is why overriding the stored value is safe, and why this heals existing stored schemas without a migration.
* The three shipped m3 profiles change license's view to `render_as: license` so newly seeded schemas agree with the code. `related_url` keeps its `external_link`, and the helper leaves fields without a semantic mapping untouched (covered by spec).

### Testing

Spec additions in the existing `#conform_options` block cover both semantic fields, the override of a stored `external_link`, and non-semantic fields passing through unchanged. Written and verified downstream first: this fix originated as a Hyku decorator (samvera/hyku#3212), verified live against seeded flexible-metadata tenants where the license row now shows the authority label; upstreaming it here per review feedback since the helper and the profiles are Hyrax's. I could not run the full engine suite locally, so leaning on CI for the suite run.

Downstream note: once this lands, the Hyku decorator in samvera/hyku#3212 becomes redundant and that PR slims to nothing (its profile fix is Hyku's own copy, also being handled).

🤖 Generated with [Claude Code](https://claude.com/claude-code)