### PR TITLE
Disallow crawling the same page in every language

### DIFF
--- a/app/views/hyrax/homepage/robots.text.erb
+++ b/app/views/hyrax/homepage/robots.text.erb
@@ -15,3 +15,5 @@ Disallow: /leases
 Disallow: /admin
 # Tell them where they should look!
 Sitemap: <%= "#{request.base_url}/sitemap" %>
+# Don't allow bots to look at every locale for the same page
+Disallow: /*locale=


### PR DESCRIPTION
We've seen a lot of crawlers crawling the same exact page in every language, they should just use the default locale & not scrape every localization.

### Fixes

The perpetual bot crawling problems.

### Summary

Asks well-behaved bots not to crawl the same page in every language

### Type of change (for release notes)
Choose from:
- `notes-bugfix` Bug Fixes

@samvera/hyrax-code-reviewers
