### PR TITLE
Add global.hyraxFullnameOverride / hyrax.effectiveFullname

### DIFF
--- a/chart/hyrax/templates/_helpers.tpl
+++ b/chart/hyrax/templates/_helpers.tpl
@@ -25,6 +25,14 @@ If release name contains chart name it will be used as a full name.
 {{- end }}
 
 {{/*
+The fullname to use for resources shared with subcharts (e.g. the uploads PVC),
+honoring global.hyraxFullnameOverride since subcharts can't reach hyrax.fullname.
+*/}}
+{{- define "hyrax.effectiveFullname" -}}
+{{- .Values.global.hyraxFullnameOverride | default (include "hyrax.fullname" .) -}}
+{{- end }}
+
+{{/*
 Create chart name and version as used by the chart label.
 */}}
 {{- define "hyrax.chart" -}}

--- a/chart/hyrax/templates/deployment-worker.yaml
+++ b/chart/hyrax/templates/deployment-worker.yaml
@@ -117,7 +117,7 @@ spec:
             claimName: {{ .Values.uploadsVolume.existingClaim }}
           {{- else if .Values.uploadsVolume.enabled }}
           persistentVolumeClaim:
-            claimName: {{ template "hyrax.fullname" . }}-uploads
+            claimName: {{ include "hyrax.effectiveFullname" . }}-uploads
           {{ else }}
           emptyDir: {}
           {{ end }}

--- a/chart/hyrax/templates/deployment.yaml
+++ b/chart/hyrax/templates/deployment.yaml
@@ -198,7 +198,7 @@ spec:
             claimName: {{ .Values.uploadsVolume.existingClaim }}
           {{- else if .Values.uploadsVolume.enabled }}
           persistentVolumeClaim:
-            claimName: {{ template "hyrax.fullname" . }}-uploads
+            claimName: {{ include "hyrax.effectiveFullname" . }}-uploads
           {{ else }}
           emptyDir: {}
           {{ end }}

--- a/chart/hyrax/templates/uploads-pvc.yaml
+++ b/chart/hyrax/templates/uploads-pvc.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: {{ template "hyrax.fullname" . }}-uploads
+  name: {{ include "hyrax.effectiveFullname" . }}-uploads
   labels:
     {{- include "hyrax.labels" . | nindent 4 }}
 spec:

--- a/chart/hyrax/tests/uploads_pvc_test.yaml
+++ b/chart/hyrax/tests/uploads_pvc_test.yaml
@@ -1,0 +1,17 @@
+suite: uploads PVC naming
+templates:
+  - templates/uploads-pvc.yaml
+tests:
+  - it: names the claim after hyrax.fullname
+    asserts:
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-hyrax-uploads
+
+  - it: honors global.hyraxFullnameOverride
+    set:
+      global.hyraxFullnameOverride: custom-name
+    asserts:
+      - equal:
+          path: metadata.name
+          value: custom-name-uploads

--- a/chart/hyrax/values.yaml
+++ b/chart/hyrax/values.yaml
@@ -474,6 +474,8 @@ autoscaling:
   # targetMemoryUtilizationPercentage: 80
 
 global:
+  # Set to match nameOverride/fullnameOverride so nginx's uploads mount stays in sync (it can't reach hyrax.fullname).
+  hyraxFullnameOverride: ""
   # These global postgresql values are used by the fcrepo chart
   postgresql:
     auth:


### PR DESCRIPTION
Preparation step for getting nginx mounting defaults working: adds a global hyraxFullnameOverride so that the nginx chart will be able to find the correctly-named PVCs. 

`hyrax.fullname`'s `.Chart.Name` fallback resolves to the wrong chart name when re-rendered inside a subchart's own tpl context (confirmed while working on nginx.extraVolumes — it silently computed `RELEASE-NAME-nginx-uploads` instead of the real PVC name). Adds `global.hyraxFullnameOverride` as an explicit escape hatch and routes the PVC's existing consumers through it; default behavior for anyone not using nameOverride/fullnameOverride is unchanged (verified via test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)