### PR TITLE
Shared prep: fcrepo bump, yamllint fixes, base chart CI

### DIFF
--- a/.github/workflows/chart-test.yml
+++ b/.github/workflows/chart-test.yml
@@ -1,0 +1,46 @@
+name: Chart Test
+run-name: Chart Test of ${{ github.ref_name }} by @${{ github.actor }}
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "chart/**"
+  pull_request:
+    branches:
+      - main
+    paths:
+      - "chart/**"
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint-and-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - uses: azure/setup-helm@v5
+
+      - uses: helm/chart-testing-action@v2.8.0
+
+      # fits is a plain HTTP chart repo (the others are oci://, which don't need this); helm's dependency resolution requires all non-OCI deps pre-registered.
+      - name: Add fits chart repo
+        run: helm repo add fits https://samvera-labs.github.io/fits-charts
+
+      - name: Build chart dependencies
+        run: helm dependency update chart/hyrax
+
+      - name: Run ct lint
+        run: ct lint --chart-dirs chart --target-branch ${{ github.event.repository.default_branch }} --validate-maintainers=false
+
+      - name: Install helm-unittest plugin
+        run: helm plugin install https://github.com/helm-unittest/helm-unittest --verify=false
+
+      - name: Run helm unittest
+        run: helm unittest chart/hyrax

--- a/chart/hyrax/Chart.yaml
+++ b/chart/hyrax/Chart.yaml
@@ -2,11 +2,11 @@ apiVersion: v2
 name: hyrax
 description: An open-source, Samvera-powered digital repository system
 type: application
-version: 3.7.4
+version: 3.7.5
 appVersion: 5.2.0
 dependencies:
   - name: fcrepo
-    version: 2.0.2
+    version: 2.0.3
     repository: oci://ghcr.io/samvera-labs/charts
     condition: fcrepo.enabled
   - name: memcached

--- a/chart/hyrax/values.yaml
+++ b/chart/hyrax/values.yaml
@@ -61,7 +61,7 @@ extraEnvFrom: []
 # Example: (enabling pry debugging for local development)
 # Note: with this enabled, one can `kubectl attach` to a running container with a binding.pry breakpoint
 #
-#extraContainerConfiguration:
+# extraContainerConfiguration:
 # stdin: true
 # tty: true
 extraContainerConfiguration: []
@@ -242,7 +242,7 @@ fcrepo:
 #   ignored if `fits.enabled` is true
 externalFits:
   enabled: false
-  url: "" # existing FITS servlet endpoint
+  url: ""  # existing FITS servlet endpoint
 
 fits:
   enabled: true


### PR DESCRIPTION
Shared prep work for the two either/or nginx approaches (#7603, #7606): fcrepo bump to `2.0.3` (`2.0.1`/`2.0.2` ship a packaging defect breaking `helm dependency update`), two pre-existing yamllint nits, and the base Helm chart CI (`ct lint` + `helm-unittest`, no nginx-specific step). Both option branches will rebase onto this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
