### PR TITLE
Handle missing object key in TrophyCleanupListener in Wings

### DIFF
--- a/app/services/hyrax/listeners/trophy_cleanup_listener.rb
+++ b/app/services/hyrax/listeners/trophy_cleanup_listener.rb
@@ -9,10 +9,12 @@ module Hyrax
       # @param [Dry::Events::Event] event
       # @return [void]
       def on_object_deleted(event)
+        event = event.to_h
         object_id = event[:object]&.id || event[:id]
+        return if object_id.blank?
         Trophy.where(work_id: object_id).destroy_all
       rescue StandardError => err
-        Hyrax.logger.warn "Failed to delete trophies for #{event[:id]}. " \
+        Hyrax.logger.warn "Failed to delete trophies for #{object_id}. " \
                           'These trophies might be orphaned.' \
                           "\n\t#{err.message}"
       end

--- a/spec/services/hyrax/listeners/trophy_cleanup_listener_spec.rb
+++ b/spec/services/hyrax/listeners/trophy_cleanup_listener_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+RSpec.describe Hyrax::Listeners::TrophyCleanupListener do
+  subject(:listener) { described_class.new }
+
+  describe '#on_object_deleted' do
+    let(:user)         { FactoryBot.create(:user) }
+    let(:event)        { Dry::Events::Event.new(:on_object_deleted, data) }
+    let(:target_id)    { data[:object]&.id || data[:id] }
+
+    before do
+      Trophy.where(work_id: [target_id, 'other-work']).delete_all
+      Trophy.create(user_id: user.id, work_id: target_id)
+      Trophy.create(user_id: user.id + 1, work_id: 'other-work')
+    end
+
+    context 'when the deleted event includes only an id' do
+      let(:data) { { id: 'z890s9938', user: user } }
+
+      it 'deletes matching trophies without raising' do
+        expect { listener.on_object_deleted(event) }
+          .to change { Trophy.where(work_id: target_id).count }
+          .from(1).to(0)
+
+        expect(Trophy.where(work_id: 'other-work').count).to eq(1)
+      end
+    end
+
+    context 'when the deleted event includes an object' do
+      let(:data) { { object: instance_double('resource', id: 'z890s9938'), user: user } }
+
+      it 'deletes matching trophies' do
+        expect { listener.on_object_deleted(event) }
+          .to change { Trophy.where(work_id: target_id).count }
+          .from(1).to(0)
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Summary
When using Wings in hyrax 5.2.0 we are getting errors like the following every time an object is deleted:
```
Failed to delete trophies for z890s9938. These trophies might be orphaned.
        key not found: :object
```
This is probably preventing trophies from getting deleted in Wings, although for us it is just a nuisance since we don't allow trophies to be created.

### Guidance for testing, such as acceptance criteria or new user interface behaviors:
Trophies should now be deleted in wings and there shouldn't be a warning, whether or not there are trophies associated with a work that is being delete.

### Type of change (for release notes)

notes-bugfix

### Detailed Description

This PR prevents the error by using the same approach used in ObjectLifecycleListener to ensure the event is a hash before trying to access optional keys, and then does an early return if there is no ID to save an unnecessary query.

@samvera/hyrax-code-reviewers
