### PR TITLE
Add a QA-backed vocabulary label resolver

### DIFF
--- a/app/services/hyrax/qa_controlled_vocabulary_label_service.rb
+++ b/app/services/hyrax/qa_controlled_vocabulary_label_service.rb
@@ -1,0 +1,111 @@
+# frozen_string_literal: true
+
+module Hyrax
+  ##
+  # Resolves controlled vocabulary term ids to labels using the local
+  # Questioning Authority vocabularies an application has configured in
+  # `config/authorities/`.
+  #
+  # Not installed by default — Hyrax ships
+  # {Hyrax::ControlledVocabularyLabelService}, which resolves nothing. Register
+  # this to have labels indexed and displayed:
+  #
+  # @example config/initializers/hyrax.rb
+  #   Hyrax.config.controlled_vocabulary_label_service =
+  #     Hyrax::QaControlledVocabularyLabelService.new
+  #
+  # A property's `controlled_values.sources` entry is matched to a local
+  # subauthority of the same name, so a property citing `licenses` resolves
+  # against `config/authorities/licenses.yml`.
+  #
+  # Reindex after registering: the show page and catalog read the label fields
+  # the indexer writes, so an existing corpus keeps displaying ids until it is
+  # reindexed.
+  class QaControlledVocabularyLabelService < ControlledVocabularyLabelService
+    CACHE_KEY_PREFIX = 'hyrax_controlled_vocabulary_labels-v1-'
+    CACHE_EXPIRATION = 1.hour
+
+    ##
+    # @param source [String] a controlled vocabulary name
+    # @return [Boolean] whether a local authority of that name exists. Remote
+    #   authorities are excluded structurally — Qa's registry only holds locally
+    #   registered subauthorities — so resolving one never costs a request.
+    def resolvable?(source)
+      name = source.to_s.strip
+      return false if name.empty?
+
+      local_authority_names.include?(name)
+    end
+
+    ##
+    # @param source [String] a controlled vocabulary name
+    # @param values [Array, Object, nil] the stored term ids
+    # @return [Array] one entry per value, in the order given, falling back to
+    #   the value itself where the authority does not know it
+    def labels_for(source, values)
+      values = Array.wrap(values)
+      return values if values.empty?
+
+      name = source.to_s.strip
+      # Checked before the cache rather than only inside the map builder:
+      # Rails.cache outlives the authority's availability, so a map cached while
+      # a vocabulary existed would otherwise keep answering after it is gone.
+      return values unless resolvable?(name)
+
+      map = label_map(name)
+      return values if map.empty?
+
+      values.map { |value| map.fetch(value.to_s, value) }
+    end
+
+    private
+
+    # Assigned inside the rescue as well: Qa raises rather than memoizing when
+    # an application has no config/authorities, so a bare `||=` would pay a
+    # raised-and-caught exception on every call.
+    def local_authority_names
+      @local_authority_names ||= Qa::Authorities::Local.subauthorities.map(&:to_s)
+    rescue StandardError => e
+      Hyrax.logger.debug { "No local authorities available: #{e.message}" }
+      @local_authority_names = [].freeze
+    end
+
+    # Held in-process as well as in Rails.cache, so a reindex builds each map
+    # once per process however short the cache expiry is.
+    def label_map(name)
+      @label_maps ||= {}
+      @label_maps.fetch(name) do
+        @label_maps[name] = Rails.cache.fetch(cache_key(name), expires_in: CACHE_EXPIRATION) do
+          build_label_map(name)
+        end
+      end
+    end
+
+    # One map per authority rather than a lookup per value: a file-based
+    # authority re-reads and re-parses its yaml on every call, so resolving id
+    # by id costs a parse per value per document during a reindex.
+    #
+    # `#all` is what both backends normalize through — a file-based authority's
+    # `term:` is emitted as `label:`, and a table-based one emits `label:`
+    # natively. The `term` reads cover a plain-Hash double.
+    def build_label_map(name)
+      return {} unless resolvable?(name)
+
+      Qa::Authorities::Local.subauthority_for(name).all.each_with_object({}) do |term, map|
+        id = term[:id] || term['id']
+        next if id.blank?
+
+        label = term[:label] || term['label'] || term[:term] || term['term']
+        map[id.to_s] = label.presence || id.to_s
+      end
+    rescue StandardError => e
+      # A missing or broken authority must not fail an indexing run.
+      Hyrax.logger.warn("Unable to load labels for controlled vocabulary #{name}: #{e.message}")
+      {}
+    end
+
+    def cache_key(name)
+      "#{CACHE_KEY_PREFIX}#{name}"
+    end
+  end
+end

--- a/documentation/flexible_metadata.md
+++ b/documentation/flexible_metadata.md
@@ -134,10 +134,22 @@ Because this is driven by the profile, a property or vocabulary added to an m3 p
 
 ### Registering a label service
 
-Hyrax has no vocabulary store of its own, so resolution is injectable. The default resolves nothing, which leaves indexing and rendering byte-identical to an installation without this feature. An application registers its own resolver:
+Hyrax has no vocabulary store of its own, so resolution is injectable. The default resolves nothing, which leaves indexing and rendering byte-identical to an installation without this feature.
+
+Hyrax ships a resolver backed by the local [Questioning Authority](https://github.com/samvera/questioning_authority) vocabularies in `config/authorities/`. It is **not** installed by default; register it to turn the feature on:
 
 ```ruby
 # config/initializers/hyrax.rb
+Hyrax.config.controlled_vocabulary_label_service = Hyrax::QaControlledVocabularyLabelService.new
+```
+
+A property's `controlled_values.sources` entry is matched to a local subauthority of the same name, so a property citing `licenses` resolves against `config/authorities/licenses.yml`. Remote authorities (Geonames, LOC) are never resolved — doing so would mean a network request per value during indexing.
+
+**Reindex after registering.** The show page and catalog read the label fields the indexer writes, so an existing corpus keeps displaying ids until it has been reindexed.
+
+An application with its own vocabulary store registers its own resolver instead:
+
+```ruby
 Hyrax.config.controlled_vocabulary_label_service = MyLabelService.new
 ```
 

--- a/spec/services/hyrax/qa_controlled_vocabulary_label_service_spec.rb
+++ b/spec/services/hyrax/qa_controlled_vocabulary_label_service_spec.rb
@@ -1,0 +1,128 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Hyrax::QaControlledVocabularyLabelService do
+  subject(:service) { described_class.new }
+
+  # `Qa::Authorities::Local#all` normalizes a file-based authority's `term:` to
+  # `label:`, while a table-based one emits `label:` natively. Both shapes are
+  # exercised, since the resolver reads whichever is present.
+  let(:label_keyed_terms) do
+    [HashWithIndifferentAccess.new(id: 'http://example.org/by', label: 'Attribution', active: true),
+     HashWithIndifferentAccess.new(id: 'http://example.org/nc', label: 'NonCommercial', active: false)]
+  end
+
+  let(:term_keyed_terms) do
+    [HashWithIndifferentAccess.new(id: 'Article', term: 'Article'),
+     HashWithIndifferentAccess.new(id: 'local_auth_123', term: 'Opaque Term')]
+  end
+
+  let(:licenses)       { FakeAuthority.new(label_keyed_terms) }
+  let(:resource_types) { FakeAuthority.new(term_keyed_terms) }
+
+  # Rails.cache is process-wide and outlives an example, so a map built by one
+  # would otherwise answer for the next.
+  around do |example|
+    original = Rails.cache
+    Rails.cache = ActiveSupport::Cache::MemoryStore.new
+    example.run
+    Rails.cache = original
+  end
+
+  before do
+    allow(Qa::Authorities::Local).to receive(:subauthorities).and_return(['licenses', 'resource_types'])
+    allow(Qa::Authorities::Local).to receive(:subauthority_for).with('licenses').and_return(licenses)
+    allow(Qa::Authorities::Local).to receive(:subauthority_for).with('resource_types').and_return(resource_types)
+  end
+
+  describe '#resolvable?' do
+    it 'is true for a local authority' do
+      expect(service.resolvable?('licenses')).to be true
+    end
+
+    it 'is false for a remote authority, which would cost a request per value' do
+      expect(service.resolvable?('geonames')).to be false
+    end
+
+    it 'is false for the free-text sentinel and for blanks' do
+      expect(service.resolvable?('null')).to be false
+      expect(service.resolvable?('')).to be false
+      expect(service.resolvable?(nil)).to be false
+    end
+
+    it 'tolerates a surrounding whitespace in a profile source' do
+      expect(service.resolvable?(' licenses ')).to be true
+    end
+  end
+
+  describe '#labels_for' do
+    it 'resolves a label-keyed authority' do
+      expect(service.labels_for('licenses', ['http://example.org/by'])).to eq ['Attribution']
+    end
+
+    it 'resolves a term-keyed authority' do
+      expect(service.labels_for('resource_types', ['local_auth_123'])).to eq ['Opaque Term']
+    end
+
+    it 'keeps one entry per value, in order, for a mix of known and unknown ids' do
+      expect(service.labels_for('resource_types', ['local_auth_123', 'unmapped', 'Article']))
+        .to eq ['Opaque Term', 'unmapped', 'Article']
+    end
+
+    it 'wraps a single value' do
+      expect(service.labels_for('resource_types', 'local_auth_123')).to eq ['Opaque Term']
+    end
+
+    it 'returns an empty array for no values' do
+      expect(service.labels_for('licenses', nil)).to eq []
+    end
+
+    it 'returns the values unchanged for an authority it cannot resolve' do
+      expect(service.labels_for('geonames', ['anything'])).to eq ['anything']
+    end
+
+    # An object may hold a term deactivated after it was deposited; it should
+    # still display its label rather than a bare id.
+    it 'resolves an inactive term' do
+      expect(service.labels_for('licenses', ['http://example.org/nc'])).to eq ['NonCommercial']
+    end
+  end
+
+  describe 'failure handling' do
+    context 'when the application has no config/authorities at all' do
+      before do
+        allow(Qa::Authorities::Local).to receive(:subauthorities).and_raise(StandardError, 'no config directory')
+      end
+
+      it 'reports nothing resolvable rather than raising' do
+        expect(service.resolvable?('licenses')).to be false
+      end
+
+      it 'returns the values unchanged' do
+        expect(service.labels_for('licenses', ['http://example.org/by'])).to eq ['http://example.org/by']
+      end
+    end
+
+    context 'when an authority raises while listing its terms' do
+      before { allow(licenses).to receive(:all).and_raise(StandardError, 'backend down') }
+
+      it 'returns the values unchanged rather than failing an indexing run' do
+        expect(service.labels_for('licenses', ['http://example.org/by'])).to eq ['http://example.org/by']
+      end
+    end
+  end
+
+  describe 'memoization' do
+    it 'builds an authority label map once, however many times it is asked' do
+      3.times { service.labels_for('licenses', ['http://example.org/by']) }
+
+      expect(Qa::Authorities::Local).to have_received(:subauthority_for).with('licenses').once
+    end
+
+    it 'keeps separate maps per authority' do
+      expect(service.labels_for('licenses', ['http://example.org/by'])).to eq ['Attribution']
+      expect(service.labels_for('resource_types', ['local_auth_123'])).to eq ['Opaque Term']
+    end
+  end
+end


### PR DESCRIPTION
## Summary
Ships a working controlled-vocabulary label resolver backed by the local Questioning Authority vocabularies in `config/authorities/`. **Not installed by default** — nothing changes until an application registers it.

Refs #7618 to add a default resolver

## Details
- Register it in `config/initializers/hyrax.rb`:
  `Hyrax.config.controlled_vocabulary_label_service = Hyrax::QaControlledVocabularyLabelService.new`
- A property's `controlled_values.sources` entry is matched to a local subauthority of the same name. Remote authorities (Geonames, LOC) are never resolved — that would mean a network request per value during indexing.
- Labels are read one map per authority rather than one lookup per value: a file-based authority re-parses its YAML on every call, which measured ~640× slower for indexing.
- Reindex after registering; the show page and catalog read the label fields the indexer writes.

## Testing
- Register the service, add a real authority name to a property's `controlled_values.sources`, reindex, and confirm the term's label appears on the show page, in search rows, and in the facet.
- Confirm an installation that registers nothing sees no change.
