### PR TITLE
fix: cap selenium-webdriver for node compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,4 +1,7 @@
 {
+  "resolutions": {
+    "selenium-webdriver": "4.46.0"
+  },
   "devDependencies": {
     "dotenv": "^16.0.1",
     "jasmine-core": "^3.99",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,6 @@
     "karma-jasmine": "^4.0.2",
     "karma-selenium-grid-launcher": "^0.3.0",
     "karma-spec-reporter": "^0.0.34",
-    "selenium-webdriver": "^4.10.0"
+    "selenium-webdriver": ">=4.10.0 <=4.46.0"
   }
 }


### PR DESCRIPTION
## Summary
- Caps the npm `selenium-webdriver` devDependency at `4.46.0`
- Keeps the existing lower bound at `4.10.0` while avoiding `4.47.0`, which requires Node 22+

## Test Plan
- `git diff --check`
- `npm view 'selenium-webdriver@>=4.10.0 <=4.46.0' version --json`
- `npm install --dry-run --ignore-scripts`
