### PR TITLE
Make the Helm chart's DB connection pool size configurable

### DIFF
--- a/chart/hyrax/templates/_helpers.tpl
+++ b/chart/hyrax/templates/_helpers.tpl
@@ -156,7 +156,12 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- end -}}
 
 {{- define "hyrax.postgresql.url" -}}
-{{- printf "postgresql://%s:%s@%s/%s?pool=%d" ( include "hyrax.postgresql.username" . ) ( include "hyrax.postgresql.password" . ) ( include "hyrax.postgresql.host" . ) ( include "hyrax.postgresql.database" . ) ( .Values.dbPool | default 5 | int ) -}}
+{{- $base := printf "postgresql://%s:%s@%s/%s" ( include "hyrax.postgresql.username" . ) ( include "hyrax.postgresql.password" . ) ( include "hyrax.postgresql.host" . ) ( include "hyrax.postgresql.database" . ) -}}
+{{- if .Values.dbPoolInUrl -}}
+{{- printf "%s?pool=%d" $base ( .Values.dbPool | default 5 | int ) -}}
+{{- else -}}
+{{- $base -}}
+{{- end -}}
 {{- end -}}
 
 {{- define "hyrax.redis.fullname" -}}

--- a/chart/hyrax/templates/_helpers.tpl
+++ b/chart/hyrax/templates/_helpers.tpl
@@ -156,7 +156,7 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- end -}}
 
 {{- define "hyrax.postgresql.url" -}}
-{{- printf "postgresql://%s:%s@%s/%s?pool=5" ( include "hyrax.postgresql.username" . ) ( include "hyrax.postgresql.password" . ) ( include "hyrax.postgresql.host" . ) ( include "hyrax.postgresql.database" . ) -}}
+{{- printf "postgresql://%s:%s@%s/%s?pool=%d" ( include "hyrax.postgresql.username" . ) ( include "hyrax.postgresql.password" . ) ( include "hyrax.postgresql.host" . ) ( include "hyrax.postgresql.database" . ) ( .Values.dbPool | default 5 | int ) -}}
 {{- end -}}
 
 {{- define "hyrax.redis.fullname" -}}

--- a/chart/hyrax/values.yaml
+++ b/chart/hyrax/values.yaml
@@ -122,13 +122,24 @@ externalPostgresql: {}
 #  port:
 
 # ActiveRecord connection pool size, written into DATABASE_URL's ?pool=
-# param. Size this to the app's own thread concurrency (e.g. Puma's
-# RAILS_MAX_THREADS, or a job runner's own thread count) — a pool smaller
-# than the thread count causes threads to queue for a connection even
-# when the database itself has headroom, and a pool much larger than
-# needed can exhaust a shared database's max_connections faster than
-# expected across multiple replicas/consumers.
+# param when dbPoolInUrl is true. Size this to the app's own thread
+# concurrency (e.g. Puma's RAILS_MAX_THREADS, or a job runner's own
+# thread count) — a pool smaller than the thread count causes threads to
+# queue for a connection even when the database itself has headroom, and
+# a pool much larger than needed can exhaust a shared database's
+# max_connections faster than expected across multiple replicas/consumers.
 dbPool: 5
+
+# Whether DATABASE_URL includes a ?pool= param at all. Defaults to true
+# to preserve existing behavior on upgrade. DATABASE_URL's ?pool= (when
+# present) is treated by ActiveRecord as authoritative, silently
+# overriding whatever pool: a consuming app's own database.yml computes
+# (e.g. from its own RAILS_MAX_THREADS) — which is surprising if you
+# don't know to look for it. If your app already sizes its own pool via
+# database.yml and you want that to be the single source of truth, set
+# this false so DATABASE_URL omits the param entirely and your app's own
+# config takes over unmodified. dbPool is ignored when this is false.
+dbPoolInUrl: true
 
 embargoRelease:
   enabled: true

--- a/chart/hyrax/values.yaml
+++ b/chart/hyrax/values.yaml
@@ -121,6 +121,15 @@ externalPostgresql: {}
 #  database:
 #  port:
 
+# ActiveRecord connection pool size, written into DATABASE_URL's ?pool=
+# param. Size this to the app's own thread concurrency (e.g. Puma's
+# RAILS_MAX_THREADS, or a job runner's own thread count) — a pool smaller
+# than the thread count causes threads to queue for a connection even
+# when the database itself has headroom, and a pool much larger than
+# needed can exhaust a shared database's max_connections faster than
+# expected across multiple replicas/consumers.
+dbPool: 5
+
 embargoRelease:
   enabled: true
   schedule: "0 0 * * *"


### PR DESCRIPTION
## Summary
- `hyrax.postgresql.url` (in `chart/hyrax/templates/_helpers.tpl`) hardcodes `?pool=5` into `DATABASE_URL`, with no `values.yaml` field to override it.
- This matters more than it looks: `DATABASE_URL` takes priority over `database.yml`'s own `pool:` setting whenever it's present, so a consuming app has effectively no way to control its own connection pool size via normal Rails configuration — the chart silently overrides it, even if the app's own `database.yml` computes pool size from its own thread concurrency (`RAILS_MAX_THREADS`, etc.).
- We hit this directly: one of our deployments has `RAILS_MAX_THREADS=12` (Puma) but was still only ever opening 5 real DB connections per pod, because `DATABASE_URL`'s `pool=5` won. Under load, threads queued for a connection well before the database itself had any real capacity problem, surfacing as `ActiveRecord::ConnectionTimeoutError` (`could not obtain a connection from the pool ... all pooled connections were in use`).

## Change
- Adds a `dbPool` value, defaulting to `5` (identical to current behavior for anyone not setting it), for apps that just want a different fixed global pool size without changing anything else.
- Adds a `dbPoolInUrl` boolean, defaulting to `true` (also preserving current behavior exactly). When set to `false`, `DATABASE_URL` omits the `?pool=` param entirely, so a consuming app's own `database.yml` becomes the single source of truth for pool size — no more risk of the two silently disagreeing. `dbPool` is ignored when this is `false`.
- Both default to today's exact behavior — this is purely additive/opt-in, nothing changes for existing deployments unless they explicitly set one of these.

## Test plan
- [x] `helm template` with default values → `DATABASE_URL` decodes to `...?pool=5` (unchanged behavior)
- [x] `helm template --set dbPool=20` → decodes to `...?pool=20`
- [x] `helm template --set dbPoolInUrl=false` → decodes with no `pool=` param at all
- [x] `helm template --set dbPoolInUrl=false --set dbPool=99` → `dbPool` correctly ignored, no `pool=` param

🤖 Generated with [Claude Code](https://claude.com/claude-code)