### PR TITLE
Show IIIF viewer when child works are viewable

### DIFF
--- a/app/presenters/hyrax/work_show_presenter.rb
+++ b/app/presenters/hyrax/work_show_presenter.rb
@@ -11,16 +11,11 @@ module Hyrax
     attr_writer :member_presenter_factory
     attr_accessor :solr_document, :current_ability, :request
 
-    class_attribute :collection_presenter_class, :presenter_factory_class, :iiif_viewer_max_child_depth
+    class_attribute :collection_presenter_class, :presenter_factory_class
 
     # modify this attribute to use an alternate presenter class for the collections
     self.collection_presenter_class = CollectionPresenter
     self.presenter_factory_class = MemberPresenterFactory
-
-    # how many member levels #iiif_viewer? descends into when a work has no
-    # representative of its own; bounds the number of Solr queries an empty, deeply
-    # nested collection can trigger to one per direct child
-    self.iiif_viewer_max_child_depth = 1
 
     # @param [SolrDocument] solr_document
     # @param [Ability] current_ability
@@ -375,15 +370,8 @@ module Hyrax
         (av_viewable? || image_viewable? || pdf_viewable?)
     end
 
-    # depth lives in Thread.current, not an ivar, since each recursive call
-    # builds a new presenter instance
     def child_works_viewable?
-      depth = Thread.current[:hyrax_iiif_viewer_child_depth] ||= 0
-      return false if depth >= iiif_viewer_max_child_depth
-      Thread.current[:hyrax_iiif_viewer_child_depth] = depth + 1
-      work_presenters.any?(&:iiif_viewer?)
-    ensure
-      Thread.current[:hyrax_iiif_viewer_child_depth] = depth
+      Hyrax::ViewableChildWorksService.viewable?(solr_document: solr_document, ability: current_ability)
     end
   end
 end

--- a/app/presenters/hyrax/work_show_presenter.rb
+++ b/app/presenters/hyrax/work_show_presenter.rb
@@ -85,10 +85,12 @@ module Hyrax
     end
 
     # @return [Boolean] render a IIIF viewer
-    def iiif_viewer?
-      representative_id.present? &&
-        representative_presenter.present? &&
-        (av_viewable? || image_viewable? || pdf_viewable?)
+    def iiif_viewer?(seen: Set.new)
+      return @iiif_viewer if defined?(@iiif_viewer)
+      @iiif_viewer = (representative_id.present? &&
+                     representative_presenter.present? &&
+                     (av_viewable? || image_viewable? || pdf_viewable?)) ||
+                     child_works_viewable?(seen)
     end
 
     alias universal_viewer? iiif_viewer?
@@ -363,6 +365,13 @@ module Hyrax
     def pdf_viewable?
       return false unless Flipflop.iiif_pdf?
       representative_presenter.pdf?
+    end
+
+    def child_works_viewable?(seen)
+      work_presenters.any? do |presenter|
+        next unless seen.add?(presenter.id)
+        presenter.iiif_viewer?(seen: seen)
+      end
     end
   end
 end

--- a/app/presenters/hyrax/work_show_presenter.rb
+++ b/app/presenters/hyrax/work_show_presenter.rb
@@ -11,11 +11,16 @@ module Hyrax
     attr_writer :member_presenter_factory
     attr_accessor :solr_document, :current_ability, :request
 
-    class_attribute :collection_presenter_class, :presenter_factory_class
+    class_attribute :collection_presenter_class, :presenter_factory_class, :iiif_viewer_max_child_depth
 
     # modify this attribute to use an alternate presenter class for the collections
     self.collection_presenter_class = CollectionPresenter
     self.presenter_factory_class = MemberPresenterFactory
+
+    # how many member levels #iiif_viewer? descends into when a work has no
+    # representative of its own; bounds the number of Solr queries an empty, deeply
+    # nested collection can trigger to one per direct child
+    self.iiif_viewer_max_child_depth = 1
 
     # @param [SolrDocument] solr_document
     # @param [Ability] current_ability
@@ -85,12 +90,9 @@ module Hyrax
     end
 
     # @return [Boolean] render a IIIF viewer
-    def iiif_viewer?(seen: Set.new)
+    def iiif_viewer?
       return @iiif_viewer if defined?(@iiif_viewer)
-      @iiif_viewer = (representative_id.present? &&
-                     representative_presenter.present? &&
-                     (av_viewable? || image_viewable? || pdf_viewable?)) ||
-                     child_works_viewable?(seen)
+      @iiif_viewer = representative_viewable? || child_works_viewable?
     end
 
     alias universal_viewer? iiif_viewer?
@@ -367,11 +369,21 @@ module Hyrax
       representative_presenter.pdf?
     end
 
-    def child_works_viewable?(seen)
-      work_presenters.any? do |presenter|
-        next unless seen.add?(presenter.id)
-        presenter.iiif_viewer?(seen: seen)
-      end
+    def representative_viewable?
+      representative_id.present? &&
+        representative_presenter.present? &&
+        (av_viewable? || image_viewable? || pdf_viewable?)
+    end
+
+    # depth lives in Thread.current, not an ivar, since each recursive call
+    # builds a new presenter instance
+    def child_works_viewable?
+      depth = Thread.current[:hyrax_iiif_viewer_child_depth] ||= 0
+      return false if depth >= iiif_viewer_max_child_depth
+      Thread.current[:hyrax_iiif_viewer_child_depth] = depth + 1
+      work_presenters.any?(&:iiif_viewer?)
+    ensure
+      Thread.current[:hyrax_iiif_viewer_child_depth] = depth
     end
   end
 end

--- a/app/services/hyrax/viewable_child_works_service.rb
+++ b/app/services/hyrax/viewable_child_works_service.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+module Hyrax
+  ##
+  # Answers whether any direct member of a work has a representative the
+  # user can see in a IIIF viewer, with a single Solr query.
+  class ViewableChildWorksService
+    ##
+    # @param solr_document [::SolrDocument] the work's solr document
+    # @param ability [::Ability] the current user's ability
+    #
+    # @return [Boolean]
+    def self.viewable?(solr_document:, ability:)
+      new(solr_document: solr_document, ability: ability).viewable?
+    end
+
+    attr_reader :solr_document, :ability, :solr_service
+
+    def initialize(solr_document:, ability:, solr_service: Hyrax::SolrService)
+      @solr_document = solr_document
+      @ability = ability
+      @solr_service = solr_service
+    end
+
+    # @return [Boolean]
+    def viewable?
+      return false if viewable_mime_filter.empty? || member_ids.empty?
+
+      viewable_member_count.positive?
+    end
+
+    private
+
+    def member_ids
+      @member_ids ||= Array(solr_document.member_ids)
+    end
+
+    def viewable_member_count
+      solr_service.query_result(join_query, fq: filter_queries, rows: 0)
+                  .dig('response', 'numFound')
+    end
+
+    def join_query
+      "{!join from=hasRelatedMediaFragment_ssim to=id cache=false}{!terms f=id}#{member_ids.join(',')}"
+    end
+
+    def filter_queries
+      [viewable_mime_filter, access_query]
+    end
+
+    def access_query
+      Hyrax::SolrQueryService.new(query: ['*:*']).accessible_by(ability: ability).build
+    end
+
+    def viewable_mime_filter
+      @viewable_mime_filter ||= [image_clause, av_clause, pdf_clause].compact.join(' OR ')
+    end
+
+    def image_clause
+      'mime_type_ssi:image\/*' if Hyrax.config.iiif_image_server?
+    end
+
+    def av_clause
+      'mime_type_ssi:audio\/* OR mime_type_ssi:video\/*' if Flipflop.iiif_av?
+    end
+
+    def pdf_clause
+      'mime_type_ssi:application\/pdf' if Flipflop.iiif_pdf?
+    end
+  end
+end

--- a/app/views/hyrax/base/_representative_media.html.erb
+++ b/app/views/hyrax/base/_representative_media.html.erb
@@ -1,9 +1,7 @@
-<% if presenter.representative_id.present? && presenter.representative_presenter.present? %>
-  <% if defined?(viewer) && viewer %>
-    <%= iiif_viewer_display presenter %>
-  <% else %>
-    <%= render media_display_partial(presenter.representative_presenter), file_set: presenter.representative_presenter  %>
-  <% end %>
+<% if defined?(viewer) && viewer %>
+  <%= iiif_viewer_display presenter %>
+<% elsif presenter.representative_id.present? && presenter.representative_presenter.present? %>
+  <%= render media_display_partial(presenter.representative_presenter), file_set: presenter.representative_presenter %>
 <% else %>
   <%= image_tag 'default.png', class: "canonical-image", alt: 'default representative image' %>
 <% end %>

--- a/spec/presenters/hyrax/work_show_presenter_spec.rb
+++ b/spec/presenters/hyrax/work_show_presenter_spec.rb
@@ -141,6 +141,26 @@ RSpec.describe Hyrax::WorkShowPresenter do
           expect(member_presenter_factory).to have_received(:work_presenters).once
         end
       end
+
+      context 'and the child presenter overrides #iiif_viewer? with the legacy zero-arg signature' do
+        # e.g. Hyrax::IiifAv::DisplaysIiifAv from the hyrax-iiif_av gem
+        let(:child_presenter_class) do
+          Class.new do
+            def id
+              'child-1'
+            end
+
+            def iiif_viewer?
+              true
+            end
+          end
+        end
+        let(:child_presenter) { child_presenter_class.new }
+
+        it 'does not raise ArgumentError' do
+          expect { presenter.iiif_viewer? }.not_to raise_error
+        end
+      end
     end
 
     context 'with non-image representative_presenter' do
@@ -261,6 +281,26 @@ RSpec.describe Hyrax::WorkShowPresenter do
 
       it 'terminates and is false when neither work has viewable content' do
         expect(presenter.iiif_viewer?).to be false
+      end
+    end
+
+    context 'when a parent has several children with no viewable content of their own' do
+      let(:ability) { double(Ability, can?: true) }
+      let(:children) { Array.new(3) { |i| FactoryBot.valkyrie_create(:monograph, title: ["Child #{i}"]) } }
+      let(:work) { FactoryBot.valkyrie_create(:monograph, title: ['Parent'], members: children) }
+      let(:solr_document) { SolrDocument.new(Hyrax::ValkyrieIndexer.for(resource: work).to_solr) }
+
+      it 'issues a single Solr query naming every child work, not one per child' do
+        queries = []
+        allow(Hyrax::SolrService).to receive(:post).and_wrap_original do |original, query, **opts|
+          queries << query
+          original.call(query, **opts)
+        end
+
+        presenter.iiif_viewer?
+
+        expect(queries.size).to eq(1)
+        children.each { |child| expect(queries.first).to include(child.id) }
       end
     end
   end

--- a/spec/presenters/hyrax/work_show_presenter_spec.rb
+++ b/spec/presenters/hyrax/work_show_presenter_spec.rb
@@ -82,7 +82,7 @@ RSpec.describe Hyrax::WorkShowPresenter do
     let(:iiif_enabled) { true }
     let(:file_set_presenter) { double(Hyrax::FileSetPresenter, id: '888888', image?: true) }
     let(:file_set_presenters) { [file_set_presenter] }
-    let(:member_presenter_factory) { instance_double(Hyrax::MemberPresenterFactory, work_presenters: []) }
+    let(:member_presenter_factory) { instance_double(Hyrax::MemberPresenterFactory) }
     let(:read_permission) { true }
     let(:representative_present) { false }
 
@@ -122,43 +122,26 @@ RSpec.describe Hyrax::WorkShowPresenter do
 
     context 'with no representative but viewable child works' do
       let(:representative_id) { nil }
-      let(:child_presenter) { double('child work presenter', id: 'child-1', iiif_viewer?: true) }
+      let(:ability) { Ability.new(nil) }
+      let(:attributes) { super().merge('member_ids_ssim' => ['child-1']) }
+      let(:viewable_count) { 1 }
 
       before do
-        allow(member_presenter_factory).to receive(:work_presenters).and_return([child_presenter])
+        allow(Hyrax::SolrService).to receive(:query_result)
+          .and_return('response' => { 'numFound' => viewable_count })
       end
 
       it { is_expected.to be true }
 
       context 'and no child work is viewable' do
-        let(:child_presenter) { double('child work presenter', id: 'child-1', iiif_viewer?: false) }
+        let(:viewable_count) { 0 }
 
         it { is_expected.to be false }
 
         it 'memoizes the result, even a false one' do
           2.times { presenter.iiif_viewer? }
 
-          expect(member_presenter_factory).to have_received(:work_presenters).once
-        end
-      end
-
-      context 'and the child presenter overrides #iiif_viewer? with the legacy zero-arg signature' do
-        # e.g. Hyrax::IiifAv::DisplaysIiifAv from the hyrax-iiif_av gem
-        let(:child_presenter_class) do
-          Class.new do
-            def id
-              'child-1'
-            end
-
-            def iiif_viewer?
-              true
-            end
-          end
-        end
-        let(:child_presenter) { child_presenter_class.new }
-
-        it 'does not raise ArgumentError' do
-          expect { presenter.iiif_viewer? }.not_to raise_error
+          expect(Hyrax::SolrService).to have_received(:query_result).once
         end
       end
     end
@@ -244,7 +227,7 @@ RSpec.describe Hyrax::WorkShowPresenter do
       let(:representative_presenter) do
         double('representative', present?: true, image?: false, audio?: false, video?: false, pdf?: true)
       end
-      let(:member_presenter_factory) { instance_double(Hyrax::MemberPresenterFactory, work_presenters: []) }
+      let(:member_presenter_factory) { instance_double(Hyrax::MemberPresenterFactory) }
 
       before do
         presenter.member_presenter_factory = member_presenter_factory
@@ -269,7 +252,7 @@ RSpec.describe Hyrax::WorkShowPresenter do
 
   describe '#iiif_viewer?', :clean_repo do
     context 'when a parent work and child work are members of each other' do
-      let(:ability) { double(Ability, can?: true) }
+      let(:ability) { Ability.new(nil) }
       let(:child_work) { FactoryBot.valkyrie_create(:monograph, title: ['Child']) }
       let(:work) do
         FactoryBot.valkyrie_create(:monograph, title: ['Parent'], members: [child_work]).tap do |parent|
@@ -285,22 +268,22 @@ RSpec.describe Hyrax::WorkShowPresenter do
     end
 
     context 'when a parent has several children with no viewable content of their own' do
-      let(:ability) { double(Ability, can?: true) }
+      let(:ability) { Ability.new(nil) }
       let(:children) { Array.new(3) { |i| FactoryBot.valkyrie_create(:monograph, title: ["Child #{i}"]) } }
       let(:work) { FactoryBot.valkyrie_create(:monograph, title: ['Parent'], members: children) }
       let(:solr_document) { SolrDocument.new(Hyrax::ValkyrieIndexer.for(resource: work).to_solr) }
 
       it 'issues a single Solr query naming every child work, not one per child' do
         queries = []
-        allow(Hyrax::SolrService).to receive(:post).and_wrap_original do |original, query, **opts|
-          queries << query
+        allow(Hyrax::SolrService).to receive(:query_result).and_wrap_original do |original, query, **opts|
+          queries << opts.merge(q: query)
           original.call(query, **opts)
         end
 
         presenter.iiif_viewer?
 
         expect(queries.size).to eq(1)
-        children.each { |child| expect(queries.first).to include(child.id) }
+        children.each { |child| expect(queries.first[:q]).to include(child.id.to_s) }
       end
     end
   end

--- a/spec/presenters/hyrax/work_show_presenter_spec.rb
+++ b/spec/presenters/hyrax/work_show_presenter_spec.rb
@@ -82,7 +82,7 @@ RSpec.describe Hyrax::WorkShowPresenter do
     let(:iiif_enabled) { true }
     let(:file_set_presenter) { double(Hyrax::FileSetPresenter, id: '888888', image?: true) }
     let(:file_set_presenters) { [file_set_presenter] }
-    let(:member_presenter_factory) { instance_double(Hyrax::MemberPresenterFactory) }
+    let(:member_presenter_factory) { instance_double(Hyrax::MemberPresenterFactory, work_presenters: []) }
     let(:read_permission) { true }
     let(:representative_present) { false }
 
@@ -118,6 +118,29 @@ RSpec.describe Hyrax::WorkShowPresenter do
       let(:representative_id) { 'representative-123' }
 
       it { is_expected.to be false }
+    end
+
+    context 'with no representative but viewable child works' do
+      let(:representative_id) { nil }
+      let(:child_presenter) { double('child work presenter', id: 'child-1', iiif_viewer?: true) }
+
+      before do
+        allow(member_presenter_factory).to receive(:work_presenters).and_return([child_presenter])
+      end
+
+      it { is_expected.to be true }
+
+      context 'and no child work is viewable' do
+        let(:child_presenter) { double('child work presenter', id: 'child-1', iiif_viewer?: false) }
+
+        it { is_expected.to be false }
+
+        it 'memoizes the result, even a false one' do
+          2.times { presenter.iiif_viewer? }
+
+          expect(member_presenter_factory).to have_received(:work_presenters).once
+        end
+      end
     end
 
     context 'with non-image representative_presenter' do
@@ -201,7 +224,7 @@ RSpec.describe Hyrax::WorkShowPresenter do
       let(:representative_presenter) do
         double('representative', present?: true, image?: false, audio?: false, video?: false, pdf?: true)
       end
-      let(:member_presenter_factory) { instance_double(Hyrax::MemberPresenterFactory) }
+      let(:member_presenter_factory) { instance_double(Hyrax::MemberPresenterFactory, work_presenters: []) }
 
       before do
         presenter.member_presenter_factory = member_presenter_factory
@@ -220,6 +243,24 @@ RSpec.describe Hyrax::WorkShowPresenter do
         end
 
         it { is_expected.to be false }
+      end
+    end
+  end
+
+  describe '#iiif_viewer?', :clean_repo do
+    context 'when a parent work and child work are members of each other' do
+      let(:ability) { double(Ability, can?: true) }
+      let(:child_work) { FactoryBot.valkyrie_create(:monograph, title: ['Child']) }
+      let(:work) do
+        FactoryBot.valkyrie_create(:monograph, title: ['Parent'], members: [child_work]).tap do |parent|
+          child_work.member_ids += [parent.id]
+          Hyrax.index_adapter.save(resource: Hyrax.persister.save(resource: child_work))
+        end
+      end
+      let(:solr_document) { SolrDocument.new(Hyrax::ValkyrieIndexer.for(resource: work).to_solr) }
+
+      it 'terminates and is false when neither work has viewable content' do
+        expect(presenter.iiif_viewer?).to be false
       end
     end
   end

--- a/spec/services/hyrax/viewable_child_works_service_spec.rb
+++ b/spec/services/hyrax/viewable_child_works_service_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+RSpec.describe Hyrax::ViewableChildWorksService do
+  subject(:service) { described_class.new(solr_document: solr_document, ability: ability) }
+
+  let(:solr_document) { SolrDocument.new('id' => 'parent', 'member_ids_ssim' => member_ids) }
+  let(:member_ids) { ['child-1', 'child-2'] }
+  let(:ability) { Ability.new(nil) }
+  let(:num_found) { 1 }
+
+  before do
+    allow(Hyrax.config).to receive(:iiif_image_server?).and_return(true)
+    allow(Hyrax::SolrService).to receive(:query_result)
+      .and_return('response' => { 'numFound' => num_found })
+  end
+
+  describe '#viewable?' do
+    it { expect(service.viewable?).to be true }
+
+    it 'asks Solr once, naming every member in one query' do
+      service.viewable?
+
+      expect(Hyrax::SolrService).to have_received(:query_result)
+        .once
+        .with(a_string_including('{!terms f=id}child-1,child-2'), hash_including(rows: 0))
+    end
+
+    context 'when no member has a viewable representative' do
+      let(:num_found) { 0 }
+
+      it { expect(service.viewable?).to be false }
+    end
+
+    context 'when the work has no members' do
+      let(:member_ids) { [] }
+
+      it 'is false without querying Solr' do
+        expect(service.viewable?).to be false
+        expect(Hyrax::SolrService).not_to have_received(:query_result)
+      end
+    end
+
+    context 'when no media type is viewable' do
+      before do
+        allow(Hyrax.config).to receive(:iiif_image_server?).and_return(false)
+        allow(Flipflop).to receive(:iiif_av?).and_return(false)
+        allow(Flipflop).to receive(:iiif_pdf?).and_return(false)
+      end
+
+      it 'is false without querying Solr' do
+        expect(service.viewable?).to be false
+        expect(Hyrax::SolrService).not_to have_received(:query_result)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Screenshot
<img width="1132" height="817" alt="image" src="https://github.com/user-attachments/assets/7e9c7b03-b3a7-482f-9b9f-b265e03399ba" />

## Collection Manifests

### V2

<img width="1128" height="444" alt="image" src="https://github.com/user-attachments/assets/b2ba017e-a35f-4151-bf07-e98d6fc0b882" />

### V3

<img width="1049" height="470" alt="image" src="https://github.com/user-attachments/assets/bb84827b-14c3-45ea-b0af-98a0f82a39e1" />


## Summary

Previously, if we had an empty parent work that holds child works with viewable content, the IIIF manifest that gets created is a Collection manifest.  The manifest is viewable but Hyrax view logic did not render the IIIF viewer.  This commit will make it so that a viewer does render and child works are viewable, albeit through a Collection manifest.

---
_**🤖 Assisted-by: Opus 5**_