### PR TITLE
Bump Hyrax chart version to 3.7.4

### DIFF
--- a/chart/hyrax/Chart.yaml
+++ b/chart/hyrax/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: hyrax
 description: An open-source, Samvera-powered digital repository system
 type: application
-version: 3.7.3
+version: 3.7.4
 appVersion: 5.2.0
 dependencies:
   - name: fcrepo


### PR DESCRIPTION
Creates a release to the Hyrax helm chart so that postgres pool size is configurable, not hard-coded. See https://github.com/samvera/hyrax/pull/7586 for details of released change.

@samvera/hyrax-code-reviewers
