### PR TITLE
Honor correct iiif_manifest_factory when caching

### DIFF
--- a/app/presenters/hyrax/iiif_manifest_presenter.rb
+++ b/app/presenters/hyrax/iiif_manifest_presenter.rb
@@ -163,7 +163,8 @@ module Hyrax
     #
     # @return [String] a string tag suitable for cache keys for this manifiest
     def version
-      object.try(:modified_date)&.to_s || ''
+      timestamp = model['system_modified_dtsi'] if model.is_a?(::SolrDocument)
+      timestamp || object.try(:modified_date)&.to_s || object.try(:updated_at)&.to_s || ''
     end
 
     ##

--- a/app/services/hyrax/caching_iiif_manifest_builder.rb
+++ b/app/services/hyrax/caching_iiif_manifest_builder.rb
@@ -17,7 +17,7 @@ module Hyrax
     #        object and returns an object that responds to `#to_h`
     # @param expires_in [Integer] the number of seconds until the cache expires
     # @see Hyrax::Configuration#iiif_manifest_cache_duration
-    def initialize(iiif_manifest_factory: ::IIIFManifest::ManifestFactory, expires_in: Hyrax.config.iiif_manifest_cache_duration)
+    def initialize(iiif_manifest_factory: Hyrax.config.iiif_manifest_factory, expires_in: Hyrax.config.iiif_manifest_cache_duration)
       self.expires_in = expires_in
 
       super(iiif_manifest_factory: iiif_manifest_factory)

--- a/spec/presenters/hyrax/iiif_manifest_presenter_spec.rb
+++ b/spec/presenters/hyrax/iiif_manifest_presenter_spec.rb
@@ -680,5 +680,13 @@ RSpec.describe Hyrax::IiifManifestPresenter, :clean_repo do
 
       it('is still a string') { expect(presenter.version).to be_a String }
     end
+
+    context 'with a solr document' do
+      let(:work) { SolrDocument.new(id: 'moomin', system_modified_dtsi: '2026-08-20T01:02:03Z') }
+
+      it 'uses the full solr timestamp, so same-day changes still bust caches' do
+        expect(presenter.version).to eq '2026-08-20T01:02:03Z'
+      end
+    end
   end
 end

--- a/spec/services/hyrax/caching_iiif_manifest_builder_spec.rb
+++ b/spec/services/hyrax/caching_iiif_manifest_builder_spec.rb
@@ -26,4 +26,35 @@ RSpec.describe Hyrax::CachingIiifManifestBuilder, :clean_repo do
 
     builder.manifest_for(presenter: presenter)
   end
+
+  it 'defaults to the configured manifest factory' do
+    allow(Hyrax.config).to receive(:iiif_manifest_factory).and_return(::IIIFManifest::V3::ManifestFactory)
+
+    expect(builder.manifest_factory).to eq ::IIIFManifest::V3::ManifestFactory
+  end
+
+  context 'with a real cache store' do
+    subject(:builder) { described_class.new(iiif_manifest_factory: factory) }
+    let(:factory) { double('manifest factory') }
+    let(:manifest) { double('manifest', to_h: { 'label' => 'moomin' }) }
+
+    before do
+      allow(Rails).to receive(:cache).and_return(ActiveSupport::Cache::MemoryStore.new)
+      allow(factory).to receive(:new).and_return(manifest)
+    end
+
+    it 'builds the manifest only once for repeated calls' do
+      2.times { builder.manifest_for(presenter: presenter) }
+
+      expect(factory).to have_received(:new).once
+    end
+
+    it 'rebuilds when the presenter version changes' do
+      builder.manifest_for(presenter: presenter)
+      allow(presenter).to receive(:version).and_return('changed_etag')
+      builder.manifest_for(presenter: presenter)
+
+      expect(factory).to have_received(:new).twice
+    end
+  end
 end


### PR DESCRIPTION
## Honor correct iiif_manifest_factory when caching

fb9d552c857f5090963c99968c164a41855bb068

Prior, CachingIiifManifestBuilder defaulted to hardcoded
::IIIFManifest::ManifestFactory while the non-caching
ManifestBuilderService defaulted to Hyrax.config.iiif_manifest_factory.
An app that configures a different factory (e.g. V3) and enables the
cache_work_iiif_manifest feature would silently get manifests built with
the wrong factory on the cached path.  Both builders now read the same
config.

## Use solr timestamp for IIIF manifest cache keys

3796133a37535427cfe1094a6e261a0d50535dc5

Cache key was built from modified_date so editing a work after its
manifest was cached on the same day served the stale manifest until
midnight.  `system_modified_dtsi` carries the full timestamp, fall back
to modified_date/updated_at for presenters wrapping resources directly
instead of solr documents.

---
_**🤖 Assisted-by: Opus 5**_