### PR TITLE
Fixes a bug where fits characterization silently fails

### DIFF
--- a/app/jobs/valkyrie_characterization_job.rb
+++ b/app/jobs/valkyrie_characterization_job.rb
@@ -1,6 +1,13 @@
 # frozen_string_literal: true
 class ValkyrieCharacterizationJob < Hyrax::ApplicationJob
   queue_as Hyrax.config.ingest_queue_name
+
+  # The characterization tool reported a definitive failure (e.g. a file
+  # exceeding its configured size limit); retrying won't change the outcome.
+  discard_on Hyrax::CharacterizationError do |job, error|
+    Hyrax.logger.error("ValkyrieCharacterizationJob discarded for FileMetadata #{job.arguments.first}: #{error.message}")
+  end
+
   def perform(file_metadata_id)
     file_metadata = Hyrax.custom_queries.find_file_metadata_by(id: file_metadata_id)
     Hyrax.config.characterization_service

--- a/app/services/hyrax/characterization/valkyrie_characterization_service.rb
+++ b/app/services/hyrax/characterization/valkyrie_characterization_service.rb
@@ -67,11 +67,25 @@ class Hyrax::Characterization::ValkyrieCharacterizationService
   #
   # @return [void]
   def characterize
-    terms = parse_metadata(extract_metadata(content))
-    apply_metadata(terms)
+    raw_metadata = extract_metadata(content)
+    raise_on_characterization_error(raw_metadata)
+    apply_metadata(parse_metadata(raw_metadata))
   end
 
   protected
+
+  # FITS (and fits-servlet) reports failures, e.g. a file exceeding its
+  # configured upload size limit, as a 200-shaped XML <error> document
+  # rather than a request failure. Parsed as normal FITS output it just
+  # yields no terms, so characterization silently no-ops instead of erroring.
+  def raise_on_characterization_error(raw_metadata)
+    doc = Nokogiri::XML(raw_metadata.to_s)
+    status_code = doc.at_xpath('//statusCode')&.text
+    return unless status_code
+
+    message = doc.at_xpath('//message')&.text || raw_metadata
+    raise Hyrax::CharacterizationError, "characterization failed for #{file_name} (status #{status_code}): #{message}"
+  end
 
   def content
     source.rewind

--- a/lib/hyrax/errors.rb
+++ b/lib/hyrax/errors.rb
@@ -17,4 +17,8 @@ module Hyrax
   class ObjectNotFoundError < ActiveFedora::ObjectNotFoundError; end
 
   class ModelMismatchError < HyraxError; end
+
+  # Raised when a characterization tool (e.g. FITS) returns an error response
+  # instead of characterization output
+  class CharacterizationError < HyraxError; end
 end

--- a/spec/fixtures/fits_error_response.xml
+++ b/spec/fixtures/fits_error_response.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<error>
+  <statusCode>500</statusCode>
+  <message>the request was rejected because its size (5238729944) exceeds the configured maximum
+    (2097152000)</message>
+  <request>http://fits:8080/fits/examine</request>
+  <support>[toString version]Processing halted.</support>
+</error>

--- a/spec/jobs/valkyrie_characterization_job_spec.rb
+++ b/spec/jobs/valkyrie_characterization_job_spec.rb
@@ -15,5 +15,10 @@ RSpec.describe ValkyrieCharacterizationJob, valkyrie_adapter: :test_adapter do
       expect(Hyrax.config.characterization_service).to receive(:run).with(metadata: file_metadata, file: file, **Hyrax.config.characterization_options)
       described_class.perform_now(file_metadata.id)
     end
+
+    it 'discards, without raising, on a characterization error' do
+      allow(Hyrax.config.characterization_service).to receive(:run).and_raise(Hyrax::CharacterizationError, 'file too large')
+      expect { described_class.perform_now(file_metadata.id) }.not_to raise_error
+    end
   end
 end

--- a/spec/services/hyrax/characterization/valkyrie_characterization_service_spec.rb
+++ b/spec/services/hyrax/characterization/valkyrie_characterization_service_spec.rb
@@ -39,4 +39,18 @@ RSpec.describe Hyrax::Characterization::ValkyrieCharacterizationService do
       end
     end
   end
+
+  describe "run with a FITS error response" do
+    let(:characterizer) { double(characterize: fits_error_response) }
+    let(:fits_error_response) { IO.read('spec/fixtures/fits_error_response.xml') }
+
+    let(:file_set)      { FactoryBot.valkyrie_create(:hyrax_file_set, files: [file_metadata], original_file: file_metadata) }
+    let(:file_metadata) { valkyrie_create(:file_metadata, :original_file, :with_file, file: file, mime_type: 'image/png') }
+    let(:file)          { create(:uploaded_file, file: File.open('spec/fixtures/world.png')) }
+
+    it 'raises instead of silently applying empty metadata' do
+      expect { described_class.run(metadata: file_metadata, file: file_set.original_file.file, characterizer: characterizer) }
+        .to raise_error(Hyrax::CharacterizationError, /the request was rejected because its size/)
+    end
+  end
 end


### PR DESCRIPTION
### Fixes
Fixes bug discovered by @kirkkwang, described in https://samvera.slack.com/archives/C0F9JQJDQ/p1785199309995839. 

### Summary
When fits fails to characterize something, it still returns a 200 and an xml document, it's just that that xml document explains the error. We should raise and log the error, instead of swallowing it.

### Guidance for testing, such as acceptance criteria or new user interface behaviors:
* Upload a file over 2 gigs to an application using the `ghcr.io/samvera/fitsservlet` docker image, watch background jobs.
  * *Before the fix*: The background job for characterization will succeed, but the file will not have been characterized or gotten derivatives created
  * *After the fix*: The background job will fail with a clear error message

### Changes proposed in this pull request:
* Pass errors in fits on to the background job - when fits fails, the characterization job should fail

@samvera/hyrax-code-reviewers
