### PR TITLE
Pin json below 3.0 to fix broken CI

### DIFF
--- a/.dassie/Gemfile
+++ b/.dassie/Gemfile
@@ -34,6 +34,7 @@ gem 'hydra-role-management'
 gemspec name: 'hyrax', path: ENV.fetch('HYRAX_ENGINE_PATH', '..')
 gem 'jbuilder', '~> 2.5'
 gem 'jquery-rails'
+gem 'json', '< 3.0' # remove once Hyrax allows rails >= 8.0 - ActiveSupport::JSON only stops passing the quirks_mode kwarg that json 3.0 dropped as of Rails 8
 gem 'okcomputer'
 gem 'pg', '~> 1.3'
 gem 'puma'

--- a/.koppie/Gemfile
+++ b/.koppie/Gemfile
@@ -33,6 +33,7 @@ gem 'hydra-role-management'
 gemspec name: 'hyrax', path: ENV.fetch('HYRAX_ENGINE_PATH', '..')
 gem 'jbuilder', '~> 2.5'
 gem 'jquery-rails'
+gem 'json', '< 3.0' # remove once Hyrax allows rails >= 8.0 - ActiveSupport::JSON only stops passing the quirks_mode kwarg that json 3.0 dropped as of Rails 8
 gem 'okcomputer'
 gem 'pg', '~> 1.3'
 gem 'puma'

--- a/Gemfile
+++ b/Gemfile
@@ -15,6 +15,7 @@ group :development, :test do
   gem 'benchmark-ips'
   gem 'easy_translate'
   gem 'i18n-tasks'
+  gem 'json', '< 3.0' # remove once Hyrax allows rails >= 8.0 - ActiveSupport::JSON only stops passing the quirks_mode kwarg that json 3.0 dropped as of Rails 8
   gem 'okcomputer'
   gem 'pry' unless ENV['CI']
   gem 'pry-byebug' unless ENV['CI']

--- a/hyrax.gemspec
+++ b/hyrax.gemspec
@@ -64,7 +64,6 @@ SUMMARY
   spec.add_dependency 'hydra-head', '~> 13.0'
   spec.add_dependency 'hydra-works', '>= 0.16'
   spec.add_dependency 'iiif_manifest', '>= 0.3', '< 2.0'
-  spec.add_dependency 'json', '< 3.0' # remove once Hyrax allows rails >= 8.0 - ActiveSupport::JSON only stops passing the quirks_mode kwarg that json 3.0 dropped as of Rails 8
   spec.add_dependency 'json-schema' # for Arkivo
   spec.add_dependency 'json_schemer' # Required for m3 schema validation
   spec.add_dependency 'legato', '~> 0.3'

--- a/hyrax.gemspec
+++ b/hyrax.gemspec
@@ -64,6 +64,7 @@ SUMMARY
   spec.add_dependency 'hydra-head', '~> 13.0'
   spec.add_dependency 'hydra-works', '>= 0.16'
   spec.add_dependency 'iiif_manifest', '>= 0.3', '< 2.0'
+  spec.add_dependency 'json', '< 3.0' # 3.0 dropped the quirks_mode kwarg ActiveSupport::JSON still passes
   spec.add_dependency 'json-schema' # for Arkivo
   spec.add_dependency 'json_schemer' # Required for m3 schema validation
   spec.add_dependency 'legato', '~> 0.3'

--- a/hyrax.gemspec
+++ b/hyrax.gemspec
@@ -64,7 +64,7 @@ SUMMARY
   spec.add_dependency 'hydra-head', '~> 13.0'
   spec.add_dependency 'hydra-works', '>= 0.16'
   spec.add_dependency 'iiif_manifest', '>= 0.3', '< 2.0'
-  spec.add_dependency 'json', '< 3.0' # 3.0 dropped the quirks_mode kwarg ActiveSupport::JSON still passes
+  spec.add_dependency 'json', '< 3.0' # remove once Hyrax allows rails >= 8.0 - ActiveSupport::JSON only stops passing the quirks_mode kwarg that json 3.0 dropped as of Rails 8
   spec.add_dependency 'json-schema' # for Arkivo
   spec.add_dependency 'json_schemer' # Required for m3 schema validation
   spec.add_dependency 'legato', '~> 0.3'


### PR DESCRIPTION
`json 3.0.0`'s `JSON.generate` dropped the `quirks_mode` keyword that `ActiveSupport::JSON::Encoding` still passes, raising `ArgumentError: unknown keyword: quirks_mode` on essentially any ActiveRecord JSON serialization. This broke CI across every test app (allinson/dassie/koppie/sirenia) today, unrelated to any in-flight PR. Pins `json` below 3.0 in the gemspec.
