### PR TITLE
Coerce blank thumbnail/representative to nil

### DIFF
--- a/app/forms/hyrax/forms/pcdm_object_form.rb
+++ b/app/forms/hyrax/forms/pcdm_object_form.rb
@@ -34,8 +34,8 @@ module Hyrax
       property :member_of_collections_attributes, virtual: true, populator: :in_collections_populator
       validates_with CollectionMembershipValidator
 
-      property :representative_id, type: Valkyrie::Types::String
-      property :thumbnail_id, type: Valkyrie::Types::String
+      property :representative_id, type: Valkyrie::Types::Params::ID
+      property :thumbnail_id, type: Valkyrie::Types::Params::ID
       property :rendering_ids, default: [], type: Valkyrie::Types::Array
 
       # backs the child work search element;

--- a/spec/forms/hyrax/forms/resource_form_spec.rb
+++ b/spec/forms/hyrax/forms/resource_form_spec.rb
@@ -9,6 +9,22 @@ RSpec.describe Hyrax::Forms::ResourceForm do
   let(:default_admin_set) { instance_double(Hyrax::AdministrativeSet, title: "DEFAULT_ADMINSET", id: "DEFAULT_ADMINSET_ID") }
   before { allow(Hyrax::AdminSetCreateService).to receive(:find_or_create_default_admin_set).and_return(default_admin_set) }
 
+  describe 'thumbnail_id and representative_id' do
+    it 'coerces blank submissions to nil' do
+      form.validate(thumbnail_id: '', representative_id: '')
+
+      expect(form.thumbnail_id).to be_nil
+      expect(form.representative_id).to be_nil
+    end
+
+    it 'casts present values to ids' do
+      form.validate(thumbnail_id: 'fake_id', representative_id: 'fake_id')
+
+      expect(form.thumbnail_id.to_s).to eq 'fake_id'
+      expect(form.representative_id.to_s).to eq 'fake_id'
+    end
+  end
+
   # Redirects is a Work/Collection concern, never a FileSet one. The FileSet
   # form must not declare the property (its model has no `redirects` attribute) —
   # guarding the regression where declaring redirects on the shared base


### PR DESCRIPTION
The representative_id and thumbnail_id form properties were typed as Valkyrie::Types::String, which passes an empty string through as a valid value.  Use Valkyrie::Types::Params::ID as it was purpose built for this because it coerces a blank input to nil.  Anything else would be a Valkyrie::ID.

## Before
<img width="1001" height="465" alt="image" src="https://github.com/user-attachments/assets/386469a7-d9cd-49ff-b388-b8af63371f0a" />

## After
<img width="1004" height="445" alt="Screenshot 2026-08-20 at 12 03 58" src="https://github.com/user-attachments/assets/62817aa2-a78d-4075-8be3-bf1280f0d0fa" />

---
_**🤖 Assisted-by: Opus 5**_