### PR TITLE
Allow setting of thumbnail on empty parent work

### DIFF
--- a/app/helpers/hyrax/work_form_helper.rb
+++ b/app/helpers/hyrax/work_form_helper.rb
@@ -84,21 +84,31 @@ module Hyrax
     end
 
     ##
-    # Constructs a hash for a form `select`.
+    # Constructs options for a form `select`.
     #
     # @param form [Object]
     #
-    # @return [Array<Hash{String => String}>] a map from file set labels to ids for
-    #   the parent object
+    # @return [Array<Array(String, String)>] label/id pairs for the work's own
+    #   file sets and all descendant works' file sets (legacy forms return their
+    #   own label => id Hash via #select_files)
     def form_file_set_select_for(parent:)
       return parent.select_files if parent.respond_to?(:select_files)
       return {} unless parent.respond_to?(:member_ids)
 
-      file_sets =
-        Hyrax::PcdmMemberPresenterFactory.new(parent, nil).file_set_presenters
+      @form_file_set_select_for ||= begin
+        factory = Hyrax::PcdmMemberPresenterFactory.new(parent, nil)
 
-      file_sets.each_with_object({}) do |presenter, hash|
-        hash[presenter.title_or_label] = presenter.id
+        factory.file_set_presenters.map { |fsp| [fsp.title_or_label, fsp.id] } +
+          descendant_file_set_options(factory.work_presenters)
+      end
+    end
+
+    def descendant_file_set_options(work_presenters, seen: Set.new)
+      work_presenters.flat_map do |presenter|
+        next [] unless seen.add?(presenter.id.to_s)
+
+        presenter.file_set_presenters.map { |fsp| ["#{fsp.title_or_label} (#{presenter})", fsp.id] } +
+          descendant_file_set_options(presenter.work_presenters, seen: seen)
       end
     end
   end

--- a/app/presenters/hyrax/pcdm_member_presenter_factory.rb
+++ b/app/presenters/hyrax/pcdm_member_presenter_factory.rb
@@ -30,14 +30,14 @@ module Hyrax
     def file_set_presenters
       return enum_for(:file_set_presenters).to_a unless block_given?
 
-      results = query_docs(generic_type: "FileSet")
+      results = member_docs.select(&:file_set?)
 
       object.member_ids.each do |id|
         id = id.to_s
         indx = results.index { |doc| id == doc['id'] }
         next if indx.nil?
-        hash = results.delete_at(indx)
-        yield presenter_for(document: ::SolrDocument.new(hash), ability: ability)
+        document = results.delete_at(indx)
+        yield presenter_for(document: document, ability: ability)
       end
     end
 
@@ -79,14 +79,14 @@ module Hyrax
     def work_presenters
       return enum_for(:work_presenters) unless block_given?
 
-      results = query_docs(generic_type: "Work")
+      results = member_docs.reject(&:file_set?)
 
       object.member_ids.each do |id|
         id = id.to_s
         indx = results.index { |doc| id == doc['id'] }
         next if indx.nil?
-        hash = results.delete_at(indx)
-        yield presenter_for(document: ::SolrDocument.new(hash), ability: ability)
+        document = results.delete_at(indx)
+        yield presenter_for(document: document, ability: ability)
       end
     end
 
@@ -96,7 +96,7 @@ module Hyrax
     #
     # @return
     def presenter_for(document:, ability:)
-      case document['has_model_ssim'].first
+      case Array(document['has_model_ssim']).first
       when *Hyrax::ModelRegistry.file_set_rdf_representations
         file_presenter_class.new(document, ability)
       else
@@ -105,6 +105,10 @@ module Hyrax
     end
 
     private
+
+    def member_docs
+      @member_docs ||= query_docs.map { |hash| ::SolrDocument.new(hash) }
+    end
 
     def query_docs(generic_type: nil, ids: object.member_ids)
       query = "{!terms f=id}#{ids.join(',')}"

--- a/app/views/hyrax/base/_form_representative.html.erb
+++ b/app/views/hyrax/base/_form_representative.html.erb
@@ -6,7 +6,7 @@
         </legend>
         <div class="form-group">
           <span class="form-text"><%= t("hyrax.base.form_representative.help_html") %></span>
-          <%= f.select :representative_id, form_file_set_select_for(parent: @form), {}, { class: 'form-control' } %>
+          <%= f.select :representative_id, form_file_set_select_for(parent: @form), { include_blank: true }, { class: 'form-control' } %>
         </div>
       </fieldset>
     </div>

--- a/app/views/hyrax/base/_form_thumbnail.html.erb
+++ b/app/views/hyrax/base/_form_thumbnail.html.erb
@@ -6,7 +6,7 @@
         </legend>
         <div class="form-group">
           <span class="form-text"><%= t("hyrax.base.form_thumbnail.help_html") %></span>
-          <%= f.select :thumbnail_id, form_file_set_select_for(parent: @form), {}, { class: 'form-control' } %>
+          <%= f.select :thumbnail_id, form_file_set_select_for(parent: @form), { include_blank: true }, { class: 'form-control' } %>
         </div>
       </fieldset>
     </div>

--- a/spec/helpers/hyrax/work_form_helper_spec.rb
+++ b/spec/helpers/hyrax/work_form_helper_spec.rb
@@ -79,8 +79,8 @@ RSpec.describe Hyrax::WorkFormHelper do
       let(:form) { Valkyrie::ChangeSet.new(work) }
       let(:work) { FactoryBot.build(:hyrax_work) }
 
-      it 'gives an empty hash' do
-        expect(form_file_set_select_for(parent: form)).to eq({})
+      it 'gives no options' do
+        expect(form_file_set_select_for(parent: form)).to be_empty
       end
     end
 
@@ -88,8 +88,8 @@ RSpec.describe Hyrax::WorkFormHelper do
       let(:form) { Hyrax::Forms::ResourceForm.for(resource: work) }
       let(:work) { FactoryBot.build(:hyrax_work) }
 
-      it 'gives an empty hash' do
-        expect(form_file_set_select_for(parent: form)).to eq({})
+      it 'gives no options' do
+        expect(form_file_set_select_for(parent: form)).to be_empty
       end
 
       context 'with file_set members', index_adapter: :solr_index, valkyrie_adapter: :test_adapter do
@@ -102,10 +102,10 @@ RSpec.describe Hyrax::WorkFormHelper do
 
         before { file_sets.each { |fs| Hyrax.index_adapter.save(resource: fs) } }
 
-        it 'gives labels => ids' do
+        it 'gives label/id pairs' do
           expect(form_file_set_select_for(parent: form))
-            .to include('moominpapa.jpg' => an_instance_of(String),
-                        'snorkmaiden.jpg' => an_instance_of(String))
+            .to include(['moominpapa.jpg', an_instance_of(String)],
+                        ['snorkmaiden.jpg', an_instance_of(String)])
         end
 
         context 'and work members' do
@@ -113,9 +113,46 @@ RSpec.describe Hyrax::WorkFormHelper do
           let(:member_ids) { file_sets.map(&:id) + [member_work.id] }
           let(:member_work) { FactoryBot.build(:hyrax_work) }
 
-          it 'gives labels => ids for file_sets only' do
-            expect(form_file_set_select_for(parent: form).values)
+          it 'gives label/id pairs for file_sets only' do
+            expect(form_file_set_select_for(parent: form).map(&:last))
               .not_to include member_work.id.to_s
+          end
+
+          context 'and the child works have file sets' do
+            let(:member_work) do
+              FactoryBot.valkyrie_create(:hyrax_work, title: ['Child Work'], member_ids: [child_file_set.id])
+            end
+            let(:child_file_set) { FactoryBot.valkyrie_create(:hyrax_file_set, title: 'moomintroll.jpg') }
+
+            before do
+              Hyrax.index_adapter.save(resource: child_file_set)
+              Hyrax.index_adapter.save(resource: member_work)
+            end
+
+            it 'includes file sets from child works, labels qualified by the owning work' do
+              expect(form_file_set_select_for(parent: form))
+                .to include(['moominpapa.jpg', an_instance_of(String)],
+                            ['moomintroll.jpg (Child Work)', child_file_set.id.to_s])
+            end
+
+            context 'and membership contains a cycle' do
+              let(:work) { FactoryBot.valkyrie_create(:hyrax_work, member_ids: member_ids) }
+              let(:member_work) do
+                FactoryBot.valkyrie_create(:hyrax_work, title: ['Child Work'], member_ids: [child_file_set.id])
+              end
+
+              before do
+                member_work.member_ids += [work.id]
+                Hyrax.persister.save(resource: member_work)
+                Hyrax.index_adapter.save(resource: member_work)
+                Hyrax.index_adapter.save(resource: work)
+              end
+
+              it 'terminates and still lists the descendant file sets' do
+                expect(form_file_set_select_for(parent: form))
+                  .to include(['moomintroll.jpg (Child Work)', child_file_set.id.to_s])
+              end
+            end
           end
         end
       end

--- a/spec/presenters/hyrax/pcdm_member_presenter_factory_spec.rb
+++ b/spec/presenters/hyrax/pcdm_member_presenter_factory_spec.rb
@@ -49,6 +49,13 @@ RSpec.describe Hyrax::PcdmMemberPresenterFactory do
         it 'gives members in order' do
           expect(factory.file_set_presenters.map(&:id)).to eq file_sets.map(&:id)
         end
+
+        it 'queries solr once when listing both member types' do
+          expect(Hyrax::SolrService).to receive(:post).once.and_call_original
+
+          factory.file_set_presenters
+          factory.work_presenters
+        end
       end
     end
 


### PR DESCRIPTION
## Allow setting of thumbnail on empty parent work

<img width="3344" height="4648" alt="image" src="https://github.com/user-attachments/assets/b5cd761a-85fe-46ce-875a-59a533533fde" />

<img width="990" height="491" alt="image" src="https://github.com/user-attachments/assets/a9ccb7a8-62ee-4774-b183-3933f8e6dc25" />

---

958c45e6e71e3502ac9b78852c47844ab2463d62

Prior, if you have an empty parent work (no file set of its own) and add
child work(s) (with file sets on them), the Representative Media /
Thumbnail / Rendering input fields render on the edit form of the parent
work.  However, there's nothing to set them to, just empty dropdowns.
This commit allows the parent work's edit form to get all of the
descendant works' file sets as well as its own so they can be used in
the parent's fields.  This also changes #form_file_set_select_for to
return an array of arrays instead of a hash in case we have a situation
where multiple child works have the same file set label.  A hash would
have collapsed that down to one ambiguous option.  Now instead of just
0001.tif as the option it'll be "0001.tif (Volume 1)", the "Volume 1"
being the work's title.

The change in the `PcdmMemberPresenterFactory` is for efficiency's sake.
Previously, each call returning the work and file set presenters would
make a query to Solr.  The memoization fixes that and since in the
`WorkFormHelper` we're asking for both work and file set presenters, we
adjust the call to query for all of them and use Ruby to select/reject
what we need so only one query is needed.  A separate memoization was
added to the edit form because all three fields (Representative Media /
Thumbnail / Rendering) have the same options so we don't need to do
three separate queries to populate them.

The change to the views is so we get an empty option so it doesn't look
like the thumbnail is set when it really isn't.  Without the empty
option when a depositor visits the empty parent work, the thumbnail
looks like it's already selected which isn't actually true.
