### PR TITLE
Tidy up admin show page

### DIFF
--- a/app/views/hyrax/admin/admin_sets/_show_document_list.html.erb
+++ b/app/views/hyrax/admin/admin_sets/_show_document_list.html.erb
@@ -4,10 +4,11 @@
   <tr>
     <th>&nbsp;</th>
     <th><%= I18n.t("hyrax.admin.admin_sets.show_document_list.title", :default => "Title") %></th>
-    <th><%= I18n.t("hyrax.admin.admin_sets.show_document_list.date_uploaded", :default => "Date Uploaded") %></th>
-    <th><%= I18n.t("hyrax.admin.admin_sets.show_document_list.visibility", :default => "Visibility") %></th>
-    <th><%= I18n.t("hyrax.admin.admin_sets.show_document_list.status", :default => "Status") %></th>
-    <th><%= I18n.t("hyrax.admin.admin_sets.show_document_list.actions", :default => "Actions") %></th>
+    <th class="text-center"><%= I18n.t("hyrax.admin.admin_sets.show_document_list.date_uploaded", :default => "Date Uploaded") %></th>
+    <th class="text-center"><%= t("hyrax.dashboard.my.heading.highlighted") %></th>
+    <th class="text-center"><%= I18n.t("hyrax.admin.admin_sets.show_document_list.visibility", :default => "Visibility") %></th>
+    <th class="text-center"><%= I18n.t("hyrax.admin.admin_sets.show_document_list.status", :default => "Status") %></th>
+    <th class="text-center"><%= I18n.t("hyrax.admin.admin_sets.show_document_list.actions", :default => "Actions") %></th>
   </tr>
   </thead>
   <tbody>

--- a/app/views/hyrax/admin/admin_sets/_show_document_list_row.html.erb
+++ b/app/views/hyrax/admin/admin_sets/_show_document_list_row.html.erb
@@ -8,7 +8,7 @@
   </td>
   <td>
     <div class="media">
-      <%= link_to [main_app, document], "class" => "media-left", "aria-hidden" => "true" do %>
+      <%= link_to [main_app, document], "class" => "media-left mr-3", "aria-hidden" => "true" do %>
         <%= document_presenter(document)&.thumbnail&.thumbnail_tag({ class: "d-none d-md-block file_listing_thumbnail", alt: thumbnail_alt_text_for(document) }, { suppress_link: true }) %>
       <% end %>
       <div class="media-body">
@@ -22,6 +22,9 @@
   </td>
   <td class="text-center date"><%= document.date_uploaded %> </td>
   <td class="text-center">
+    <span class="fa <%= current_user&.trophies&.where(work_id: id)&.exists? ? 'fa-star highlighted-work' : 'fa-star-o trophy-off' %>" aria-hidden="true"></span>
+  </td>
+  <td class="text-center">
     <%= render_visibility_link(document) %>
   </td>
   <td class="text-center">
@@ -32,7 +35,7 @@
   </td>
 </tr>
 <tr id="detail_<%= id %>"> <!--  document detail"> -->
-  <td colspan="6">
+  <td colspan="7">
     <dl class="expanded-details row">
       <dt class="col-3 col-lg-2"><%= I18n.t("hyrax.admin.admin_sets.show_document_list_row.creator", :default => "Creator:") %></dt>
       <dd class="col-9 col-lg-4"><%= document.creator.to_a.to_sentence %></dd>

--- a/app/views/hyrax/collections/_list_works.html.erb
+++ b/app/views/hyrax/collections/_list_works.html.erb
@@ -7,7 +7,7 @@
 
   <td>
     <div class='media'>
-      <%= link_to [main_app, document], class: 'media-left', 'aria-hidden' => true do %>
+      <%= link_to [main_app, document], class: 'media-left mr-2', 'aria-hidden' => true do %>
         <%= document_presenter(document)&.thumbnail&.thumbnail_tag(
           { class: 'd-none d-md-block file_listing_thumbnail', alt: thumbnail_alt_text_for(document) }, { suppress_link: true }
         ) %>

--- a/app/views/hyrax/dashboard/works/_list_works.html.erb
+++ b/app/views/hyrax/dashboard/works/_list_works.html.erb
@@ -5,7 +5,7 @@
   </td>
   <td>
     <div class='media'>
-      <%= link_to [main_app, document], class: 'media-left' do %>
+      <%= link_to [main_app, document], class: 'media-left mr-2' do %>
         <%= document_presenter(document)&.thumbnail&.thumbnail_tag(
           { class: 'd-none d-md-block file_listing_thumbnail', alt: thumbnail_alt_text_for(document) },
           { suppress_link: true }


### PR DESCRIPTION
This commit will tidy up the admin show page with bootstrap utility classes.

## Before
<img width="3344" height="3542" alt="image" src="https://github.com/user-attachments/assets/ccf4a6c2-5bf8-4db5-a147-f01b325e0811" />

## After
<img width="3344" height="3542" alt="image" src="https://github.com/user-attachments/assets/73e1b05f-c3a8-44d9-ab4a-2b5ffaee1dfa" />

## Before
<img width="3344" height="3175" alt="image" src="https://github.com/user-attachments/assets/da3e28b9-d937-4203-8a51-9da3eeec04e6" />

## After
<img width="3344" height="3175" alt="image" src="https://github.com/user-attachments/assets/903d01c8-db5e-4937-9818-3d26d25b8c8c" />

