### PR TITLE
Keep one profile's fields off the form class

### DIFF
--- a/app/forms/hyrax/forms/resource_form.rb
+++ b/app/forms/hyrax/forms/resource_form.rb
@@ -76,6 +76,7 @@ module Hyrax
         r = resource || deprecated_resource
         if r.flexible?
           self.class.deserializer_class = nil # need to reload this on first use after schema is loaded
+          reset_flexible_definitions!
           singleton_class.schema_definitions = self.class.definitions
           contexts = r.respond_to?(:contexts) ? r.contexts : nil
           current_schema_fields = Hyrax::Schema.m3_schema_loader.form_definitions_for(schema: r.class.name, version: Hyrax::FlexibleSchema.current_schema_id, contexts: contexts)
@@ -199,6 +200,14 @@ module Hyrax
           required_fields
         end
 
+        ##
+        # The form's own properties. Memoized on the first call, which
+        # {ResourceForm#reset_flexible_definitions!} makes before any profile
+        # field has been added, so the snapshot excludes them.
+        def static_schema_definitions
+          @static_schema_definitions ||= definitions.dup
+        end
+
         def schema_definitions
           @definitions
         end
@@ -211,7 +220,7 @@ module Hyrax
           @expose_class = Class.new(Disposable::Expose).from(schema_definitions.values)
         end
 
-        public :expose_class, :required_fields, :required_fields=, :schema_definitions, :schema_definitions=
+        public :expose_class, :required_fields, :required_fields=, :schema_definitions, :schema_definitions=, :static_schema_definitions
       end
       ##
       # @param [#to_s] attr
@@ -301,6 +310,18 @@ module Hyrax
       delegate :flexible?, to: :model
 
       private
+
+      # The flexible schema is declared on the singleton, but +Declarative+
+      # resolves +definitions+ as <tt>@definitions ||= ...</tt> on whichever
+      # object receives it, so the singleton and the class share one container
+      # and each build writes its profile's fields onto the class. Without this
+      # reset, a form built for one profile inherits the fields of whichever
+      # profile was built before it.
+      def reset_flexible_definitions!
+        baseline = self.class.static_schema_definitions
+        definitions = self.class.definitions
+        (definitions.keys - baseline.keys).each { |name| definitions.delete(name) }
+      end
 
       # A copy of the resource loaded at the current schema version, so its
       # singleton schema reflects the live profile (including compounds added

--- a/spec/forms/hyrax/forms/resource_form_spec.rb
+++ b/spec/forms/hyrax/forms/resource_form_spec.rb
@@ -285,6 +285,84 @@ RSpec.describe Hyrax::Forms::ResourceForm do
     end
   end
 
+  describe 'flexible form definitions and the shared form class' do
+    let(:profile_fields) do
+      { 'title' => { required: true, primary: true, display: true } }
+    end
+
+    # `attributes_for` is driven from the same profile hash as the form fields:
+    # in a real install the model answers whatever the profile declares, and
+    # stubbing only the form side creates a divergence that cannot occur.
+    let(:schema_loader) do
+      loader = instance_double(Hyrax::M3SchemaLoader)
+      allow(loader).to receive(:current_version).and_return(1)
+      allow(loader).to receive(:index_rules_for).and_return({})
+      allow(loader).to receive(:form_definitions_for) { profile_fields }
+      allow(loader).to receive(:attributes_for) do
+        profile_fields.keys.each_with_object({}) do |name, attrs|
+          attrs[name.to_sym] = Valkyrie::Types::Array.of(Valkyrie::Types::String)
+        end
+      end
+      loader
+    end
+
+    let(:work_class) do
+      klass = Class.new(Hyrax::Work) do
+        def self.name
+          'TestSharedDefinitionsWork'
+        end
+      end
+      klass.acts_as_flexible_resource
+      klass
+    end
+
+    let(:form_class) { Class.new(Hyrax::Forms::ResourceForm(work_class)) }
+    let(:work) { work_class.new }
+
+    before do
+      allow(Hyrax.config).to receive(:flexible?).and_return(true)
+      allow(Hyrax::Schema).to receive(:m3_schema_loader).and_return(schema_loader)
+      allow(Hyrax::FlexibleSchema).to receive(:current_schema_id).and_return(1)
+    end
+
+    after do
+      Hyrax.config.flexible_classes.delete('TestSharedDefinitionsWork')
+    end
+
+    # `display: false` is load-bearing: the pre-existing prune drops only fields
+    # marked for display, so these examples pass without the fix if the field is
+    # visible. `redirects` is the shipped hidden field.
+    let(:hidden_field) { { required: false, primary: false, display: false } }
+
+    it "does not carry a previous profile's hidden field into the next form" do
+      profile_fields['extra_profile_field'] = hidden_field
+      form_class.new(resource: work)
+
+      profile_fields.delete('extra_profile_field')
+      form = form_class.new(resource: work)
+
+      expect(form.singleton_class.definitions.keys).not_to include('extra_profile_field')
+    end
+
+    it "clears a previous profile's hidden field from the form class" do
+      profile_fields['extra_profile_field'] = hidden_field
+      form_class.new(resource: work)
+      expect(form_class.definitions.keys).to include('extra_profile_field')
+
+      profile_fields.delete('extra_profile_field')
+      form_class.new(resource: work)
+
+      expect(form_class.definitions.keys).not_to include('extra_profile_field')
+    end
+
+    it 'still exposes the profile fields on the instance' do
+      form = form_class.new(resource: work)
+
+      expect(form.singleton_class.definitions.keys).to include('title')
+      expect(form.title).to eq []
+    end
+  end
+
   describe 'flexible form after M3 profile update adds a compound field' do
     # Regression: a work created on an older schema version, edited after a
     # compound (e.g. :participants) is added to the M3 profile, raised


### PR DESCRIPTION
## Summary
Fixes work and collection forms picking up metadata fields from a different metadata profile than the one they were built for, which could make a form fail to load.
- Refs notch8/hyku-community-issues#154

## Details
- Flexible form fields are declared on the instance's singleton, but `Declarative` resolves `definitions` on whichever object receives it, so the singleton and the form class share one container.
- Each build therefore writes its profile's fields onto the shared class, where the next form built inherits them.
- The pre-existing cleanup only drops fields marked `display`, so a hidden field — `redirects` is the shipped one — survived onto the class even for a profile that never declared it.
- A flexible build now resets the class to its own static properties first. ~10 lines of production code; no `respond_to?` probing.
- Verified against a multi-profile reproduction: the form class stops accumulating fields, and each build sees only what its own profile declares.
- Known follow-up, out of scope here: `required_fields=` mutates `Definition` objects in place, which reaches the class the same way.
