### PR TITLE
Fix compound metadata removal without restart

### DIFF
--- a/app/services/hyrax/compound_schema.rb
+++ b/app/services/hyrax/compound_schema.rb
@@ -64,28 +64,55 @@ module Hyrax
     end
     private_class_method :flexible_attributes_for
 
-    # For a class, its own schema. For an instance, both the singleton schema
-    # (flexible mode) and the class schema (non-flexible mode), so {.for} works
-    # in both.
+    # A flexible instance resolves compounds from the loader's attribute map at
+    # the current profile version, NOT from its Dry schemas. Neither Dry schema
+    # can reflect a compound being removed from the profile:
+    # `Hyrax::Flexibility.attributes` merges attributes in with no way to express
+    # a deletion, and builds the singleton schema from the class schema
+    # (`schema_location = self.superclass`), so a compound present at class-load
+    # survives in both — still carrying its folded `subproperties:` — for the
+    # life of the process.
     #
-    # Order is load-bearing: the singleton schema must come first so it wins
-    # {#build_definitions}' first-source-per-name dedup. The class schema is
-    # frozen at class-load and not refreshed when the active FlexibleSchema
-    # version changes, so a flexible instance's singleton schema (rebuilt at the
-    # current version) is the authoritative source for a freshly-uploaded
-    # profile. In non-flexible mode the singleton has no extra schema, so order
-    # is moot.
+    # Falling back to those schemas is still right for a class, and for when the
+    # loader cannot answer (non-flexible installs, early boot, a missing profile
+    # row). The singleton comes first there so it wins {#build_definitions}'
+    # first-source-per-name dedup; in non-flexible mode it carries no extra
+    # schema, so order is moot.
     def self.schema_sources_for(resource)
       if resource.is_a?(Class)
-        [(resource.schema if resource.respond_to?(:schema))]
-      else
-        sources = []
-        sources << resource.singleton_class.schema if resource.respond_to?(:singleton_class) && resource.singleton_class.respond_to?(:schema)
-        sources << resource.class.schema if resource.class.respond_to?(:schema)
-        sources
-      end.compact
+        return [(resource.schema if resource.respond_to?(:schema))].compact
+      end
+
+      current = current_flexible_attributes_for(resource)
+      return [current] if current.present?
+
+      dry_schema_sources_for(resource)
     end
     private_class_method :schema_sources_for
+
+    # Honors the resource's own contexts so a context-filtered compound cannot
+    # leak in from another context. Nil unless the resource is flexible and the
+    # loader can answer.
+    def self.current_flexible_attributes_for(resource)
+      return nil unless resource.respond_to?(:flexible?) && resource.flexible?
+
+      loader = Hyrax::Schema.m3_schema_loader
+      loader.attributes_for(schema: resource.class.name,
+                            version: Hyrax::FlexibleSchema.current_schema_id,
+                            contexts: (resource.contexts if resource.respond_to?(:contexts)))
+    rescue StandardError => e
+      Hyrax.logger.debug("CompoundSchema: could not read the current profile: #{e.message}")
+      nil
+    end
+    private_class_method :current_flexible_attributes_for
+
+    def self.dry_schema_sources_for(resource)
+      sources = []
+      sources << resource.singleton_class.schema if resource.respond_to?(:singleton_class) && resource.singleton_class.respond_to?(:schema)
+      sources << resource.class.schema if resource.class.respond_to?(:schema)
+      sources.compact
+    end
+    private_class_method :dry_schema_sources_for
 
     attr_reader :schema_sources
 

--- a/app/services/hyrax/compound_schema.rb
+++ b/app/services/hyrax/compound_schema.rb
@@ -87,8 +87,11 @@ module Hyrax
         return [(resource.schema if resource.respond_to?(:schema))].compact
       end
 
+      # NOT `present?`: an empty map is a real answer (the profile governs the
+      # class and yields nothing for it), and falling back on it would resurrect
+      # the compounds the profile dropped. Only nil means "could not answer".
       current = current_flexible_attributes_for(resource) if profile_governs?(resource)
-      return [current] if current.present?
+      return [current] unless current.nil?
 
       dry_schema_sources_for(resource)
     end

--- a/app/services/hyrax/compound_schema.rb
+++ b/app/services/hyrax/compound_schema.rb
@@ -12,9 +12,10 @@ module Hyrax
   #
   # The schema loaders exclude subproperties from a resource's real attributes
   # (so they get no accessor of their own) but fold each compound's members into
-  # the parent's Dry type `meta` (`subproperties:`). This class reads that meta —
-  # off the resource's own schema — so resolution is identical in both flex
-  # modes and needs no knowledge of which schema file the resource used.
+  # the parent's Dry type `meta` (`subproperties:`). This class reads that meta,
+  # in the same shape whichever source supplies it, so it needs no knowledge of
+  # which schema file the resource used. Which source is authoritative does
+  # differ — see {.schema_sources_for}.
   class CompoundSchema # rubocop:disable Metrics/ClassLength
     ##
     # Build a CompoundSchema for a resource instance or class.
@@ -64,38 +65,53 @@ module Hyrax
     end
     private_class_method :flexible_attributes_for
 
-    # A flexible instance resolves compounds from the loader's attribute map at
-    # the current profile version, NOT from its Dry schemas. Neither Dry schema
-    # can reflect a compound being removed from the profile:
+    # When the profile governs the resource's class it is the only source read,
+    # because neither Dry schema can reflect a compound being REMOVED from it:
     # `Hyrax::Flexibility.attributes` merges attributes in with no way to express
     # a deletion, and builds the singleton schema from the class schema
     # (`schema_location = self.superclass`), so a compound present at class-load
-    # survives in both — still carrying its folded `subproperties:` — for the
-    # life of the process.
+    # survives in both — still carrying its folded `subproperties:` — for the life
+    # of the process.
     #
-    # Falling back to those schemas is still right for a class, and for when the
-    # loader cannot answer (non-flexible installs, early boot, a missing profile
-    # row). The singleton comes first there so it wins {#build_definitions}'
-    # first-source-per-name dedup; in non-flexible mode it carries no extra
-    # schema, so order is moot.
+    # Otherwise the Dry schemas are read: a class the profile does not govern can
+    # only have declared its compounds in the class body, as a plain `attribute`
+    # call. The loader cannot stand in for those — asked about a class it does not
+    # know, it answers with a fallback schema rather than nothing, which would
+    # silently drop the compound.
+    #
+    # In that fallback the singleton schema comes first, so it wins
+    # {#build_definitions}' first-source-per-name dedup; in non-flexible mode it
+    # carries no extra schema, so the order is moot.
     def self.schema_sources_for(resource)
       if resource.is_a?(Class)
         return [(resource.schema if resource.respond_to?(:schema))].compact
       end
 
-      current = current_flexible_attributes_for(resource)
+      current = current_flexible_attributes_for(resource) if profile_governs?(resource)
       return [current] if current.present?
 
       dry_schema_sources_for(resource)
     end
     private_class_method :schema_sources_for
 
-    # Honors the resource's own contexts so a context-filtered compound cannot
-    # leak in from another context. Nil unless the resource is flexible and the
-    # loader can answer.
-    def self.current_flexible_attributes_for(resource)
-      return nil unless resource.respond_to?(:flexible?) && resource.flexible?
+    # Whether the current profile declares this resource's class. Asked from the
+    # class list rather than by requesting attributes, which answers for an
+    # unknown class too.
+    def self.profile_governs?(resource)
+      return false unless resource.respond_to?(:flexible?) && resource.flexible?
 
+      classes = Hyrax::FlexibleSchema.current_version&.dig('classes')
+      classes.is_a?(::Hash) && classes.key?(resource.class.name)
+    rescue StandardError => e
+      Hyrax.logger.debug("CompoundSchema: could not read the profile's class list: #{e.message}")
+      false
+    end
+    private_class_method :profile_governs?
+
+    # Honors the resource's own contexts so a context-filtered compound cannot
+    # leak in from another context. Nil when the loader cannot answer. Only
+    # called for a resource {.profile_governs?} has already vetted.
+    def self.current_flexible_attributes_for(resource)
       loader = Hyrax::Schema.m3_schema_loader
       loader.attributes_for(schema: resource.class.name,
                             version: Hyrax::FlexibleSchema.current_schema_id,

--- a/spec/services/hyrax/compound_schema_profile_removal_spec.rb
+++ b/spec/services/hyrax/compound_schema_profile_removal_spec.rb
@@ -151,4 +151,22 @@ RSpec.describe 'removing a compound from the m3 profile' do
       expect(form.primary_terms + form.secondary_terms).not_to include(:abstract)
     end
   end
+
+  # An empty attribute map is a real answer, not a failure to answer: the profile
+  # governs the class and yields nothing for it (every field filtered out by the
+  # resource's contexts). Treating it as "no answer" would fall back to the Dry
+  # schemas and resurrect the very compound the profile dropped.
+  describe 'when the profile governs the class but yields no attributes' do
+    # `Hyrax::Schema.m3_schema_loader` builds a new loader per call, so pin one
+    # instance and empty its answer.
+    let(:empty_loader) do
+      Hyrax::M3SchemaLoader.new.tap { |loader| allow(loader).to receive(:attributes_for).and_return({}) }
+    end
+
+    before { allow(Hyrax::Schema).to receive(:m3_schema_loader).and_return(empty_loader) }
+
+    it 'does not fall back to the stale schemas' do
+      expect(Hyrax::CompoundSchema.for(work).compound_names).not_to include(:participants)
+    end
+  end
 end

--- a/spec/services/hyrax/compound_schema_profile_removal_spec.rb
+++ b/spec/services/hyrax/compound_schema_profile_removal_spec.rb
@@ -1,0 +1,151 @@
+# frozen_string_literal: true
+
+# Removing a compound from the m3 profile must remove it from the form, without
+# an app restart.
+#
+# The failure needs a specific boot order: the compound has to be present in the
+# profile when the model class loads. `acts_as_flexible_resource` then bakes the
+# compound parent into the CLASS schema, where it stays for the life of the
+# process - `Hyrax::Flexibility.attributes` merges attributes in and has no way
+# to express a removal. A later profile that omits the compound produces an
+# attribute map without it, but `Hyrax::CompoundSchema.schema_sources_for`
+# consults `resource.class.schema` as a fallback source, and that stale entry
+# still carries the folded `subproperties:` in its Dry type meta - so the
+# compound keeps resolving.
+#
+# Scalars do NOT show this, which is why the bug reads as compound-specific:
+# `ResourceForm#initialize` prunes any Reform definition absent from
+# `form_definitions_for` at the current schema id, so a removed scalar stops
+# rendering even while a stale key lingers in the Dry schema. Compounds never
+# reach that prune - they render via `#compound_terms` (i.e. CompoundSchema),
+# not through Reform's displayed definitions. The scalar example below is the
+# control that pins this distinction.
+RSpec.describe 'removing a compound from the m3 profile' do
+  let(:base_profile) { YAML.safe_load_file(Hyrax::Engine.root.join('spec', 'fixtures', 'files', 'm3_profile.yaml')) }
+
+  # The boot-time profile: declares the `participants` compound (a `type: hash`
+  # parent with two members naming it via `available_on: { properties: }`) plus a
+  # plain scalar to act as the control.
+  let(:profile_with_compound) do
+    base_profile.deep_merge(YAML.safe_load(<<-YAML))
+      classes:
+        Hyrax::Test::CompoundRemoval::TestWork:
+          display_label: Test Work
+      properties:
+        title:
+          available_on:
+            class: [Hyrax::Test::CompoundRemoval::TestWork]
+        abstract:
+          type: string
+          data_type: array
+          form:
+            primary: false
+          available_on:
+            class: [Hyrax::Test::CompoundRemoval::TestWork]
+        participants:
+          type: hash
+          data_type: array
+          form:
+            primary: false
+          available_on:
+            class: [Hyrax::Test::CompoundRemoval::TestWork]
+        participant_name:
+          type: string
+          name: name
+          available_on:
+            properties: [participants]
+        participant_role:
+          type: string
+          name: role
+          available_on:
+            properties: [participants]
+    YAML
+  end
+
+  # The replacement profile: same classes, but the compound parent, both of its
+  # subproperties, and the control scalar are all gone.
+  let(:profile_without_compound) do
+    base_profile.deep_merge(YAML.safe_load(<<-YAML))
+      classes:
+        Hyrax::Test::CompoundRemoval::TestWork:
+          display_label: Test Work
+      properties:
+        title:
+          available_on:
+            class: [Hyrax::Test::CompoundRemoval::TestWork]
+    YAML
+  end
+
+  let(:schema_with_compound) { Hyrax::FlexibleSchema.create(profile: profile_with_compound) }
+  let(:schema_without_compound) { Hyrax::FlexibleSchema.create(profile: profile_without_compound) }
+
+  before(:all) do
+    module Hyrax::Test::CompoundRemoval
+      class TestWork < Hyrax::Resource; end
+    end
+  end
+
+  after(:all) do
+    Hyrax::Test::CompoundRemoval.send(:remove_const, :TestWork)
+  end
+
+  before do
+    allow(Hyrax.config).to receive(:flexible?).and_return(true)
+
+    # Boot the class against the profile that HAS the compound. This is the step
+    # that seeds the class schema, and the step the working case never performs.
+    activate(schema_with_compound)
+    Hyrax::Test::CompoundRemoval::TestWork.acts_as_flexible_resource
+
+    # Now swap in the profile without it - no class reload, no restart.
+    activate(schema_without_compound)
+  end
+
+  after do
+    allow(Hyrax.config).to receive(:flexible?).and_return(false)
+  end
+
+  # Point every schema-version lookup at one profile row. `current_schema_id` is
+  # what the loader and ResourceForm read; `find_by` is what `resolve_schema`
+  # uses; `order(...).pick(:id)` is what `Flexibility.load` defaults to when a
+  # resource carries no schema_version.
+  def activate(schema)
+    allow(Hyrax::FlexibleSchema).to receive(:current_schema_id).and_return(schema.id)
+    allow(Hyrax::FlexibleSchema).to receive(:find_by).and_return(schema)
+    allow(Hyrax::FlexibleSchema).to receive(:order).and_return(
+      instance_double(ActiveRecord::Relation, pick: schema.id, last: schema)
+    )
+  end
+
+  let(:work) { Hyrax::Test::CompoundRemoval::TestWork.new(title: ['t']) }
+
+  describe 'Hyrax::CompoundSchema' do
+    it 'no longer reports the compound' do
+      expect(Hyrax::CompoundSchema.for(work).compound_names).not_to include(:participants)
+    end
+
+    it 'no longer treats the removed attribute as a compound' do
+      expect(Hyrax::CompoundSchema.for(work)).not_to be_compound(:participants)
+    end
+  end
+
+  describe 'the work form' do
+    let(:form) { Hyrax::Forms::ResourceForm.for(resource: work) }
+
+    it 'does not offer the compound as a form term' do
+      expect(form.compound_terms).not_to include(:participants)
+    end
+
+    it 'does not render the compound in the additional-fields section' do
+      expect(form.secondary_compound_terms).not_to include(:participants)
+    end
+
+    # The control: a removed SCALAR already disappears from the form, via
+    # ResourceForm's prune of definitions absent from the current profile. If
+    # this example ever fails alongside the compound ones, the cause is broader
+    # than CompoundSchema's class-schema fallback.
+    it 'does not offer a removed scalar as a form term' do
+      expect(form.primary_terms + form.secondary_terms).not_to include(:abstract)
+    end
+  end
+end

--- a/spec/services/hyrax/compound_schema_profile_removal_spec.rb
+++ b/spec/services/hyrax/compound_schema_profile_removal_spec.rb
@@ -3,15 +3,17 @@
 # Removing a compound from the m3 profile must remove it from the form, without
 # an app restart.
 #
-# The failure needs a specific boot order: the compound has to be present in the
-# profile when the model class loads. `acts_as_flexible_resource` then bakes the
-# compound parent into the CLASS schema, where it stays for the life of the
-# process - `Hyrax::Flexibility.attributes` merges attributes in and has no way
-# to express a removal. A later profile that omits the compound produces an
-# attribute map without it, but `Hyrax::CompoundSchema.schema_sources_for`
-# consults `resource.class.schema` as a fallback source, and that stale entry
-# still carries the folded `subproperties:` in its Dry type meta - so the
-# compound keeps resolving.
+# The failure needs a specific boot order, which is why `before` builds the
+# resource against a profile that HAS the compound before swapping in one that
+# does not: the compound must be present when the model class loads.
+# `Hyrax::Flexibility.attributes` then leaves it in the class schema for the life
+# of the process (it merges attributes in with no way to express a removal), and
+# in the singleton schema too, since that is built from the class schema. Both
+# still carry the folded `subproperties:`, so resolving compounds from either one
+# outlives the profile that declared them.
+#
+# Starting from a profile with no compound, then adding and removing one, does
+# NOT reproduce it - there is no stale class-schema entry to fall back to.
 #
 # An ordinary single-value property does NOT show this, which is why the bug
 # reads as compound-specific: `ResourceForm#initialize` prunes any Reform

--- a/spec/services/hyrax/compound_schema_profile_removal_spec.rb
+++ b/spec/services/hyrax/compound_schema_profile_removal_spec.rb
@@ -13,19 +13,20 @@
 # still carries the folded `subproperties:` in its Dry type meta - so the
 # compound keeps resolving.
 #
-# Scalars do NOT show this, which is why the bug reads as compound-specific:
-# `ResourceForm#initialize` prunes any Reform definition absent from
-# `form_definitions_for` at the current schema id, so a removed scalar stops
-# rendering even while a stale key lingers in the Dry schema. Compounds never
-# reach that prune - they render via `#compound_terms` (i.e. CompoundSchema),
-# not through Reform's displayed definitions. The scalar example below is the
-# control that pins this distinction.
+# An ordinary single-value property does NOT show this, which is why the bug
+# reads as compound-specific: `ResourceForm#initialize` prunes any Reform
+# definition absent from `form_definitions_for` at the current schema id, so a
+# removed property like `abstract` stops rendering even while a stale key
+# lingers in the Dry schema. Compounds never reach that prune - they render via
+# `#compound_terms` (i.e. CompoundSchema), not through Reform's displayed
+# definitions. The `abstract` example below is the control that pins this
+# distinction.
 RSpec.describe 'removing a compound from the m3 profile' do
   let(:base_profile) { YAML.safe_load_file(Hyrax::Engine.root.join('spec', 'fixtures', 'files', 'm3_profile.yaml')) }
 
   # The boot-time profile: declares the `participants` compound (a `type: hash`
   # parent with two members naming it via `available_on: { properties: }`) plus a
-  # plain scalar to act as the control.
+  # ordinary single-value property (`abstract`) to act as the control.
   let(:profile_with_compound) do
     base_profile.deep_merge(YAML.safe_load(<<-YAML))
       classes:
@@ -63,7 +64,7 @@ RSpec.describe 'removing a compound from the m3 profile' do
   end
 
   # The replacement profile: same classes, but the compound parent, both of its
-  # subproperties, and the control scalar are all gone.
+  # subproperties, and the control property are all gone.
   let(:profile_without_compound) do
     base_profile.deep_merge(YAML.safe_load(<<-YAML))
       classes:
@@ -140,11 +141,11 @@ RSpec.describe 'removing a compound from the m3 profile' do
       expect(form.secondary_compound_terms).not_to include(:participants)
     end
 
-    # The control: a removed SCALAR already disappears from the form, via
-    # ResourceForm's prune of definitions absent from the current profile. If
-    # this example ever fails alongside the compound ones, the cause is broader
-    # than CompoundSchema's class-schema fallback.
-    it 'does not offer a removed scalar as a form term' do
+    # The control: an ordinary single-value property already disappears from the
+    # form, via ResourceForm's prune of definitions absent from the current
+    # profile. If this example ever fails alongside the compound ones, the cause
+    # is broader than how CompoundSchema resolves its sources.
+    it 'does not offer a removed single-value property as a form term' do
       expect(form.primary_terms + form.secondary_terms).not_to include(:abstract)
     end
   end


### PR DESCRIPTION
## Summary

Fix compound metadata removal without restart. If an app is booted with flexible metadata and includes compound metadata, removing the compound metadata from the m3 profile didn't take effect until restarting the app.

## Details

The first commit adds a failing spec that reproduces a compound metadata field continuing to render on work forms after it is removed from the m3 profile, until the app is restarted.

The second commit fixes the bug: flexible resources now read compound declarations from the loader's attribute map at the current profile version, rather than from the resource's Dry schemas. A compound removed from the m3 profile disappears from work forms immediately, with no restart.

The Dry schemas cannot represent a removal. `Hyrax::Flexibility.attributes` only merges attributes in, and builds the singleton schema from the class schema, so a compound present when the class loaded survives in both the class and singleton schemas — folded `subproperties:` and all — for the life of the process. Ordinary single-value properties were unaffected because `ResourceForm#initialize` already prunes definitions absent from the current profile; compounds bypass that prune, rendering via `#compound_terms` instead.

## Testing

- Boot the app with an m3 profile that declares a compound (a `type: hash` parent property with at least one member declaring `available_on: { properties: [<parent>] }`). Confirm the compound renders on a work's edit form.
- Without restarting, upload a profile with the compound parent and its subproperties removed.
- Reload the work's edit form. The compound field should be gone.
- Add the compound back via another profile upload, still without restarting, and confirm it reappears on the form.

