### PR TITLE
Add a reusable hyrax-nginx image and build it in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,6 +53,16 @@ jobs:
           tags: |
             ${{ env.REGISTRY }}/${{ env.REPO_LOWER }}/hyrax-worker-base:${{ env.TAG }}
             ${{ env.REGISTRY }}/${{ env.REPO_LOWER }}/hyrax-worker-base:${{ github.ref_name }}
+      - name: Build and push nginx
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          target: hyrax-nginx
+          push: true
+          tags: |
+            ${{ env.REGISTRY }}/${{ env.REPO_LOWER }}/hyrax-nginx:${{ env.TAG }}
+            ${{ env.REGISTRY }}/${{ env.REPO_LOWER }}/hyrax-nginx:${{ github.ref_name }}
       - name: Build and push dassie
         uses: docker/build-push-action@v7
         with:

--- a/.github/workflows/lint-build-test.yml
+++ b/.github/workflows/lint-build-test.yml
@@ -26,6 +26,20 @@ env:
   COMPOSE_DOCKER_CLI_BUILD: 1
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      nginx: ${{ steps.filter.outputs.nginx }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            nginx:
+              - 'Dockerfile'
+              - 'docker/**'
+
   lint:
     runs-on: ubuntu-latest
     steps:
@@ -98,7 +112,8 @@ jobs:
           path: ${{runner.temp}}/hyrax-dev-${{ github.sha }}.tar
 
   build-nginx:
-    needs: lint
+    needs: [lint, changes]
+    if: needs.changes.outputs.nginx == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -110,9 +125,12 @@ jobs:
         with:
           context: .
           target: hyrax-nginx
-          push: false
+          load: true
+          tags: hyrax-nginx:ci-test
           cache-from: type=gha
           cache-to: type=gha, mode=max
+      - name: nginx -t
+        run: docker run --rm hyrax-nginx:ci-test nginx -t
 
   test:
     needs: build

--- a/.github/workflows/lint-build-test.yml
+++ b/.github/workflows/lint-build-test.yml
@@ -97,6 +97,23 @@ jobs:
           name: hyrax-dev
           path: ${{runner.temp}}/hyrax-dev-${{ github.sha }}.tar
 
+  build-nginx:
+    needs: lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+      - name: Build hyrax-nginx
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          target: hyrax-nginx
+          push: false
+          cache-from: type=gha
+          cache-to: type=gha, mode=max
+
   test:
     needs: build
     runs-on: ubuntu-latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 ARG DEBIAN_VERSION=trixie
 ARG RUBY_VERSION=3.3
+ARG NGINX_VERSION=1.29-alpine
 
 FROM ruby:$RUBY_VERSION-$DEBIAN_VERSION AS hyrax-base
 
@@ -153,3 +154,16 @@ ARG BUILD_GITSHA
 ARG BUILD_TIMESTAMP
 ENV BUILD_GITSHA=$BUILD_GITSHA \
     BUILD_TIMESTAMP=$BUILD_TIMESTAMP
+
+FROM nginxinc/nginx-unprivileged:$NGINX_VERSION AS hyrax-nginx
+# root
+USER 0
+# Owned by nginx user and group (101:101)
+COPY --chown=101:101 docker/nginx/nginx.conf /etc/nginx/nginx.conf
+# Make backwards compatible with Bitnami image, which is no longer being updated
+RUN mkdir -p /opt/bitnami/nginx/logs && \
+    ln -sf /dev/stdout /opt/bitnami/nginx/logs/access.log && \
+    ln -sf /dev/stderr /opt/bitnami/nginx/logs/error.log && \
+    chown -R 101:101 /opt/bitnami
+# nginx user
+USER 101

--- a/docker/nginx/nginx.conf
+++ b/docker/nginx/nginx.conf
@@ -1,0 +1,29 @@
+# This config is compatible with the Bitnami nginx helm chart, while allowing us to use updated nginx Docker images.
+# We previously used the Bitnami helm chart with the Bitnami Docker image; however
+# Bitnami is no longer releasing new free versions of its nginx Docker images
+worker_processes  auto;
+
+error_log  /opt/bitnami/nginx/logs/error.log warn;
+pid        /tmp/nginx.pid;
+
+events {
+    worker_connections  1024;
+}
+
+http {
+    proxy_temp_path /tmp/proxy_temp;
+    client_body_temp_path /tmp/client_temp;
+    fastcgi_temp_path /tmp/fastcgi_temp;
+    uwsgi_temp_path /tmp/uwsgi_temp;
+    scgi_temp_path /tmp/scgi_temp;
+
+    include       /etc/nginx/mime.types;
+    default_type  application/octet-stream;
+
+    access_log  /opt/bitnami/nginx/logs/access.log;
+
+    sendfile        on;
+    keepalive_timeout  65;
+
+    include /opt/bitnami/nginx/conf/server_blocks/*.conf;
+}


### PR DESCRIPTION
bitnamilegacy/nginx has no free updated releases; rebase on nginxinc/nginx-unprivileged instead, keeping the Bitnami nginx chart's expected log/config paths so the Helm chart can keep using that chart unchanged.

Part of a stack — nothing in the Helm chart references this image yet.

Connected to #7599

🤖 Generated with [Claude Code](https://claude.com/claude-code)