### PR TITLE
Prune schema fields the flexible resource cannot answer

### DIFF
--- a/app/forms/hyrax/forms/resource_form.rb
+++ b/app/forms/hyrax/forms/resource_form.rb
@@ -93,12 +93,7 @@ module Hyrax
         if resource.nil?
           if !deprecated_resource.nil?
             Deprecation.warn "Initializing Valkyrie forms without an explicit resource parameter is deprecated. Pass the resource with `resource:` instead."
-            # Remove form definitions for attributes the model doesn't support,
-            # mirroring the cleanup in the resource: keyword path below.
-            if deprecated_resource.respond_to?(:flexible?) && deprecated_resource.flexible?
-              to_remove = singleton_class.definitions.select { |k, v| !deprecated_resource.respond_to?(k) && v.instance_variable_get("@options")[:display] }
-              to_remove.keys.each { |removed_field| singleton_class.definitions.delete(removed_field) }
-            end
+            prune_unbacked_definitions!(deprecated_resource, current_schema_fields.keys.map(&:to_s)) if deprecated_resource.respond_to?(:flexible?) && deprecated_resource.flexible?
             super(deprecated_resource)
           else
             super()
@@ -109,12 +104,7 @@ module Hyrax
             hash = resource.attributes.dup
             hash[:schema_version] = Hyrax::FlexibleSchema.current_schema_id
             resource = resource.class.new(hash)
-            # find any fields removed by the current schema
-            current_field_keys = current_schema_fields.keys.map(&:to_s)
-            to_remove = singleton_class.definitions.select { |k, v| !current_field_keys.include?(k.to_s) && v.instance_variable_get("@options")[:display] }
-            to_remove.keys.each do |removed_field|
-              singleton_class.definitions.delete(removed_field)
-            end
+            prune_unbacked_definitions!(resource, current_schema_fields.keys.map(&:to_s))
           end
 
           super(resource)
@@ -301,6 +291,20 @@ module Hyrax
       delegate :flexible?, to: :model
 
       private
+
+      # Only metadata-schema definitions carry a `:display` option. The form's
+      # own structural properties (`permissions`, `embargo`, the
+      # `<name>_attributes` writers) do not, and must survive even though the
+      # resource has no matching attribute.
+      def prune_unbacked_definitions!(resource, current_field_keys)
+        removable = singleton_class.definitions.select do |name, definition|
+          next false if current_field_keys.include?(name.to_s)
+          options = definition.instance_variable_get("@options")
+          next false unless options.key?(:display)
+          options[:display] || !resource.respond_to?(name)
+        end
+        removable.each_key { |name| singleton_class.definitions.delete(name) }
+      end
 
       # A copy of the resource loaded at the current schema version, so its
       # singleton schema reflects the live profile (including compounds added

--- a/spec/forms/hyrax/forms/resource_form_spec.rb
+++ b/spec/forms/hyrax/forms/resource_form_spec.rb
@@ -285,6 +285,69 @@ RSpec.describe Hyrax::Forms::ResourceForm do
     end
   end
 
+  describe 'flexible form with a field the profile never declared' do
+    # `redirects` is the shipped case: installed from config/metadata whenever
+    # `Hyrax.config.redirects_enabled?`, never from the profile. Stated without
+    # it so the example runs regardless of HYRAX_REDIRECTS_ENABLED.
+
+    let(:current_form_defs) do
+      { 'title' => { required: true, primary: true, display: true } }
+    end
+
+    let(:schema_loader) do
+      loader = instance_double(Hyrax::M3SchemaLoader)
+      allow(loader).to receive(:current_version).and_return(1)
+      allow(loader).to receive(:attributes_for).and_return({})
+      allow(loader).to receive(:form_definitions_for) { current_form_defs }
+      allow(loader).to receive(:index_rules_for).and_return({})
+      loader
+    end
+
+    let(:work_class) do
+      klass = Class.new(Hyrax::Work) do
+        def self.name
+          'TestUndeclaredFieldWork'
+        end
+      end
+      klass.acts_as_flexible_resource
+      klass
+    end
+
+    # `display: false` mirrors redirects.yaml, and is why the old prune could
+    # not reach it.
+    let(:form_class) do
+      Class.new(Hyrax::Forms::ResourceForm(work_class)) do
+        property :wired_from_static_config, display: false
+      end
+    end
+
+    let(:work) { work_class.new }
+
+    before do
+      allow(Hyrax.config).to receive(:flexible?).and_return(true)
+      allow(Hyrax::Schema).to receive(:m3_schema_loader).and_return(schema_loader)
+      allow(Hyrax::FlexibleSchema).to receive(:current_schema_id).and_return(1)
+    end
+
+    after do
+      Hyrax.config.flexible_classes.delete('TestUndeclaredFieldWork')
+    end
+
+    it 'builds the form instead of raising' do
+      expect { form_class.new(resource: work) }.not_to raise_error
+    end
+
+    it 'drops the undeclared field from the instance schema' do
+      form = form_class.new(resource: work)
+      expect(form.singleton_class.definitions.keys).not_to include('wired_from_static_config')
+    end
+
+    it 'keeps fields the resource can answer' do
+      form = form_class.new(resource: work)
+      expect(form.singleton_class.definitions.keys).to include('title')
+    end
+  end
+
   describe 'flexible form after M3 profile update adds a compound field' do
     # Regression: a work created on an older schema version, edited after a
     # compound (e.g. :participants) is added to the M3 profile, raised


### PR DESCRIPTION
A tenant on flexible metadata whose M3 profile does not declare `redirects` gets a 500 on work and collection `new` and `edit`. Hyrax's own `config/metadata_profiles/m3_profile.yaml` does not declare it, so `HYRAX_FLEXIBLE=true` with `HYRAX_REDIRECTS_ENABLED=true` reproduces this with no adopter customisation. `redirects` is installed onto the forms from `config/metadata/redirects.yaml` on the env flag alone, while the matching resource attribute comes from the profile, and the two can disagree.

`ResourceForm#initialize` already pruned definitions the current schema does not declare, but only ones marked `display`. `redirects.yaml` sets `form: display: false`, so the field could be neither found nor pruned, and Disposable then read it off a resource with no such attribute.

Worth arguing with:

- Candidacy is keyed on the definition carrying a `:display` option at all, which is what separates a metadata-schema field from the form's structural properties (`permissions`, `embargo`, the `<name>_attributes` writers). Those carry no `:display` key and must survive despite the resource not answering them. Keying on `respond_to?` alone prunes them and breaks the form.
- The deprecated positional-argument path now shares the same helper. Its comment already claimed it mirrored the keyword path; it did not.

Testing:

`bundle exec rspec ./spec/forms` gives 288 examples, 0 failures, 18 pending. Rubocop clean on both changed files.
