### PR TITLE
Index controlled vocabulary labels

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -80,6 +80,10 @@ db/schema.rb
 .byebug_history
 .tool-versions
 
+# Files uploaded through the app while developing against the test stacks
+/.koppie/uploads/
+/.dassie/uploads/
+
 ## Carried over from hyrax-models (RIP)
 *.gem
 *.rbc

--- a/app/controllers/concerns/hyrax/flexible_catalog_behavior.rb
+++ b/app/controllers/concerns/hyrax/flexible_catalog_behavior.rb
@@ -12,6 +12,7 @@ module Hyrax
         current_profile = previous_profile if current_profile.nil?
         remove_old_properties!(previous_profile['properties'], current_profile['properties'].keys) if current_profile != previous_profile
         properties_hash = current_profile['properties']
+        resolvable = {}
         properties_hash.each do |itemprop, prop|
           label = display_label_for(itemprop, prop)
 
@@ -28,10 +29,19 @@ module Hyrax
             # Only the surrogate's own keys. Passing its `indexing:` array would
             # fold in any field names it declares — which for a surrogate are
             # the target attribute's — and delete the target's registration.
-            blacklight_config.facet_fields.delete("#{itemprop}_sim")
-            blacklight_config.index_fields.delete("#{itemprop}_tesim")
+            solr_field_names_for(itemprop, nil).each do |name|
+              blacklight_config.facet_fields.delete(name)
+              blacklight_config.index_fields.delete(name)
+            end
             itemprop = indexed_name
           end
+
+          # Only when the indexer will actually write label fields. `facetable`
+          # and `stored_searchable` are directives that AttributeDefinition
+          # strips, so a property declaring only those has no index keys and no
+          # label companions — treating it as controlled would hide a working id
+          # facet behind an empty label one.
+          controlled_source = (controlled_source_for(prop, resolvable) if indexed?(indexing))
 
           # prevents all restricted fields from being added to blacklight config
           # to prevent them from being exposed in catalog search results.
@@ -50,7 +60,7 @@ module Hyrax
             index_args = { itemprop:, label: }
 
             if facetable?(indexing, itemprop)
-              index_args[:link_to_facet] = "#{itemprop}_sim"
+              index_args[:link_to_facet] = facet_name_for(itemprop, controlled_source)
             end
 
             name = blacklight_config.index_fields.keys.detect { |key| key.start_with?(itemprop) }
@@ -96,26 +106,143 @@ module Hyrax
               blacklight_config.index_fields[name].search_results_truncate = view_options['search_results_truncate']
             end
 
-            qf = blacklight_config.search_fields['all_fields'].solr_parameters[:qf]
-            unless qf.include?(name)
-              qf << " #{name}"
+            field = blacklight_config.index_fields[name]
+            if controlled_source
+              field.values = Hyrax::ControlledVocabularyFieldValues.to_proc
+              field.reads_labels = true
+            elsif field.reads_labels
+              # Only one we set: an application's own `values:` has to stand.
+              field.values = nil
+              field.reads_labels = false
             end
+
+            # The label field too, so a free-text search for a term's label
+            # finds the work. Without it only the opaque id matches.
+            names = [name]
+            names << Hyrax::ControlledVocabularyFieldValues.label_key(name) if controlled_source
+            append_query_fields!(names)
           end
 
           if facetable?(indexing, itemprop)
-            name = "#{itemprop}_sim"
-            unless blacklight_config.facet_fields[name].present?
-              blacklight_config.add_facet_field(name, label: label)
-            end
+            register_facet_field(itemprop, label, controlled_source, indexing)
           else
             # if the property does not have facetable in the indexing section of the metadata profile, remove the facet field from the blacklight config
-            name = "#{itemprop}_sim"
-            blacklight_config.facet_fields.delete(name)
+            blacklight_config.facet_fields.delete("#{itemprop}_sim")
+            blacklight_config.facet_fields.delete("#{itemprop}_label_sim")
           end
         end
       end
 
       private
+
+      # A controlled property facets on its labels, because Blacklight queries a
+      # facet with whatever the row displayed — so row and facet move together.
+      #
+      # Runs once per request against a class-level config that persists, so
+      # both the swap and the add have to be safe to repeat; Blacklight raises
+      # when a facet is added twice.
+      def register_facet_field(itemprop, label, controlled_source, indexing)
+        id_name = "#{itemprop}_sim"
+        id_facet = blacklight_config.facet_fields[id_name]
+        id_facet = blacklight_config.add_facet_field(id_name, label: label) if id_facet.blank?
+
+        # Restore a facet an earlier pass hid, for a property that has since
+        # stopped being controlled. Only one we hid ourselves: a `show: false`
+        # an application set in its own CatalogController has to stand.
+        unless swap_facet_to_labels?(itemprop, controlled_source, indexing)
+          id_facet.show = true if id_facet.hidden_for_labels
+          id_facet.hidden_for_labels = false
+          return
+        end
+
+        name = facet_name_for(itemprop, controlled_source)
+        unless blacklight_config.facet_fields[name].present?
+          # Resolved rather than copied: a facet declared in a CatalogController
+          # without a label stores the titleized solr key ("Keyword Sim"), which
+          # normally stays hidden only because display_label finds the
+          # `…fields.facet.<key>` translation first — and the renamed key has no
+          # such translation.
+          blacklight_config.add_facet_field(name, label: id_facet.display_label('facet'))
+        end
+
+        # The id facet stays configured but drops out of the sidebar: listing
+        # both would show the same label twice, one over the opaque ids this
+        # feature exists to hide. Keeping it configured is what lets
+        # `f[<prop>_sim][]` from a saved search or bookmark still resolve, and
+        # keeps its constraint chip rendering.
+        id_facet.show = false
+        id_facet.hidden_for_labels = true
+      end
+
+      # The facet swap needs `<itemprop>_sim` specifically, not merely some
+      # literal key: that is the field the indexer writes label companions for.
+      # A property declaring only `<itemprop>_tesim` gets label values in rows
+      # but none in a facet, so swapping would hide a working id facet behind an
+      # empty label one.
+      def swap_facet_to_labels?(itemprop, controlled_source, indexing)
+        controlled_source.present? && Array(indexing).include?("#{itemprop}_sim")
+      end
+
+      def facet_name_for(itemprop, controlled_source)
+        controlled_source ? "#{itemprop}_label_sim" : "#{itemprop}_sim"
+      end
+
+      # An installation with no label service registered gets nil for every
+      # property, and so keeps the catalog it has today.
+      def controlled_source_for(config, resolvable = {})
+        return unless config.is_a?(Hash)
+
+        # Not `config.dig`: a profile is editable data, and a scalar here would
+        # raise TypeError while building the catalog config.
+        controlled = config['controlled_values']
+        return unless controlled.is_a?(Hash)
+
+        # The *first real* source, then a resolvability check — not the first
+        # resolvable one. AttributeDefinition#authority_source picks the first
+        # real source and the indexer writes labels only if that one resolves,
+        # so choosing differently here would swap a facet to a label field
+        # nothing writes into.
+        source = Array(controlled['sources'])
+                 .map { |candidate| candidate.to_s.strip }
+                 .find { |candidate| candidate.present? && !candidate.casecmp('null').zero? }
+
+        source if source && resolvable?(source, resolvable)
+      rescue StandardError => e
+        Hyrax.logger.debug("controlled_source_for: #{e.message}")
+        nil
+      end
+
+      # Memoized for the duration of one load: this runs per property, and a
+      # service backed by a vocabulary table would otherwise query once per
+      # property per request.
+      def resolvable?(source, memo)
+        memo.fetch(source) do
+          memo[source] = Hyrax.config.controlled_vocabulary_label_service.resolvable?(source)
+        end
+      end
+
+      # Split on whitespace rather than substring-matching:
+      # `qf.include?("type_tesim")` is true once `resource_type_tesim` is
+      # listed, so a substring check would silently drop the shorter field.
+      def append_query_fields!(names)
+        qf = blacklight_config.search_fields['all_fields']&.solr_parameters&.dig(:qf)
+        return if qf.nil?
+
+        listed = qf.split
+        names.each do |field|
+          next if listed.include?(field)
+
+          qf << " #{field}"
+          listed << field
+        end
+      end
+
+      # Whether `indexing:` names any literal solr field, as opposed to only the
+      # directives (`stored_searchable`, `facetable`, the role flags) that carry
+      # no field name of their own.
+      def indexed?(indexing)
+        (Array(indexing) - INDEXING_DIRECTIVES).any?
+      end
 
       def indexed_name_for(itemprop, config)
         return itemprop unless config.is_a?(Hash)
@@ -206,18 +333,28 @@ module Hyrax
           blacklight_config.index_fields.delete(name)
         end
 
+        remove_query_fields!(names)
+      end
+
+      # Rebuilt from whole tokens rather than sliced out as substrings:
+      # `qf.slice!("type_tesim")` would cut that run of characters out of
+      # `resource_type_tesim`, leaving `resource_` and silently dropping the
+      # longer field from free-text search.
+      def remove_query_fields!(names)
         qf = blacklight_config.search_fields['all_fields']&.solr_parameters&.dig(:qf)
         return if qf.nil?
-        names.each do |name|
-          qf.slice!(" #{name}")
-          qf.slice!(name)
-        end
+
+        qf.replace((qf.split - names).join(' '))
       end
 
       def solr_field_names_for(itemprop, indexing)
         default_fields = ["#{itemprop}_tesim", "#{itemprop}_sim"]
         declared_fields = (indexing || []) - INDEXING_DIRECTIVES
-        (default_fields + declared_fields).uniq
+        fields = (default_fields + declared_fields).uniq
+        # blacklight_config is class-level and persists between requests, so a
+        # property that leaves the profile or becomes restricted would otherwise
+        # keep a live label facet pointing at a field nothing writes to.
+        (fields + fields.map { |field| Hyrax::ControlledVocabularyFieldValues.label_key(field) }).uniq
       end
     end
 

--- a/app/presenters/hyrax/presents_attributes.rb
+++ b/app/presenters/hyrax/presents_attributes.rb
@@ -22,8 +22,9 @@ module Hyrax
         return
       end
 
-      options = options.merge(subproperties: compound_subproperties_for(field)) if options[:render_as].to_s == 'compound'
-      renderer = renderer_for(field, options).new(field, send(field), options)
+      values = send(field)
+      options = renderer_options_for(field, values, options)
+      renderer = renderer_for(field, options).new(field, values, options)
 
       if options[:value_only] && renderer.respond_to?(:render_value)
         renderer.render_value
@@ -53,6 +54,59 @@ module Hyrax
     end
 
     private
+
+    def renderer_options_for(field, values, options)
+      options = options.merge(subproperties: compound_subproperties_for(field)) if options[:render_as].to_s == 'compound'
+      labels = controlled_labels_for(field, values)
+      options = options.merge(labels: labels) if labels.present?
+      options
+    end
+
+    # Keyed by value rather than position: AttributeRenderer sorts the values
+    # when `options[:sort]` is set, so index-based pairing attaches the wrong
+    # label. nil for an uncontrolled property, or a work indexed before the
+    # label fields existed — the renderer then falls back to the ids.
+    #
+    # The counts must match exactly. A label service is contracted to return one
+    # entry per value, but nothing enforces it, and zipping a short list shifts
+    # every later label onto the wrong value — showing one term's label under
+    # another term's id, which is worse than showing the id.
+    def controlled_labels_for(field, values)
+      @controlled_labels ||= {}
+      return @controlled_labels[field] if @controlled_labels.key?(field)
+
+      @controlled_labels[field] = compute_controlled_labels(field, values)
+    end
+
+    # Scans the document's keys, so it is memoized per field above: a show page
+    # renders many fields against one document.
+    def compute_controlled_labels(field, values)
+      return unless respond_to?(:solr_document)
+
+      document = solr_document
+      return unless document.respond_to?(:[])
+
+      values = Array(values).map(&:to_s)
+      labels = indexed_labels_for(document, field)
+      return if labels.blank? || labels.size != values.size
+
+      values.zip(labels).to_h
+    end
+
+    # Read from the document rather than probed against a fixed suffix list: a
+    # property can declare any index key (`creator_ssim`), and the indexer
+    # writes a label companion for each.
+    def indexed_labels_for(document, field)
+      prefix = Hyrax::ControlledVocabularyFieldValues.label_prefix(field)
+      pattern = /\A#{Regexp.escape(prefix)}_[^_]+\z/
+      keys = document.keys.select { |key| key.to_s.match?(pattern) }
+      # `_tesim` first, since `_sim` is indexed but not stored and usually reads
+      # back empty; an empty key must fall through rather than end the search.
+      keys.sort_by { |k| k.to_s.end_with?('_tesim') ? 0 : 1 }
+          .lazy
+          .filter_map { |key| Array(document[key]).presence }
+          .first
+    end
 
     # Normalized sub-property specs for a compound, so the renderer can translate
     # controlled ids to their terms; nil if the resource class can't be

--- a/app/renderers/hyrax/renderers/attribute_renderer.rb
+++ b/app/renderers/hyrax/renderers/attribute_renderer.rb
@@ -19,6 +19,9 @@ module Hyrax
       # @option options [String] :include_empty Do we render if if the values are empty?
       # @option options [String] :work_type Used for some I18n logic
       # @option options [Boolean] :sort sort the values with +Array#sort+ if truthy
+      # @option options [Hash] :labels controlled vocabulary term labels, keyed
+      #   by the value they belong to. The value is still what renders as a
+      #   link's href; only the displayed text becomes the label.
       def initialize(field, values, options = {})
         @field = field
         @values = values
@@ -101,7 +104,24 @@ module Hyrax
       end
 
       def li_value(value)
-        auto_link(ERB::Util.h(value))
+        term_label = controlled_label_for(value)
+        return auto_link(ERB::Util.h(value)) if term_label.nil?
+
+        if Hyrax::AuthorityRenderingHelper.linkable_uri?(value)
+          %(<a href="#{ERB::Util.h(value)}">#{ERB::Util.h(term_label)}</a>).html_safe
+        else
+          ERB::Util.h(term_label)
+        end
+      end
+
+      def controlled_label_for(value)
+        labels = options[:labels]
+        return unless labels.is_a?(Hash)
+
+        label = labels[value.to_s]
+        return if label.blank? || label.to_s == value.to_s
+
+        label
       end
 
       def work_type_label_key

--- a/app/renderers/hyrax/renderers/faceted_attribute_renderer.rb
+++ b/app/renderers/hyrax/renderers/faceted_attribute_renderer.rb
@@ -5,7 +5,7 @@ module Hyrax
       private
 
       def li_value(value)
-        link_to(ERB::Util.h(value), search_path(value))
+        link_to(ERB::Util.h(controlled_label_for(value) || value), search_path(value))
       end
 
       def search_path(value)

--- a/app/renderers/hyrax/renderers/linked_attribute_renderer.rb
+++ b/app/renderers/hyrax/renderers/linked_attribute_renderer.rb
@@ -5,7 +5,7 @@ module Hyrax
       private
 
       def li_value(value)
-        link_to(ERB::Util.h(value), search_path(value))
+        link_to(ERB::Util.h(controlled_label_for(value) || value), search_path(value))
       end
 
       def search_path(value)

--- a/app/services/hyrax/controlled_vocabulary_field_values.rb
+++ b/app/services/hyrax/controlled_vocabulary_field_values.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+module Hyrax
+  ##
+  # A Blacklight `values:` lambda showing a controlled term's label where one is
+  # indexed, and its stored id otherwise.
+  #
+  # A lambda rather than pointing the field at the label key: Blacklight drops a
+  # field whose Solr key is absent, so repointing would blank the row for every
+  # work indexed before the label fields existed. `field:` cannot express the
+  # fallback either — it reaches `document.fetch`, which takes a single key.
+  class ControlledVocabularyFieldValues
+    def self.to_proc
+      lambda do |field_config, document, _view_context|
+        key = field_config.field.to_s
+        document.fetch(label_key(key), nil).presence || document.fetch(key, nil)
+      end
+    end
+
+    ##
+    # The prefix every label companion of `field` shares: `license` ->
+    # `license_label`. Used to find them without assuming a suffix, since a
+    # property may declare any index key.
+    #
+    # @param field [String, Symbol] an attribute name
+    # @return [String]
+    def self.label_prefix(field)
+      "#{field}_label"
+    end
+
+    ##
+    # `license_tesim` -> `license_label_tesim`.
+    #
+    # The suffix has to stay last: Solr resolves these through dynamic field
+    # rules keyed on the suffix, so `license_sim_label` is not a field at all and
+    # indexing it fails the whole document with a 400.
+    #
+    # A profile declaring a literal `<name>_label` property would collide with
+    # the companion field of `<name>`.
+    #
+    # @param key [String, Symbol] a solr index key
+    # @return [String] the key its labels are written to
+    def self.label_key(key)
+      base, _, suffix = key.to_s.rpartition('_')
+      return key.to_s if base.blank? || suffix.blank?
+
+      "#{base}_label_#{suffix}"
+    end
+  end
+end

--- a/app/services/hyrax/controlled_vocabulary_label_service.rb
+++ b/app/services/hyrax/controlled_vocabulary_label_service.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+module Hyrax
+  ##
+  # Resolves a controlled vocabulary term's id to its human-readable label.
+  #
+  # Hyrax has no vocabulary store of its own, so this is the seam: the default
+  # resolves nothing and Hyrax behaves exactly as it did before, while an
+  # application registers a real implementation on
+  # {Hyrax::Configuration#controlled_vocabulary_label_service}. A replacement
+  # need only respond to the two methods below.
+  #
+  # @example registering an application's own resolver
+  #   Hyrax.config.controlled_vocabulary_label_service = MyLabelService.new
+  class ControlledVocabularyLabelService
+    ##
+    # One entry per value, in the order given: the term's label, or the value
+    # itself where the authority does not know it. Implementations must stay
+    # positional — the renderer pairs values to labels, so an unresolved value
+    # has to hold its place. Never compact the result.
+    #
+    # @param source [String] the name of the controlled vocabulary
+    # @param values [Array, Object, nil] the stored term ids
+    # @return [Array]
+    def labels_for(_source, values)
+      Array.wrap(values)
+    end
+
+    ##
+    # Whether labels can be resolved for the named vocabulary; a property whose
+    # authority is not resolvable keeps its ids alone. Answer false for remote
+    # authorities — resolving one means a network call per value, which has no
+    # place in an indexing run.
+    #
+    # @param source [String]
+    # @return [Boolean]
+    def resolvable?(_source)
+      false
+    end
+  end
+end

--- a/app/services/hyrax/schema_loader.rb
+++ b/app/services/hyrax/schema_loader.rb
@@ -54,6 +54,25 @@ module Hyrax
     end
 
     ##
+    # @param [Symbol] schema
+    #
+    # @return [{Symbol => String}] a map from attribute names to the name of the
+    #   controlled vocabulary backing them. Only attributes declaring a real
+    #   `controlled_values.sources` entry appear; the `"null"` sentinel the
+    #   profile uses to mean "free text" is not an authority.
+    #
+    # Read through the definitions, not the profile hash: only they apply
+    # `available_on` and collapse a `name:` surrogate, so a property standing in
+    # for another on a particular class resolves to the authority its own entry
+    # declares rather than the one the shared name declares.
+    def authority_rules_for(schema:, version: 1, contexts: nil)
+      definitions(schema, version, contexts).each_with_object({}) do |definition, hash|
+        source = definition.authority_source
+        hash[definition.name] = source if source
+      end
+    end
+
+    ##
     # The raw per-attribute configs for a schema, INCLUDING compound
     # subproperties (entries declaring `available_on: { properties: [...] }`). Unlike
     # {#attributes_for} et al. — which exclude subproperties so they never become
@@ -135,6 +154,20 @@ module Hyrax
       # @return [Enumerable<Symbol>]
       def index_keys
         (config.fetch('indexing', nil) || config.fetch('index_keys', []))&.reject { |k| ['facetable', 'stored_searchable', 'admin_only', 'editor_only'].include?(k) }&.map(&:to_sym) || []
+      end
+
+      ##
+      # The first real source wins, matching how the deposit form picks which
+      # authority to offer when a property lists several.
+      #
+      # @return [String, nil] nil when the attribute is free text.
+      def authority_source
+        sources = config.fetch('controlled_values', nil)
+        return unless sources.is_a?(Hash)
+
+        Array(sources['sources'])
+          .map { |source| source.to_s.strip }
+          .find { |source| source.present? && !source.casecmp('null').zero? }
       end
 
       ##

--- a/documentation/flexible_metadata.md
+++ b/documentation/flexible_metadata.md
@@ -102,6 +102,54 @@ admin_note:
 
 Use `admin_only` in place of `editor_only` to restrict visibility to admins only.
 
+## Controlled-vocabulary labels
+
+A controlled vocabulary term has two parts: an **id** — the value works store — and a **label**. Where the two differ, an id alone reads as opaque: a term whose id is `local_auth_123` and whose label is "Opaque Term" would otherwise display as `local_auth_123` on work pages, in search results, and in facets.
+
+A property is treated as controlled when its `controlled_values.sources` names an authority (anything other than the `"null"` free-text sentinel), the configured label service can resolve that authority, and its `indexing:` array names the Solr fields the labels ride beside.
+
+The `indexing:` array must name the Solr fields themselves. `stored_searchable` and `facetable` are directives that carry no field name, and a property declaring only those has no index keys for the indexer to write label companions beside — such a property is left exactly as it is today.
+
+```yaml
+resource_type:
+  controlled_values:
+    format: http://www.w3.org/2001/XMLSchema#string
+    sources:
+      - resource_types
+  indexing:
+    - resource_type_tesim   # required for labels in rows and on show pages
+    - resource_type_sim     # required for the label facet
+    - facetable
+```
+
+Given that, Hyrax:
+
+- **indexes** the labels beside the stored ids, as `<index_key>_label` — `resource_type_tesim` gains `resource_type_label_tesim`. The ids are left in place: they are the link target for a URI-valued authority and what OAI harvests. Labels are positionally parallel to the values, repeating the id where a term does not resolve.
+- **renders** the label on the show page, linking it to the id where the id is an `http`/`https` URI.
+- **facets and links** on `<property>_label_sim`, and shows the label in the search-result row, falling back to the id for works indexed before the label fields existed. The id facet stays configured alongside the label facet — hidden from the sidebar, so the ids are not listed beside the labels, but still resolving `f[<property>_sim][]` from saved searches and bookmarks.
+
+Reindex after registering a service. Until then the label fields are empty: search-result rows fall back to showing the id, while the row's facet link points at the label facet, so clicking a value returns nothing. Both agree once the corpus is reindexed.
+
+Because this is driven by the profile, a property or vocabulary added to an m3 profile is covered with no `CatalogController` change.
+
+### Registering a label service
+
+Hyrax has no vocabulary store of its own, so resolution is injectable. The default resolves nothing, which leaves indexing and rendering byte-identical to an installation without this feature. An application registers its own resolver:
+
+```ruby
+# config/initializers/hyrax.rb
+Hyrax.config.controlled_vocabulary_label_service = MyLabelService.new
+```
+
+A service need only implement the two methods on `Hyrax::ControlledVocabularyLabelService`:
+
+| method | returns |
+| --- | --- |
+| `resolvable?(source)` | whether labels can be resolved for the named vocabulary |
+| `labels_for(source, values)` | one label per value, in order, the id where unresolved |
+
+`labels_for` must stay positional — the renderer pairs values to labels, so an unresolved value has to hold its place. `resolvable?` should answer `false` for remote authorities: resolving one means a network call per value, which has no place in an indexing run.
+
 ## Rich-text fields
 
 A string property can be edited with a rich-text (WYSIWYG) editor and rendered as sanitized HTML. This works in both flexible and non-flexible mode and is driven by two independent directives:

--- a/lib/hyrax/configuration.rb
+++ b/lib/hyrax/configuration.rb
@@ -1049,6 +1049,20 @@ module Hyrax
     end
     attr_writer :location_service
 
+    # A configuration point for resolving controlled vocabulary term ids to
+    # their labels, used when indexing and rendering controlled properties.
+    #
+    # Defaults to a no-op that returns values unchanged, because Hyrax has no
+    # vocabulary store of its own. Register an application's own resolver to
+    # have labels indexed and displayed.
+    #
+    # @!attribute [w] controlled_vocabulary_label_service
+    #   @see Hyrax::ControlledVocabularyLabelService for the expected interface
+    def controlled_vocabulary_label_service
+      @controlled_vocabulary_label_service ||= Hyrax::ControlledVocabularyLabelService.new
+    end
+    attr_writer :controlled_vocabulary_label_service
+
     attr_writer :active_deposit_agreement_acceptance
     def active_deposit_agreement_acceptance?
       return true if @active_deposit_agreement_acceptance.nil?

--- a/lib/hyrax/indexer.rb
+++ b/lib/hyrax/indexer.rb
@@ -47,10 +47,26 @@ module Hyrax
       @schema_name = schema_name
       @index_loader = index_loader
       @rules = rules
+      # Written from `to_solr`, which runs on request and job threads against one
+      # module instance, so this cannot be a plain Hash.
+      @authorities = Concurrent::Map.new
       define_solr_method(schema_name:, index_loader:)
     end
 
+    ##
+    # @api private
+    #
+    # Memoized per schema/version/contexts rather than resolved per document:
+    # `to_solr` runs once per record in a reindex, and walking the profile there
+    # would repeat that work for every one. Mirrors how `@rules` is held.
+    def authorities_for(index_loader, schema_args)
+      @authorities.compute_if_absent(schema_args) do
+        Hyrax::Indexer.authority_rules(index_loader, schema_args)
+      end
+    end
+
     def define_solr_method(schema_name:, index_loader:) # rubocop:disable Metrics/MethodLength
+      indexer_module = self
       define_method :to_solr do |*args|
         super(*args).tap do |document|
           schema_args = if index_loader.is_a?(Hyrax::M3SchemaLoader)
@@ -62,11 +78,89 @@ module Hyrax
                         end
           rules = @rules || index_loader.index_rules_for(**schema_args)
 
+          authorities = indexer_module.authorities_for(index_loader, schema_args)
+          # Memo per attribute, not per index key: a property that is both
+          # stored_searchable and facetable has several index keys carrying the
+          # same values, and resolving them once each repeats the lookup.
+          labels = {}
+
           rules.each do |index_key, method|
-            document[index_key] = resource.try(method)
+            value = resource.try(method)
+            document[index_key] = value
+
+            Hyrax::Indexer.add_label(document, index_key, authorities[method], value,
+                                     memo: labels, attribute: method)
           end
         end
       end
+    end
+
+    ##
+    # @api private
+    #
+    # Write a controlled property's term labels beside its stored ids, as
+    # `<index_key>_label`. The ids are left in place: they are the link target
+    # for a URI-valued authority and what OAI harvests.
+    #
+    # A no-op unless the configured label service can resolve the authority, so
+    # an application that registers none indexes exactly as it did before.
+    def self.add_label(document, index_key, source, value, memo: {}, attribute: nil)
+      return if source.blank?
+
+      label_key = label_key_for(index_key)
+      return if label_key.blank?
+
+      # Keyed on the attribute, not the authority: two properties can cite the
+      # same vocabulary while holding different values. Holds the resolvable?
+      # answer too, so neither call repeats across a property's index keys.
+      memo_key = attribute || index_key
+      labels = memo.fetch(memo_key) { memo[memo_key] = resolve_labels(source, value) }
+      document[label_key] = labels if labels.present?
+    rescue StandardError => e
+      # Never fail an indexing run over a label; the ids index as-is. Debug
+      # rather than warn: this fires per index key per document, so a service
+      # that is broken for a whole corpus would otherwise flood the log.
+      Hyrax.logger.debug { "Unable to index labels for #{index_key}: #{e.message}" }
+    end
+
+    ##
+    # @api private
+    #
+    # nil when the configured service cannot resolve the vocabulary, so the memo
+    # holds that answer and `resolvable?` is asked once per attribute.
+    def self.resolve_labels(source, value)
+      service = Hyrax.config.controlled_vocabulary_label_service
+      return unless service.resolvable?(source)
+
+      service.labels_for(source, value)
+    end
+
+    ##
+    # @api private
+    #
+    # @see Hyrax::ControlledVocabularyFieldValues.label_key for the derivation
+    #   the catalog and presenter read back through.
+    def self.label_key_for(index_key)
+      key = index_key.to_s
+      label_key = Hyrax::ControlledVocabularyFieldValues.label_key(key)
+      return if label_key == key
+
+      label_key.to_sym
+    end
+
+    ##
+    # @api private
+    #
+    # @return [Hash{Symbol => String}] the controlled authority backing each
+    #   attribute. Empty for a custom loader predating
+    #   {SchemaLoader#authority_rules_for}, so third-party loaders keep working.
+    def self.authority_rules(index_loader, schema_args)
+      return {} unless index_loader.respond_to?(:authority_rules_for)
+
+      index_loader.authority_rules_for(**schema_args) || {}
+    rescue StandardError => e
+      Hyrax.logger.warn("Unable to resolve controlled vocabulary authorities: #{e.message}")
+      {}
     end
   end
 end

--- a/spec/controllers/concerns/hyrax/flexible_catalog_behavior_labels_spec.rb
+++ b/spec/controllers/concerns/hyrax/flexible_catalog_behavior_labels_spec.rb
@@ -1,0 +1,433 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Hyrax::FlexibleCatalogBehavior, 'controlled vocabulary labels', type: :controller do
+  let(:base_profile) { YAML.safe_load_file(Hyrax::Engine.root.join('spec', 'fixtures', 'files', 'm3_profile.yaml')) }
+
+  let(:custom_properties) do
+    YAML.safe_load(<<-YAML)
+      properties:
+        resource_type:
+          available_on:
+            class:
+              - GenericWork
+              - Monograph
+          controlled_values:
+            format: http://www.w3.org/2001/XMLSchema#string
+            sources:
+              - resource_types
+          display_label:
+            default: Resource Type
+          indexing:
+            - stored_searchable
+            - facetable
+          property_uri: http://purl.org/dc/terms/type
+          range: http://www.w3.org/2001/XMLSchema#string
+        monograph_resource_type:
+          name: resource_type
+          available_on:
+            class:
+              - Monograph
+          controlled_values:
+            format: http://www.w3.org/2001/XMLSchema#string
+            sources:
+              - monograph_types
+          display_label:
+            default: Resource Type
+          indexing:
+            - resource_type_sim
+            - resource_type_tesim
+            - stored_searchable
+            - facetable
+          property_uri: http://purl.org/dc/terms/type
+          range: http://www.w3.org/2001/XMLSchema#string
+        free_text_note:
+          available_on:
+            class:
+              - GenericWork
+          controlled_values:
+            format: http://www.w3.org/2001/XMLSchema#string
+            sources:
+              - "null"
+          display_label:
+            default: Free Text Note
+          indexing:
+            - stored_searchable
+            - facetable
+          property_uri: http://example.org/free_text_note
+          range: http://www.w3.org/2001/XMLSchema#string
+    YAML
+  end
+
+  controller(ApplicationController) do
+    include Blacklight::Configurable
+    include Blacklight::SearchContext
+    include Hyrax::FlexibleCatalogBehavior
+
+    configure_blacklight do |config|
+      config.search_builder_class = Hyrax::CatalogSearchBuilder
+      config.default_solr_params = { qt: 'search', rows: 10 }
+
+      config.add_search_field('all_fields') do |field|
+        field.solr_parameters = { qf: String.new('') }
+      end
+    end
+
+    def index
+      @response = Blacklight::Solr::Response.new({}, {})
+      render plain: 'OK'
+    end
+  end
+
+  let(:label_service) do
+    Class.new(Hyrax::ControlledVocabularyLabelService) do
+      def resolvable?(source)
+        ['resource_types', 'monograph_types'].include?(source)
+      end
+    end.new
+  end
+
+  # blacklight_config is class-level state, so without this a facet registered
+  # by one example is still there for the next.
+  around do |example|
+    klass = self.class.controller_class
+    original = klass.blacklight_config.deep_copy
+    example.run
+    klass.blacklight_config = original
+  end
+
+  before do
+    allow(Hyrax.config).to receive(:flexible?).and_return(true)
+    allow(Hyrax.config).to receive(:controlled_vocabulary_label_service).and_return(label_service)
+    routes.draw { get 'index' => 'anonymous#index' }
+
+    mock_schema = double('FlexibleSchema', profile: base_profile.deep_merge(custom_properties))
+
+    allow(Hyrax::FlexibleSchema)
+      .to receive_message_chain(:order, :last)
+      .with("created_at asc")
+      .with(2)
+      .and_return([mock_schema])
+
+    controller.class.load_flexible_schema
+  end
+
+  let(:blacklight_config) do
+    get :index
+    controller.blacklight_config
+  end
+
+  describe 'a facetable controlled property' do
+    it 'facets on the label field' do
+      expect(blacklight_config.facet_fields).to have_key('resource_type_label_sim')
+    end
+
+    it 'links the search-result row to the label facet' do
+      expect(blacklight_config.index_fields['resource_type_tesim'].link_to_facet)
+        .to eq('resource_type_label_sim')
+    end
+
+    it 'resolves the facet label rather than titleizing the renamed solr key' do
+      stored = blacklight_config.facet_fields['resource_type_label_sim'].label
+      resolved = stored.respond_to?(:call) ? stored.call : stored
+
+      expect(resolved).to match(/\AResource [Tt]ype\z/)
+    end
+
+    it 'shows the label in the search-result row, falling back to the id' do
+      field = blacklight_config.index_fields['resource_type_tesim']
+      expect(field.values).to be_present
+
+      document = { 'resource_type_tesim' => ['local_auth_123'],
+                   'resource_type_label_tesim' => ['Opaque Term'] }
+      expect(field.values.call(field, document, nil)).to eq(['Opaque Term'])
+
+      unlabeled = { 'resource_type_tesim' => ['local_auth_123'] }
+      expect(field.values.call(field, unlabeled, nil)).to eq(['local_auth_123'])
+    end
+  end
+
+  describe 'the id facet' do
+    it 'stays registered so an un-reindexed corpus keeps its facet' do
+      expect(blacklight_config.facet_fields).to have_key('resource_type_sim')
+      expect(blacklight_config.facet_fields).to have_key('resource_type_label_sim')
+    end
+
+    it 'keeps existing bookmarked and saved-search facet URLs working' do
+      expect(blacklight_config.facet_fields['resource_type_sim']).to be_present
+    end
+  end
+
+  describe 'the id facet, once a label facet exists' do
+    it 'stays configured so saved searches and bookmarks keep resolving' do
+      expect(blacklight_config.facet_fields).to have_key('resource_type_sim')
+    end
+
+    it 'is not listed in the sidebar, so the ids are not shown beside the labels' do
+      expect(blacklight_config.facet_fields['resource_type_sim'].show).to be false
+    end
+
+    it 'leaves the label facet listed' do
+      expect(blacklight_config.facet_fields['resource_type_label_sim'].show).not_to be false
+    end
+  end
+
+  describe 'a controlled property declaring only shorthand indexing directives' do
+    let(:custom_properties) do
+      YAML.safe_load(<<-YAML)
+        properties:
+          shorthand_type:
+            available_on:
+              class:
+                - GenericWork
+                - Monograph
+            controlled_values:
+              format: http://www.w3.org/2001/XMLSchema#string
+              sources:
+                - resource_types
+            display_label:
+              default: Shorthand Type
+            indexing:
+              - stored_searchable
+              - facetable
+            property_uri: http://purl.org/dc/terms/type
+            range: http://www.w3.org/2001/XMLSchema#string
+      YAML
+    end
+
+    it 'registers no label facet, because nothing is indexed to one' do
+      expect(blacklight_config.facet_fields).not_to have_key('shorthand_type_label_sim')
+    end
+
+    it 'leaves the id facet listed rather than hiding it behind an empty one' do
+      expect(blacklight_config.facet_fields['shorthand_type_sim'].show).not_to be false
+    end
+  end
+
+  describe 'a controlled property declaring only a stored key, no facet key' do
+    let(:custom_properties) do
+      YAML.safe_load(<<-YAML)
+        properties:
+          mixed_type:
+            available_on:
+              class:
+                - GenericWork
+                - Monograph
+            controlled_values:
+              format: http://www.w3.org/2001/XMLSchema#string
+              sources:
+                - resource_types
+            display_label:
+              default: Mixed Type
+            indexing:
+              - mixed_type_tesim
+              - facetable
+            property_uri: http://purl.org/dc/terms/type
+            range: http://www.w3.org/2001/XMLSchema#string
+      YAML
+    end
+
+    it 'registers no label facet, because no label facet field is indexed' do
+      expect(blacklight_config.facet_fields).not_to have_key('mixed_type_label_sim')
+    end
+
+    it 'leaves the id facet listed' do
+      expect(blacklight_config.facet_fields['mixed_type_sim'].show).not_to be false
+    end
+  end
+
+  describe 'a property that stops being controlled' do
+    let(:config) { controller.class.blacklight_config }
+
+    it 'restores the id facet to the sidebar' do
+      expect(config.facet_fields['resource_type_sim'].show).to be false
+
+      allow(Hyrax.config).to receive(:controlled_vocabulary_label_service)
+        .and_return(Hyrax::ControlledVocabularyLabelService.new)
+      controller.class.load_flexible_schema
+
+      expect(config.facet_fields['resource_type_sim'].show).not_to be false
+    end
+  end
+
+  describe 'free-text search' do
+    let(:qf) { blacklight_config.search_fields['all_fields'].solr_parameters[:qf] }
+
+    it 'queries the label field, so searching a term by its label finds the work' do
+      expect(qf).to include('resource_type_label_tesim')
+    end
+
+    it 'still queries the id field' do
+      expect(qf).to include('resource_type_tesim')
+    end
+
+    it 'does not add a label field for an uncontrolled property' do
+      expect(qf).not_to include('free_text_note_label_tesim')
+    end
+  end
+
+  describe 'a property that stops being controlled' do
+    let(:config) { controller.class.blacklight_config }
+
+    before do
+      expect(config.index_fields['resource_type_tesim'].values).to be_present
+
+      allow(Hyrax.config).to receive(:controlled_vocabulary_label_service)
+        .and_return(Hyrax::ControlledVocabularyLabelService.new)
+      controller.class.load_flexible_schema
+    end
+
+    it 'stops reading the label field in search results' do
+      expect(config.index_fields['resource_type_tesim'].values).to be_nil
+    end
+  end
+
+  describe 'the free-text search fields' do
+    let(:qf) { blacklight_config.search_fields['all_fields'].solr_parameters[:qf] }
+
+    it 'appends a field whose name is a substring of one already listed' do
+      # A substring check reports `type_tesim` as present once
+      # `resource_type_tesim` is in the list, so it would never be appended.
+      qf # resolve the config before appending
+      controller.class.send(:append_query_fields!, ['type_tesim'])
+
+      current = controller.class.blacklight_config.search_fields['all_fields'].solr_parameters[:qf]
+      expect(current.split).to include('type_tesim', 'resource_type_tesim')
+    end
+  end
+
+  describe 'a property whose first source is not resolvable' do
+    let(:custom_properties) do
+      YAML.safe_load(<<-YAML)
+        properties:
+          mixed_sources:
+            available_on:
+              class:
+                - GenericWork
+                - Monograph
+            controlled_values:
+              format: http://www.w3.org/2001/XMLSchema#string
+              sources:
+                - geonames
+                - resource_types
+            display_label:
+              default: Mixed Sources
+            indexing:
+              - mixed_sources_sim
+              - mixed_sources_tesim
+              - facetable
+            property_uri: http://purl.org/dc/terms/type
+            range: http://www.w3.org/2001/XMLSchema#string
+      YAML
+    end
+
+    it 'agrees with the indexer, which resolves the first real source' do
+      expect(blacklight_config.facet_fields).not_to have_key('mixed_sources_label_sim')
+      expect(blacklight_config.facet_fields['mixed_sources_sim'].show).not_to be false
+    end
+  end
+
+  describe 'removing a property from the query fields' do
+    let(:config) { controller.class.blacklight_config }
+    let(:qf) { config.search_fields['all_fields'].solr_parameters[:qf] }
+
+    # Substring removal would take `resource_type_tesim` down to `resource_`
+    # when asked to remove the shorter `type_tesim`.
+    it 'leaves a longer field whose name contains the removed one intact' do
+      controller.class.send(:append_query_fields!, ['type_tesim'])
+      expect(qf.split).to include('type_tesim', 'resource_type_tesim')
+
+      controller.class.send(:remove_from_blacklight_config!, 'type', ['type_tesim'])
+
+      expect(qf.split).not_to include('type_tesim')
+      expect(qf.split).to include('resource_type_tesim')
+    end
+  end
+
+  describe 'an uncontrolled property' do
+    it 'keeps faceting on its own solr key' do
+      expect(blacklight_config.facet_fields).to have_key('free_text_note_sim')
+      expect(blacklight_config.facet_fields).not_to have_key('free_text_note_label_sim')
+    end
+
+    it 'is left reading the stored values' do
+      expect(blacklight_config.index_fields['free_text_note_tesim'].values).to be_nil
+    end
+  end
+
+  describe 'a name: surrogate property' do
+    it 'registers no facet under its own key, where nothing is indexed' do
+      expect(blacklight_config.facet_fields).not_to have_key('monograph_resource_type_sim')
+      expect(blacklight_config.facet_fields).not_to have_key('monograph_resource_type_label_sim')
+    end
+  end
+
+  describe 'resolvable? lookups' do
+    it 'asks the label service once per distinct vocabulary, not once per property' do
+      allow(label_service).to receive(:resolvable?).and_call_original
+
+      controller.class.load_flexible_schema
+
+      expect(label_service).to have_received(:resolvable?).with('resource_types').at_most(:once)
+    end
+  end
+
+  describe 'a surrogate declaring the target attribute\'s solr fields' do
+    it 'does not delete the target property\'s own registrations' do
+      expect(blacklight_config.facet_fields).to have_key('resource_type_sim')
+      expect(blacklight_config.index_fields).to have_key('resource_type_tesim')
+    end
+  end
+
+  describe 'a controlled property that leaves the profile' do
+    let(:config) { controller.class.blacklight_config }
+
+    before do
+      expect(config.facet_fields).to have_key('resource_type_label_sim')
+      controller.class.send(:remove_from_blacklight_config!, 'resource_type',
+                            ['stored_searchable', 'facetable'])
+    end
+
+    it 'removes its label facet along with its id facet' do
+      expect(config.facet_fields).not_to have_key('resource_type_label_sim')
+      expect(config.facet_fields).not_to have_key('resource_type_sim')
+    end
+
+    it 'removes its label column along with its id column' do
+      expect(config.index_fields).not_to have_key('resource_type_label_tesim')
+      expect(config.index_fields).not_to have_key('resource_type_tesim')
+    end
+  end
+
+  describe 'a property that becomes a surrogate mid-process' do
+    let(:config) { controller.class.blacklight_config }
+
+    it 'leaves no label facet behind under the surrogate key' do
+      config.add_facet_field('monograph_resource_type_label_sim', label: 'Stale')
+
+      controller.class.load_flexible_schema
+
+      expect(config.facet_fields).not_to have_key('monograph_resource_type_label_sim')
+      expect(config.facet_fields).not_to have_key('monograph_resource_type_sim')
+    end
+  end
+
+  describe 'repeated loads' do
+    it 'is safe to run once per request' do
+      expect { 5.times { controller.class.load_flexible_schema } }.not_to raise_error
+
+      expect(blacklight_config.facet_fields).to have_key('resource_type_label_sim')
+    end
+  end
+
+  context 'with no label service registered' do
+    let(:label_service) { Hyrax::ControlledVocabularyLabelService.new }
+
+    it 'leaves the catalog config exactly as upstream builds it' do
+      expect(blacklight_config.facet_fields).to have_key('resource_type_sim')
+      expect(blacklight_config.facet_fields).not_to have_key('resource_type_label_sim')
+      expect(blacklight_config.index_fields['resource_type_tesim'].values).to be_nil
+    end
+  end
+end

--- a/spec/hyrax/indexer_controlled_labels_spec.rb
+++ b/spec/hyrax/indexer_controlled_labels_spec.rb
@@ -1,0 +1,160 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Hyrax::Indexer, '.Indexer controlled vocabulary labels' do
+  subject(:document) { indexer_class.new(resource: work).to_solr }
+
+  let(:work) { FactoryBot.build(:hyrax_work, title: ['A Title']) }
+
+  let(:index_loader) do
+    instance_double(Hyrax::SimpleSchemaLoader,
+                    index_rules_for: index_rules,
+                    authority_rules_for: authority_rules)
+  end
+
+  let(:index_rules)     { { title_tesim: :title, title_sim: :title } }
+  let(:authority_rules) { {} }
+
+  let(:indexer_class) do
+    loader = index_loader
+    Class.new(Hyrax::ValkyrieIndexer) do
+      include Hyrax::Indexer(:core_metadata, index_loader: loader)
+    end
+  end
+
+  context 'with no label service registered' do
+    let(:authority_rules) { { title: 'title_authority' } }
+
+    it 'indexes the stored ids and no label fields' do
+      expect(document).to include(title_tesim: ['A Title'])
+      expect(document.keys.grep(/_label_/)).to be_empty
+    end
+  end
+
+  context 'with a label service that resolves the authority' do
+    let(:authority_rules) { { title: 'title_authority' } }
+
+    let(:label_service) do
+      Class.new(Hyrax::ControlledVocabularyLabelService) do
+        def resolvable?(source)
+          source == 'title_authority'
+        end
+
+        def labels_for(_source, values)
+          Array.wrap(values).map { |value| value == 'A Title' ? 'Resolved Label' : value }
+        end
+      end.new
+    end
+
+    before { allow(Hyrax.config).to receive(:controlled_vocabulary_label_service).and_return(label_service) }
+
+    it 'writes the labels beside the untouched ids' do
+      expect(document).to include(title_tesim: ['A Title'],
+                                  title_label_tesim: ['Resolved Label'])
+    end
+
+    it 'keeps the label suffix last so the solr dynamic field matches' do
+      expect(document).to have_key(:title_label_sim)
+      expect(document).not_to have_key(:title_sim_label)
+    end
+
+    context 'and a property the service cannot resolve' do
+      let(:authority_rules) { { title: 'unknown_authority' } }
+
+      it 'indexes no label field for it' do
+        expect(document.keys.grep(/_label_/)).to be_empty
+      end
+    end
+
+    context 'and an uncontrolled property' do
+      let(:authority_rules) { {} }
+
+      it 'is left unchanged' do
+        expect(document).to include(title_tesim: ['A Title'])
+        expect(document.keys.grep(/_label_/)).to be_empty
+      end
+    end
+
+    context 'with a multi-valued property only partly resolvable' do
+      let(:work) { FactoryBot.build(:hyrax_work, title: ['A Title', 'Opaque', 'A Title']) }
+
+      it 'keeps the labels positionally aligned with the values' do
+        expect(document[:title_label_tesim]).to eq(['Resolved Label', 'Opaque', 'Resolved Label'])
+      end
+    end
+  end
+
+  context 'with two attributes citing the same authority' do
+    let(:index_rules)     { { title_tesim: :title, title_sim: :title, creator_tesim: :creator } }
+    let(:authority_rules) { { title: 'shared_authority', creator: 'shared_authority' } }
+    let(:work)            { FactoryBot.build(:hyrax_work, title: ['A Title'], creator: ['A Creator']) }
+
+    let(:label_service) do
+      Class.new(Hyrax::ControlledVocabularyLabelService) do
+        def resolvable?(_source)
+          true
+        end
+
+        def labels_for(_source, values)
+          Array.wrap(values).map { |value| "Label for #{value}" }
+        end
+      end.new
+    end
+
+    before { allow(Hyrax.config).to receive(:controlled_vocabulary_label_service).and_return(label_service) }
+
+    it 'resolves each attribute against its own values' do
+      expect(document[:title_label_tesim]).to eq(['Label for A Title'])
+      expect(document[:creator_label_tesim]).to eq(['Label for A Creator'])
+    end
+  end
+
+  context 'with a property carrying several index keys' do
+    let(:index_rules)     { { title_tesim: :title, title_sim: :title } }
+    let(:authority_rules) { { title: 'title_authority' } }
+
+    let(:label_service) do
+      Class.new(Hyrax::ControlledVocabularyLabelService) do
+        def resolvable?(_source)
+          true
+        end
+
+        def labels_for(_source, values)
+          Array.wrap(values)
+        end
+      end.new
+    end
+
+    before do
+      allow(Hyrax.config).to receive(:controlled_vocabulary_label_service).and_return(label_service)
+      allow(label_service).to receive(:resolvable?).and_call_original
+      allow(label_service).to receive(:labels_for).and_call_original
+    end
+
+    it 'asks the service once for the attribute, not once per index key' do
+      document
+
+      expect(label_service).to have_received(:labels_for).once
+      expect(label_service).to have_received(:resolvable?).once
+    end
+  end
+
+  context 'when the label service raises' do
+    let(:authority_rules) { { title: 'title_authority' } }
+
+    let(:label_service) do
+      Class.new(Hyrax::ControlledVocabularyLabelService) do
+        def resolvable?(_source)
+          raise 'vocabulary backend is down'
+        end
+      end.new
+    end
+
+    before { allow(Hyrax.config).to receive(:controlled_vocabulary_label_service).and_return(label_service) }
+
+    it 'still indexes the ids rather than failing the run' do
+      expect(document).to include(title_tesim: ['A Title'])
+    end
+  end
+end

--- a/spec/lib/hyrax/configuration_spec.rb
+++ b/spec/lib/hyrax/configuration_spec.rb
@@ -85,6 +85,14 @@ RSpec.describe Hyrax::Configuration do
   it { is_expected.to respond_to(:libreoffice_path) }
   it { is_expected.to respond_to(:license_service_class) }
   it { is_expected.to respond_to(:license_service_class=) }
+  it { is_expected.to respond_to(:controlled_vocabulary_label_service) }
+  it { is_expected.to respond_to(:controlled_vocabulary_label_service=) }
+
+  describe '#controlled_vocabulary_label_service' do
+    it 'defaults to the no-op resolver' do
+      expect(subject.controlled_vocabulary_label_service).to be_a(Hyrax::ControlledVocabularyLabelService)
+    end
+  end
   it { is_expected.to respond_to(:logger) }
   it { is_expected.to respond_to(:logger=) }
   it { is_expected.to respond_to(:max_days_between_fixity_checks) }

--- a/spec/presenters/hyrax/presents_attributes_labels_spec.rb
+++ b/spec/presenters/hyrax/presents_attributes_labels_spec.rb
@@ -1,0 +1,140 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Hyrax::PresentsAttributes, 'controlled vocabulary labels' do
+  subject(:presenter) { presenter_class.new(document) }
+
+  let(:presenter_class) do
+    Class.new do
+      include Hyrax::PresentsAttributes
+
+      attr_reader :solr_document
+
+      def initialize(solr_document)
+        @solr_document = solr_document
+      end
+
+      def resource_type
+        Array(solr_document['resource_type_tesim'])
+      end
+    end
+  end
+
+  let(:document) { SolrDocument.new(fields) }
+
+  context 'when the document carries indexed labels' do
+    let(:fields) do
+      { 'resource_type_tesim' => ['local_auth_123'],
+        'resource_type_label_tesim' => ['Opaque Term'] }
+    end
+
+    it 'renders the label rather than the id' do
+      expect(presenter.attribute_to_html(:resource_type)).to include('Opaque Term')
+    end
+
+    it 'passes the labels to the renderer keyed by value, alongside the values' do
+      expect(Hyrax::Renderers::AttributeRenderer)
+        .to receive(:new)
+        .with(:resource_type, ['local_auth_123'], hash_including(labels: { 'local_auth_123' => 'Opaque Term' }))
+        .and_call_original
+
+      presenter.attribute_to_html(:resource_type)
+    end
+  end
+
+  context 'when the id is a linkable URI' do
+    let(:fields) do
+      { 'resource_type_tesim' => ['http://example.org/terms/image'],
+        'resource_type_label_tesim' => ['Image'] }
+    end
+
+    it 'links the label to the id' do
+      expect(presenter.attribute_to_html(:resource_type))
+        .to include('<a href="http://example.org/terms/image"', '>Image</a>')
+    end
+  end
+
+  context 'when the values are sorted' do
+    let(:fields) do
+      { 'resource_type_tesim' => ['zebra_id', 'apple_id'],
+        'resource_type_label_tesim' => ['Zebra Label', 'Apple Label'] }
+    end
+
+    it 'keeps each label with its own value rather than pairing by position' do
+      html = presenter.attribute_to_html(:resource_type, sort: true)
+
+      expect(html.index('Apple Label')).to be < html.index('Zebra Label')
+    end
+  end
+
+  context 'when the label count does not match the value count' do
+    let(:fields) do
+      { 'resource_type_tesim' => ['a', 'b', 'c'],
+        'resource_type_label_tesim' => ['Label A', 'Label C'] }
+    end
+
+    it 'falls back to the ids rather than pairing a value with another value label' do
+      html = presenter.attribute_to_html(:resource_type)
+
+      expect(html).to include('a', 'b', 'c')
+      expect(html).not_to include('Label C')
+    end
+  end
+
+  context 'when the property declares a custom index key' do
+    let(:fields) do
+      { 'resource_type_tesim' => ['local_auth_123'],
+        'resource_type_label_ssim' => ['Opaque Term'] }
+    end
+
+    it 'reads the label companion the indexer wrote for that key' do
+      expect(presenter.attribute_to_html(:resource_type)).to include('Opaque Term')
+    end
+  end
+
+  context 'when a sibling property shares the label prefix' do
+    let(:fields) do
+      { 'resource_type_tesim' => ['local_auth_123'],
+        'resource_type_label_note_tesim' => ['A different property'] }
+    end
+
+    it 'does not read the sibling property as this one\'s labels' do
+      expect(presenter.attribute_to_html(:resource_type)).to include('local_auth_123')
+      expect(presenter.attribute_to_html(:resource_type)).not_to include('A different property')
+    end
+  end
+
+  context 'when a preferred label field is present but empty' do
+    let(:fields) do
+      { 'resource_type_tesim' => ['local_auth_123'],
+        'resource_type_label_tesim' => [],
+        'resource_type_label_ssim' => ['Opaque Term'] }
+    end
+
+    it 'falls through to a populated label field rather than giving up' do
+      expect(presenter.attribute_to_html(:resource_type)).to include('Opaque Term')
+    end
+  end
+
+  context 'when the work was indexed before the label fields existed' do
+    let(:fields) { { 'resource_type_tesim' => ['local_auth_123'] } }
+
+    it 'falls back to the id rather than rendering blank' do
+      expect(presenter.attribute_to_html(:resource_type)).to include('local_auth_123')
+    end
+  end
+
+  context 'when a value has no label indexed for it' do
+    let(:fields) do
+      { 'resource_type_tesim' => ['known_id', 'unknown_id'],
+        'resource_type_label_tesim' => ['Known Label', 'unknown_id'] }
+    end
+
+    it 'shows the label for the resolved value and the id for the other' do
+      html = presenter.attribute_to_html(:resource_type)
+
+      expect(html).to include('Known Label', 'unknown_id')
+    end
+  end
+end

--- a/spec/renderers/hyrax/renderers/attribute_renderer_labels_spec.rb
+++ b/spec/renderers/hyrax/renderers/attribute_renderer_labels_spec.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Hyrax::Renderers::AttributeRenderer, 'controlled vocabulary labels' do
+  subject(:renderer) { described_class.new(:resource_type, values, options) }
+
+  let(:values) { ['local_auth_123'] }
+
+  describe 'with a labels hash' do
+    let(:options) { { labels: { 'local_auth_123' => 'Opaque Term' } } }
+
+    it 'renders the label in place of the id' do
+      expect(renderer.render).to include('Opaque Term')
+      expect(renderer.render).not_to include('>local_auth_123<')
+    end
+  end
+
+  describe 'with a value the hash does not cover' do
+    let(:values)  { ['local_auth_123', 'unmapped'] }
+    let(:options) { { labels: { 'local_auth_123' => 'Opaque Term' } } }
+
+    it 'renders the label for the covered value and the id for the other' do
+      expect(renderer.render).to include('Opaque Term', 'unmapped')
+    end
+  end
+
+  describe 'with a label identical to its value' do
+    let(:options) { { labels: { 'local_auth_123' => 'local_auth_123' } } }
+
+    it 'renders the value once, without a redundant substitution' do
+      expect(renderer.render).to include('local_auth_123')
+    end
+  end
+
+  describe 'with a linkable URI value' do
+    let(:values)  { ['http://example.org/terms/image'] }
+    let(:options) { { labels: { 'http://example.org/terms/image' => 'Image' } } }
+
+    it 'links the id and displays the label' do
+      expect(renderer.render).to include('<a href="http://example.org/terms/image"', '>Image</a>')
+    end
+  end
+
+  describe 'with a non-linkable value carrying HTML in its label' do
+    let(:options) { { labels: { 'local_auth_123' => '<script>alert(1)</script>' } } }
+
+    it 'escapes the label' do
+      expect(renderer.render).to include('&lt;script&gt;')
+      expect(renderer.render).not_to include('<script>')
+    end
+  end
+
+  # These shapes cannot arise from Hyrax's own presenter, which always builds a
+  # hash; they come from downstream callers, since options is public and free-form.
+  describe 'with a labels option that is not a hash' do
+    [true, false, 'Opaque Term', ['Opaque Term'], 42, nil].each do |bad|
+      context "when labels is #{bad.inspect}" do
+        let(:options) { { labels: bad } }
+
+        it 'renders the values unchanged rather than raising' do
+          expect { renderer.render }.not_to raise_error
+          expect(renderer.render).to include('local_auth_123')
+        end
+      end
+    end
+  end
+
+  describe 'with no labels option at all' do
+    let(:options) { {} }
+
+    it 'renders exactly as it did before labels existed' do
+      expect(renderer.render).to eq(described_class.new(:resource_type, values, {}).render)
+      expect(renderer.render).to include('local_auth_123')
+    end
+  end
+end

--- a/spec/renderers/hyrax/renderers/faceted_linked_labels_spec.rb
+++ b/spec/renderers/hyrax/renderers/faceted_linked_labels_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe 'controlled vocabulary labels in linking renderers' do
+  let(:values)  { ['local_auth_123'] }
+  let(:options) { { labels: { 'local_auth_123' => 'Opaque Term' } } }
+
+  describe Hyrax::Renderers::FacetedAttributeRenderer do
+    subject(:renderer) { described_class.new(:resource_type, values, options) }
+
+    it 'shows the label as the link text' do
+      expect(renderer.render).to include('Opaque Term')
+    end
+
+    it 'still searches on the stored id' do
+      expect(renderer.render).to include('local_auth_123')
+    end
+
+    context 'with no labels' do
+      let(:options) { {} }
+
+      it 'renders the id as before' do
+        expect(renderer.render).to include('local_auth_123')
+      end
+    end
+  end
+
+  describe Hyrax::Renderers::LinkedAttributeRenderer do
+    subject(:renderer) { described_class.new(:resource_type, values, options) }
+
+    it 'shows the label as the link text' do
+      expect(renderer.render).to include('Opaque Term')
+    end
+
+    it 'still searches on the stored id' do
+      expect(renderer.render).to include('local_auth_123')
+    end
+  end
+end

--- a/spec/services/hyrax/controlled_vocabulary_label_service_spec.rb
+++ b/spec/services/hyrax/controlled_vocabulary_label_service_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Hyrax::ControlledVocabularyLabelService do
+  subject(:service) { described_class.new }
+
+  describe '#labels_for' do
+    it 'returns the values unchanged' do
+      expect(service.labels_for('resource_types', ['local_auth_123', 'Image']))
+        .to eq(['local_auth_123', 'Image'])
+    end
+
+    it 'wraps a single value in an array' do
+      expect(service.labels_for('resource_types', 'local_auth_123')).to eq(['local_auth_123'])
+    end
+
+    it 'returns an empty array for no values' do
+      expect(service.labels_for('resource_types', nil)).to eq([])
+    end
+  end
+
+  describe '#resolvable?' do
+    it 'resolves nothing, so no property is treated as controlled' do
+      expect(service.resolvable?('resource_types')).to be false
+    end
+  end
+end

--- a/spec/services/hyrax/m3_schema_loader_spec.rb
+++ b/spec/services/hyrax/m3_schema_loader_spec.rb
@@ -80,6 +80,91 @@ RSpec.describe Hyrax::M3SchemaLoader do
     end
   end
 
+  describe '#authority_rules_for' do
+    let(:controlled_properties) do
+      YAML.safe_load(<<-YAML)
+        properties:
+          resource_type:
+            available_on:
+              class:
+                - GenericWork
+                - Monograph
+            controlled_values:
+              format: http://www.w3.org/2001/XMLSchema#string
+              sources:
+                - resource_types
+            display_label:
+              default: Resource Type
+            indexing:
+              - resource_type_sim
+              - resource_type_tesim
+            property_uri: http://purl.org/dc/terms/type
+            range: http://www.w3.org/2001/XMLSchema#string
+          monograph_resource_type:
+            name: resource_type
+            available_on:
+              class:
+                - Monograph
+            controlled_values:
+              format: http://www.w3.org/2001/XMLSchema#string
+              sources:
+                - monograph_types
+            display_label:
+              default: Resource Type
+            indexing:
+              - resource_type_sim
+              - resource_type_tesim
+            property_uri: http://purl.org/dc/terms/type
+            range: http://www.w3.org/2001/XMLSchema#string
+          free_text_note:
+            available_on:
+              class:
+                - GenericWork
+                - Monograph
+            controlled_values:
+              format: http://www.w3.org/2001/XMLSchema#string
+              sources:
+                - "null"
+            display_label:
+              default: Free Text Note
+            indexing:
+              - free_text_note_tesim
+            property_uri: http://example.org/free_text_note
+            range: http://www.w3.org/2001/XMLSchema#string
+      YAML
+    end
+
+    let(:profile) do
+      base = YAML.safe_load_file(Hyrax::Engine.root.join('spec', 'fixtures', 'files', 'm3_profile.yaml'))
+      base['properties'] = base['properties'].merge(controlled_properties['properties'])
+      base
+    end
+
+    it 'maps a controlled attribute to its authority name' do
+      expect(schema_loader.authority_rules_for(schema: 'GenericWork'))
+        .to include(resource_type: 'resource_types')
+    end
+
+    it 'omits free-text properties whose only source is the null sentinel' do
+      expect(schema_loader.authority_rules_for(schema: 'GenericWork'))
+        .not_to have_key(:free_text_note)
+    end
+
+    it 'answers the authority the class-specific entry declares, not the shared one' do
+      expect(schema_loader.authority_rules_for(schema: Monograph.to_s))
+        .to include(resource_type: 'monograph_types')
+      expect(schema_loader.authority_rules_for(schema: 'GenericWork'))
+        .to include(resource_type: 'resource_types')
+    end
+
+    it 'keys a name: surrogate under the attribute it stands in for' do
+      rules = schema_loader.authority_rules_for(schema: Monograph.to_s)
+
+      expect(rules).to have_key(:resource_type)
+      expect(rules).not_to have_key(:monograph_resource_type)
+    end
+  end
+
   describe '#form_definitions_for' do
     it 'provides form configuration' do
       expect(schema_loader.form_definitions_for(schema: Monograph.to_s))


### PR DESCRIPTION
## Summary
Adds an opt-in seam for resolving controlled-vocabulary term ids to their labels. **No behavior changes unless an application registers a label service** — Hyrax ships no resolver, and the default returns values unchanged.
- Refs samvera/hyku#3254

## Details

**What is unchanged.** With no label service registered — which is every Hyrax installation today — indexing, show pages, search results, and facets are byte-identical to before. Shipped m3 profiles also declare `sources: ['null']` everywhere, and the properties Hyrax does treat as controlled (`license`, `rights_statement`, `resource_type`) get that from dedicated edit-field partials and service classes rather than the profile. This PR does not touch those.

**What changes, and only then.** Behavior changes for a property that meets all three conditions:

1. Its `controlled_values.sources` names an authority (not the `'null'` sentinel).
2. A registered label service reports that authority resolvable.
3. Its `indexing:` array names the Solr fields themselves — `stored_searchable` / `facetable` alone carry no field name, so such a property is left alone.

For those properties: labels are indexed as `<property>_label_*` beside the untouched ids, the show page and search row display the label, the facet reads labels, and the label field joins free-text search.

**Design notes for review.**
- Ids are never replaced — they are the link target for a URI-valued authority and what OAI harvests.
- Row and facet move together, because Blacklight queries a facet with whatever the row displayed.
- The id facet stays configured but hidden, so saved searches and bookmarks carrying `f[<property>_sim][]` keep resolving; it is restored if the property stops being controlled.

**Unrelated change**
Gitignores uploads the koppie and dassie dev stacks write into the repo.
