### PR TITLE
Fix facet for a name: surrogate property

### DIFF
--- a/app/controllers/concerns/hyrax/flexible_catalog_behavior.rb
+++ b/app/controllers/concerns/hyrax/flexible_catalog_behavior.rb
@@ -19,6 +19,20 @@ module Hyrax
           indexing = prop['indexing']
           next if indexing.nil?
 
+          # A property may declare `name:` to stand in for another on a
+          # particular class. The named attribute is what gets indexed, so it is
+          # the name every solr field derives from — registering under the
+          # surrogate's own key produces a facet nothing is indexed into.
+          indexed_name = indexed_name_for(itemprop, prop)
+          if indexed_name != itemprop
+            # Only the surrogate's own keys. Passing its `indexing:` array would
+            # fold in any field names it declares — which for a surrogate are
+            # the target attribute's — and delete the target's registration.
+            blacklight_config.facet_fields.delete("#{itemprop}_sim")
+            blacklight_config.index_fields.delete("#{itemprop}_tesim")
+            itemprop = indexed_name
+          end
+
           # prevents all restricted fields from being added to blacklight config
           # to prevent them from being exposed in catalog search results.
           # They remain available on show pages, based on visibility.
@@ -102,6 +116,12 @@ module Hyrax
       end
 
       private
+
+      def indexed_name_for(itemprop, config)
+        return itemprop unless config.is_a?(Hash)
+
+        config['name'].presence || itemprop
+      end
 
       # Returns true if the view options require a helper method to render the linked field correctly in the index view
       # @param view_options [Hash] the view options ex: {"render_as"=>"linked", "html_dl"=>true}

--- a/spec/controllers/concerns/hyrax/flexible_catalog_behavior_surrogate_spec.rb
+++ b/spec/controllers/concerns/hyrax/flexible_catalog_behavior_surrogate_spec.rb
@@ -1,0 +1,107 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Hyrax::FlexibleCatalogBehavior, 'name: surrogate properties', type: :controller do
+  let(:base_profile) { YAML.safe_load_file(Hyrax::Engine.root.join('spec', 'fixtures', 'files', 'm3_profile.yaml')) }
+
+  let(:custom_properties) do
+    YAML.safe_load(<<-YAML)
+      properties:
+        resource_type:
+          available_on:
+            class:
+              - GenericWork
+          display_label:
+            default: Resource Type
+          indexing:
+            - stored_searchable
+            - facetable
+          property_uri: http://purl.org/dc/terms/type
+          range: http://www.w3.org/2001/XMLSchema#string
+        monograph_resource_type:
+          name: resource_type
+          available_on:
+            class:
+              - Monograph
+          display_label:
+            default: Resource Type
+          indexing:
+            - resource_type_sim
+            - resource_type_tesim
+            - stored_searchable
+            - facetable
+          property_uri: http://purl.org/dc/terms/type
+          range: http://www.w3.org/2001/XMLSchema#string
+    YAML
+  end
+
+  controller(ApplicationController) do
+    include Blacklight::Configurable
+    include Blacklight::SearchContext
+    include Hyrax::FlexibleCatalogBehavior
+
+    configure_blacklight do |config|
+      config.search_builder_class = Hyrax::CatalogSearchBuilder
+      config.default_solr_params = { qt: 'search', rows: 10 }
+
+      config.add_search_field('all_fields') do |field|
+        field.solr_parameters = { qf: String.new('') }
+      end
+    end
+
+    def index
+      @response = Blacklight::Solr::Response.new({}, {})
+      render plain: 'OK'
+    end
+  end
+
+  # blacklight_config is class-level state, so without this a facet registered
+  # by one example is still there for the next.
+  around do |example|
+    klass = self.class.controller_class
+    original = klass.blacklight_config.deep_copy
+    example.run
+    klass.blacklight_config = original
+  end
+
+  before do
+    allow(Hyrax.config).to receive(:flexible?).and_return(true)
+    routes.draw { get 'index' => 'anonymous#index' }
+
+    mock_schema = double('FlexibleSchema', profile: base_profile.deep_merge(custom_properties))
+
+    allow(Hyrax::FlexibleSchema)
+      .to receive_message_chain(:order, :last)
+      .with("created_at asc")
+      .with(2)
+      .and_return([mock_schema])
+
+    controller.class.load_flexible_schema
+  end
+
+  let(:blacklight_config) do
+    get :index
+    controller.blacklight_config
+  end
+
+  it 'registers no facet under the surrogate key, where nothing is indexed' do
+    expect(blacklight_config.facet_fields).not_to have_key('monograph_resource_type_sim')
+  end
+
+  it 'registers no search-result column under the surrogate key' do
+    expect(blacklight_config.index_fields).not_to have_key('monograph_resource_type_tesim')
+  end
+
+  it 'registers the attribute the surrogate stands in for' do
+    expect(blacklight_config.facet_fields).to have_key('resource_type_sim')
+    expect(blacklight_config.index_fields).to have_key('resource_type_tesim')
+  end
+
+  it 'is safe to run once per request' do
+    expect { 5.times { controller.class.load_flexible_schema } }.not_to raise_error
+
+    expect(blacklight_config.facet_fields).not_to have_key('monograph_resource_type_sim')
+    expect(blacklight_config.facet_fields).to have_key('resource_type_sim')
+  end
+end


### PR DESCRIPTION
## Summary
Fixes a metadata property that used `name:` to stand in for another. If the property was facetable or searchable, it would show an always-empty facet or search-results column.

## Details
- A profile property can declare `name:` to represent a different attribute for a particular class. The attribute named is what gets indexed.
- Registration derived every Solr field name from the property's own profile key, so the facet and column pointed at fields nothing is ever written to and listed no values for any search.
- Registration now derives from the attribute actually indexed, and removes only the surrogate's own keys — a surrogate that declares the target attribute's field names no longer deletes the target's registration.
- Only affects profiles that use `name:` surrogates; installations without one see no change.

## Testing
- In an installation whose m3 profile has a property declaring `name:` for another attribute on a different class, confirm the sidebar no longer offers a facet under the surrogate's own name.
- Confirm the facet for the attribute it stands in for is present and lists values.
- Reload a catalog page several times without restarting the server, and confirm no error.

#### Sample M3 addition for testing

The two entries must be on **disjoint** classes — the profile validator rejects two properties sharing a resolved name on overlapping classes.

```yaml
  edition:
    available_on:
      class:
      - GenericWork
    cardinality:
      minimum: 0
    data_type: array
    display_label:
      default: Edition
    indexing:
    - edition_sim
    - edition_tesim
    - facetable
    property_uri: http://purl.org/ontology/bibo/edition
    range: http://www.w3.org/2001/XMLSchema#string
  monograph_edition:
    name: edition
    available_on:
      class:
      - Monograph
    cardinality:
      minimum: 0
    data_type: array
    display_label:
      default: Edition
    indexing:
    - edition_sim
    - edition_tesim
    - facetable
    property_uri: http://purl.org/ontology/bibo/edition
    range: http://www.w3.org/2001/XMLSchema#string
```
