### PR TITLE
Fixes CSRF error when relabeling files in File Manager

### DIFF
--- a/app/assets/javascripts/hyrax/file_manager/member.es6
+++ b/app/assets/javascripts/hyrax/file_manager/member.es6
@@ -87,7 +87,7 @@ export class FileManagerMember {
         form.off('ajax:success')
         form.off('ajax:error')
       })
-      form.submit()
+      Rails.fire(form[0], "submit")
       return deferred
     } else {
       return $.Deferred().resolve()


### PR DESCRIPTION
### Fixes

Fixes #7571 

### Summary

Fixes CSRF error when saving new file name in File Manager

### Guidance for testing, such as acceptance criteria or new user interface behaviors:
* Create a work with two or more files
* In File Manager, edit a file's title and click **Save**. It should save successfully.

### Type of change (for release notes)

- `notes-bugfix` Bug Fixes

### Detailed Description

Confirmed by reproducing issue locally
Previously the page reloaded to submit the change, which was missing the required security token
The fix swaps one line to submit the form with the security token

### Changes proposed in this pull request:
* In `app/assets/javascripts/hyrax/file_manager/member.es6`, replace `form.submit()` with `Rails.fire(form[0], "submit")`

@samvera/hyrax-code-reviewers
