### PR TITLE
Add child iiif viewer regression tests & fixes

### DIFF
--- a/app/presenters/hyrax/work_show_presenter.rb
+++ b/app/presenters/hyrax/work_show_presenter.rb
@@ -11,11 +11,16 @@ module Hyrax
     attr_writer :member_presenter_factory
     attr_accessor :solr_document, :current_ability, :request
 
-    class_attribute :collection_presenter_class, :presenter_factory_class
+    class_attribute :collection_presenter_class, :presenter_factory_class, :iiif_viewer_max_child_depth
 
     # modify this attribute to use an alternate presenter class for the collections
     self.collection_presenter_class = CollectionPresenter
     self.presenter_factory_class = MemberPresenterFactory
+
+    # how many member levels #iiif_viewer? descends into when a work has no
+    # representative of its own; bounds the number of Solr queries an empty, deeply
+    # nested collection can trigger to one per direct child
+    self.iiif_viewer_max_child_depth = 1
 
     # @param [SolrDocument] solr_document
     # @param [Ability] current_ability
@@ -85,12 +90,9 @@ module Hyrax
     end
 
     # @return [Boolean] render a IIIF viewer
-    def iiif_viewer?(seen: Set.new)
+    def iiif_viewer?
       return @iiif_viewer if defined?(@iiif_viewer)
-      @iiif_viewer = (representative_id.present? &&
-                     representative_presenter.present? &&
-                     (av_viewable? || image_viewable? || pdf_viewable?)) ||
-                     child_works_viewable?(seen)
+      @iiif_viewer = representative_viewable? || child_works_viewable?
     end
 
     alias universal_viewer? iiif_viewer?
@@ -367,11 +369,21 @@ module Hyrax
       representative_presenter.pdf?
     end
 
-    def child_works_viewable?(seen)
-      work_presenters.any? do |presenter|
-        next unless seen.add?(presenter.id)
-        presenter.iiif_viewer?(seen: seen)
-      end
+    def representative_viewable?
+      representative_id.present? &&
+        representative_presenter.present? &&
+        (av_viewable? || image_viewable? || pdf_viewable?)
+    end
+
+    # depth lives in Thread.current, not an ivar, since each recursive call
+    # builds a new presenter instance
+    def child_works_viewable?
+      depth = Thread.current[:hyrax_iiif_viewer_child_depth] ||= 0
+      return false if depth >= iiif_viewer_max_child_depth
+      Thread.current[:hyrax_iiif_viewer_child_depth] = depth + 1
+      work_presenters.any?(&:iiif_viewer?)
+    ensure
+      Thread.current[:hyrax_iiif_viewer_child_depth] = depth
     end
   end
 end

--- a/spec/presenters/hyrax/work_show_presenter_spec.rb
+++ b/spec/presenters/hyrax/work_show_presenter_spec.rb
@@ -141,6 +141,26 @@ RSpec.describe Hyrax::WorkShowPresenter do
           expect(member_presenter_factory).to have_received(:work_presenters).once
         end
       end
+
+      context 'and the child presenter overrides #iiif_viewer? with the legacy zero-arg signature' do
+        # e.g. Hyrax::IiifAv::DisplaysIiifAv from the hyrax-iiif_av gem
+        let(:child_presenter_class) do
+          Class.new do
+            def id
+              'child-1'
+            end
+
+            def iiif_viewer?
+              true
+            end
+          end
+        end
+        let(:child_presenter) { child_presenter_class.new }
+
+        it 'does not raise ArgumentError' do
+          expect { presenter.iiif_viewer? }.not_to raise_error
+        end
+      end
     end
 
     context 'with non-image representative_presenter' do
@@ -261,6 +281,26 @@ RSpec.describe Hyrax::WorkShowPresenter do
 
       it 'terminates and is false when neither work has viewable content' do
         expect(presenter.iiif_viewer?).to be false
+      end
+    end
+
+    context 'when a parent has several children with no viewable content of their own' do
+      let(:ability) { double(Ability, can?: true) }
+      let(:children) { Array.new(3) { |i| FactoryBot.valkyrie_create(:monograph, title: ["Child #{i}"]) } }
+      let(:work) { FactoryBot.valkyrie_create(:monograph, title: ['Parent'], members: children) }
+      let(:solr_document) { SolrDocument.new(Hyrax::ValkyrieIndexer.for(resource: work).to_solr) }
+
+      it 'issues a single Solr query naming every child work, not one per child' do
+        queries = []
+        allow(Hyrax::SolrService).to receive(:post).and_wrap_original do |original, query, **opts|
+          queries << query
+          original.call(query, **opts)
+        end
+
+        presenter.iiif_viewer?
+
+        expect(queries.size).to eq(1)
+        children.each { |child| expect(queries.first).to include(child.id) }
       end
     end
   end


### PR DESCRIPTION
@kirkkwang - tests that fail for the right reasons

- One checks for other child presenters that haven't had their signature `iiif_viewer?` updated
- Other checks for N+1 Solr query problem - if a work has many children, this would flood Solr with tons of queries. 