### PR TITLE
Add #with_join to SolrQueryService

### DIFF
--- a/app/services/hyrax/solr_query_service.rb
+++ b/app/services/hyrax/solr_query_service.rb
@@ -127,6 +127,17 @@ module Hyrax
     end
 
     ##
+    # @param from [String] field on the documents matched by +query+
+    # @param to [String] field on the documents to return
+    # @param query [String, #build] the query selecting the documents to join from
+    # @return [SolrQueryService] the existing service with a join query appended
+    def with_join(from:, to:, query:)
+      inner_query = query.respond_to?(:build) ? query.build : query
+      @query += ["_query_:\"{!join from=#{from} to=#{to} v='#{inner_query}'}\""]
+      self
+    end
+
+    ##
     # @param ability [???] the user's abilities
     # @param action [Symbol] the action the user is taking (e.g. :index, :edit, :show, etc.) (default: :index)
     # @return [SolrQueryService] the existing service with access filters query appended

--- a/app/services/hyrax/viewable_child_works_service.rb
+++ b/app/services/hyrax/viewable_child_works_service.rb
@@ -25,30 +25,18 @@ module Hyrax
     def viewable?
       return false if viewable_mime_filter.empty? || member_ids.empty?
 
-      viewable_member_count.positive?
+      Hyrax::SolrQueryService.new(query: ["(#{viewable_mime_filter})"], solr_service: solr_service)
+                             .with_join(from: 'hasRelatedMediaFragment_ssim', to: 'id',
+                                        query: Hyrax::SolrQueryService.new.with_ids(ids: member_ids))
+                             .accessible_by(ability: ability)
+                             .count
+                             .positive?
     end
 
     private
 
     def member_ids
       @member_ids ||= Array(solr_document.member_ids)
-    end
-
-    def viewable_member_count
-      solr_service.query_result(join_query, fq: filter_queries, rows: 0)
-                  .dig('response', 'numFound')
-    end
-
-    def join_query
-      "{!join from=hasRelatedMediaFragment_ssim to=id cache=false}{!terms f=id}#{member_ids.join(',')}"
-    end
-
-    def filter_queries
-      [viewable_mime_filter, access_query]
-    end
-
-    def access_query
-      Hyrax::SolrQueryService.new(query: ['*:*']).accessible_by(ability: ability).build
     end
 
     def viewable_mime_filter

--- a/spec/presenters/hyrax/work_show_presenter_spec.rb
+++ b/spec/presenters/hyrax/work_show_presenter_spec.rb
@@ -127,8 +127,7 @@ RSpec.describe Hyrax::WorkShowPresenter do
       let(:viewable_count) { 1 }
 
       before do
-        allow(Hyrax::SolrService).to receive(:query_result)
-          .and_return('response' => { 'numFound' => viewable_count })
+        allow(Hyrax::SolrService).to receive(:count).and_return(viewable_count)
       end
 
       it { is_expected.to be true }
@@ -141,7 +140,7 @@ RSpec.describe Hyrax::WorkShowPresenter do
         it 'memoizes the result, even a false one' do
           2.times { presenter.iiif_viewer? }
 
-          expect(Hyrax::SolrService).to have_received(:query_result).once
+          expect(Hyrax::SolrService).to have_received(:count).once
         end
       end
     end
@@ -275,15 +274,15 @@ RSpec.describe Hyrax::WorkShowPresenter do
 
       it 'issues a single Solr query naming every child work, not one per child' do
         queries = []
-        allow(Hyrax::SolrService).to receive(:query_result).and_wrap_original do |original, query, **opts|
-          queries << opts.merge(q: query)
-          original.call(query, **opts)
+        allow(Hyrax::SolrService).to receive(:count).and_wrap_original do |original, query|
+          queries << query
+          original.call(query)
         end
 
         presenter.iiif_viewer?
 
         expect(queries.size).to eq(1)
-        children.each { |child| expect(queries.first[:q]).to include(child.id.to_s) }
+        children.each { |child| expect(queries.first).to include(child.id.to_s) }
       end
     end
   end

--- a/spec/services/hyrax/solr_query_service_spec.rb
+++ b/spec/services/hyrax/solr_query_service_spec.rb
@@ -81,6 +81,26 @@ RSpec.describe Hyrax::SolrQueryService, :clean_repo do
     end
   end
 
+  describe '#with_join' do
+    subject(:solr_query_service) { described_class.new }
+
+    let!(:child_work) { FactoryBot.valkyrie_create(:monograph, title: ['Child']) }
+    let!(:work) { FactoryBot.valkyrie_create(:monograph, title: ['Parent'], members: [child_work]) }
+
+    it 'matches documents joined to from those matching the given query service' do
+      ids = solr_query_service.with_join(from: 'member_ids_ssim', to: 'id',
+                                         query: described_class.new.with_ids(ids: [work.id])).get_ids
+
+      expect(ids).to contain_exactly(child_work.id.to_s)
+    end
+
+    it 'accepts a raw query string' do
+      ids = solr_query_service.with_join(from: 'member_ids_ssim', to: 'id', query: "id:#{work.id}").get_ids
+
+      expect(ids).to contain_exactly(child_work.id.to_s)
+    end
+  end
+
   describe '#build' do
     context 'when no query clauses have been constructed' do
       subject(:solr_query_service) { described_class.new }

--- a/spec/services/hyrax/viewable_child_works_service_spec.rb
+++ b/spec/services/hyrax/viewable_child_works_service_spec.rb
@@ -9,8 +9,7 @@ RSpec.describe Hyrax::ViewableChildWorksService do
 
   before do
     allow(Hyrax.config).to receive(:iiif_image_server?).and_return(true)
-    allow(Hyrax::SolrService).to receive(:query_result)
-      .and_return('response' => { 'numFound' => num_found })
+    allow(Hyrax::SolrService).to receive(:count).and_return(num_found)
   end
 
   describe '#viewable?' do
@@ -19,9 +18,9 @@ RSpec.describe Hyrax::ViewableChildWorksService do
     it 'asks Solr once, naming every member in one query' do
       service.viewable?
 
-      expect(Hyrax::SolrService).to have_received(:query_result)
+      expect(Hyrax::SolrService).to have_received(:count)
         .once
-        .with(a_string_including('{!terms f=id}child-1,child-2'), hash_including(rows: 0))
+        .with(a_string_including('{!terms f=id}child-1,child-2'))
     end
 
     context 'when no member has a viewable representative' do
@@ -35,7 +34,7 @@ RSpec.describe Hyrax::ViewableChildWorksService do
 
       it 'is false without querying Solr' do
         expect(service.viewable?).to be false
-        expect(Hyrax::SolrService).not_to have_received(:query_result)
+        expect(Hyrax::SolrService).not_to have_received(:count)
       end
     end
 
@@ -48,7 +47,7 @@ RSpec.describe Hyrax::ViewableChildWorksService do
 
       it 'is false without querying Solr' do
         expect(service.viewable?).to be false
-        expect(Hyrax::SolrService).not_to have_received(:query_result)
+        expect(Hyrax::SolrService).not_to have_received(:count)
       end
     end
   end


### PR DESCRIPTION
This commit moves the join clause into SolrQueryService next to the other builders, so the ViewableChildWorksService can compose the query using #with_join, #with_ids, and #accessible_by instead of using raw Solr strings.

---
_**🤖 Assisted-by: Opus 5**_