### PR TITLE
Add `select_active_options` method

### DIFF
--- a/app/services/hyrax/authority_service.rb
+++ b/app/services/hyrax/authority_service.rb
@@ -2,8 +2,8 @@
 module Hyrax
   # Shared behavior for authority-backed services. Module-level services
   # (such as {Hyrax::ResourceTypesService}) `extend` this module to gain a
-  # tolerant `label` / `active?` / `include_current_value` API plus the
-  # declarative macros described below.
+  # tolerant `label` / `active?` / `select_active_options` /
+  # `include_current_value` API plus the declarative macros described below.
   #
   # The tolerant methods are intentionally forgiving of off-authority values:
   # `label` falls back to the id itself, `active?` returns false for ids that
@@ -79,6 +79,18 @@ module Hyrax
     def label(id, &block)
       block ||= ->(_key) { id }
       authority.find(id).fetch('term', &block)
+    end
+
+    # @return [Array<Array(String, #to_s)>] the active entries as
+    #   `[label, id]` pairs, for a select input's `collection:`.
+    #
+    # An entry stating no `active` flag is treated as active, matching
+    # {#active?}. Note {Hyrax::QaSelectService} raises `KeyError` on such an
+    # entry instead.
+    def select_active_options
+      authority.all
+               .select { |element| element.fetch('active', true) }
+               .map { |element| [element[:label], element[:id]] }
     end
 
     # @return [Boolean] whether the id is an active entry. Returns false for

--- a/spec/services/hyrax/authority_service_spec.rb
+++ b/spec/services/hyrax/authority_service_spec.rb
@@ -23,6 +23,23 @@ RSpec.describe Hyrax::AuthorityService do
 
   include_examples "a tolerant authority service"
 
+  describe "#select_active_options" do
+    it "omits the inactive terms" do
+      expect(service.select_active_options)
+        .to contain_exactly(['Active Label', 'active-id'],
+                            ['Active No Term', 'active-no-term-id'],
+                            ['No Active Flag Label', 'no-active-flag-id'])
+    end
+
+    it "keeps a term that states no status" do
+      expect(service.select_active_options).to include ['No Active Flag Label', 'no-active-flag-id']
+    end
+
+    it "is available without the authority_name macro" do
+      expect(service).to respond_to(:select_active_options)
+    end
+  end
+
   describe ".authority_name" do
     let(:service) do
       fake_authority = service_authority


### PR DESCRIPTION
## Summary

Defines `select_active_options` on Hyrax::AuthorityService, so a module-level service can filter its inactive terms the way a class-based one already does through Hyrax::QaSelectService.

### Detail

The two halves of the API had drifted: views and helpers call `select_active_options` freely, but only the class-based services defined it, so a service extending the module fell back to `select_all_options` and offered terms marked inactive. It is a plain method rather than one generated by the authority_name macro, so it also reaches a host that supplies its own authority.
