### PR TITLE
Sane defaults for nginx extraVolumes/extraVolumeMounts

### DIFF
--- a/chart/hyrax/tests/nginx_test.yaml
+++ b/chart/hyrax/tests/nginx_test.yaml
@@ -1,0 +1,20 @@
+suite: nginx sane defaults (values.yaml nginx block)
+templates:
+  - charts/nginx/templates/deployment.yaml
+tests:
+  - it: nginx's uploads claimName matches the actual uploads PVC name (hyrax.fullname-uploads)
+    set:
+      nginx.enabled: true
+    asserts:
+      - equal:
+          path: spec.template.spec.volumes[0].persistentVolumeClaim.claimName
+          value: RELEASE-NAME-hyrax-uploads
+
+  - it: stays in sync with the uploads PVC when global.hyraxFullnameOverride is set
+    set:
+      nginx.enabled: true
+      global.hyraxFullnameOverride: custom-name
+    asserts:
+      - equal:
+          path: spec.template.spec.volumes[0].persistentVolumeClaim.claimName
+          value: custom-name-uploads

--- a/chart/hyrax/values.yaml
+++ b/chart/hyrax/values.yaml
@@ -305,25 +305,25 @@ nginx:
   service:
     type: ClusterIP
     port: 80
-  # The set up below does malicious bot / ip blocking and mounts
-  # volumes to allow nginx to server assets and other public directory items
-  # extraVolumes:
-  #   - name: "uploads"
-  #     persistentVolumeClaim:
-  #       claimName: {{ .Values.global.hyraxHostName }}-uploads
-  # extraVolumeMounts:
-  #   - name: uploads
-  #     mountPath: /app/samvera/hyrax-webapp/public/system
-  #     subPath: public-system
-  #   - name: uploads
-  #     mountPath: /app/samvera/hyrax-webapp/public/uploads
-  #     subPath: public-uploads
-  #   - name: uploads
-  #     mountPath: /app/samvera/hyrax-webapp/public/uv
-  #     subPath: public-uv
-  #   - name: uploads
-  #     mountPath: /app/samvera/hyrax-webapp/public/assets
-  #     subPath: public-assets
+  # Mounts volumes to allow nginx to serve assets and other public directory items
+  extraVolumes:
+    - name: "uploads"
+      persistentVolumeClaim:
+        # inlined hyrax.fullname (.Chart.Name is "nginx" here, not "hyrax"); set global.hyraxFullnameOverride to match nameOverride/fullnameOverride.
+        claimName: '{{ .Values.global.hyraxFullnameOverride | default (ternary .Release.Name (printf "%s-hyrax" .Release.Name) (contains "hyrax" .Release.Name)) }}-uploads'
+  extraVolumeMounts:
+    - name: uploads
+      mountPath: /app/samvera/hyrax-webapp/public/system
+      subPath: public-system
+    - name: uploads
+      mountPath: /app/samvera/hyrax-webapp/public/uploads
+      subPath: public-uploads
+    - name: uploads
+      mountPath: /app/samvera/hyrax-webapp/public/uv
+      subPath: public-uv
+    - name: uploads
+      mountPath: /app/samvera/hyrax-webapp/public/assets
+      subPath: public-assets
   # serverBlock: |-
   #   upstream rails_app {
   #     server {{ .Values.global.hyraxHostName }};


### PR DESCRIPTION
Stacked on #7597. Mounts the same uploads PVC the main app already uses (system/uploads/uv/assets), using the previous PR's effectiveFullname override so the claimName can't drift from the real PVC. Does not touch nginx.image — that's stack 1's job (#7595).

🤖 Generated with [Claude Code](https://claude.com/claude-code)