### PR TITLE
Honor collection and admin set model configuration

### DIFF
--- a/app/forms/hyrax/forms/administrative_set_form.rb
+++ b/app/forms/hyrax/forms/administrative_set_form.rb
@@ -6,7 +6,7 @@ module Hyrax
     # @api public
     # @see https://github.com/samvera/valkyrie/wiki/ChangeSets-and-Dirty-Tracking
     class AdministrativeSetForm < Hyrax::Forms::ResourceForm
-      check_if_flexible(Hyrax::AdministrativeSet)
+      check_if_flexible(Hyrax.config.admin_set_class)
 
       ##
       # @api private

--- a/app/forms/hyrax/forms/pcdm_collection_form.rb
+++ b/app/forms/hyrax/forms/pcdm_collection_form.rb
@@ -10,7 +10,7 @@ module Hyrax
       # Wire the compound form properties (non-flexible mode), mirroring the
       # work-side wiring in the PcdmObjectForm factory.
       if !Hyrax.config.flexible? &&
-         Hyrax::PcdmCollection.ancestors.detect { |k| k.inspect == "Hyrax::Schema(compound_metadata)" }
+         Hyrax.config.collection_class.ancestors.detect { |k| k.inspect == "Hyrax::Schema(compound_metadata)" }
         include Hyrax::FormFields(:compound_metadata)
       end
 
@@ -24,7 +24,7 @@ module Hyrax
         end
       end
 
-      check_if_flexible(Hyrax::PcdmCollection)
+      check_if_flexible(Hyrax.config.collection_class)
 
       BannerInfoPrepopulator = lambda do |**_options|
         self.banner_info ||= begin

--- a/app/forms/hyrax/forms/resource_form.rb
+++ b/app/forms/hyrax/forms/resource_form.rb
@@ -136,7 +136,7 @@ module Hyrax
         end
 
         def check_if_flexible(model)
-          return unless model.flexible?
+          return unless model.respond_to?(:flexible?) && model.flexible?
           include FlexibleFormBehavior
           include Hyrax::FormFields(model.to_s, definition_loader: Hyrax::Schema.m3_schema_loader)
         end

--- a/app/indexers/hyrax/indexers/administrative_set_indexer.rb
+++ b/app/indexers/hyrax/indexers/administrative_set_indexer.rb
@@ -8,7 +8,7 @@ module Hyrax
       include Hyrax::PermissionIndexer
       include Hyrax::VisibilityIndexer
       include Hyrax::Indexer(:core_metadata) if Hyrax.config.admin_set_include_metadata
-      check_if_flexible(Hyrax::AdministrativeSet)
+      check_if_flexible(Hyrax.config.admin_set_class)
 
       def to_solr # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength
         super.tap do |solr_doc|

--- a/app/indexers/hyrax/indexers/pcdm_collection_indexer.rb
+++ b/app/indexers/hyrax/indexers/pcdm_collection_indexer.rb
@@ -14,7 +14,7 @@ module Hyrax
       # Flatten compound (hierarchical) metadata sub-properties into Solr. No-op for
       # collections without compounds. See documentation/compound_fields.md.
       include Hyrax::Indexers::CompoundIndexer
-      check_if_flexible(Hyrax::PcdmCollection)
+      check_if_flexible(Hyrax.config.collection_class)
 
       self.thumbnail_path_service = CollectionThumbnailPathService
 

--- a/app/indexers/hyrax/indexers/resource_indexer.rb
+++ b/app/indexers/hyrax/indexers/resource_indexer.rb
@@ -61,7 +61,8 @@ module Hyrax
 
       class << self
         def check_if_flexible(model)
-          include Hyrax::Indexer(model.to_s, index_loader: Hyrax::Schema.m3_schema_loader) if model.flexible?
+          return unless model.respond_to?(:flexible?) && model.flexible?
+          include Hyrax::Indexer(model.to_s, index_loader: Hyrax::Schema.m3_schema_loader)
         end
 
         ##

--- a/app/services/hyrax/flexible_schema_validators/class_validator.rb
+++ b/app/services/hyrax/flexible_schema_validators/class_validator.rb
@@ -19,7 +19,7 @@ module Hyrax
       #
       # @return [void]
       def validate_availability!
-        classes_to_validate = all_profile_classes - @required_classes
+        classes_to_validate = all_profile_classes - @required_classes - non_work_classes
         invalid_classes = []
         mismatched_valkyrie_classes = []
 
@@ -52,6 +52,29 @@ module Hyrax
 
       private
 
+      # `validate_class` holds every class it is given to the curation concern
+      # check, so these must be excluded. `@required_classes` covers only the
+      # configured collection/admin set/file set; a profile may legitimately name
+      # others, since one migrating between collection classes carries both.
+      #
+      # @return [Array<String>]
+      def non_work_classes
+        clean_class_names(Hyrax::ModelRegistry.collection_class_names +
+                          Hyrax::ModelRegistry.admin_set_class_names +
+                          Hyrax::ModelRegistry.file_set_class_names)
+      end
+
+      # @param klass [String]
+      # @return [Boolean] whether the named class resolves to a collection,
+      #   admin set, or file set model rather than a work type.
+      def non_work_model?(klass)
+        constant = klass.safe_constantize
+        return false if constant.nil?
+
+        constant.respond_to?(:pcdm_collection?) && constant.pcdm_collection? ||
+          constant.respond_to?(:file_set?) && constant.file_set?
+      end
+
       # Gathers all unique class names from both the top-level `classes`
       # definition and all `available_on` property references.
       #
@@ -78,6 +101,11 @@ module Hyrax
       # @param mismatched_valkyrie_classes [Array<Hash>] an array to append Valkyrie mismatch errors to
       # @return [void]
       def validate_class(klass, invalid_classes, mismatched_valkyrie_classes)
+        # Catches a collection or admin set class that is in neither
+        # `@required_classes` nor the registry, which `non_work_classes` cannot
+        # exclude by name.
+        return if non_work_model?(klass)
+
         base_class_name = klass.gsub(/(?<=.)Resource$/, '')
         unless Hyrax.config.registered_curation_concern_types.include?(base_class_name)
           invalid_classes << klass

--- a/app/views/catalog/_index_header_list_default.html.erb
+++ b/app/views/catalog/_index_header_list_default.html.erb
@@ -1,6 +1,5 @@
-<% model = document.hydra_model %>
 <div class="search-results-title-row col-12 d-flex flex-row align-items-center pb-2">
-  <% if model == Hyrax::PcdmCollection || model < Hyrax::PcdmCollection %>
+  <% if document.collection? %>
     <h3 class="search-result-title"><%= link_to document.title_or_label, [hyrax, document] %></h3>
     <%= Hyrax::CollectionPresenter.new(document, current_ability).collection_type_badge %>
   <% else %>

--- a/app/views/catalog/_thumbnail_list_default.html.erb
+++ b/app/views/catalog/_thumbnail_list_default.html.erb
@@ -1,6 +1,5 @@
-<% model = document.hydra_model %>
 <div class="col-md-3">
-  <% if model == Hyrax::PcdmCollection || model < Hyrax::PcdmCollection %>
+  <% if document.collection? %>
     <%= document_presenter(document)&.thumbnail&.thumbnail_tag({ alt: thumbnail_alt_text_for(document, block_name: 'default_collection_image_text') }, { suppress_link: true }) %>
   <% else %>
     <div class="list-thumbnail">

--- a/lib/hyrax/transactions/steps/add_to_collections.rb
+++ b/lib/hyrax/transactions/steps/add_to_collections.rb
@@ -36,11 +36,19 @@ module Hyrax
         private
 
         def check_multi_membership(change_set, collection_ids)
-          return if change_set.is_a? Hyrax::Forms::PcdmCollectionForm
+          # Collections-in-collections have no multi-membership limit. Keyed on
+          # the model, not the form class: an app may configure a
+          # `pcdm_collection_form` outside the PcdmCollectionForm hierarchy.
+          return if collection?(change_set)
 
           Hyrax::MultipleMembershipChecker
             .new(item: change_set)
             .check(collection_ids: [collection_ids], include_current_members: true)
+        end
+
+        def collection?(change_set)
+          model = change_set.try(:model) || change_set
+          Hyrax::ModelRegistry.collection_classes.any? { |klass| model.is_a?(klass) }
         end
       end
     end

--- a/spec/forms/hyrax/forms/resource_form_spec.rb
+++ b/spec/forms/hyrax/forms/resource_form_spec.rb
@@ -9,6 +9,18 @@ RSpec.describe Hyrax::Forms::ResourceForm do
   let(:default_admin_set) { instance_double(Hyrax::AdministrativeSet, title: "DEFAULT_ADMINSET", id: "DEFAULT_ADMINSET_ID") }
   before { allow(Hyrax::AdminSetCreateService).to receive(:find_or_create_default_admin_set).and_return(default_admin_set) }
 
+  describe '.check_if_flexible' do
+    it 'treats a model that does not respond to flexible? as not flexible' do
+      model = Class.new do
+        def self.to_s
+          'ModelWithoutFlexibleSupport'
+        end
+      end
+
+      expect { Class.new(described_class) { check_if_flexible(model) } }.not_to raise_error
+    end
+  end
+
   # Redirects is a Work/Collection concern, never a FileSet one. The FileSet
   # form must not declare the property (its model has no `redirects` attribute) —
   # guarding the regression where declaring redirects on the shared base

--- a/spec/hyrax/transactions/steps/add_to_collections_spec.rb
+++ b/spec/hyrax/transactions/steps/add_to_collections_spec.rb
@@ -53,5 +53,35 @@ RSpec.describe Hyrax::Transactions::Steps::AddToCollections do
         expect(step.call(change_set, collection_ids: collection_ids)).to be_failure
       end
     end
+
+    context 'when the resource is a collection' do
+      let(:resource) { FactoryBot.build(:hyrax_collection) }
+
+      before do
+        allow_any_instance_of(Hyrax::MultipleMembershipChecker) # rubocop:disable RSpec/AnyInstance
+          .to receive(:check).with(any_args).and_return('VIOLATION')
+      end
+
+      it 'skips the multiple membership check' do
+        expect(step.call(change_set, collection_ids: collection_ids)).to be_success
+      end
+
+      context 'with a form class outside the PcdmCollectionForm hierarchy' do
+        let(:change_set) { form_class.new(resource: resource) }
+        let(:form_class) do
+          Class.new(Hyrax::Forms::ResourceForm) do
+            property :member_of_collection_ids, default: [], type: Valkyrie::Types::Array
+
+            def self.name
+              'CustomCollectionForm'
+            end
+          end
+        end
+
+        it 'skips the multiple membership check' do
+          expect(step.call(change_set, collection_ids: collection_ids)).to be_success
+        end
+      end
+    end
   end
 end

--- a/spec/indexers/hyrax/indexers/resource_indexer_spec.rb
+++ b/spec/indexers/hyrax/indexers/resource_indexer_spec.rb
@@ -9,6 +9,18 @@ RSpec.describe Hyrax::Indexers::ResourceIndexer do
 
   it_behaves_like 'a Hyrax::Resource indexer'
 
+  describe '.check_if_flexible' do
+    it 'treats a model that does not respond to flexible? as not flexible' do
+      model = Class.new do
+        def self.to_s
+          'ModelWithoutFlexibleSupport'
+        end
+      end
+
+      expect { Class.new(described_class) { check_if_flexible(model) } }.not_to raise_error
+    end
+  end
+
   describe '.for' do
     it 'gives an instance of itself as the default indexer class' do
       expect(described_class.for(resource: Valkyrie::Resource.new).class)

--- a/spec/services/hyrax/flexible_schema_validators/class_validator_spec.rb
+++ b/spec/services/hyrax/flexible_schema_validators/class_validator_spec.rb
@@ -138,6 +138,33 @@ RSpec.describe Hyrax::FlexibleSchemaValidators::ClassValidator do
           expect(errors).to include('Invalid classes: InvalidWork.')
         end
       end
+
+      context 'with collection and admin set classes beyond the configured ones' do
+        let(:required_classes) { ['ConfiguredAdminSet', 'ConfiguredCollection', 'Hyrax::FileSet'] }
+
+        let(:profile) do
+          {
+            'classes' => {
+              'ConfiguredAdminSet' => { 'display_label' => 'Configured Admin Set' },
+              'ConfiguredCollection' => { 'display_label' => 'Configured Collection' },
+              'SupersededAdminSet' => { 'display_label' => 'Superseded Admin Set' },
+              'SupersededCollection' => { 'display_label' => 'Superseded Collection' }
+            }
+          }
+        end
+
+        before do
+          stub_const('ConfiguredAdminSet', Class.new(Hyrax::AdministrativeSet))
+          stub_const('ConfiguredCollection', Class.new(Hyrax::PcdmCollection))
+          stub_const('SupersededAdminSet', Class.new(Hyrax::AdministrativeSet))
+          stub_const('SupersededCollection', Class.new(Hyrax::PcdmCollection))
+        end
+
+        it 'does not report the non-configured collection and admin set classes as invalid' do
+          validator.validate_availability!
+          expect(errors).to be_empty
+        end
+      end
     end
   end
 

--- a/spec/views/catalog/_index_header_list_default.html.erb_spec.rb
+++ b/spec/views/catalog/_index_header_list_default.html.erb_spec.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+RSpec.describe 'catalog/_index_header_list_default', type: :view do
+  let(:document) { SolrDocument.new(attributes) }
+  let(:badge) { 'COLLECTION_TYPE_BADGE' }
+
+  before do
+    allow(view).to receive(:current_ability).and_return(double('Ability'))
+    allow(Hyrax::CollectionPresenter).to receive(:new).and_return(
+      instance_double(Hyrax::CollectionPresenter, collection_type_badge: badge)
+    )
+  end
+
+  context 'with a work' do
+    let(:attributes) { { 'id' => 'wk1', 'title_tesim' => ['A Work'], 'has_model_ssim' => ['GenericWork'] } }
+
+    it 'renders the title without a collection type badge' do
+      render 'catalog/index_header_list_default', document: document
+
+      expect(rendered).to include 'A Work'
+      expect(rendered).not_to include badge
+    end
+  end
+
+  context 'with the configured collection class' do
+    let(:attributes) do
+      { 'id' => 'col1',
+        'title_tesim' => ['A Collection'],
+        'has_model_ssim' => [Hyrax.config.collection_class.to_rdf_representation] }
+    end
+
+    it 'renders the collection type badge' do
+      render 'catalog/index_header_list_default', document: document
+
+      expect(rendered).to include badge
+    end
+  end
+
+  context 'with a collection class that does not inherit from Hyrax::PcdmCollection' do
+    let(:attributes) { { 'id' => 'col2', 'title_tesim' => ['Standalone'], 'has_model_ssim' => ['StandaloneCollection'] } }
+
+    before do
+      stub_const('StandaloneCollection', Class.new(Hyrax::Resource) do
+        def self.name
+          'StandaloneCollection'
+        end
+
+        def self.to_rdf_representation
+          name
+        end
+
+        def self._hyrax_default_name_class
+          Hyrax::CollectionName
+        end
+      end)
+      allow(Hyrax.config).to receive(:collection_model).and_return('StandaloneCollection')
+    end
+
+    it 'renders the collection type badge' do
+      render 'catalog/index_header_list_default', document: document
+
+      expect(rendered).to include badge
+    end
+  end
+end

--- a/spec/views/catalog/_thumbnail_list_default.html.erb_spec.rb
+++ b/spec/views/catalog/_thumbnail_list_default.html.erb_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+RSpec.describe 'catalog/_thumbnail_list_default', type: :view do
+  let(:document) { SolrDocument.new(attributes) }
+  let(:thumbnail) { instance_double(Blacklight::ThumbnailPresenter, thumbnail_tag: 'THUMBNAIL_TAG') }
+
+  before do
+    allow(view).to receive(:document_presenter).and_return(double('presenter', thumbnail: thumbnail))
+    allow(view).to receive(:thumbnail_alt_text_for).and_return('alt text')
+  end
+
+  context 'with a work' do
+    let(:attributes) { { 'id' => 'wk1', 'has_model_ssim' => ['GenericWork'] } }
+
+    it 'wraps the thumbnail in the work list-thumbnail treatment' do
+      render 'catalog/thumbnail_list_default', document: document
+
+      expect(rendered).to include 'list-thumbnail'
+    end
+  end
+
+  context 'with a collection class that does not inherit from Hyrax::PcdmCollection' do
+    let(:attributes) { { 'id' => 'col1', 'has_model_ssim' => ['StandaloneCollection'] } }
+
+    before do
+      stub_const('StandaloneCollection', Class.new(Hyrax::Resource) do
+        def self.name
+          'StandaloneCollection'
+        end
+
+        def self.to_rdf_representation
+          name
+        end
+      end)
+      allow(Hyrax.config).to receive(:collection_model).and_return('StandaloneCollection')
+    end
+
+    it 'uses the collection thumbnail treatment rather than the work one' do
+      render 'catalog/thumbnail_list_default', document: document
+
+      expect(rendered).not_to include 'list-thumbnail'
+    end
+  end
+end


### PR DESCRIPTION
## Summary
Collections and admin sets now follow the class named in `config.collection_model` / `config.admin_set_model`, so an application that substitutes its own class gets that class's metadata fields, search-result display, and validation.
- Refs notch8/utk_knapsack#13

## Details
- **Custom collections got the wrong metadata fields.** The base form and indexer looked up the m3 schema for `Hyrax::PcdmCollection`, not the configured class. Generated subclasses inherit that lookup, so they never corrected it.
- **Collections could render as works in search results.** Two catalog partials identified collections by descent from `Hyrax::PcdmCollection`, losing the type badge and thumbnail treatment for a class outside that hierarchy. They now use the existing `SolrDocument#collection?`.
- **Profiles could not be loaded mid-migration.** The validator treated any unrecognized class as a work type, so naming both an old and a new collection class — necessary while migrating between them — failed as `Invalid classes`.
- **Nesting a collection could fail validation.** The multiple-membership check was skipped based on the change set's form class, which is not a reliable signal: `Hyrax::ChangeSet.for` returns an anonymous subclass when no named form exists.

