### PR TITLE
Home content touch ups

### DIFF
--- a/app/assets/javascripts/hyrax/featured_works.js
+++ b/app/assets/javascripts/hyrax/featured_works.js
@@ -48,6 +48,9 @@ Blacklight.onLoad(function() {
   $('a[data-behavior="unfeature"]').on('click', function(evt) {
     evt.preventDefault();
     anchor = $(this);
+    var confirmText = anchor.data('confirmText');
+    if (confirmText && !confirm(confirmText)) { return; }
+
     $.ajax({
        url: anchor.attr('href'),
        type: "post",

--- a/app/assets/javascripts/hyrax/featured_works.js
+++ b/app/assets/javascripts/hyrax/featured_works.js
@@ -56,8 +56,18 @@ Blacklight.onLoad(function() {
        type: "post",
        data: {"_method":"delete"},
        success: function(data) {
-         anchor.addClass('collapse');
-         $('a[data-behavior="feature"]').removeClass('collapse')
+         var item = anchor.closest('li.featured-item');
+         if (item.length) {
+           var list = item.closest('ol');
+           item.remove();
+           if (list.children('li').length === 0) {
+             list.closest('form').addClass('collapse');
+             $('p[data-behavior="no-featured-works"]').removeClass('collapse');
+           }
+         } else {
+           anchor.addClass('collapse');
+           $('a[data-behavior="feature"]').removeClass('collapse')
+         }
        }
     });
   });

--- a/app/assets/stylesheets/hyrax/_featured.scss
+++ b/app/assets/stylesheets/hyrax/_featured.scss
@@ -47,4 +47,7 @@ ol#featured_works {
 
 .dd-handle.dd3-handle {
   z-index: 1;
+  top: 13px;
+  bottom: 13px;
+  height: auto;
 }

--- a/app/assets/stylesheets/hyrax/_featured.scss
+++ b/app/assets/stylesheets/hyrax/_featured.scss
@@ -2,6 +2,8 @@ ol#featured_works {
   list-style: none;
   margin-left: 0;
   padding-left: 0;
+  font-size: $font-size-base;
+  line-height: $line-height-base;
 }
 
 /* don't nest .featured-item in the ol, because it's detached from the list when being dragged */
@@ -63,4 +65,8 @@ ol#featured_works {
   top: 13px;
   bottom: 13px;
   height: auto;
+}
+
+.dd-dragel > .featured-item > .dd3-content {
+  margin: 5px 0;
 }

--- a/app/assets/stylesheets/hyrax/_featured.scss
+++ b/app/assets/stylesheets/hyrax/_featured.scss
@@ -18,12 +18,25 @@ ol#featured_works {
   h3 {
     font-size: 1.1em;
     margin-top: 0;
+
+    &.float-right {
+      padding-left: 1em;
+
+      a {
+        color: $danger;
+      }
+    }
   }
 
   img {
     width: 90px;
     float: left;
     padding-right: 1em;
+  }
+
+  .featured-item-title-text {
+    display: block;
+    overflow: hidden;
   }
 
   .main {

--- a/app/assets/stylesheets/hyrax/_recent.scss
+++ b/app/assets/stylesheets/hyrax/_recent.scss
@@ -21,6 +21,11 @@
     padding-right: 1em;
   }
 
+  .recent-item-title-text {
+    display: block;
+    overflow: hidden;
+  }
+
   .recent-label {
     color: $gray;
     font-weight: bold;
@@ -28,5 +33,6 @@
 
   .recent-field {
     padding-left: 90px;
+    margin-bottom: 0;
   }
 }

--- a/app/views/hyrax/homepage/_featured_fields.html.erb
+++ b/app/views/hyrax/homepage/_featured_fields.html.erb
@@ -3,14 +3,14 @@
     <span class="sr-only"><%= t('hyrax.homepage.featured_works.document.title_label') %></span>
     <h3>
       <%= link_to [main_app, featured] do %>
-        <%= document_presenter(featured).thumbnail.thumbnail_tag({width: 90, alt: thumbnail_alt_text_for(featured.solr_document) }, {suppress_link: true})%><%= featured.title.first %>
+        <%= document_presenter(featured).thumbnail.thumbnail_tag({width: 90, alt: thumbnail_alt_text_for(featured.solr_document) }, {suppress_link: true})%><span class="featured-item-title-text"><%= featured.title.first %></span>
       <% end %>
     </h3>
   </div>
   <div class="featured-field featured-item-depositor">
-    <span class="featured-label"><%= t('hyrax.homepage.featured_works.document.depositor_label') %>:</span> <%= link_to_profile featured.depositor(t('hyrax.homepage.featured_works.document.depositor_missing')) %>
+    <span class="featured-label text-dark"><%= t('hyrax.homepage.featured_works.document.depositor_label') %>:</span> <%= link_to_profile featured.depositor(t('hyrax.homepage.featured_works.document.depositor_missing')) %>
   </div>
   <div class="featured-field featured-item-keywords">
-    <span class="featured-label"><%= t('hyrax.homepage.featured_works.document.keyword_label') %>:</span> <%= link_to_facet_list(featured.keyword, 'keyword', t('hyrax.homepage.featured_works.document.keyword_missing')) %>
+    <span class="featured-label text-dark"><%= t('hyrax.homepage.featured_works.document.keyword_label') %>:</span> <%= link_to_facet_list(featured.keyword, 'keyword', t('hyrax.homepage.featured_works.document.keyword_missing')) %>
   </div>
 </div>

--- a/app/views/hyrax/homepage/_featured_works.html.erb
+++ b/app/views/hyrax/homepage/_featured_works.html.erb
@@ -2,6 +2,7 @@
 <% if @featured_work_list.empty? %>
   <p><%= t('hyrax.homepage.featured_works.no_works') %></p>
 <% elsif can? :update, FeaturedWork %>
+  <p class="collapse" data-behavior="no-featured-works"><%= t('hyrax.homepage.featured_works.no_works') %></p>
   <%= form_for [hyrax, @featured_work_list] do |f| %>
     <div class="panel-group dd" id="dd">
       <ol id="featured_works">

--- a/app/views/hyrax/homepage/_recent_document.html.erb
+++ b/app/views/hyrax/homepage/_recent_document.html.erb
@@ -7,7 +7,7 @@
             <%= document_presenter(recent_document)&.thumbnail&.thumbnail_tag(
               { width: 90, alt: thumbnail_alt_text_for(recent_document) },
               { suppress_link: true }
-            ) %><%= recent_document %>
+            ) %><span class="recent-item-title-text"><%= recent_document %></span>
           <% end %>
         </h3>
         <p class="recent-field">

--- a/app/views/hyrax/homepage/_sortable_featured.html.erb
+++ b/app/views/hyrax/homepage/_sortable_featured.html.erb
@@ -10,7 +10,7 @@
           <h3 class="float-right">
             <%= link_to hyrax.featured_work_path(presenter, format: :json),
               title: "Remove work from feature section",
-              data: {behavior: 'unfeature'} do %>
+              data: {behavior: 'unfeature', confirm_text: t('hyrax.homepage.featured_works.confirm_unfeature')} do %>
               <i class='fa fa-times'></i>
             <% end %>
             <p class="sr-only"><%= t 'helpers.action.remove' %></p>

--- a/config/locales/hyrax.de.yml
+++ b/config/locales/hyrax.de.yml
@@ -1449,6 +1449,7 @@ de:
           keyword_label: Schlüsselwörter
           keyword_missing: keine Schlüsselwörter angegeben
           title_label: Titel
+        confirm_unfeature: Aus den ausgewählten Arbeiten entfernen?
         drag: Ziehen
         no_works: Es wurden keine Arbeiten vorgestellt
         tab_label: Ausgewählte Arbeiten

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -1550,6 +1550,7 @@ en:
           keyword_label: Keywords
           keyword_missing: no keywords specified
           title_label: Title
+        confirm_unfeature: Remove from featured works?
         drag: Drag
         no_works: No works have been featured
         tab_label: Featured Works

--- a/config/locales/hyrax.es.yml
+++ b/config/locales/hyrax.es.yml
@@ -1458,6 +1458,7 @@ es:
           keyword_label: Palabras clave
           keyword_missing: no palabras clave especificadas
           title_label: Título
+        confirm_unfeature: ¿Eliminar de los trabajos destacados?
         drag: Arrastrar
         no_works: No hay trabajos destacados
         tab_label: Trabajos destacados

--- a/config/locales/hyrax.fr.yml
+++ b/config/locales/hyrax.fr.yml
@@ -1456,6 +1456,7 @@ fr:
           keyword_label: Mots clés
           keyword_missing: aucun mot-clé spécifié
           title_label: Titre
+        confirm_unfeature: Retirer des travaux en vedette ?
         drag: Traîne
         no_works: Aucun travail n'a été présenté
         tab_label: Travaux en vedette

--- a/config/locales/hyrax.it.yml
+++ b/config/locales/hyrax.it.yml
@@ -1455,6 +1455,7 @@ it:
           keyword_label: parole
           keyword_missing: nessuna parola chiave specificata
           title_label: Titolo
+        confirm_unfeature: Rimuovere dalle opere in primo piano?
         drag: Trascinare
         no_works: Nessun lavoro è stato descritto
         tab_label: Opere in primo piano

--- a/config/locales/hyrax.pt-BR.yml
+++ b/config/locales/hyrax.pt-BR.yml
@@ -1448,6 +1448,7 @@ pt-BR:
           keyword_label: Palavras-chave
           keyword_missing: sem palavras-chave especificadas
           title_label: Título
+        confirm_unfeature: Remover das obras em destaque?
         drag: Arrastar
         no_works: Nenhuma obra foi destacada
         tab_label: Obras em destaque

--- a/config/locales/hyrax.zh.yml
+++ b/config/locales/hyrax.zh.yml
@@ -1453,6 +1453,7 @@ zh:
           keyword_label: 关键词
           keyword_missing: 没有指定关键字
           title_label: 标题
+        confirm_unfeature: 从特色作品中移除？
         drag: 拖
         no_works: 没有特色作品
         tab_label: 特色作品

--- a/vendor/assets/javascripts/nestable.js
+++ b/vendor/assets/javascripts/nestable.js
@@ -326,7 +326,7 @@
             this.dragRootEl = this.el;
 
             this.dragEl = $(document.createElement(this.options.listNodeName)).addClass(this.options.listClass + ' ' + this.options.dragClass);
-            this.dragEl.css('width', dragItem.width());
+            this.dragEl.css('width', dragItem.outerWidth());
 
             // fix for zepto.js
             //dragItem.after(this.placeEl).detach().appendTo(this.dragEl);


### PR DESCRIPTION
## Align handle for featured works

### Before
<img width="139" height="613" alt="image" src="https://github.com/user-attachments/assets/4245eff9-417e-4bf8-a535-57a84d9c58c0" />

### After
<img width="148" height="647" alt="image" src="https://github.com/user-attachments/assets/21600f70-81a2-4da8-ab97-c5710dccecce" />

38b2bdfeaf6f10d4c2d6eeec62bceea56c583844

This commit will align the handle that displays to admins on the home
page featured works.  Previously the handle was over extended compared
to the card itself.

## Add confirmation when unfeaturing

<img width="442" height="231" alt="image" src="https://github.com/user-attachments/assets/5d180824-9045-46cd-a2ad-c466cbf89eb0" />

1a6b838bf05c0604f99208be85544ab052070f59

Prior, when you unfeature a work from the home page it would immediately
remove it.  This commit will add a confirmation before the work gets
unfeatured.

## Make removing featured works look correct

a5c8569bb3ae1c5cf41f5ef281d6961fb7fe73db

### Before
<img alt="featured-works" src="https://github.com/user-attachments/assets/aa9bf7be-bfb0-4e0d-b0c0-e82bc856caa6" />

### After
<img alt="featured-works-after" src="https://github.com/user-attachments/assets/7b7d73e1-230c-410f-b740-30a805255810" />

Prior, when a featured work was removed, the only thing that goes away
is the x button, the work card still remains until the user refreshes
the page.  This commit will make it so that the card goes away as well.
If the last featured work gets removed then the list returns back to the
original state where nothing has been added.

## Clean up admin featured works card styling

d10370786f673b4e2367d5f83a16f7c08567d90d

### Before
<img width="586" height="228" alt="image" src="https://github.com/user-attachments/assets/e6a9401b-196e-45ca-9cd2-805fbb7f09a7" />

### After
<img width="569" height="216" alt="image" src="https://github.com/user-attachments/assets/ac3ecef3-41c1-4fa1-83e5-d337d9404aac" />

This commit just cleans up the admin featured works card, notably there
was a PR to make the label NOT muted (WCAG reasons) but the admin side
of things was left out.

Ref:
- https://github.com/samvera/hyrax/commit/7014aea9f

## Match recent uploads tab with featured works

76cf2b1f4203547f939d73744a39dbfa97a0688b

### Before
<img width="571" height="217" alt="image" src="https://github.com/user-attachments/assets/31f52f21-2979-4d0c-9a96-0ab8f3c8c54a" />

### After
<img width="578" height="152" alt="image" src="https://github.com/user-attachments/assets/83e33bc4-cd5f-4f97-977f-45076c05531c" />

Previously, featured works tab was updated to fix some UI issues, this
commit will match the look with that.

## Make admin view look like public view

### Before
<img width="509" height="383" alt="image" src="https://github.com/user-attachments/assets/663fd7a2-79d2-44d5-aa77-b2959d9f71bf" />

### After
<img width="490" height="424" alt="image" src="https://github.com/user-attachments/assets/aceb6457-cd05-4f35-8f5b-a81eff3b12f8" />

d93a9c6c0ac0b8a91f44bbec8d47d851a5fa1956

This commit will make the admin view of the featured works look like the
public view, so it uses the same size fonts.  Also the dragged ghost
state looks proper now as well.

