### PR TITLE
Show readable labels for table-backed vocabularies

### DIFF
--- a/app/services/hyrax/authority_service.rb
+++ b/app/services/hyrax/authority_service.rb
@@ -74,11 +74,12 @@ module Hyrax
     # @return [String] the label for the authority entry, falling back to the
     #   id itself when no matching term is found.
     #
-    # @yield when no 'term' value is present for the id
+    # @yield when no 'term' or 'label' value is present for the id
     # @yieldreturn [String] an alternate label to return
     def label(id, &block)
       block ||= ->(_key) { id }
-      authority.find(id).fetch('term', &block)
+      result = authority.find(id)
+      result.fetch('term') { result.fetch('label', &block) }
     end
 
     # @return [Boolean] whether the id is an active entry. Returns false for

--- a/app/services/hyrax/qa_select_service.rb
+++ b/app/services/hyrax/qa_select_service.rb
@@ -39,11 +39,12 @@ module Hyrax
     #   when no matching term exists. Callers may pass a block to override the
     #   fallback value.
     #
-    # @yield when no 'term' value is present for the id
+    # @yield when no 'term' or 'label' value is present for the id
     # @yieldreturn [String] an alternate label to return
     def label(id, &block)
       block ||= ->(_key) { id }
-      authority.find(id).fetch('term', &block)
+      result = authority.find(id)
+      result.fetch('term') { result.fetch('label', &block) }
     end
 
     ##

--- a/spec/support/shared_examples_for_tolerant_authority_service.rb
+++ b/spec/support/shared_examples_for_tolerant_authority_service.rb
@@ -13,6 +13,10 @@
 # treats an entry with no `active:` flag — the mixin defaults to true; the
 # base class raises) stay asserted in each individual spec, not here.
 #
+# `#label` resolves in precedence order `term` → `label` → block (or the id when
+# no block is given), so that both file-based authorities (which emit `term`) and
+# table-based ones (which emit only `label`) produce a human-readable label.
+#
 # Hosts must provide:
 #   - `service` — the object under test, responding to label/include_current_value
 #   - `service_authority` — the FakeAuthority instance backing the service, so
@@ -24,12 +28,24 @@ RSpec.shared_examples "a tolerant authority service" do
       expect(service.label('active-id')).to eq 'Active Label'
     end
 
-    it "falls back to the id when the entry has no term" do
-      expect(service.label('active-no-term-id')).to eq 'active-no-term-id'
+    it "falls back to the label when the entry has no term" do
+      expect(service.label('active-no-term-id')).to eq 'Active No Term'
+    end
+
+    it "falls back to the id when the entry has neither term nor label" do
+      allow(service_authority).to receive(:find).with('bare-id').and_return({ id: 'bare-id' }.with_indifferent_access)
+      expect(service.label('bare-id')).to eq 'bare-id'
     end
 
     it "accepts a block to override the fallback" do
-      expect(service.label('active-no-term-id') { :backup }).to eq :backup
+      allow(service_authority).to receive(:find).with('bare-id').and_return({ id: 'bare-id' }.with_indifferent_access)
+      expect(service.label('bare-id') { :backup }).to eq :backup
+    end
+
+    it "prefers the term over the label when both are present" do
+      allow(service_authority).to receive(:find).with('both-id')
+                                                .and_return({ id: 'both-id', term: 'Term Wins', label: 'Label Loses' }.with_indifferent_access)
+      expect(service.label('both-id')).to eq 'Term Wins'
     end
   end
 


### PR DESCRIPTION
## Summary
Table-backed local authorities now show a readable label instead of a raw identifier wherever a single value is displayed.

## Details
- The two QA local-authority backends name the same field differently: file-based authorities emit `term`, table-based ones emit `label`. The label lookup read only `term`, so any table-backed value fell through to its id.
- `label` now resolves `term`, then `label`, then the caller's block (or the id). `term` stays first, so file-based authorities are unaffected.
- The bug was only visible on show pages and in edit-form current values if using a table-backed authority — select options read the normalized `label` key and already rendered correctly.
- Applies to both service shapes: the `Hyrax::AuthorityService` mixin and the `Hyrax::QaSelectService` base class.

The underlying inconsistency is in the `qa` gem; this is a possible contender for a change there, but solves the current issue.
