### PR TITLE
Point the chart's nginx.image default at the new hyrax-nginx image

### DIFF
--- a/bin/check-nginx-image-tag.sh
+++ b/bin/check-nginx-image-tag.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+# nginx.image.tag has no Chart.AppVersion fallback (see chart/hyrax/values.yaml), so it must be bumped by hand alongside appVersion.
+set -e
+
+app_version=$(yq '.appVersion' chart/hyrax/Chart.yaml)
+nginx_tag=$(yq '.nginx.image.tag' chart/hyrax/values.yaml)
+
+if [ "$app_version" != "$nginx_tag" ]; then
+  echo "chart/hyrax/values.yaml's nginx.image.tag ($nginx_tag) doesn't match chart/hyrax/Chart.yaml's appVersion ($app_version)."
+  echo "Update nginx.image.tag to $app_version."
+  exit 1
+fi
+
+echo "nginx.image.tag matches appVersion ($app_version)."

--- a/chart/hyrax/tests/nginx_test.yaml
+++ b/chart/hyrax/tests/nginx_test.yaml
@@ -1,0 +1,11 @@
+suite: nginx sane defaults (values.yaml nginx block)
+templates:
+  - charts/nginx/templates/deployment.yaml
+tests:
+  - it: renders a resolvable image reference (no blank tag)
+    set:
+      nginx.enabled: true
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.containers[0].image
+          pattern: ^ghcr\.io/samvera/hyrax/hyrax-nginx:.+$

--- a/chart/hyrax/values.yaml
+++ b/chart/hyrax/values.yaml
@@ -295,8 +295,11 @@ postgresql:
 nginx:
   enabled: false
   image:
-    repository: bitnamilegacy/nginx
-    tag: 1.23.0-debian-11-r1
+    registry: ghcr.io
+    repository: samvera/hyrax/hyrax-nginx
+    pullPolicy: IfNotPresent
+    # no Chart.AppVersion fallback here (unlike image.tag above); keep in sync with appVersion.
+    tag: "5.2.0"
   # this needs to be set since templates/ingress.yaml tries to
   # evaluate .Values.nginx.service.port, and it needs to at least evaluate to
   # nil, rather than throw an error (which it does if `service` itself is nil).


### PR DESCRIPTION
Stacked on #7594. bitnamilegacy/nginx has no free updated releases. The nginx subchart has no Chart.AppVersion fallback for a blank tag (unlike the main image.tag), so it needs a real pinned value — adds a drift-check script + test so it can't silently fall out of sync with appVersion.

Not running in CI yet because of an unrelated issue with the fcrepo chart

Connected to #7339
Connected to #7599 

🤖 Generated with [Claude Code](https://claude.com/claude-code)