### PR TITLE
Dropdown item on anchor

### DIFF
--- a/app/assets/javascripts/hyrax/trophy.js
+++ b/app/assets/javascripts/hyrax/trophy.js
@@ -25,10 +25,12 @@ function trophyOff(anchor) {
     } else {
         setAnchorAttrs(anchor, 'Highlight work', 'add-text');
     }
+    $('#document_' + gid + ' .highlighted-work').removeClass('fa-star highlighted-work').addClass('fa-star-o trophy-off');
 }
 
 function trophyOn(anchor) {
     setAnchorAttrs(anchor, 'Unhighlight work', 'remove-text');
+    $('#document_' + gid + ' .fa-star-o').removeClass('fa-star-o trophy-off').addClass('fa-star highlighted-work');
 }
 
 function setAnchorAttrs(anchor, title, data) {

--- a/app/helpers/hyrax/trophy_helper.rb
+++ b/app/helpers/hyrax/trophy_helper.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 module Hyrax
   module TrophyHelper
+    # rubocop:disable Metrics/AbcSize
     def display_trophy_link(user, id, args = {}, &_block)
       return unless user
       trophy = user.trophies.where(work_id: id).exists?
@@ -15,10 +16,10 @@ module Hyrax
       args[:data]['remove-text'] = args[:remove_text]
 
       args[:data][:url] = hyrax.trophy_work_path(id)
-      link_to '#', id: 'action-highlight-work', role: args[:role], class: args[:class], data: args[:data] do
+      link_to '#', id: 'action-highlight-work', role: args[:role], tabindex: args[:tabindex], class: args[:class], data: args[:data] do
         yield(text)
       end
     end
-    # rubocop:enable Metrics/MethodLength
+    # rubocop:enable Metrics/AbcSize
   end
 end

--- a/app/views/hyrax/base/_citations.html.erb
+++ b/app/views/hyrax/base/_citations.html.erb
@@ -7,10 +7,10 @@
       <button type="button" class="btn btn-secondary btn-sm dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
         <%= t('.header') %>
       </button>
-      <ul class="dropdown-menu">
-        <li class="dropdown-item"><%= link_to t('.endnote'), polymorphic_path([main_app, presenter], format: 'endnote') %></li>
-        <li class="dropdown-item"><%= link_to t('.zotero'), hyrax.zotero_path, id: 'zoteroLink', name: 'zotero' %></li>
-        <li class="dropdown-item"><%= link_to t('.mendeley'), hyrax.mendeley_path, id: 'mendeleyLink', name: 'mendeley' %></li>
-      </ul>
+      <div class="dropdown-menu">
+        <%= link_to t('.endnote'), polymorphic_path([main_app, presenter], format: 'endnote'), class: 'dropdown-item' %>
+        <%= link_to t('.zotero'), hyrax.zotero_path, id: 'zoteroLink', name: 'zotero', class: 'dropdown-item' %>
+        <%= link_to t('.mendeley'), hyrax.mendeley_path, id: 'mendeleyLink', name: 'mendeley', class: 'dropdown-item' %>
+      </div>
     </div>
 </div>

--- a/app/views/hyrax/dashboard/collections/_show_document_list_menu.html.erb
+++ b/app/views/hyrax/dashboard/collections/_show_document_list_menu.html.erb
@@ -13,10 +13,10 @@
         </li>
       <% end %>
     <% end %>
-    <%= display_trophy_link(current_user, document.id, role: 'menuitem') do |text| %>
-      <li class="dropdown-item">
+    <li role="presentation">
+      <%= display_trophy_link(current_user, document.id, class: 'dropdown-item', role: 'menuitem', tabindex: -1) do |text| %>
         <i class="fa fa-star" aria-hidden="true"></i> <%= text %>
-      </li>
-    <% end %>
+      <% end %>
+    </li>
   </ul>
 </div>

--- a/app/views/hyrax/dashboard/collections/_show_document_list_menu.html.erb
+++ b/app/views/hyrax/dashboard/collections/_show_document_list_menu.html.erb
@@ -3,15 +3,16 @@
   </button>
   <ul class="dropdown-menu dropdown-menu-right" role="menu">
     <% if can?( :edit, document ) && !workflow_restriction?(@presenter) %>
-      <%= link_to [main_app, :edit, document],
-                  class: "itemicon itemedit",
-                  role: 'menuitem',
-                  title: t('hyrax.collection.document_list.edit'),
-                  id: "edit_work_link_#{document.id}" do %>
-        <li class="dropdown-item">
+      <li role="presentation">
+        <%= link_to [main_app, :edit, document],
+                    class: "dropdown-item itemicon itemedit",
+                    role: 'menuitem',
+                    tabindex: -1,
+                    title: t('hyrax.collection.document_list.edit'),
+                    id: "edit_work_link_#{document.id}" do %>
           <i class="fa fa-pencil" aria-hidden="true"></i> <%= t('hyrax.collection.document_list.edit') %>
-        </li>
-      <% end %>
+        <% end %>
+      </li>
     <% end %>
     <li role="presentation">
       <%= display_trophy_link(current_user, document.id, class: 'dropdown-item', role: 'menuitem', tabindex: -1) do |text| %>

--- a/app/views/hyrax/file_sets/_actions.html.erb
+++ b/app/views/hyrax/file_sets/_actions.html.erb
@@ -16,40 +16,43 @@
 
     <ul role="menu" class="dropdown-menu dropdown-menu-right" aria-labelledby="dropdownMenu_<%= file_set.id %>">
     <% if can?(:edit, file_set.id) %>
-      <li class="dropdown-item" role="menuitem" tabindex="-1">
+      <li role="presentation">
         <%= link_to t('.edit'), edit_polymorphic_path([main_app, file_set]),
-          { title: t('.edit_title', file_set: file_set) } %>
+          { class: 'dropdown-item', role: 'menuitem', tabindex: -1, title: t('.edit_title', file_set: file_set) } %>
       </li>
 
-      <li class="dropdown-item" role="menuitem" tabindex="-1">
+      <li role="presentation">
         <%= link_to t('.versions'),  edit_polymorphic_path([main_app, file_set], anchor: 'versioning_display'),
-          { title: t('.versions_title') } %>
+          { class: 'dropdown-item', role: 'menuitem', tabindex: -1, title: t('.versions_title') } %>
       </li>
     <% end %>
 
     <% if can?(:destroy, file_set.id) %>
-      <li class="dropdown-item" role="menuitem" tabindex="-1">
+      <li role="presentation">
         <%= link_to t('.delete'), polymorphic_path([main_app, file_set]),
-          method: :delete, title: t('.delete_title', file_set: file_set),
+          method: :delete, class: 'dropdown-item', role: 'menuitem', tabindex: -1,
+          title: t('.delete_title', file_set: file_set),
           data: { confirm: t('.delete_confirm', file_set: file_set, application_name: application_name) } %>
       </li>
     <% end %>
 
     <% if can?(:download, file_set.id) %>
-      <li class="dropdown-item" role="menuitem" tabindex="-1">
+      <li role="presentation">
         <%= link_to t('.download'),
                     hyrax.download_path(file_set),
                     title: t('.download_title', file_set: file_set),
                     target: "_blank",
                     id: "file_download",
-                    class: "download",
+                    class: "dropdown-item download",
+                    role: 'menuitem',
+                    tabindex: -1,
                     data: { label: file_set.id, work_id: @presenter.id, collection_ids: @presenter.member_of_collection_ids } %>
       </li>
 
       <% file_set.extensions_and_mime_types&.each do |hash| %>
         <% next unless hash[:name] %>
-        <li class ="dropdown-item" role="menuitem" tabindex="-1">
-          <a href="<%= download_url(id: file_set.id, locale: 'en', file: hash[:name], mime_type: hash[:mime_type]) %>" download>
+        <li role="presentation">
+          <a class="dropdown-item" role="menuitem" tabindex="-1" href="<%= download_url(id: file_set.id, locale: 'en', file: hash[:name], mime_type: hash[:mime_type]) %>" download>
             Download <em>(as <%= hash[:name] %>)</em>
           </a>
         </li>

--- a/app/views/hyrax/my/_admin_set_action_menu.html.erb
+++ b/app/views/hyrax/my/_admin_set_action_menu.html.erb
@@ -7,43 +7,47 @@
     <%= t("hyrax.dashboard.my.action.select") %>
   </button>
   <ul role="menu" id="<%= ul_id %>" class="dropdown-menu dropdown-menu-right" aria-labelledby="dropdownMenu_<%= id %>">
-    <%= link_to hyrax.admin_admin_set_path(id),
-                class: 'itemicon itemedit',
-                role: 'menuitem',
-                title: t("hyrax.dashboard.my.action.view_admin_set") do %>
-      <li class="dropdown-item" tabindex="-1">
+    <li role="presentation">
+      <%= link_to hyrax.admin_admin_set_path(id),
+                  class: 'dropdown-item itemicon itemedit',
+                  role: 'menuitem',
+                  tabindex: -1,
+                  title: t("hyrax.dashboard.my.action.view_admin_set") do %>
         <%= t("hyrax.dashboard.my.action.view_admin_set") %>
-      </li>
-    <% end %>
+      <% end %>
+    </li>
     <% if can? :edit, admin_set_presenter.solr_document %>
-      <%= link_to hyrax.edit_admin_admin_set_path(id),
-                  class: 'itemicon itemedit',
-                  role: 'menuitem',
-                  title: t("hyrax.dashboard.my.action.edit_admin_set") do %>
-        <li class="dropdown-item" tabindex="-1">
+      <li role="presentation">
+        <%= link_to hyrax.edit_admin_admin_set_path(id),
+                    class: 'dropdown-item itemicon itemedit',
+                    role: 'menuitem',
+                    tabindex: -1,
+                    title: t("hyrax.dashboard.my.action.edit_admin_set") do %>
           <%= t("hyrax.dashboard.my.action.edit_admin_set") %>
-        </li>
-      <% end %>
+        <% end %>
+      </li>
     <% else %>
-      <%= link_to "#",
-                  class: 'itemicon itemedit edit-collection-deny-button',
-                  role: 'menuitem',
-                  title: t("hyrax.dashboard.my.action.edit_collection") do %>
-        <li class="dropdown-item" tabindex="-1">
+      <li role="presentation">
+        <%= link_to "#",
+                    class: 'dropdown-item itemicon itemedit edit-collection-deny-button',
+                    role: 'menuitem',
+                    tabindex: -1,
+                    title: t("hyrax.dashboard.my.action.edit_collection") do %>
           <%= t("hyrax.dashboard.my.action.edit_collection") %>
-        </li>
-      <% end %>
-    <% end %>
-    <%= link_to "#",
-                class: 'itemicon itemtrash delete-collection-button',
-                role: 'menuitem',
-                title: t("hyrax.dashboard.my.action.delete_admin_set"),
-                data: { totalitems: admin_set_presenter.total_items,
-                        membership: admin_set_presenter.collection_type_is_require_membership?,
-                        hasaccess: (can?(:edit, admin_set_presenter.solr_document)) } do %>
-      <li class="dropdown-item" tabindex="-1">
-        <%= t("hyrax.dashboard.my.action.delete_admin_set") %>
+        <% end %>
       </li>
     <% end %>
+    <li role="presentation">
+      <%= link_to "#",
+                  class: 'dropdown-item itemicon itemtrash delete-collection-button',
+                  role: 'menuitem',
+                  tabindex: -1,
+                  title: t("hyrax.dashboard.my.action.delete_admin_set"),
+                  data: { totalitems: admin_set_presenter.total_items,
+                          membership: admin_set_presenter.collection_type_is_require_membership?,
+                          hasaccess: (can?(:edit, admin_set_presenter.solr_document)) } do %>
+        <%= t("hyrax.dashboard.my.action.delete_admin_set") %>
+      <% end %>
+    </li>
   </ul>
 </div>

--- a/app/views/hyrax/my/_collection_action_menu.html.erb
+++ b/app/views/hyrax/my/_collection_action_menu.html.erb
@@ -7,57 +7,62 @@
     <%= t("hyrax.dashboard.my.action.select") %>
   </button>
   <ul role="menu" id="<%= ul_id %>" class="dropdown-menu dropdown-menu-right" aria-labelledby="dropdownMenu_<%= id %>">
-    <%= link_to hyrax.dashboard_collection_path(id),
-                class: 'itemicon itemedit',
-                role: 'menuitem',
-                title: t("hyrax.dashboard.my.action.view_collection") do %>
-      <li class="dropdown-item" tabindex="-1">
+    <li role="presentation">
+      <%= link_to hyrax.dashboard_collection_path(id),
+                  class: 'dropdown-item itemicon itemedit',
+                  role: 'menuitem',
+                  tabindex: -1,
+                  title: t("hyrax.dashboard.my.action.view_collection") do %>
         <%= t("hyrax.dashboard.my.action.view_collection") %>
-      </li>
-    <% end %>
+      <% end %>
+    </li>
     <% if can? :edit, collection_presenter.solr_document %>
-      <%= link_to hyrax.edit_dashboard_collection_path(id),
-                  class: 'itemicon itemedit',
-                  role: 'menuitem',
-                  title: t("hyrax.dashboard.my.action.edit_collection")  do %>
-        <li class="dropdown-item" tabindex="-1">
+      <li role="presentation">
+        <%= link_to hyrax.edit_dashboard_collection_path(id),
+                    class: 'dropdown-item itemicon itemedit',
+                    role: 'menuitem',
+                    tabindex: -1,
+                    title: t("hyrax.dashboard.my.action.edit_collection") do %>
           <%= t("hyrax.dashboard.my.action.edit_collection") %>
-        </li>
-      <% end %>
+        <% end %>
+      </li>
     <% else %>
-      <%= link_to "#",
-                  class: 'itemicon itemedit edit-collection-deny-button',
-                  role: 'menuitem',
-                  title: t("hyrax.dashboard.my.action.edit_collection") do %>
-        <li class="dropdown-item" tabindex="-1">
+      <li role="presentation">
+        <%= link_to "#",
+                    class: 'dropdown-item itemicon itemedit edit-collection-deny-button',
+                    role: 'menuitem',
+                    tabindex: -1,
+                    title: t("hyrax.dashboard.my.action.edit_collection") do %>
           <%= t("hyrax.dashboard.my.action.edit_collection") %>
-        </li>
-      <% end %>
-    <% end %>
-    <%= link_to "#",
-                class: 'itemicon itemtrash delete-collection-button',
-                role: 'menuitem',
-                title: t("hyrax.dashboard.my.action.delete_collection"),
-                data: { totalitems: collection_presenter.total_items ,
-                        membership: collection_presenter.collection_type_is_require_membership? ,
-                        hasaccess: (can?(:edit, collection_presenter.solr_document)) } do %>
-      <li class="dropdown-item" tabindex="-1">
-        <%= t("hyrax.dashboard.my.action.delete_collection") %>
+        <% end %>
       </li>
     <% end %>
+    <li role="presentation">
+      <%= link_to "#",
+                  class: 'dropdown-item itemicon itemtrash delete-collection-button',
+                  role: 'menuitem',
+                  tabindex: -1,
+                  title: t("hyrax.dashboard.my.action.delete_collection"),
+                  data: { totalitems: collection_presenter.total_items ,
+                          membership: collection_presenter.collection_type_is_require_membership? ,
+                          hasaccess: (can?(:edit, collection_presenter.solr_document)) } do %>
+        <%= t("hyrax.dashboard.my.action.delete_collection") %>
+      <% end %>
+    </li>
 
     <% if collection_presenter.collection_type_is_nestable? %>
       <% # The user should have deposit access to the parent we are adding, and read access to the child (the collection we are linking here). %>
-      <%= link_to "#",
-                  class: 'itemicon add-to-collection',
-                  role: 'menuitem',
-                  title: t("hyrax.dashboard.my.action.add_to_collection"),
-                  data: { nestable: collection_presenter.collection_type_is_nestable? ,
-                          hasaccess: (can?(:read, collection_presenter.solr_document)) } do %>
-        <li class="dropdown-item" tabindex="-1">
+      <li role="presentation">
+        <%= link_to "#",
+                    class: 'dropdown-item itemicon add-to-collection',
+                    role: 'menuitem',
+                    tabindex: -1,
+                    title: t("hyrax.dashboard.my.action.add_to_collection"),
+                    data: { nestable: collection_presenter.collection_type_is_nestable? ,
+                            hasaccess: (can?(:read, collection_presenter.solr_document)) } do %>
           <%= t("hyrax.dashboard.my.action.add_to_collection") %>
-        </li>
-      <% end %>
+        <% end %>
+      </li>
     <% end %>
   </ul>
 </div>

--- a/app/views/hyrax/my/_work_action_menu.html.erb
+++ b/app/views/hyrax/my/_work_action_menu.html.erb
@@ -9,23 +9,28 @@
 
   <ul role="menu" id="<%= ul_id %>" class="dropdown-menu dropdown-menu-right" aria-labelledby="dropdownMenu_<%= document.id %>">
     <% if can? :edit, document.id %>
-      <%= link_to [main_app, :edit, document],
-                  id: 'action-edit-work', role: 'menuitem' do %>
-        <li class="dropdown-item" tabindex="-1">
+      <li role="presentation">
+        <%= link_to [main_app, :edit, document],
+                    id: 'action-edit-work',
+                    class: 'dropdown-item',
+                    role: 'menuitem',
+                    tabindex: -1 do %>
           <%= t("hyrax.dashboard.my.action.edit_work") %>
-        </li>
-      <% end %>
+        <% end %>
+      </li>
 
-      <%= link_to [main_app, document],
-                  method: :delete,
-                  id: 'action-delete-work',
-                  role: 'menuitem',
-                  data: {
-                    confirm: t("hyrax.dashboard.my.action.work_confirmation", application_name: application_name) } do %>
-        <li class="dropdown-item" tabindex="-1">
+      <li role="presentation">
+        <%= link_to [main_app, document],
+                    method: :delete,
+                    id: 'action-delete-work',
+                    class: 'dropdown-item',
+                    role: 'menuitem',
+                    tabindex: -1,
+                    data: {
+                      confirm: t("hyrax.dashboard.my.action.work_confirmation", application_name: application_name) } do %>
           <%= t("hyrax.dashboard.my.action.delete_work") %>
-        </li>
-      <% end %>
+        <% end %>
+      </li>
     <% end %>
 
     <li role="presentation">
@@ -35,12 +40,16 @@
     </li>
 
     <% if can? :transfer, document.id %>
-      <%= link_to(hyrax.new_work_transfer_path(document.id), id: 'action-transfer-work', role: 'menuitem',
-                  class: 'itemicon itemtransfer', title: t("hyrax.dashboard.my.action.transfer")) do %>
-        <li class="dropdown-item" tabindex="-1">
+      <li role="presentation">
+        <%= link_to(hyrax.new_work_transfer_path(document.id),
+                    id: 'action-transfer-work',
+                    role: 'menuitem',
+                    tabindex: -1,
+                    class: 'dropdown-item itemicon itemtransfer',
+                    title: t("hyrax.dashboard.my.action.transfer")) do %>
           <%= t("hyrax.dashboard.my.action.transfer") %>
-        </li>
-      <% end %>
+        <% end %>
+      </li>
     <% end %>
   </ul>
 </div>

--- a/app/views/hyrax/my/_work_action_menu.html.erb
+++ b/app/views/hyrax/my/_work_action_menu.html.erb
@@ -28,11 +28,11 @@
       <% end %>
     <% end %>
 
-    <%= display_trophy_link(current_user, document.id, role: 'menuitem' ) do |text| %>
-      <li class="dropdown-item" tabindex="-1">
+    <li role="presentation">
+      <%= display_trophy_link(current_user, document.id, class: 'dropdown-item', role: 'menuitem', tabindex: -1) do |text| %>
         <%= text %>
-      </li>
-    <% end %>
+      <% end %>
+    </li>
 
     <% if can? :transfer, document.id %>
       <%= link_to(hyrax.new_work_transfer_path(document.id), id: 'action-transfer-work', role: 'menuitem',

--- a/app/views/hyrax/transfers/_received.html.erb
+++ b/app/views/hyrax/transfers/_received.html.erb
@@ -24,17 +24,11 @@
             <div class="btn-group">
               <button class="btn btn-sm btn-primary" href="#"><%= t(".accept") %></button>
               <button class="btn btn-sm dropdown-toggle accept" data-toggle="dropdown" href="#"><span class="sr-only">accept options</span></button>
-              <ul class="dropdown-menu">
-                <li class="dropdown-item">
-                  <%= link_to t(".allow_depositor_to_retain_edit_access"), hyrax.accept_transfer_path(req), method: :put, class: 'accept-retain', title: t(".accept_the_file_and_allow_the_original_depositor_to_retain_access_to_edit_the_file_and_metadata") %>
-                </li>
-                <li class="dropdown-item">
-                  <%= link_to t(".remove_depositor_access"), hyrax.accept_transfer_path(req, reset: true), method: :put, class: 'accept-reset', title: t(".accept_the_file_remove_access_from_the_original_depositor") %>
-                </li>
-                <li class="dropdown-item">
-                  <%= link_to t(".authorize_depositor_as_proxy"), hyrax.accept_transfer_path(req, sticky: true), method: :put, class: 'accept-stick', title: t(".accept_the_file_and_allow_the_original_depositor_to_retain_access_and_authorize") %>
-                </li>
-              </ul>
+              <div class="dropdown-menu">
+                <%= link_to t(".allow_depositor_to_retain_edit_access"), hyrax.accept_transfer_path(req), method: :put, class: 'dropdown-item accept-retain', title: t(".accept_the_file_and_allow_the_original_depositor_to_retain_access_to_edit_the_file_and_metadata") %>
+                <%= link_to t(".remove_depositor_access"), hyrax.accept_transfer_path(req, reset: true), method: :put, class: 'dropdown-item accept-reset', title: t(".accept_the_file_remove_access_from_the_original_depositor") %>
+                <%= link_to t(".authorize_depositor_as_proxy"), hyrax.accept_transfer_path(req, sticky: true), method: :put, class: 'dropdown-item accept-stick', title: t(".accept_the_file_and_allow_the_original_depositor_to_retain_access_and_authorize") %>
+              </div>
             </div>
 
           <%# = button_to "Accept and allow depositor to retain edit access", hyrax.accept_transfer_path(req), method: :put, class: 'btn btn-primary' %>

--- a/spec/helpers/hyrax/trophy_helper_spec.rb
+++ b/spec/helpers/hyrax/trophy_helper_spec.rb
@@ -6,14 +6,14 @@ RSpec.describe Hyrax::TrophyHelper, type: :helper do
 
     let(:text_attributes) { '[data-add-text="Highlight work on profile"][data-remove-text="Unhighlight work"]' }
     let(:url_attribute) { "[data-url=\"/works/#{id}/trophy\"]" }
-    let(:args) { { role: 'menuitem' } }
+    let(:args) { { role: 'menuitem', tabindex: -1, class: 'dropdown-item' } }
 
     context "when there is no trophy" do
       it "has a link for highlighting" do
         out = helper.display_trophy_link(user, id, args) { |text| "foo #{text} bar" }
         node = Capybara::Node::Simple.new(out)
         expect(node).to have_selector("a.trophy-class.trophy-off#{text_attributes}#{url_attribute}")
-        expect(node).to have_selector("a.trophy-class[role='menuitem']")
+        expect(node).to have_selector("a.trophy-class.dropdown-item[role='menuitem'][tabindex='-1']")
         expect(node).to have_link 'foo Highlight work on profile bar', href: '#'
       end
     end
@@ -27,7 +27,7 @@ RSpec.describe Hyrax::TrophyHelper, type: :helper do
         out = helper.display_trophy_link(user, id, args) { |text| "foo #{text} bar" }
         node = Capybara::Node::Simple.new(out)
         expect(node).to have_selector("a.trophy-class.trophy-on#{text_attributes}#{url_attribute}")
-        expect(node).to have_selector("a.trophy-class[role='menuitem']")
+        expect(node).to have_selector("a.trophy-class.dropdown-item[role='menuitem'][tabindex='-1']")
         expect(node).to have_link 'foo Unhighlight work bar', href: '#'
       end
 


### PR DESCRIPTION
## Let display_trophy_link pass tabindex

35531847fecc17a182e83ffa78393976c7de5fc0

The dropdown menu partials should have tabindex="-1" on the menuitem
anchor and this helper drops the attribute.

Ref
- https://www.w3.org/WAI/ARIA/apg/patterns/menubar/

## Move trophy menu items onto the anchor tag

### Before
<img width="303" height="198" alt="image" src="https://github.com/user-attachments/assets/ac297b80-a22b-4174-92d6-1c159f43ed2a" />

<img width="311" height="278" alt="image" src="https://github.com/user-attachments/assets/e5a2ee6c-7e0c-4e64-a15a-e9791f9920e5" />

### After
<img width="358" height="239" alt="image" src="https://github.com/user-attachments/assets/316262c9-a997-40e6-b923-67c1ef3c3b62" />

<img width="320" height="228" alt="image" src="https://github.com/user-attachments/assets/e423cfdb-0091-4ee0-8c3b-22d68b43a353" />

35d833ab42aa6759f83b401c1a76e67127d185f9

The dropdown styling sat on the list item instead of the link inside it,
so arrow keys could not reach the link.  The list item is now marked as
decoration since a menu only allows menu items.

## Move menu items onto the anchor tag

### Before
<img width="311" height="279" alt="image" src="https://github.com/user-attachments/assets/3fd36aaf-575b-4a6c-b35a-d6bcae11f44d" />

<img width="231" height="242" alt="image" src="https://github.com/user-attachments/assets/dfbdb9ce-10bc-4c54-87af-856cb2faccfd" />

<img width="321" height="335" alt="image" src="https://github.com/user-attachments/assets/6602ef78-94e0-4f65-9cee-6a60a39f315d" />

### After

<img width="334" height="242" alt="image" src="https://github.com/user-attachments/assets/e6132e20-0ffa-46aa-b408-b4d4d4049d37" />

<img width="242" height="247" alt="image" src="https://github.com/user-attachments/assets/28d5fe55-ff89-4c72-bb6d-aaa4254c5de8" />

<img width="315" height="304" alt="image" src="https://github.com/user-attachments/assets/54a27512-15b1-46c8-a18f-bd92c1e735db" />

95d33a1a8f265f3b81bcf5729b82fb673745cb28

The dropdown styling sat on the list item instead of the link inside it,
so arrow keys could not reach the link.  The list item is now marked as
decoration since a menu only allows menu items.

Ref
- https://www.w3.org/WAI/ARIA/apg/patterns/menubar/#keyboardinteraction

## Use dropdown-item on the plain dropdown links

### Before
<img width="230" height="198" alt="image" src="https://github.com/user-attachments/assets/6f8be154-f9c0-4d7a-a5bd-0bdf29466fe8" />

<img width="403" height="224" alt="image" src="https://github.com/user-attachments/assets/58fc5be6-c56e-40dc-995d-d28b1425f6c2" />

### After

<img width="230" height="189" alt="image" src="https://github.com/user-attachments/assets/66eff07f-9419-46a0-99c8-c9743ef45b2c" />

<img width="405" height="232" alt="image" src="https://github.com/user-attachments/assets/012832a3-5073-4afa-9e73-bb045ce8daf0" />

e031ad2e48459a9c147735230065e8138005f985

These two dropdowns are not menus, but the dropdown-item class sat on
the list item instead of the link, so the links rendered unstyled.

## Update the highlighted column without a refresh

### Before
<img alt="highlighted-before" src="https://github.com/user-attachments/assets/b0d82ee2-1ecb-41d3-ac29-e97442a5dc8b" />

### After
<img alt="highlighted-after" src="https://github.com/user-attachments/assets/b54f5ae3-834b-472a-8738-4fa7ee5f3064" />

36304e50dabc6c060ee649ab40176232d461b8eb

Clicking highlight or unhighlight in the work menu toggled the link but
left the star in the highlighted column showing the old state until the
page was refreshed.

---
_**🤖 Assisted-by: Opus 5**_